### PR TITLE
fix(chart): improve Office-compatible chart fidelity

### DIFF
--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -68,7 +68,7 @@ set textBaseline=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,312.95
+moveTo 82.5,312.95
 lineTo 88.8,312.95
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
@@ -79,7 +79,7 @@ fillText "0" 82.8,312.95 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,271.3208
+moveTo 82.5,271.3208
 lineTo 88.8,271.3208
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
@@ -88,7 +88,7 @@ fillText "2" 82.8,271.3208 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,229.6917
+moveTo 82.5,229.6917
 lineTo 88.8,229.6917
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
@@ -97,7 +97,7 @@ fillText "4" 82.8,229.6917 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,188.0625
+moveTo 82.5,188.0625
 lineTo 88.8,188.0625
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
@@ -106,7 +106,7 @@ fillText "6" 82.8,188.0625 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,146.4333
+moveTo 82.5,146.4333
 lineTo 88.8,146.4333
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
@@ -115,7 +115,7 @@ fillText "8" 82.8,146.4333 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,104.8042
+moveTo 82.5,104.8042
 lineTo 88.8,104.8042
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
@@ -124,7 +124,7 @@ fillText "10" 82.8,104.8042 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,63.175
+moveTo 82.5,63.175
 lineTo 88.8,63.175
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
@@ -137,55 +137,55 @@ moveTo 88.8,312.95
 lineTo 540,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 88.8,316.95
+moveTo 88.8,319.25
 lineTo 88.8,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 126.4,316.95
+moveTo 126.4,319.25
 lineTo 126.4,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 164,316.95
+moveTo 164,319.25
 lineTo 164,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 201.6,316.95
+moveTo 201.6,319.25
 lineTo 201.6,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 239.2,316.95
+moveTo 239.2,319.25
 lineTo 239.2,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 276.8,316.95
+moveTo 276.8,319.25
 lineTo 276.8,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 314.4,316.95
+moveTo 314.4,319.25
 lineTo 314.4,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 352,316.95
+moveTo 352,319.25
 lineTo 352,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 389.6,316.95
+moveTo 389.6,319.25
 lineTo 389.6,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 427.2,316.95
+moveTo 427.2,319.25
 lineTo 427.2,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 464.8,316.95
+moveTo 464.8,319.25
 lineTo 464.8,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 502.4,316.95
+moveTo 502.4,319.25
 lineTo 502.4,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 540,316.95
+moveTo 540,319.25
 lineTo 540,312.95
 stroke ss=#aaa lw=1 dash=
 set textAlign=center
@@ -205,10 +205,10 @@ fillText "Dec" 521.2,315.95 fs=#555 font=11px sans-serif al=center bl=top
 set font=10.5px sans-serif
 set textBaseline=middle
 set fillStyle=#4472C4
-fillRect 576,180.8125,10,10.5 fs=#4472C4
+fillRect 576,184.3875,7.35,7.35 fs=#4472C4
 set fillStyle=#333
 set textAlign=left
-fillText "A" 590,186.0625 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "A" 587.35,186.0625 fs=#333 font=10.5px sans-serif al=left bl=middle
 save
 set font=bold 10.5px sans-serif
 set fillStyle=#555
@@ -235,60 +235,112 @@ fillText "0" 84.8,335.45 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 84.8,335.45
+moveTo 82.5,335.45
 lineTo 88.8,335.45
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 88.8,274.38
-lineTo 620,274.38
+moveTo 88.8,301.5222
+lineTo 620,301.5222
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "1" 84.8,274.38 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "0.5" 84.8,301.5222 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 84.8,274.38
-lineTo 88.8,274.38
+moveTo 82.5,301.5222
+lineTo 88.8,301.5222
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 88.8,213.31
-lineTo 620,213.31
+moveTo 88.8,267.5944
+lineTo 620,267.5944
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "2" 84.8,213.31 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "1" 84.8,267.5944 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 84.8,213.31
-lineTo 88.8,213.31
+moveTo 82.5,267.5944
+lineTo 88.8,267.5944
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 88.8,152.24
-lineTo 620,152.24
+moveTo 88.8,233.6667
+lineTo 620,233.6667
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "3" 84.8,152.24 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "1.5" 84.8,233.6667 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 84.8,152.24
-lineTo 88.8,152.24
+moveTo 82.5,233.6667
+lineTo 88.8,233.6667
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 88.8,91.17
-lineTo 620,91.17
+moveTo 88.8,199.7389
+lineTo 620,199.7389
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "4" 84.8,91.17 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "2" 84.8,199.7389 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 84.8,91.17
-lineTo 88.8,91.17
+moveTo 82.5,199.7389
+lineTo 88.8,199.7389
+stroke ss=#888 lw=1 dash=
+set strokeStyle=#e0e0e0
+set lineWidth=0.5
+beginPath
+moveTo 88.8,165.8111
+lineTo 620,165.8111
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "2.5" 84.8,165.8111 fs=#555 font=11px sans-serif al=right bl=middle
+set strokeStyle=#888
+set lineWidth=1
+beginPath
+moveTo 82.5,165.8111
+lineTo 88.8,165.8111
+stroke ss=#888 lw=1 dash=
+set strokeStyle=#e0e0e0
+set lineWidth=0.5
+beginPath
+moveTo 88.8,131.8833
+lineTo 620,131.8833
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "3" 84.8,131.8833 fs=#555 font=11px sans-serif al=right bl=middle
+set strokeStyle=#888
+set lineWidth=1
+beginPath
+moveTo 82.5,131.8833
+lineTo 88.8,131.8833
+stroke ss=#888 lw=1 dash=
+set strokeStyle=#e0e0e0
+set lineWidth=0.5
+beginPath
+moveTo 88.8,97.9556
+lineTo 620,97.9556
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "3.5" 84.8,97.9556 fs=#555 font=11px sans-serif al=right bl=middle
+set strokeStyle=#888
+set lineWidth=1
+beginPath
+moveTo 82.5,97.9556
+lineTo 88.8,97.9556
+stroke ss=#888 lw=1 dash=
+set strokeStyle=#e0e0e0
+set lineWidth=0.5
+beginPath
+moveTo 88.8,64.0278
+lineTo 620,64.0278
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "4" 84.8,64.0278 fs=#555 font=11px sans-serif al=right bl=middle
+set strokeStyle=#888
+set lineWidth=1
+beginPath
+moveTo 82.5,64.0278
+lineTo 88.8,64.0278
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
@@ -296,11 +348,11 @@ beginPath
 moveTo 88.8,30.1
 lineTo 620,30.1
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "5" 84.8,30.1 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "4.5" 84.8,30.1 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 84.8,30.1
+moveTo 82.5,30.1
 lineTo 88.8,30.1
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
@@ -323,58 +375,58 @@ set textAlign=center
 set textBaseline=top
 fillText "0" 88.8,339.45 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
-moveTo 88.8,339.45
+moveTo 88.8,341.75
 lineTo 88.8,335.45
 stroke ss=#888 lw=1 dash=
 fillText "0.5" 164.6857,339.45 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
-moveTo 164.6857,339.45
+moveTo 164.6857,341.75
 lineTo 164.6857,335.45
 stroke ss=#888 lw=1 dash=
 fillText "1" 240.5714,339.45 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
-moveTo 240.5714,339.45
+moveTo 240.5714,341.75
 lineTo 240.5714,335.45
 stroke ss=#888 lw=1 dash=
 fillText "1.5" 316.4571,339.45 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
-moveTo 316.4571,339.45
+moveTo 316.4571,341.75
 lineTo 316.4571,335.45
 stroke ss=#888 lw=1 dash=
 fillText "2" 392.3429,339.45 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
-moveTo 392.3429,339.45
+moveTo 392.3429,341.75
 lineTo 392.3429,335.45
 stroke ss=#888 lw=1 dash=
 fillText "2.5" 468.2286,339.45 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
-moveTo 468.2286,339.45
+moveTo 468.2286,341.75
 lineTo 468.2286,335.45
 stroke ss=#888 lw=1 dash=
 fillText "3" 544.1143,339.45 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
-moveTo 544.1143,339.45
+moveTo 544.1143,341.75
 lineTo 544.1143,335.45
 stroke ss=#888 lw=1 dash=
 fillText "3.5" 620,339.45 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
-moveTo 620,339.45
+moveTo 620,341.75
 lineTo 620,335.45
 stroke ss=#888 lw=1 dash=
 save
 set fillStyle=#4472C4
 beginPath
-arc 240.5714,213.31,26.9894,0,6.2832
+arc 240.5714,199.7389,26.9894,0,6.2832
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-arc 392.3429,91.17,38.1687,0,6.2832
+arc 392.3429,64.0278,38.1687,0,6.2832
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-arc 544.1143,152.24,31.9343,0,6.2832
+arc 544.1143,131.8833,31.9343,0,6.2832
 fill fs=#4472C4 ga=1
 restore
 restore"
@@ -506,60 +558,60 @@ moveTo 68.5,312.95
 lineTo 552.8,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 64.5,312.95
+moveTo 62.2,312.95
 lineTo 68.5,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 64.5,271.3208
+moveTo 62.2,271.3208
 lineTo 68.5,271.3208
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 64.5,229.6917
+moveTo 62.2,229.6917
 lineTo 68.5,229.6917
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 64.5,188.0625
+moveTo 62.2,188.0625
 lineTo 68.5,188.0625
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 64.5,146.4333
+moveTo 62.2,146.4333
 lineTo 68.5,146.4333
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 64.5,104.8042
+moveTo 62.2,104.8042
 lineTo 68.5,104.8042
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 64.5,63.175
+moveTo 62.2,63.175
 lineTo 68.5,63.175
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 68.5,316.95
+moveTo 68.5,319.25
 lineTo 68.5,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 229.9333,316.95
+moveTo 229.9333,319.25
 lineTo 229.9333,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 391.3667,316.95
+moveTo 391.3667,319.25
 lineTo 391.3667,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 552.8,316.95
+moveTo 552.8,319.25
 lineTo 552.8,312.95
 stroke ss=#aaa lw=1 dash=
 set font=10.5px sans-serif
 set textBaseline=middle
 set fillStyle=#4472C4
-fillRect 576,173.5625,10,10.5 fs=#4472C4
+fillRect 576,177.1375,7.35,7.35 fs=#4472C4
 set fillStyle=#333
 set textAlign=left
-fillText "Alpha" 590,178.8125 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Alpha" 587.35,178.8125 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
-fillRect 576,188.0625,10,10.5 fs=#ED7D31
+fillRect 576,191.6375,7.35,7.35 fs=#ED7D31
 set fillStyle=#333
-fillText "Beta" 590,193.3125 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Beta" 587.35,193.3125 fs=#333 font=10.5px sans-serif al=left bl=middle
 save
 set font=bold 10.5px sans-serif
 set fillStyle=#555
@@ -698,59 +750,59 @@ moveTo 30.775,63.175
 lineTo 30.775,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 30.775,339.45
+moveTo 30.775,341.75
 lineTo 30.775,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 117.7792,339.45
+moveTo 117.7792,341.75
 lineTo 117.7792,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 204.7833,339.45
+moveTo 204.7833,341.75
 lineTo 204.7833,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 291.7875,339.45
+moveTo 291.7875,341.75
 lineTo 291.7875,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 378.7917,339.45
+moveTo 378.7917,341.75
 lineTo 378.7917,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 465.7958,339.45
+moveTo 465.7958,341.75
 lineTo 465.7958,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 552.8,339.45
+moveTo 552.8,341.75
 lineTo 552.8,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 26.775,63.175
+moveTo 24.475,63.175
 lineTo 30.775,63.175
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 26.775,153.9333
+moveTo 24.475,153.9333
 lineTo 30.775,153.9333
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 26.775,244.6917
+moveTo 24.475,244.6917
 lineTo 30.775,244.6917
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 26.775,335.45
+moveTo 24.475,335.45
 lineTo 30.775,335.45
 stroke ss=#aaa lw=1 dash=
 set font=10.5px sans-serif
 set fillStyle=#4472C4
-fillRect 576,184.8125,10,10.5 fs=#4472C4
+fillRect 576,188.3875,7.35,7.35 fs=#4472C4
 set fillStyle=#333
 set textAlign=left
-fillText "Alpha" 590,190.0625 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Alpha" 587.35,190.0625 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
-fillRect 576,199.3125,10,10.5 fs=#ED7D31
+fillRect 576,202.8875,7.35,7.35 fs=#ED7D31
 set fillStyle=#333
-fillText "Beta" 590,204.5625 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Beta" 587.35,204.5625 fs=#333 font=10.5px sans-serif al=left bl=middle
 restore"
 `;
 
@@ -760,17 +812,17 @@ set textBaseline=middle
 set font=11px sans-serif
 set fillStyle=#555
 set fillStyle=#4472C4
-fillRect 31.2,292.8367,120.32,45.6933 fs=#4472C4
+fillRect 31.2,292.8367,133.6889,45.6933 fs=#4472C4
 set fillStyle=#ED7D31
-fillRect 151.52,292.8367,96.256,45.6933 fs=#ED7D31
+fillRect 164.8889,292.8367,106.9511,45.6933 fs=#ED7D31
 set fillStyle=#4472C4
-fillRect 31.2,178.6033,288.768,45.6933 fs=#4472C4
+fillRect 31.2,178.6033,320.8533,45.6933 fs=#4472C4
 set fillStyle=#ED7D31
-fillRect 319.968,178.6033,180.48,45.6933 fs=#ED7D31
+fillRect 352.0533,178.6033,200.5333,45.6933 fs=#ED7D31
 set fillStyle=#4472C4
-fillRect 31.2,64.37,204.544,45.6933 fs=#4472C4
+fillRect 31.2,64.37,227.2711,45.6933 fs=#4472C4
 set fillStyle=#ED7D31
-fillRect 235.744,64.37,264.704,45.6933 fs=#ED7D31
+fillRect 258.4711,64.37,294.1156,45.6933 fs=#ED7D31
 restore"
 `;
 
@@ -801,24 +853,49 @@ fillText "0" 35.8,335.45 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 47.8,244.6917
-lineTo 503.1,244.6917
+moveTo 47.8,301.4156
+lineTo 503.1,301.4156
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "50" 35.8,244.6917 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "20" 35.8,301.4156 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 47.8,153.9333
-lineTo 503.1,153.9333
+moveTo 47.8,267.3813
+lineTo 503.1,267.3813
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "100" 35.8,153.9333 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "40" 35.8,267.3813 fs=#555 font=11px sans-serif al=right bl=middle
+beginPath
+moveTo 47.8,233.3469
+lineTo 503.1,233.3469
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "60" 35.8,233.3469 fs=#555 font=11px sans-serif al=right bl=middle
+beginPath
+moveTo 47.8,199.3125
+lineTo 503.1,199.3125
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "80" 35.8,199.3125 fs=#555 font=11px sans-serif al=right bl=middle
+beginPath
+moveTo 47.8,165.2781
+lineTo 503.1,165.2781
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "100" 35.8,165.2781 fs=#555 font=11px sans-serif al=right bl=middle
+beginPath
+moveTo 47.8,131.2438
+lineTo 503.1,131.2438
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "120" 35.8,131.2438 fs=#555 font=11px sans-serif al=right bl=middle
+beginPath
+moveTo 47.8,97.2094
+lineTo 503.1,97.2094
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "140" 35.8,97.2094 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
 moveTo 47.8,63.175
 lineTo 503.1,63.175
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "150" 35.8,63.175 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "160" 35.8,63.175 fs=#555 font=11px sans-serif al=right bl=middle
 set fillStyle=#4472C4
-fillRect 93.33,153.9333,60.7067,181.5167 fs=#4472C4
-fillRect 245.0967,81.3267,60.7067,254.1233 fs=#4472C4
-fillRect 396.8633,117.63,60.7067,217.82 fs=#4472C4
+fillRect 93.33,165.2781,60.7067,170.1719 fs=#4472C4
+fillRect 245.0967,97.2094,60.7067,238.2406 fs=#4472C4
+fillRect 396.8633,131.2438,60.7067,204.2062 fs=#4472C4
 set fillStyle=#555
 set textAlign=center
 set textBaseline=top
@@ -850,35 +927,55 @@ moveTo 47.8,335.45
 lineTo 503.1,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 43.8,335.45
+moveTo 41.5,335.45
 lineTo 47.8,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 43.8,244.6917
-lineTo 47.8,244.6917
+moveTo 41.5,301.4156
+lineTo 47.8,301.4156
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 43.8,153.9333
-lineTo 47.8,153.9333
+moveTo 41.5,267.3813
+lineTo 47.8,267.3813
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 43.8,63.175
+moveTo 41.5,233.3469
+lineTo 47.8,233.3469
+stroke ss=#aaa lw=1 dash=
+beginPath
+moveTo 41.5,199.3125
+lineTo 47.8,199.3125
+stroke ss=#aaa lw=1 dash=
+beginPath
+moveTo 41.5,165.2781
+lineTo 47.8,165.2781
+stroke ss=#aaa lw=1 dash=
+beginPath
+moveTo 41.5,131.2438
+lineTo 47.8,131.2438
+stroke ss=#aaa lw=1 dash=
+beginPath
+moveTo 41.5,97.2094
+lineTo 47.8,97.2094
+stroke ss=#aaa lw=1 dash=
+beginPath
+moveTo 41.5,63.175
 lineTo 47.8,63.175
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 47.8,339.45
+moveTo 47.8,341.75
 lineTo 47.8,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 199.5667,339.45
+moveTo 199.5667,341.75
 lineTo 199.5667,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 351.3333,339.45
+moveTo 351.3333,341.75
 lineTo 351.3333,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 503.1,339.45
+moveTo 503.1,341.75
 lineTo 503.1,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
@@ -889,27 +986,57 @@ set fillStyle=#555
 set textAlign=left
 set textBaseline=middle
 beginPath
-moveTo 507.1,335.45
+moveTo 509.4,335.45
 lineTo 503.1,335.45
 stroke ss=#aaa lw=1 dash=
 fillText "0" 517.1,335.45 fs=#555 font=11px sans-serif al=left bl=middle
 beginPath
-moveTo 507.1,267.3813
-lineTo 503.1,267.3813
+moveTo 509.4,308.2225
+lineTo 503.1,308.2225
 stroke ss=#aaa lw=1 dash=
-fillText "5" 517.1,267.3813 fs=#555 font=11px sans-serif al=left bl=middle
+fillText "2" 517.1,308.2225 fs=#555 font=11px sans-serif al=left bl=middle
 beginPath
-moveTo 507.1,199.3125
+moveTo 509.4,280.995
+lineTo 503.1,280.995
+stroke ss=#aaa lw=1 dash=
+fillText "4" 517.1,280.995 fs=#555 font=11px sans-serif al=left bl=middle
+beginPath
+moveTo 509.4,253.7675
+lineTo 503.1,253.7675
+stroke ss=#aaa lw=1 dash=
+fillText "6" 517.1,253.7675 fs=#555 font=11px sans-serif al=left bl=middle
+beginPath
+moveTo 509.4,226.54
+lineTo 503.1,226.54
+stroke ss=#aaa lw=1 dash=
+fillText "8" 517.1,226.54 fs=#555 font=11px sans-serif al=left bl=middle
+beginPath
+moveTo 509.4,199.3125
 lineTo 503.1,199.3125
 stroke ss=#aaa lw=1 dash=
 fillText "10" 517.1,199.3125 fs=#555 font=11px sans-serif al=left bl=middle
 beginPath
-moveTo 507.1,131.2438
-lineTo 503.1,131.2438
+moveTo 509.4,172.085
+lineTo 503.1,172.085
 stroke ss=#aaa lw=1 dash=
-fillText "15" 517.1,131.2438 fs=#555 font=11px sans-serif al=left bl=middle
+fillText "12" 517.1,172.085 fs=#555 font=11px sans-serif al=left bl=middle
 beginPath
-moveTo 507.1,63.175
+moveTo 509.4,144.8575
+lineTo 503.1,144.8575
+stroke ss=#aaa lw=1 dash=
+fillText "14" 517.1,144.8575 fs=#555 font=11px sans-serif al=left bl=middle
+beginPath
+moveTo 509.4,117.63
+lineTo 503.1,117.63
+stroke ss=#aaa lw=1 dash=
+fillText "16" 517.1,117.63 fs=#555 font=11px sans-serif al=left bl=middle
+beginPath
+moveTo 509.4,90.4025
+lineTo 503.1,90.4025
+stroke ss=#aaa lw=1 dash=
+fillText "18" 517.1,90.4025 fs=#555 font=11px sans-serif al=left bl=middle
+beginPath
+moveTo 509.4,63.175
 lineTo 503.1,63.175
 stroke ss=#aaa lw=1 dash=
 fillText "20" 517.1,63.175 fs=#555 font=11px sans-serif al=left bl=middle
@@ -922,21 +1049,21 @@ fillText "Margin %" 0,0 fs=#555 font=bold 10.5px sans-serif al=center bl=middle
 restore
 set font=10.5px sans-serif
 set fillStyle=#4472C4
-fillRect 576,184.8125,10,10.5 fs=#4472C4
+fillRect 576,188.3875,7.35,7.35 fs=#4472C4
 set fillStyle=#333
 set textAlign=left
-fillText "Rev" 590,190.0625 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Rev" 587.35,190.0625 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
 set strokeStyle=#ED7D31
 set lineWidth=1.575
 beginPath
-moveTo 576,204.5625
-lineTo 592.8,204.5625
+moveTo 576,206.5625
+lineTo 592.8,206.5625
 stroke ss=#ED7D31 lw=1.575 dash=
 set lineWidth=1
 save
 beginPath
-arc 584.4,204.5625,3.045,0,6.2832
+arc 584.4,206.5625,3.045,0,6.2832
 fill fs=#ED7D31 ga=1
 restore
 set fillStyle=#333
@@ -982,18 +1109,18 @@ set fillStyle=#fff
 fillText "25%" 257.5385,119.8885 fs=#fff font=bold 14.040600000000001px sans-serif al=center bl=middle
 set font=10.5px sans-serif
 set fillStyle=#AA0000
-fillRect 280.1,365.5,10,10.5 fs=#AA0000
+fillRect 284.075,367.075,7.35,7.35 fs=#AA0000
 set fillStyle=#333
 set textAlign=left
-fillText "Q1" 294.1,370.75 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Q1" 295.425,370.75 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
-fillRect 318.7,365.5,10,10.5 fs=#ED7D31
+fillRect 320.025,367.075,7.35,7.35 fs=#ED7D31
 set fillStyle=#333
-fillText "Q2" 332.7,370.75 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Q2" 331.375,370.75 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#CC0000
-fillRect 357.3,365.5,10,10.5 fs=#CC0000
+fillRect 355.975,367.075,7.35,7.35 fs=#CC0000
 set fillStyle=#333
-fillText "Q3" 371.3,370.75 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Q3" 367.325,370.75 fs=#333 font=10.5px sans-serif al=left bl=middle
 restore"
 `;
 
@@ -1016,7 +1143,7 @@ lineTo 540,312.95
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#888
 beginPath
-moveTo 80.94,312.95
+moveTo 78.64,312.95
 lineTo 84.94,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#aaa
@@ -1032,7 +1159,7 @@ stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 80.94,271.3208
+moveTo 78.64,271.3208
 lineTo 84.94,271.3208
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
@@ -1045,7 +1172,7 @@ stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 80.94,229.6917
+moveTo 78.64,229.6917
 lineTo 84.94,229.6917
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
@@ -1058,7 +1185,7 @@ stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 80.94,188.0625
+moveTo 78.64,188.0625
 lineTo 84.94,188.0625
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
@@ -1071,7 +1198,7 @@ stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 80.94,146.4333
+moveTo 78.64,146.4333
 lineTo 84.94,146.4333
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
@@ -1084,7 +1211,7 @@ stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 80.94,104.8042
+moveTo 78.64,104.8042
 lineTo 84.94,104.8042
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
@@ -1097,7 +1224,7 @@ stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 80.94,63.175
+moveTo 78.64,63.175
 lineTo 84.94,63.175
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
@@ -1134,160 +1261,39 @@ set fillStyle=#4472C4
 beginPath
 arc 103.9008,250.5063,2.625,0,6.2832
 fill fs=#4472C4 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-set textAlign=left
-fillText "3" 115.6258,250.5063 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#4472C4
 beginPath
 arc 141.8225,208.8771,2.625,0,6.2832
 fill fs=#4472C4 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "5" 153.5475,208.8771 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#4472C4
 beginPath
 arc 179.7442,229.6917,2.625,0,6.2832
 fill fs=#4472C4 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "4" 191.4692,229.6917 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#4472C4
 beginPath
 arc 217.6658,188.0625,2.625,0,6.2832
 fill fs=#4472C4 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "6" 229.3908,188.0625 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#4472C4
 beginPath
 arc 255.5875,167.2479,2.625,0,6.2832
 fill fs=#4472C4 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "7" 267.3125,167.2479 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#4472C4
 beginPath
 arc 293.5092,208.8771,2.625,0,6.2832
 fill fs=#4472C4 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "5" 305.2342,208.8771 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#4472C4
 beginPath
 arc 331.4308,146.4333,2.625,0,6.2832
 fill fs=#4472C4 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "8" 343.1558,146.4333 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#4472C4
 beginPath
 arc 369.3525,188.0625,2.625,0,6.2832
 fill fs=#4472C4 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "6" 381.0775,188.0625 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#4472C4
 beginPath
 arc 407.2742,125.6188,2.625,0,6.2832
 fill fs=#4472C4 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "9" 418.9992,125.6188 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#4472C4
 beginPath
 arc 445.1958,167.2479,2.625,0,6.2832
 fill fs=#4472C4 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "7" 456.9208,167.2479 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#4472C4
 beginPath
 arc 483.1175,104.8042,2.625,0,6.2832
 fill fs=#4472C4 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "10" 494.8425,104.8042 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#4472C4
 beginPath
 arc 521.0392,146.4333,2.625,0,6.2832
 fill fs=#4472C4 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "8" 530.28,146.4333 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#4472C4
 set strokeStyle=#ED7D31
 setLineDash
 beginPath
@@ -1308,146 +1314,36 @@ set fillStyle=#ED7D31
 beginPath
 arc 103.9008,271.3208,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "2" 115.6258,271.3208 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#ED7D31
 beginPath
 arc 141.8225,250.5063,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "3" 153.5475,250.5063 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#ED7D31
 beginPath
 arc 179.7442,208.8771,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "5" 191.4692,208.8771 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#ED7D31
 beginPath
 arc 217.6658,229.6917,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "4" 229.3908,229.6917 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#ED7D31
 beginPath
 arc 255.5875,188.0625,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "6" 267.3125,188.0625 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#ED7D31
 beginPath
 arc 293.5092,146.4333,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "8" 305.2342,146.4333 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#ED7D31
 beginPath
 arc 331.4308,167.2479,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "7" 343.1558,167.2479 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#ED7D31
 beginPath
 arc 369.3525,125.6188,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "9" 381.0775,125.6188 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#ED7D31
 beginPath
 arc 407.2742,188.0625,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "6" 418.9992,188.0625 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#ED7D31
 beginPath
 arc 445.1958,146.4333,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "8" 456.9208,146.4333 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#ED7D31
 beginPath
 arc 483.1175,167.2479,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
-save
-save
-beginPath
-rect 84.94,63.175,455.06,249.775
-clip
-set fillStyle=#333
-fillText "7" 494.8425,167.2479 fs=#333 font=16.2px sans-serif al=left bl=middle
-restore
-restore
-set fillStyle=#ED7D31
 beginPath
 arc 521.0392,125.6188,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
@@ -1457,17 +1353,201 @@ beginPath
 rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
+set textAlign=left
+fillText "3" 115.6258,250.5063 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "5" 153.5475,208.8771 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "4" 191.4692,229.6917 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "6" 229.3908,188.0625 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "7" 267.3125,167.2479 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "5" 305.2342,208.8771 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "8" 343.1558,146.4333 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "6" 381.0775,188.0625 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "9" 418.9992,125.6188 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "7" 456.9208,167.2479 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "10" 494.8425,104.8042 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "8" 530.28,146.4333 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "2" 115.6258,271.3208 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "3" 153.5475,250.5063 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "5" 191.4692,208.8771 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "4" 229.3908,229.6917 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "6" 267.3125,188.0625 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "8" 305.2342,146.4333 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "7" 343.1558,167.2479 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "9" 381.0775,125.6188 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "6" 418.9992,188.0625 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "8" 456.9208,146.4333 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
+fillText "7" 494.8425,167.2479 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
+restore
+save
+save
+beginPath
+rect 84.94,63.175,455.06,249.775
+clip
 fillText "9" 530.28,125.6188 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
-set fillStyle=#ED7D31
 set fillStyle=#555
 set textAlign=center
 set textBaseline=top
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 103.9008,316.95
+moveTo 103.9008,319.25
 lineTo 103.9008,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
@@ -1475,7 +1555,7 @@ set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 141.8225,316.95
+moveTo 141.8225,319.25
 lineTo 141.8225,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
@@ -1483,7 +1563,7 @@ set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 179.7442,316.95
+moveTo 179.7442,319.25
 lineTo 179.7442,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
@@ -1491,7 +1571,7 @@ set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 217.6658,316.95
+moveTo 217.6658,319.25
 lineTo 217.6658,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
@@ -1499,7 +1579,7 @@ set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 255.5875,316.95
+moveTo 255.5875,319.25
 lineTo 255.5875,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
@@ -1507,7 +1587,7 @@ set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 293.5092,316.95
+moveTo 293.5092,319.25
 lineTo 293.5092,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
@@ -1515,7 +1595,7 @@ set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 331.4308,316.95
+moveTo 331.4308,319.25
 lineTo 331.4308,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
@@ -1523,7 +1603,7 @@ set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 369.3525,316.95
+moveTo 369.3525,319.25
 lineTo 369.3525,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
@@ -1531,7 +1611,7 @@ set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 407.2742,316.95
+moveTo 407.2742,319.25
 lineTo 407.2742,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
@@ -1539,7 +1619,7 @@ set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 445.1958,316.95
+moveTo 445.1958,319.25
 lineTo 445.1958,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
@@ -1547,7 +1627,7 @@ set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 483.1175,316.95
+moveTo 483.1175,319.25
 lineTo 483.1175,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
@@ -1555,7 +1635,7 @@ set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 521.0392,316.95
+moveTo 521.0392,319.25
 lineTo 521.0392,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
@@ -1578,13 +1658,13 @@ set fillStyle=#4472C4
 set strokeStyle=#4472C4
 set lineWidth=1.575
 beginPath
-moveTo 576,178.8125
-lineTo 592.8,178.8125
+moveTo 576,180.8125
+lineTo 592.8,180.8125
 stroke ss=#4472C4 lw=1.575 dash=
 set lineWidth=2.3625
 save
 beginPath
-arc 584.4,178.8125,3.045,0,6.2832
+arc 584.4,180.8125,3.045,0,6.2832
 fill fs=#4472C4 ga=1
 restore
 set fillStyle=#333
@@ -1594,13 +1674,13 @@ set fillStyle=#ED7D31
 set strokeStyle=#ED7D31
 set lineWidth=1.575
 beginPath
-moveTo 576,193.3125
-lineTo 592.8,193.3125
+moveTo 576,195.3125
+lineTo 592.8,195.3125
 stroke ss=#ED7D31 lw=1.575 dash=
 set lineWidth=2.3625
 save
 beginPath
-arc 584.4,193.3125,3.045,0,6.2832
+arc 584.4,195.3125,3.045,0,6.2832
 fill fs=#ED7D31 ga=1
 restore
 set fillStyle=#333
@@ -1672,18 +1752,18 @@ set fillStyle=#fff
 fillText "25%" 236.2441,167.7941 fs=#fff font=bold 13.141800000000002px sans-serif al=center bl=middle
 set font=10.5px sans-serif
 set fillStyle=#4472C4
-fillRect 576,201.8,10,10.5 fs=#4472C4
+fillRect 576,205.375,7.35,7.35 fs=#4472C4
 set fillStyle=#333
 set textAlign=left
-fillText "Q1" 590,207.05 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Q1" 587.35,207.05 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
-fillRect 576,216.3,10,10.5 fs=#ED7D31
+fillRect 576,219.875,7.35,7.35 fs=#ED7D31
 set fillStyle=#333
-fillText "Q2" 590,221.55 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Q2" 587.35,221.55 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#A9D18E
-fillRect 576,230.8,10,10.5 fs=#A9D18E
+fillRect 576,234.375,7.35,7.35 fs=#A9D18E
 set fillStyle=#333
-fillText "Q3" 590,236.05 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Q3" 587.35,236.05 fs=#333 font=10.5px sans-serif al=left bl=middle
 restore"
 `;
 
@@ -1700,6 +1780,14 @@ fillText "Profile" 332,29.114 fs=#333 font=bold 14.700000000000001px Calibri, Ar
 set strokeStyle=#ddd
 set lineWidth=0.5
 beginPath
+moveTo 292,203.733
+lineTo 310.8471,217.4262
+lineTo 303.6481,239.5823
+lineTo 280.3519,239.5823
+lineTo 273.1529,217.4262
+closePath
+stroke ss=#ddd lw=0.5 dash=
+beginPath
 moveTo 292,183.916
 lineTo 329.6942,211.3024
 lineTo 315.2963,255.6146
@@ -1708,11 +1796,27 @@ lineTo 254.3058,211.3024
 closePath
 stroke ss=#ddd lw=0.5 dash=
 beginPath
+moveTo 292,164.099
+lineTo 348.5413,205.1786
+lineTo 326.9444,271.6469
+lineTo 257.0556,271.6469
+lineTo 235.4587,205.1786
+closePath
+stroke ss=#ddd lw=0.5 dash=
+beginPath
 moveTo 292,144.282
 lineTo 367.3883,199.0548
 lineTo 338.5926,287.6792
 lineTo 245.4074,287.6792
 lineTo 216.6117,199.0548
+closePath
+stroke ss=#ddd lw=0.5 dash=
+beginPath
+moveTo 292,124.465
+lineTo 386.2354,192.9311
+lineTo 350.2407,303.7114
+lineTo 233.7593,303.7114
+lineTo 197.7646,192.9311
 closePath
 stroke ss=#ddd lw=0.5 dash=
 beginPath
@@ -1748,8 +1852,11 @@ set font=16.2px sans-serif
 set fillStyle=#555
 set textAlign=right
 set textBaseline=middle
+fillText "1" 289,203.733 fs=#555 font=16.2px sans-serif al=right bl=middle
 fillText "2" 289,183.916 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "3" 289,164.099 fs=#555 font=16.2px sans-serif al=right bl=middle
 fillText "4" 289,144.282 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "5" 289,124.465 fs=#555 font=16.2px sans-serif al=right bl=middle
 fillText "6" 289,104.648 fs=#555 font=16.2px sans-serif al=right bl=middle
 set font=11px sans-serif
 set fillStyle=#444
@@ -1789,8 +1896,8 @@ set fillStyle=#4472C4
 set strokeStyle=#4472C4
 set lineWidth=1.575
 beginPath
-moveTo 576,214.3
-lineTo 592.8,214.3
+moveTo 576,216.3
+lineTo 592.8,216.3
 stroke ss=#4472C4 lw=1.575 dash=
 set lineWidth=2
 set fillStyle=#333
@@ -1800,8 +1907,8 @@ set fillStyle=#ED7D31
 set strokeStyle=#ED7D31
 set lineWidth=1.575
 beginPath
-moveTo 576,228.8
-lineTo 592.8,228.8
+moveTo 576,230.8
+lineTo 592.8,230.8
 stroke ss=#ED7D31 lw=1.575 dash=
 set lineWidth=2
 set fillStyle=#333
@@ -1833,47 +1940,86 @@ fillText "0" 112.1,312.95 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 112.1,312.95
+moveTo 109.8,312.95
 lineTo 116.1,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 116.1,250.5063
-lineTo 540,250.5063
+moveTo 116.1,277.2679
+lineTo 540,277.2679
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "2" 112.1,250.5063 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "1" 112.1,277.2679 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 112.1,250.5063
-lineTo 116.1,250.5063
+moveTo 109.8,277.2679
+lineTo 116.1,277.2679
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 116.1,188.0625
-lineTo 540,188.0625
+moveTo 116.1,241.5857
+lineTo 540,241.5857
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "4" 112.1,188.0625 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "2" 112.1,241.5857 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 112.1,188.0625
-lineTo 116.1,188.0625
+moveTo 109.8,241.5857
+lineTo 116.1,241.5857
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 116.1,125.6188
-lineTo 540,125.6188
+moveTo 116.1,205.9036
+lineTo 540,205.9036
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "6" 112.1,125.6188 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "3" 112.1,205.9036 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 112.1,125.6188
-lineTo 116.1,125.6188
+moveTo 109.8,205.9036
+lineTo 116.1,205.9036
+stroke ss=#888 lw=1 dash=
+set strokeStyle=#e0e0e0
+set lineWidth=0.5
+beginPath
+moveTo 116.1,170.2214
+lineTo 540,170.2214
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "4" 112.1,170.2214 fs=#555 font=11px sans-serif al=right bl=middle
+set strokeStyle=#888
+set lineWidth=1
+beginPath
+moveTo 109.8,170.2214
+lineTo 116.1,170.2214
+stroke ss=#888 lw=1 dash=
+set strokeStyle=#e0e0e0
+set lineWidth=0.5
+beginPath
+moveTo 116.1,134.5393
+lineTo 540,134.5393
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "5" 112.1,134.5393 fs=#555 font=11px sans-serif al=right bl=middle
+set strokeStyle=#888
+set lineWidth=1
+beginPath
+moveTo 109.8,134.5393
+lineTo 116.1,134.5393
+stroke ss=#888 lw=1 dash=
+set strokeStyle=#e0e0e0
+set lineWidth=0.5
+beginPath
+moveTo 116.1,98.8571
+lineTo 540,98.8571
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "6" 112.1,98.8571 fs=#555 font=11px sans-serif al=right bl=middle
+set strokeStyle=#888
+set lineWidth=1
+beginPath
+moveTo 109.8,98.8571
+lineTo 116.1,98.8571
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
@@ -1881,11 +2027,11 @@ beginPath
 moveTo 116.1,63.175
 lineTo 540,63.175
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "8" 112.1,63.175 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "7" 112.1,63.175 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 112.1,63.175
+moveTo 109.8,63.175
 lineTo 116.1,63.175
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
@@ -1908,93 +2054,93 @@ set textAlign=center
 set textBaseline=top
 fillText "0" 116.1,316.95 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
-moveTo 116.1,316.95
+moveTo 116.1,319.25
 lineTo 116.1,312.95
 stroke ss=#888 lw=1 dash=
 fillText "1" 186.75,316.95 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
-moveTo 186.75,316.95
+moveTo 186.75,319.25
 lineTo 186.75,312.95
 stroke ss=#888 lw=1 dash=
 fillText "2" 257.4,316.95 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
-moveTo 257.4,316.95
+moveTo 257.4,319.25
 lineTo 257.4,312.95
 stroke ss=#888 lw=1 dash=
 fillText "3" 328.05,316.95 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
-moveTo 328.05,316.95
+moveTo 328.05,319.25
 lineTo 328.05,312.95
 stroke ss=#888 lw=1 dash=
 fillText "4" 398.7,316.95 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
-moveTo 398.7,316.95
+moveTo 398.7,319.25
 lineTo 398.7,312.95
 stroke ss=#888 lw=1 dash=
 fillText "5" 469.35,316.95 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
-moveTo 469.35,316.95
+moveTo 469.35,319.25
 lineTo 469.35,312.95
 stroke ss=#888 lw=1 dash=
 fillText "6" 540,316.95 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
-moveTo 540,316.95
+moveTo 540,319.25
 lineTo 540,312.95
 stroke ss=#888 lw=1 dash=
 save
 set strokeStyle=#4472C4
 set lineWidth=1.5
 beginPath
-moveTo 186.75,250.5063
-lineTo 257.4,188.0625
-lineTo 328.05,219.2844
-lineTo 398.7,156.8406
-lineTo 469.35,125.6188
+moveTo 186.75,241.5857
+lineTo 257.4,170.2214
+lineTo 328.05,205.9036
+lineTo 398.7,134.5393
+lineTo 469.35,98.8571
 stroke ss=#4472C4 lw=1.5 dash=
 restore
 save
 set fillStyle=#4472C4
 beginPath
-moveTo 186.75,247.8813
-lineTo 189.375,250.5063
-lineTo 186.75,253.1313
-lineTo 184.125,250.5063
+moveTo 186.75,238.9607
+lineTo 189.375,241.5857
+lineTo 186.75,244.2107
+lineTo 184.125,241.5857
 closePath
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-moveTo 257.4,185.4375
-lineTo 260.025,188.0625
-lineTo 257.4,190.6875
-lineTo 254.775,188.0625
+moveTo 257.4,167.5964
+lineTo 260.025,170.2214
+lineTo 257.4,172.8464
+lineTo 254.775,170.2214
 closePath
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-moveTo 328.05,216.6594
-lineTo 330.675,219.2844
-lineTo 328.05,221.9094
-lineTo 325.425,219.2844
+moveTo 328.05,203.2786
+lineTo 330.675,205.9036
+lineTo 328.05,208.5286
+lineTo 325.425,205.9036
 closePath
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-moveTo 398.7,154.2156
-lineTo 401.325,156.8406
-lineTo 398.7,159.4656
-lineTo 396.075,156.8406
+moveTo 398.7,131.9143
+lineTo 401.325,134.5393
+lineTo 398.7,137.1643
+lineTo 396.075,134.5393
 closePath
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-moveTo 469.35,122.9938
-lineTo 471.975,125.6188
-lineTo 469.35,128.2438
-lineTo 466.725,125.6188
+moveTo 469.35,96.2321
+lineTo 471.975,98.8571
+lineTo 469.35,101.4821
+lineTo 466.725,98.8571
 closePath
 fill fs=#4472C4 ga=1
 restore
@@ -2002,16 +2148,16 @@ set font=10.5px sans-serif
 set textBaseline=middle
 set lineWidth=1.575
 beginPath
-moveTo 576,186.0625
-lineTo 592.8,186.0625
+moveTo 576,188.0625
+lineTo 592.8,188.0625
 stroke ss=#4472C4 lw=1.575 dash=
 set lineWidth=1.5
 save
 beginPath
-moveTo 584.4,183.0175
-lineTo 587.445,186.0625
-lineTo 584.4,189.1075
-lineTo 581.355,186.0625
+moveTo 584.4,185.0175
+lineTo 587.445,188.0625
+lineTo 584.4,191.1075
+lineTo 581.355,188.0625
 closePath
 fill fs=#4472C4 ga=1
 restore
@@ -2046,29 +2192,45 @@ stroke ss=#aaa lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 88.8,278.08
-lineTo 620,278.08
+moveTo 88.8,303.5778
+lineTo 620,303.5778
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
-moveTo 88.8,220.71
-lineTo 620,220.71
+moveTo 88.8,271.7056
+lineTo 620,271.7056
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
-moveTo 88.8,163.34
-lineTo 620,163.34
+moveTo 88.8,239.8333
+lineTo 620,239.8333
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
-moveTo 88.8,105.97
-lineTo 620,105.97
+moveTo 88.8,207.9611
+lineTo 620,207.9611
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,176.0889
+lineTo 620,176.0889
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,144.2167
+lineTo 620,144.2167
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,112.3444
+lineTo 620,112.3444
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,80.4722
+lineTo 620,80.4722
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
 moveTo 88.8,48.6
 lineTo 620,48.6
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
-moveTo 177.3333,278.08
-lineTo 354.4,197.762
-lineTo 531.4667,237.921
+moveTo 177.3333,271.7056
+lineTo 354.4,182.4633
+lineTo 531.4667,227.0844
 lineTo 531.4667,335.45
 lineTo 354.4,335.45
 lineTo 177.3333,335.45
@@ -2080,12 +2242,12 @@ set lineWidth=1.5
 setLineDash
 stroke ss=#4472C4 lw=1.5 dash=
 beginPath
-moveTo 177.3333,232.184
-lineTo 354.4,111.707
-lineTo 531.4667,111.707
-lineTo 531.4667,237.921
-lineTo 354.4,197.762
-lineTo 177.3333,278.08
+moveTo 177.3333,220.71
+lineTo 354.4,86.8467
+lineTo 531.4667,86.8467
+lineTo 531.4667,227.0844
+lineTo 354.4,182.4633
+lineTo 177.3333,271.7056
 closePath
 set fillStyle=#ED7D31
 fill fs=#ED7D31 ga=1
@@ -2097,7 +2259,7 @@ set textBaseline=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,335.45
+moveTo 82.5,335.45
 lineTo 88.8,335.45
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#ED7D31
@@ -2108,48 +2270,84 @@ fillText "0" 82.8,335.45 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,278.08
-lineTo 88.8,278.08
+moveTo 82.5,303.5778
+lineTo 88.8,303.5778
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=1.5
-fillText "10" 82.8,278.08 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "5" 82.8,303.5778 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,220.71
-lineTo 88.8,220.71
+moveTo 82.5,271.7056
+lineTo 88.8,271.7056
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=1.5
-fillText "20" 82.8,220.71 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "10" 82.8,271.7056 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,163.34
-lineTo 88.8,163.34
+moveTo 82.5,239.8333
+lineTo 88.8,239.8333
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=1.5
-fillText "30" 82.8,163.34 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "15" 82.8,239.8333 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,105.97
-lineTo 88.8,105.97
+moveTo 82.5,207.9611
+lineTo 88.8,207.9611
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=1.5
-fillText "40" 82.8,105.97 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "20" 82.8,207.9611 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,48.6
+moveTo 82.5,176.0889
+lineTo 88.8,176.0889
+stroke ss=#aaa lw=1 dash=
+set strokeStyle=#ED7D31
+set lineWidth=1.5
+fillText "25" 82.8,176.0889 fs=#555 font=11px sans-serif al=right bl=middle
+set strokeStyle=#aaa
+set lineWidth=1
+beginPath
+moveTo 82.5,144.2167
+lineTo 88.8,144.2167
+stroke ss=#aaa lw=1 dash=
+set strokeStyle=#ED7D31
+set lineWidth=1.5
+fillText "30" 82.8,144.2167 fs=#555 font=11px sans-serif al=right bl=middle
+set strokeStyle=#aaa
+set lineWidth=1
+beginPath
+moveTo 82.5,112.3444
+lineTo 88.8,112.3444
+stroke ss=#aaa lw=1 dash=
+set strokeStyle=#ED7D31
+set lineWidth=1.5
+fillText "35" 82.8,112.3444 fs=#555 font=11px sans-serif al=right bl=middle
+set strokeStyle=#aaa
+set lineWidth=1
+beginPath
+moveTo 82.5,80.4722
+lineTo 88.8,80.4722
+stroke ss=#aaa lw=1 dash=
+set strokeStyle=#ED7D31
+set lineWidth=1.5
+fillText "40" 82.8,80.4722 fs=#555 font=11px sans-serif al=right bl=middle
+set strokeStyle=#aaa
+set lineWidth=1
+beginPath
+moveTo 82.5,48.6
 lineTo 88.8,48.6
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=1.5
-fillText "50" 82.8,48.6 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "45" 82.8,48.6 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
@@ -2157,19 +2355,19 @@ moveTo 88.8,335.45
 lineTo 620,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 88.8,339.45
+moveTo 88.8,341.75
 lineTo 88.8,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 265.8667,339.45
+moveTo 265.8667,341.75
 lineTo 265.8667,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 442.9333,339.45
+moveTo 442.9333,341.75
 lineTo 442.9333,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 620,339.45
+moveTo 620,341.75
 lineTo 620,335.45
 stroke ss=#aaa lw=1 dash=
 set textAlign=center
@@ -2180,14 +2378,14 @@ fillText "Q3" 531.4667,338.45 fs=#555 font=11px sans-serif al=center bl=top
 set font=10.5px sans-serif
 set textBaseline=middle
 set fillStyle=#4472C4
-fillRect 283.65,26,10,10.5 fs=#4472C4
+fillRect 286.3,27.575,7.35,7.35 fs=#4472C4
 set fillStyle=#333
 set textAlign=left
 fillText "Alpha" 297.65,31.25 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
-fillRect 341.15,26,10,10.5 fs=#ED7D31
+fillRect 341.15,27.575,7.35,7.35 fs=#ED7D31
 set fillStyle=#333
-fillText "Beta" 355.15,31.25 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Beta" 352.5,31.25 fs=#333 font=10.5px sans-serif al=left bl=middle
 restore"
 `;
 
@@ -2218,42 +2416,62 @@ fillText "0" 29.2,316.95 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 41.2,266.195
-lineTo 632.8,266.195
+moveTo 41.2,288.7528
+lineTo 632.8,288.7528
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "10" 29.2,266.195 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "5" 29.2,288.7528 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 41.2,215.44
-lineTo 632.8,215.44
+moveTo 41.2,260.5556
+lineTo 632.8,260.5556
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "20" 29.2,215.44 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "10" 29.2,260.5556 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 41.2,164.685
-lineTo 632.8,164.685
+moveTo 41.2,232.3583
+lineTo 632.8,232.3583
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "30" 29.2,164.685 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "15" 29.2,232.3583 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 41.2,113.93
-lineTo 632.8,113.93
+moveTo 41.2,204.1611
+lineTo 632.8,204.1611
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "40" 29.2,113.93 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "20" 29.2,204.1611 fs=#555 font=11px sans-serif al=right bl=middle
+beginPath
+moveTo 41.2,175.9639
+lineTo 632.8,175.9639
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "25" 29.2,175.9639 fs=#555 font=11px sans-serif al=right bl=middle
+beginPath
+moveTo 41.2,147.7667
+lineTo 632.8,147.7667
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "30" 29.2,147.7667 fs=#555 font=11px sans-serif al=right bl=middle
+beginPath
+moveTo 41.2,119.5694
+lineTo 632.8,119.5694
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "35" 29.2,119.5694 fs=#555 font=11px sans-serif al=right bl=middle
+beginPath
+moveTo 41.2,91.3722
+lineTo 632.8,91.3722
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "40" 29.2,91.3722 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
 moveTo 41.2,63.175
 lineTo 632.8,63.175
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "50" 29.2,63.175 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "45" 29.2,63.175 fs=#555 font=11px sans-serif al=right bl=middle
 set fillStyle=#4472C4
-fillRect 100.36,266.195,78.88,50.755 fs=#4472C4
+fillRect 100.36,260.5556,78.88,56.3944 fs=#4472C4
 set fillStyle=#ED7D31
-fillRect 100.36,225.591,78.88,40.604 fs=#ED7D31
+fillRect 100.36,215.44,78.88,45.1156 fs=#ED7D31
 set fillStyle=#4472C4
-fillRect 297.56,195.138,78.88,121.812 fs=#4472C4
+fillRect 297.56,181.6033,78.88,135.3467 fs=#4472C4
 set fillStyle=#ED7D31
-fillRect 297.56,119.0055,78.88,76.1325 fs=#ED7D31
+fillRect 297.56,97.0117,78.88,84.5917 fs=#ED7D31
 set fillStyle=#4472C4
-fillRect 494.76,230.6665,78.88,86.2835 fs=#4472C4
+fillRect 494.76,221.0794,78.88,95.8706 fs=#4472C4
 set fillStyle=#ED7D31
-fillRect 494.76,119.0055,78.88,111.661 fs=#ED7D31
+fillRect 494.76,97.0117,78.88,124.0678 fs=#ED7D31
 set fillStyle=#555
 set textAlign=center
 set textBaseline=top
@@ -2267,56 +2485,72 @@ moveTo 41.2,316.95
 lineTo 632.8,316.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 37.2,316.95
+moveTo 34.9,316.95
 lineTo 41.2,316.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 37.2,266.195
-lineTo 41.2,266.195
+moveTo 34.9,288.7528
+lineTo 41.2,288.7528
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 37.2,215.44
-lineTo 41.2,215.44
+moveTo 34.9,260.5556
+lineTo 41.2,260.5556
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 37.2,164.685
-lineTo 41.2,164.685
+moveTo 34.9,232.3583
+lineTo 41.2,232.3583
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 37.2,113.93
-lineTo 41.2,113.93
+moveTo 34.9,204.1611
+lineTo 41.2,204.1611
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 37.2,63.175
+moveTo 34.9,175.9639
+lineTo 41.2,175.9639
+stroke ss=#aaa lw=1 dash=
+beginPath
+moveTo 34.9,147.7667
+lineTo 41.2,147.7667
+stroke ss=#aaa lw=1 dash=
+beginPath
+moveTo 34.9,119.5694
+lineTo 41.2,119.5694
+stroke ss=#aaa lw=1 dash=
+beginPath
+moveTo 34.9,91.3722
+lineTo 41.2,91.3722
+stroke ss=#aaa lw=1 dash=
+beginPath
+moveTo 34.9,63.175
 lineTo 41.2,63.175
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 41.2,320.95
+moveTo 41.2,323.25
 lineTo 41.2,316.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 238.4,320.95
+moveTo 238.4,323.25
 lineTo 238.4,316.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 435.6,320.95
+moveTo 435.6,323.25
 lineTo 435.6,316.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 632.8,320.95
+moveTo 632.8,323.25
 lineTo 632.8,316.95
 stroke ss=#aaa lw=1 dash=
 set font=10.5px sans-serif
 set textBaseline=middle
 set fillStyle=#4472C4
-fillRect 283.65,365.5,10,10.5 fs=#4472C4
+fillRect 286.3,367.075,7.35,7.35 fs=#4472C4
 set fillStyle=#333
 set textAlign=left
 fillText "Alpha" 297.65,370.75 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
-fillRect 341.15,365.5,10,10.5 fs=#ED7D31
+fillRect 341.15,367.075,7.35,7.35 fs=#ED7D31
 set fillStyle=#333
-fillText "Beta" 355.15,370.75 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Beta" 352.5,370.75 fs=#333 font=10.5px sans-serif al=left bl=middle
 restore"
 `;
 
@@ -2416,76 +2650,76 @@ moveTo 134.4,335.45
 lineTo 632.8,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 130.4,335.45
+moveTo 128.1,335.45
 lineTo 134.4,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 130.4,304.915
+moveTo 128.1,304.915
 lineTo 134.4,304.915
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 130.4,274.38
+moveTo 128.1,274.38
 lineTo 134.4,274.38
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 130.4,243.845
+moveTo 128.1,243.845
 lineTo 134.4,243.845
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 130.4,213.31
+moveTo 128.1,213.31
 lineTo 134.4,213.31
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 130.4,182.775
+moveTo 128.1,182.775
 lineTo 134.4,182.775
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 130.4,152.24
+moveTo 128.1,152.24
 lineTo 134.4,152.24
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 130.4,121.705
+moveTo 128.1,121.705
 lineTo 134.4,121.705
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 130.4,91.17
+moveTo 128.1,91.17
 lineTo 134.4,91.17
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 130.4,60.635
+moveTo 128.1,60.635
 lineTo 134.4,60.635
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 130.4,30.1
+moveTo 128.1,30.1
 lineTo 134.4,30.1
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 134.4,339.45
+moveTo 134.4,341.75
 lineTo 134.4,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 300.5333,339.45
+moveTo 300.5333,341.75
 lineTo 300.5333,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 466.6667,339.45
+moveTo 466.6667,341.75
 lineTo 466.6667,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 632.8,339.45
+moveTo 632.8,341.75
 lineTo 632.8,335.45
 stroke ss=#aaa lw=1 dash=
 set font=10.5px sans-serif
 set textBaseline=middle
 set fillStyle=#4472C4
-fillRect 16,168.275,10,10.5 fs=#4472C4
+fillRect 16,171.85,7.35,7.35 fs=#4472C4
 set fillStyle=#333
 set textAlign=left
-fillText "Alpha" 30,173.525 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Alpha" 27.35,173.525 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
-fillRect 16,182.775,10,10.5 fs=#ED7D31
+fillRect 16,186.35,7.35,7.35 fs=#ED7D31
 set fillStyle=#333
-fillText "Beta" 30,188.025 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Beta" 27.35,188.025 fs=#333 font=10.5px sans-serif al=left bl=middle
 restore"
 `;
 
@@ -2500,7 +2734,7 @@ lineTo 620,335.45
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#888
 beginPath
-moveTo 53.64,335.45
+moveTo 51.34,335.45
 lineTo 57.64,335.45
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#aaa
@@ -2510,57 +2744,109 @@ fillText "0" 51.64,335.45 fs=#555 font=16.2px sans-serif al=right bl=middle
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 57.64,274.38
-lineTo 620,274.38
+moveTo 57.64,301.5222
+lineTo 620,301.5222
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 53.64,274.38
-lineTo 57.64,274.38
+moveTo 51.34,301.5222
+lineTo 57.64,301.5222
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "10" 51.64,274.38 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "5" 51.64,301.5222 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
-moveTo 57.64,213.31
-lineTo 620,213.31
+moveTo 57.64,267.5944
+lineTo 620,267.5944
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 53.64,213.31
-lineTo 57.64,213.31
+moveTo 51.34,267.5944
+lineTo 57.64,267.5944
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "20" 51.64,213.31 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "10" 51.64,267.5944 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
-moveTo 57.64,152.24
-lineTo 620,152.24
+moveTo 57.64,233.6667
+lineTo 620,233.6667
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 53.64,152.24
-lineTo 57.64,152.24
+moveTo 51.34,233.6667
+lineTo 57.64,233.6667
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "30" 51.64,152.24 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "15" 51.64,233.6667 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
-moveTo 57.64,91.17
-lineTo 620,91.17
+moveTo 57.64,199.7389
+lineTo 620,199.7389
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 53.64,91.17
-lineTo 57.64,91.17
+moveTo 51.34,199.7389
+lineTo 57.64,199.7389
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "40" 51.64,91.17 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "20" 51.64,199.7389 fs=#555 font=16.2px sans-serif al=right bl=middle
+beginPath
+moveTo 57.64,165.8111
+lineTo 620,165.8111
+stroke ss=#e0e0e0 lw=0.5 dash=
+set strokeStyle=#888
+set lineWidth=1
+beginPath
+moveTo 51.34,165.8111
+lineTo 57.64,165.8111
+stroke ss=#888 lw=1 dash=
+set strokeStyle=#e0e0e0
+set lineWidth=0.5
+fillText "25" 51.64,165.8111 fs=#555 font=16.2px sans-serif al=right bl=middle
+beginPath
+moveTo 57.64,131.8833
+lineTo 620,131.8833
+stroke ss=#e0e0e0 lw=0.5 dash=
+set strokeStyle=#888
+set lineWidth=1
+beginPath
+moveTo 51.34,131.8833
+lineTo 57.64,131.8833
+stroke ss=#888 lw=1 dash=
+set strokeStyle=#e0e0e0
+set lineWidth=0.5
+fillText "30" 51.64,131.8833 fs=#555 font=16.2px sans-serif al=right bl=middle
+beginPath
+moveTo 57.64,97.9556
+lineTo 620,97.9556
+stroke ss=#e0e0e0 lw=0.5 dash=
+set strokeStyle=#888
+set lineWidth=1
+beginPath
+moveTo 51.34,97.9556
+lineTo 57.64,97.9556
+stroke ss=#888 lw=1 dash=
+set strokeStyle=#e0e0e0
+set lineWidth=0.5
+fillText "35" 51.64,97.9556 fs=#555 font=16.2px sans-serif al=right bl=middle
+beginPath
+moveTo 57.64,64.0278
+lineTo 620,64.0278
+stroke ss=#e0e0e0 lw=0.5 dash=
+set strokeStyle=#888
+set lineWidth=1
+beginPath
+moveTo 51.34,64.0278
+lineTo 57.64,64.0278
+stroke ss=#888 lw=1 dash=
+set strokeStyle=#e0e0e0
+set lineWidth=0.5
+fillText "40" 51.64,64.0278 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
 moveTo 57.64,30.1
 lineTo 620,30.1
@@ -2568,12 +2854,12 @@ stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 53.64,30.1
+moveTo 51.34,30.1
 lineTo 57.64,30.1
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "50" 51.64,30.1 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "45" 51.64,30.1 fs=#555 font=16.2px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
@@ -2588,36 +2874,36 @@ set strokeStyle=#4472C4
 set lineWidth=2.3625
 setLineDash
 beginPath
-moveTo 57.64,274.38
-lineTo 338.82,188.882
-lineTo 620,231.631
+moveTo 57.64,267.5944
+lineTo 338.82,172.5967
+lineTo 620,220.0956
 stroke ss=#4472C4 lw=2.3625 dash=
 set fillStyle=#4472C4
 beginPath
-arc 57.64,274.38,2.625,0,6.2832
+arc 57.64,267.5944,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 beginPath
-arc 338.82,188.882,2.625,0,6.2832
+arc 338.82,172.5967,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 beginPath
-arc 620,231.631,2.625,0,6.2832
+arc 620,220.0956,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 set strokeStyle=#ED7D31
 setLineDash
 beginPath
-moveTo 57.64,225.524
-lineTo 338.82,97.277
-lineTo 620,97.277
+moveTo 57.64,213.31
+lineTo 338.82,70.8133
+lineTo 620,70.8133
 stroke ss=#ED7D31 lw=2.3625 dash=
 set fillStyle=#ED7D31
 beginPath
-arc 57.64,225.524,2.625,0,6.2832
+arc 57.64,213.31,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 beginPath
-arc 338.82,97.277,2.625,0,6.2832
+arc 338.82,70.8133,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 beginPath
-arc 620,97.277,2.625,0,6.2832
+arc 620,70.8133,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 set fillStyle=#555
 set textAlign=center
@@ -2625,7 +2911,7 @@ set textBaseline=top
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 57.64,339.45
+moveTo 57.64,341.75
 lineTo 57.64,335.45
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
@@ -2633,7 +2919,7 @@ set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 338.82,339.45
+moveTo 338.82,341.75
 lineTo 338.82,335.45
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
@@ -2641,7 +2927,7 @@ set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 620,339.45
+moveTo 620,341.75
 lineTo 620,335.45
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
@@ -2669,7 +2955,7 @@ fillText "0" 45.16,357.8 fs=#595959 font=16.2px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 45.16,357.8
+moveTo 42.86,357.8
 lineTo 49.16,357.8
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#e0e0e0
@@ -2682,7 +2968,7 @@ fillText "20" 45.16,310.9857 fs=#595959 font=16.2px sans-serif al=right bl=middl
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 45.16,310.9857
+moveTo 42.86,310.9857
 lineTo 49.16,310.9857
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#e0e0e0
@@ -2695,7 +2981,7 @@ fillText "40" 45.16,264.1714 fs=#595959 font=16.2px sans-serif al=right bl=middl
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 45.16,264.1714
+moveTo 42.86,264.1714
 lineTo 49.16,264.1714
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#e0e0e0
@@ -2708,7 +2994,7 @@ fillText "60" 45.16,217.3571 fs=#595959 font=16.2px sans-serif al=right bl=middl
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 45.16,217.3571
+moveTo 42.86,217.3571
 lineTo 49.16,217.3571
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#e0e0e0
@@ -2721,7 +3007,7 @@ fillText "80" 45.16,170.5429 fs=#595959 font=16.2px sans-serif al=right bl=middl
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 45.16,170.5429
+moveTo 42.86,170.5429
 lineTo 49.16,170.5429
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#e0e0e0
@@ -2734,7 +3020,7 @@ fillText "100" 45.16,123.7286 fs=#595959 font=16.2px sans-serif al=right bl=midd
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 45.16,123.7286
+moveTo 42.86,123.7286
 lineTo 49.16,123.7286
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#e0e0e0
@@ -2747,7 +3033,7 @@ fillText "120" 45.16,76.9143 fs=#595959 font=16.2px sans-serif al=right bl=middl
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 45.16,76.9143
+moveTo 42.86,76.9143
 lineTo 49.16,76.9143
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#e0e0e0
@@ -2760,7 +3046,7 @@ fillText "140" 45.16,30.1 fs=#595959 font=16.2px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 45.16,30.1
+moveTo 42.86,30.1
 lineTo 49.16,30.1
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#e0e0e0
@@ -2781,44 +3067,27 @@ set strokeStyle=#5B9BD5
 setLineDash
 strokeRect 67.4601,123.7286,110.9098,234.0714 ss=#5B9BD5 lw=1
 save
-set strokeStyle=#ccc
+set strokeStyle=#000000
 setLineDash
-set lineWidth=0.8
+set lineWidth=0.7875
 beginPath
 moveTo 178.3699,123.7286
 lineTo 214.9701,123.7286
-stroke ss=#ccc lw=0.8 dash=
+stroke ss=#000000 lw=0.7875 dash=
 restore
-save
-beginPath
-rect 49.16,30.1,590.04,327.7
-clip
-set fillStyle=#595959
-set textAlign=center
-set textBaseline=bottom
-fillText "100" 122.915,115.6286 fs=#595959 font=16.2px sans-serif al=center bl=bottom
-restore
-set fillStyle=#5B9BD5
 fillRect 214.9701,53.5071,110.9098,70.2214 fs=#5B9BD5
 set strokeStyle=#5B9BD5
 set lineWidth=1
 setLineDash
 strokeRect 214.9701,53.5071,110.9098,70.2214 ss=#5B9BD5 lw=1
 save
-set strokeStyle=#ccc
+set strokeStyle=#000000
 setLineDash
-set lineWidth=0.8
+set lineWidth=0.7875
 beginPath
 moveTo 325.8799,53.5071
 lineTo 362.4801,53.5071
-stroke ss=#ccc lw=0.8 dash=
-restore
-save
-beginPath
-rect 49.16,30.1,590.04,327.7
-clip
-set fillStyle=#595959
-fillText "30" 270.425,45.4071 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+stroke ss=#000000 lw=0.7875 dash=
 restore
 set fillStyle=#ED7D31
 fillRect 362.4801,53.5071,110.9098,46.8143 fs=#ED7D31
@@ -2827,21 +3096,13 @@ set lineWidth=1
 setLineDash
 strokeRect 362.4801,53.5071,110.9098,46.8143 ss=#ED7D31 lw=1
 save
-set strokeStyle=#ccc
+set strokeStyle=#000000
 setLineDash
-set lineWidth=0.8
+set lineWidth=0.7875
 beginPath
 moveTo 473.3899,100.3214
 lineTo 509.9901,100.3214
-stroke ss=#ccc lw=0.8 dash=
-restore
-save
-beginPath
-rect 49.16,30.1,590.04,327.7
-clip
-set fillStyle=#595959
-set textBaseline=top
-fillText "-20" 417.935,108.4214 fs=#595959 font=16.2px sans-serif al=center bl=top
+stroke ss=#000000 lw=0.7875 dash=
 restore
 set fillStyle=#A5A5A5
 fillRect 509.9901,100.3214,110.9098,257.4786 fs=#A5A5A5
@@ -2849,15 +3110,9 @@ set strokeStyle=#A5A5A5
 set lineWidth=1
 setLineDash
 strokeRect 509.9901,100.3214,110.9098,257.4786 ss=#A5A5A5 lw=1
-save
-beginPath
-rect 49.16,30.1,590.04,327.7
-clip
-set fillStyle=#595959
-set textBaseline=bottom
-fillText "110" 565.445,92.2214 fs=#595959 font=16.2px sans-serif al=center bl=bottom
-restore
+set textAlign=center
 set textBaseline=top
+set fillStyle=#595959
 fillText "Start" 122.915,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top
 fillText "Q1" 270.425,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top
 fillText "Q2" 417.935,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top
@@ -2881,44 +3136,27 @@ set strokeStyle=#5B9BD5
 setLineDash
 strokeRect 43.8556,123.7286,115.4887,234.0714 ss=#5B9BD5 lw=1
 save
-set strokeStyle=#ccc
+set strokeStyle=#000000
 setLineDash
-set lineWidth=0.8
+set lineWidth=0.7875
 beginPath
 moveTo 159.3444,123.7286
 lineTo 197.4556,123.7286
-stroke ss=#ccc lw=0.8 dash=
+stroke ss=#000000 lw=0.7875 dash=
 restore
-save
-beginPath
-rect 24.8,30.1,614.4,327.7
-clip
-set fillStyle=#595959
-set textAlign=center
-set textBaseline=bottom
-fillText "100" 101.6,115.6286 fs=#595959 font=16.2px sans-serif al=center bl=bottom
-restore
-set fillStyle=#5B9BD5
 fillRect 197.4556,53.5071,115.4887,70.2214 fs=#5B9BD5
 set strokeStyle=#5B9BD5
 set lineWidth=1
 setLineDash
 strokeRect 197.4556,53.5071,115.4887,70.2214 ss=#5B9BD5 lw=1
 save
-set strokeStyle=#ccc
+set strokeStyle=#000000
 setLineDash
-set lineWidth=0.8
+set lineWidth=0.7875
 beginPath
 moveTo 312.9444,53.5071
 lineTo 351.0556,53.5071
-stroke ss=#ccc lw=0.8 dash=
-restore
-save
-beginPath
-rect 24.8,30.1,614.4,327.7
-clip
-set fillStyle=#595959
-fillText "30" 255.2,45.4071 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+stroke ss=#000000 lw=0.7875 dash=
 restore
 set fillStyle=#ED7D31
 fillRect 351.0556,53.5071,115.4887,46.8143 fs=#ED7D31
@@ -2927,21 +3165,13 @@ set lineWidth=1
 setLineDash
 strokeRect 351.0556,53.5071,115.4887,46.8143 ss=#ED7D31 lw=1
 save
-set strokeStyle=#ccc
+set strokeStyle=#000000
 setLineDash
-set lineWidth=0.8
+set lineWidth=0.7875
 beginPath
 moveTo 466.5444,100.3214
 lineTo 504.6556,100.3214
-stroke ss=#ccc lw=0.8 dash=
-restore
-save
-beginPath
-rect 24.8,30.1,614.4,327.7
-clip
-set fillStyle=#595959
-set textBaseline=top
-fillText "-20" 408.8,108.4214 fs=#595959 font=16.2px sans-serif al=center bl=top
+stroke ss=#000000 lw=0.7875 dash=
 restore
 set fillStyle=#A5A5A5
 fillRect 504.6556,100.3214,115.4887,257.4786 fs=#A5A5A5
@@ -2949,15 +3179,9 @@ set strokeStyle=#A5A5A5
 set lineWidth=1
 setLineDash
 strokeRect 504.6556,100.3214,115.4887,257.4786 ss=#A5A5A5 lw=1
-save
-beginPath
-rect 24.8,30.1,614.4,327.7
-clip
-set fillStyle=#595959
-set textBaseline=bottom
-fillText "110" 562.4,92.2214 fs=#595959 font=16.2px sans-serif al=center bl=bottom
-restore
+set textAlign=center
 set textBaseline=top
+set fillStyle=#595959
 fillText "Start" 101.6,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top
 fillText "Q1" 255.2,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top
 fillText "Q2" 408.8,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top

--- a/packages/core/src/chart/axis-scale.test.ts
+++ b/packages/core/src/chart/axis-scale.test.ts
@@ -23,6 +23,16 @@ const nextUp = (value: number): number => {
   return view.getFloat64(0, false);
 };
 
+const nextDown = (value: number): number => {
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+  view.setFloat64(0, value, false);
+  let bits = view.getBigUint64(0, false);
+  bits += value > 0 ? -1n : 1n;
+  view.setBigUint64(0, bits, false);
+  return view.getFloat64(0, false);
+};
+
 describe('ceilingNiceStep', () => {
   it('advances to the next ladder step immediately above exact 1/2/5 boundaries', () => {
     expect(ceilingNiceStep(1)).toBe(1);
@@ -80,37 +90,37 @@ describe('niceAxisMin', () => {
 
 describe('valueAxisScale (shared linear compatibility policy)', () => {
   it('positive data anchored at 0 (bar/area/radar style)', () => {
-    expect(valueAxisScale(0, 41)).toEqual({ min: 0, max: 50, step: 10 });
+    expect(valueAxisScale(0, 41)).toEqual({ min: 0, max: 45, step: 5 });
   });
   it('negative data floors the min and widens the max with the niced min', () => {
-    expect(valueAxisScale(-15, 100)).toEqual({ min: -50, max: 150, step: 50 });
+    expect(valueAxisScale(-15, 100)).toEqual({ min: -40, max: 120, step: 20 });
   });
   it('explicit min/max override the computed bounds (step still from data range)', () => {
-    expect(valueAxisScale(0, 41, -5, 60)).toEqual({ min: -5, max: 60, step: 10 });
+    expect(valueAxisScale(0, 41, -5, 60)).toEqual({ min: -5, max: 60, step: 5 });
   });
   it('a null explicit bound falls back to the auto value', () => {
-    expect(valueAxisScale(0, 41, null, 60)).toEqual({ min: 0, max: 60, step: 10 });
-    expect(valueAxisScale(0, 41, -5, null)).toEqual({ min: -5, max: 50, step: 10 });
+    expect(valueAxisScale(0, 41, null, 60)).toEqual({ min: 0, max: 60, step: 5 });
+    expect(valueAxisScale(0, 41, -5, null)).toEqual({ min: -5, max: 45, step: 5 });
   });
-  it('a longer value axis gets a finer major unit (Excel axis-length model)', () => {
-    expect(valueAxisScale(0, 40)).toEqual({ min: 0, max: 50, step: 10 });
+  it('keeps fully automatic axes on the measured ten-interval policy regardless of length', () => {
+    expect(valueAxisScale(0, 40)).toEqual({ min: 0, max: 45, step: 5 });
     expect(valueAxisScale(0, 40, undefined, undefined, 380)).toEqual({ min: 0, max: 45, step: 5 });
   });
-  it('a short axis uses the target floor of four', () => {
-    expect(valueAxisScale(60, 72, 60, 72, 124.1)).toEqual({ min: 60, max: 72, step: 5 });
+  it('does not coarsen a fully automatic unit merely because the axis is short', () => {
+    expect(valueAxisScale(60, 72, 60, 72, 124.1)).toEqual({ min: 60, max: 72, step: 2 });
   });
-  it('a medium axis is not over-refined (42pt/gridline density)', () => {
+  it('keeps the same automatic unit on a medium axis', () => {
     const { step } = valueAxisScale(0, 48.6, undefined, undefined, 263.2);
     expect(step).toBe(10);
   });
   it('rounds a fine-grained positive range with a ceiling ladder step', () => {
-    expect(valueAxisScale(0, 3.5)).toEqual({ min: 0, max: 4, step: 1 });
+    expect(valueAxisScale(0, 3.5)).toEqual({ min: 0, max: 4, step: 0.5 });
   });
   it('keeps the 1/2/5 ladder below one', () => {
     const { min, max, step } = valueAxisScale(0, 0.1129);
     expect(min).toBe(0);
-    expect(step).toBeCloseTo(0.05, 12);
-    expect(max).toBeCloseTo(0.15, 12);
+    expect(step).toBeCloseTo(0.02, 12);
+    expect(max).toBeCloseTo(0.12, 12);
   });
 
   it('an explicit majorUnit overrides the auto step (min/max still auto)', () => {
@@ -140,6 +150,138 @@ describe('valueAxisScale (shared linear compatibility policy)', () => {
 });
 
 describe('planLinearValueAxis (bounded automatic value-axis policy)', () => {
+  it('matches the observed ordinary auto units used by column, stacked, combo and scatter axes', () => {
+    expect(planLinearValueAxis({ dataMin: 0, dataMax: 420, axisLenPt: 180 }).majorUnit).toBe(50);
+    expect(planLinearValueAxis({ dataMin: 0, dataMax: 1440, axisLenPt: 180 }).majorUnit).toBe(200);
+    expect(planLinearValueAxis({ dataMin: 0, dataMax: 520, axisLenPt: 180 }).majorUnit).toBe(100);
+    expect(planLinearValueAxis({ dataMin: 0, dataMax: 45, axisLenPt: 300 }).majorUnit).toBe(5);
+  });
+
+  it('keeps an authored major unit authoritative over the automatic ten-interval rule', () => {
+    expect(planLinearValueAxis({
+      dataMin: 18,
+      dataMax: 63,
+      explicitMin: 0,
+      explicitMax: 80,
+      majorUnit: 20,
+      axisLenPt: 180,
+      axisOrientation: 'vertical',
+    }).majorUnit).toBe(20);
+  });
+
+  describe('explicit vertical bounds with an omitted major unit', () => {
+    const vertical = (min: number, max: number, axisLenPt = 194) => planLinearValueAxis({
+      dataMin: min + (max - min) * 0.1,
+      dataMax: min + (max - min) * 0.9,
+      explicitMin: min,
+      explicitMax: max,
+      axisLenPt,
+      axisOrientation: 'vertical',
+      needMinor: true,
+    });
+
+    it('follows the measured boundary immediately around an authored max of 5', () => {
+      expect(vertical(0, nextDown(5))).toMatchObject({ majorUnit: 0.5, minorUnit: 0.1 });
+      expect(vertical(0, 5)).toMatchObject({ majorUnit: 0.5, minorUnit: 0.1 });
+      expect(vertical(0, nextUp(5))).toMatchObject({ majorUnit: 1, minorUnit: 0.2 });
+    });
+
+    it('uses the authored span for decimal, non-zero and cross-zero bounds', () => {
+      expect(vertical(0, 0.35)).toMatchObject({ min: 0, max: 0.35, majorUnit: 0.05, minorUnit: 0.01 });
+      expect(vertical(1, 3)).toMatchObject({ min: 1, max: 3, majorUnit: 0.2, minorUnit: 0.04 });
+      expect(vertical(-3.5, 3.5)).toMatchObject({ min: -3.5, max: 3.5, majorUnit: 1, minorUnit: 0.2 });
+    });
+
+    it('is stable across the measured ordinary-height ±1pt boundary', () => {
+      for (const axisLenPt of [193, 194, 195]) {
+        expect(vertical(0, 450, axisLenPt).majorUnit).toBe(50);
+      }
+      expect(vertical(0, 450, 108).majorUnit).toBe(100);
+    });
+
+    it('does not alter horizontal axes or authored units', () => {
+      const horizontal = planLinearValueAxis({
+        dataMin: 0.5, dataMax: 4.5, explicitMin: 0, explicitMax: 5,
+        axisLenPt: 194, axisOrientation: 'horizontal', needMinor: true,
+      });
+      const legacy = planLinearValueAxis({
+        dataMin: 0.5, dataMax: 4.5, explicitMin: 0, explicitMax: 5,
+        axisLenPt: 194, needMinor: true,
+      });
+      expect(horizontal).toEqual(legacy);
+      expect(planLinearValueAxis({
+        dataMin: 0.5, dataMax: 4.5, explicitMin: 0, explicitMax: 5,
+        axisLenPt: 194, axisOrientation: 'vertical', majorUnit: 2, minorUnit: 0.25,
+        needMinor: true,
+      })).toMatchObject({ majorUnit: 2, minorUnit: 0.25 });
+    });
+
+    it('keeps overlay X/Y authored major and minor units independent', () => {
+      const x = planLinearValueAxis({
+        dataMin: 0.25, dataMax: 1.75, explicitMin: 0, explicitMax: 2,
+        axisLenPt: 300, axisOrientation: 'horizontal', majorUnit: 0.25,
+        minorUnit: 0.05, needMinor: true,
+      });
+      const y = planLinearValueAxis({
+        dataMin: 2, dataMax: 8, explicitMin: 0, explicitMax: 10,
+        axisLenPt: 194, axisOrientation: 'vertical', majorUnit: 2,
+        minorUnit: 0.5, needMinor: true,
+      });
+      expect(x).toMatchObject({ majorUnit: 0.25, minorUnit: 0.05 });
+      expect(y).toMatchObject({ majorUnit: 2, minorUnit: 0.5 });
+      expect(x.minorTicks).not.toEqual(y.minorTicks);
+    });
+
+    it('retains the global tick cap for automatic major and minor positions', () => {
+      const bounded = vertical(0, 1e12, 194);
+      expect(bounded.majorTicks.length).toBeLessThanOrEqual(MAX_AXIS_TICKS);
+      expect(bounded.minorTicks.length).toBeLessThanOrEqual(MAX_AXIS_TICKS);
+    });
+
+    it('keeps opposite-sign near-limit explicit bounds finite and progressing', () => {
+      const bounded = planLinearValueAxis({
+        dataMin: -1e307,
+        dataMax: 1e307,
+        explicitMin: -1e308,
+        explicitMax: 1e308,
+        axisLenPt: 194,
+        axisOrientation: 'vertical',
+        needMinor: true,
+      });
+      expect([bounded.min, bounded.max, bounded.majorUnit, bounded.minorUnit]
+        .every(value => value != null && Number.isFinite(value))).toBe(true);
+      expect(bounded.majorUnit).toBeGreaterThan(0);
+      expect(bounded.majorTicks.length).toBeLessThanOrEqual(MAX_AXIS_TICKS);
+      expect(bounded.minorTicks.length).toBeLessThanOrEqual(MAX_AXIS_TICKS);
+      for (const ticks of [bounded.majorTicks, bounded.minorTicks]) {
+        expect(ticks.every(Number.isFinite)).toBe(true);
+        expect(ticks.every((value, index) => index === 0 || value > ticks[index - 1])).toBe(true);
+      }
+      expect(bounded.majorTicks.at(-1)).toBe(1e308);
+      expect(bounded.minorTicks.at(-1) as number).toBeGreaterThan(9e307);
+    });
+
+    it('keeps the smallest positive explicit span finite and representable', () => {
+      const bounded = planLinearValueAxis({
+        dataMin: 0,
+        dataMax: Number.MIN_VALUE,
+        explicitMin: 0,
+        explicitMax: Number.MIN_VALUE,
+        axisLenPt: 194,
+        axisOrientation: 'vertical',
+        needMinor: true,
+      });
+      expect(bounded).toMatchObject({
+        min: 0,
+        max: Number.MIN_VALUE,
+        majorUnit: Number.MIN_VALUE,
+        minorUnit: Number.MIN_VALUE,
+      });
+      expect(bounded.majorTicks).toEqual([0, Number.MIN_VALUE]);
+      expect(bounded.minorTicks).toEqual([]);
+    });
+  });
+
   it('keeps automatic major units on the 1/2/5 × 10ⁿ ladder', () => {
     for (const dataMax of [1.1e-12, 3.7e-6, 8.4, 173, 9.9e11]) {
       const { majorUnit } = planLinearValueAxis({ dataMin: 0, dataMax });

--- a/packages/core/src/chart/axis-scale.ts
+++ b/packages/core/src/chart/axis-scale.ts
@@ -68,6 +68,8 @@ export interface LinearValueAxisOptions {
   explicitMin?: number | null;
   explicitMax?: number | null;
   axisLenPt?: number;
+  /** Physical direction of the numeric axis. Omitted keeps the legacy policy. */
+  axisOrientation?: 'vertical' | 'horizontal';
   majorUnit?: number | null;
   minorUnit?: number | null;
   /** Minor positions are needed by either minor ticks or minor gridlines. */
@@ -104,6 +106,22 @@ function positiveUnit(value: number | null | undefined): number | null {
   return value != null && isFinite(value) && value > 0 ? value : null;
 }
 
+/** Compute `(max - min) / divisor` without first materializing an overflowing
+ * span. Dividing the endpoints before subtraction keeps opposite-sign finite
+ * bounds usable all the way through Number.MAX_VALUE. */
+function spanQuotient(min: number, max: number, divisor: number): number {
+  const directSpan = max - min;
+  const quotient = isFinite(directSpan)
+    ? directSpan / divisor
+    : max / divisor - min / divisor;
+  if (quotient > 0 && isFinite(quotient)) return quotient;
+  // A positive subnormal span may underflow when divided. The smallest
+  // representable positive step is the only meaningful density input; using a
+  // huge fallback would invert the scale (unit much larger than its range).
+  if (directSpan > 0 && isFinite(directSpan)) return Number.MIN_VALUE;
+  return Number.MAX_VALUE;
+}
+
 function tickCount(min: number, max: number, unit: number): number {
   if (!isFinite(min) || !isFinite(max) || !(max >= min) || !(unit > 0) || !isFinite(unit)) return 0;
   const span = max - min;
@@ -135,7 +153,14 @@ function indexedTicks(
   ) * 1e-9;
   let previousValue = Number.NEGATIVE_INFINITY;
   for (let index = 0; index < count; index++) {
-    const value = min + index * unit;
+    const offset = index * unit;
+    let value = min + offset;
+    // On an opposite-sign near-limit axis, `index * unit` can overflow even
+    // though the final translated tick is finite. Retry only that exceptional
+    // path in unit coordinates; ordinary values retain their exact old math.
+    if (!isFinite(offset) || !isFinite(value) || (index > 0 && !(value > previousValue))) {
+      value = (min / unit + index) * unit;
+    }
     if (!isFinite(value) || value > max + epsilon) break;
     if (index > 0 && !(value > previousValue)) break;
     previousValue = value;
@@ -186,8 +211,14 @@ export function planLinearValueAxis(options: LinearValueAxisOptions): LinearValu
     if (dataMin >= 0 && (dataMin === 0 || dataMax > 1.2 * dataMin)) lo = 0;
     if (dataMax <= 0 && (dataMax === 0
       || Math.abs(dataMin) > 1.2 * Math.abs(dataMax))) hi = 0;
-    const target = targetStepsForAxis(options.axisLenPt);
-    autoMajor = ceilingNiceStep(hi / target - lo / target);
+    // The broad automatic-axis corpus (6,354 finite line-axis cases) selected
+    // the 1/2/5 ladder from roughly ten intervals.  Using the plot length here
+    // made ordinary vertical charts collapse to only three or four labelled
+    // intervals (for example 0..600 by 200 instead of 0..600 by 100).  Physical
+    // size remains relevant only for the separately observed explicit-bounds
+    // rule below; the fully automatic compact policy is intentionally one
+    // shared ten-interval rule across chart families.
+    autoMajor = ceilingNiceStep(hi / 10 - lo / 10);
     autoMin = Math.floor(lo / autoMajor) * autoMajor;
     autoMax = Math.ceil(hi / autoMajor) * autoMajor;
     // Large offsets can erase sub-ULP padding/rounding. Keep a finite range
@@ -200,10 +231,45 @@ export function planLinearValueAxis(options: LinearValueAxisOptions): LinearValu
 
   const explicitMin = finiteBound(options.explicitMin);
   const explicitMax = finiteBound(options.explicitMax);
-  const min = explicitMin ?? autoMin;
-  const max = explicitMax ?? autoMax;
   const authoredMajor = positiveUnit(options.majorUnit);
-  let majorUnit = authoredMajor ?? autoMajor;
+  // When only a major unit is authored, Excel keeps automatic bounds aligned
+  // to that unit.  The previous coarser automatic unit happened to mask this
+  // rule for common values; make it explicit now that auto density is finer.
+  const min = explicitMin ?? (authoredMajor == null
+    ? autoMin
+    : Math.floor(autoMin / authoredMajor) * authoredMajor);
+  const max = explicitMax ?? (authoredMajor == null
+    ? autoMax
+    : Math.ceil(autoMax / authoredMajor) * authoredMajor);
+  let automaticMajor = autoMajor;
+  // OOXML defines authored min/max and majorUnit, but not the unit chosen when
+  // both bounds are present and majorUnit is omitted. A bounded corpus across
+  // column, stacked-column, line, area, scatter-Y, and combo axes found that
+  // vertical axes choose from the authored span, not the interior data range.
+  // The compact 1/2/5-ladder fit below matched all 231 measured vertical rows,
+  // including ±1pt ordinary-height probes and a small-chart control. Horizontal
+  // axes retain the legacy density policy (63/66 measured rows already match).
+  if (
+    authoredMajor == null
+    && options.axisOrientation === 'vertical'
+    && explicitMin != null
+    && explicitMax != null
+    && explicitMax > explicitMin
+  ) {
+    const axisTarget = options.axisLenPt != null
+      && isFinite(options.axisLenPt)
+      && options.axisLenPt > 0
+      ? Math.max(5, Math.round(options.axisLenPt / 28))
+      : 7;
+    automaticMajor = Math.max(
+      ceilingNiceStep(spanQuotient(explicitMin, explicitMax, 10)),
+      Math.min(
+        Number.MAX_VALUE,
+        niceStep(spanQuotient(explicitMin, explicitMax, axisTarget), 1),
+      ),
+    );
+  }
+  let majorUnit = authoredMajor ?? automaticMajor;
   // An automatic unit may be coarsened to keep explicit wide bounds safe.
   if (authoredMajor == null && tickCount(min, max, majorUnit) > MAX_AXIS_TICKS) {
     majorUnit = ceilingNiceStep(max / (MAX_AXIS_TICKS - 1) - min / (MAX_AXIS_TICKS - 1));
@@ -218,7 +284,10 @@ export function planLinearValueAxis(options: LinearValueAxisOptions): LinearValu
       majorUnit = ceilingNiceStep(max / maxMajorIntervals - min / maxMajorIntervals);
     }
   }
-  const minorUnit = options.needMinor ? (authoredMinor ?? majorUnit / 5) : null;
+  const automaticMinor = majorUnit / 5;
+  const minorUnit = options.needMinor
+    ? (authoredMinor ?? (automaticMinor > 0 && isFinite(automaticMinor) ? automaticMinor : majorUnit))
+    : null;
 
   const majorTicks = indexedTicks(min, max, majorUnit, authoredMajor == null ? 'skip' : 'truncate');
   const minorTicks = minorUnit == null

--- a/packages/core/src/chart/axis-title-defaults.test.ts
+++ b/packages/core/src/chart/axis-title-defaults.test.ts
@@ -185,8 +185,8 @@ describe('axis-title compatibility defaults', () => {
     expect(call.font).toContain('12px');
     expect(call.font).toContain('Aptos Display');
     expect(call.rotation).toBeCloseTo(Math.PI / 6);
-    expect(call.translateX).toBeCloseTo(188);
-    expect(call.translateY).toBeCloseTo(32);
+    expect(call.translateX).toBeCloseTo(187.248711, 5);
+    expect(call.translateY).toBeCloseTo(45.196152, 5);
   });
 
   it('keeps authored rot and vertical mode independent at paint time', () => {
@@ -197,5 +197,23 @@ describe('axis-title compatibility defaults', () => {
       valAxisTitleVerticalMode: 'vert270',
     }), WIDE, 1);
     expect(titleCall(texts, 'Combined').rotation).toBeCloseTo(-Math.PI / 3);
+  });
+
+  it('positions a manual vertical title by its rotated bounding box', () => {
+    const { ctx, texts } = recordingContext();
+    renderChart(ctx, model({
+      valAxisTitle: 'Vertical',
+      valAxisTitleRotation: -5_400_000,
+      valAxisTitleVerticalMode: 'horz',
+      valAxisTitleManualLayout: {
+        xMode: 'edge', yMode: 'edge', x: 0.01, y: 0.1,
+      },
+    }), WIDE, 1);
+
+    const call = titleCall(texts, 'Vertical');
+    // 8 glyphs × 7px = 56px. After a quarter turn, the fitted title box is
+    // 10×56, so edge coordinates (8,26) place its centre at (13,54).
+    expect(call.translateX).toBeCloseTo(13);
+    expect(call.translateY).toBeCloseTo(54);
   });
 });

--- a/packages/core/src/chart/layout.test.ts
+++ b/packages/core/src/chart/layout.test.ts
@@ -211,7 +211,7 @@ describe('chartLegendReserve + bands', () => {
     // 300 + 12 + 322 = 634: it fits W - 4 but not the painted W - 8.
     expect(leg).toEqual({ side: 't', reserveW: 0, reserveH: 36 });
   });
-  it('bounds a measured side reserve while leaving room for the plot', () => {
+  it('lets a measured side reserve grow to the 30% plot-safety bound', () => {
     const leg = chartLegendReserve(
       model({ showLegend: true, legendPos: 'r' }),
       W,
@@ -225,7 +225,23 @@ describe('chartLegendReserve + bands', () => {
         verticalPadding: 4,
       },
     );
-    expect(leg).toEqual({ side: 'r', reserveW: W * 0.22, reserveH: 0 });
+    expect(leg).toEqual({ side: 'r', reserveW: W * 0.3, reserveH: 0 });
+  });
+  it('keeps a short measured side reserve at the 80px compatibility minimum', () => {
+    const leg = chartLegendReserve(
+      model({ showLegend: true, legendPos: 'r' }),
+      W,
+      H,
+      0.22,
+      {
+        itemWidths: [40],
+        rowHeight: 16,
+        itemGap: 12,
+        horizontalPadding: 8,
+        verticalPadding: 4,
+      },
+    );
+    expect(leg).toEqual({ side: 'r', reserveW: 80, reserveH: 0 });
   });
 });
 

--- a/packages/core/src/chart/layout.ts
+++ b/packages/core/src/chart/layout.ts
@@ -216,7 +216,11 @@ export function chartLegendReserve(
   if (side === 'r' || side === 'l') {
     if (metrics) {
       const minWidth = Math.min(80, w * 0.3);
-      const maxWidth = Math.max(minWidth, Math.min(w * 0.3, Math.max(80, w * sideReserveFrac)));
+      // Once Canvas metrics are available, size the band from the content
+      // rather than reusing the legacy family fraction as an upper bound. The
+      // 30% safety cap still leaves the majority of the frame to the plot, but
+      // permits a long authored series name to wrap into complete words.
+      const maxWidth = w * 0.3;
       const measuredWidth = Math.max(0, ...metrics.itemWidths) + metrics.horizontalPadding;
       return {
         side,

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -13,7 +13,10 @@ import { renderChart } from './renderer.js';
 import { formatChartValWithCode } from './chart-number-format.js';
 
 interface RectCall { x: number; y: number; w: number; h: number; fs: string }
-interface StrokeRectCall { x: number; y: number; w: number; h: number; ss: string; lw: number }
+interface StrokeRectCall {
+  x: number; y: number; w: number; h: number; ss: string; lw: number;
+  dash: number[]; cap: string; join: string;
+}
 interface TextCall {
   text: string;
   x: number;
@@ -33,17 +36,23 @@ interface Recorded {
   clips: Array<{ x: number; y: number; w: number; h: number }>;
   gradients: Array<{ args: number[]; stops: Array<{ position: number; color: string }> }>;
   arcs: Array<{ x: number; y: number; r: number }>;
+  paintEvents: Array<
+    | { kind: 'stroke'; strokeStyle: string }
+    | { kind: 'text'; text: string }
+  >;
 }
 
 /** Minimal recording 2D context: captures fillRect + fillText, tracks the
  *  handful of state props the renderer reads, and models text width. */
-function recordingCtx(): Recorded {
+function recordingCtx(measureOverride?: (text: string, fontPx: number) => number | null): Recorded {
   const rects: RectCall[] = [];
   const strokeRects: StrokeRectCall[] = [];
   const texts: TextCall[] = [];
   const clips: Array<{ x: number; y: number; w: number; h: number }> = [];
   const gradients: Recorded['gradients'] = [];
   const arcs: Recorded['arcs'] = [];
+  const paintEvents: Recorded['paintEvents'] = [];
+  let dash: number[] = [];
   let pathRect: { x: number; y: number; w: number; h: number } | null = null;
   const state: Record<string, unknown> = {
     font: '10px sans-serif',
@@ -62,6 +71,8 @@ function recordingCtx(): Recorded {
   };
   const textWidth = (text: string): number => {
     const px = fontPx(String(state.font));
+    const overridden = measureOverride?.(String(text), px);
+    if (overridden != null) return overridden;
     let w = 0;
     for (const ch of String(text)) w += ch.charCodeAt(0) > 0x2e7f ? px : px * 0.6;
     return w;
@@ -76,7 +87,8 @@ function recordingCtx(): Recorded {
           return (x: number, y: number, w: number, h: number) =>
             rects.push({ x, y, w, h, fs: String(state.fillStyle) });
         case 'fillText':
-          return (text: string, x: number, y: number) =>
+          return (text: string, x: number, y: number) => {
+            paintEvents.push({ kind: 'text', text: String(text) });
             texts.push({
               text,
               x,
@@ -87,9 +99,13 @@ function recordingCtx(): Recorded {
               width: textWidth(text),
               fillStyle: String(state.fillStyle),
             });
+          };
         case 'strokeRect':
           return (x: number, y: number, w: number, h: number) =>
-            strokeRects.push({ x, y, w, h, ss: String(state.strokeStyle), lw: Number(state.lineWidth) });
+            strokeRects.push({
+              x, y, w, h, ss: String(state.strokeStyle), lw: Number(state.lineWidth),
+              dash: [...dash], cap: String(state.lineCap), join: String(state.lineJoin),
+            });
         case 'createLinearGradient':
         case 'createRadialGradient':
           return (...args: number[]) => {
@@ -110,9 +126,16 @@ function recordingCtx(): Recorded {
         case 'arc':
           return (x: number, y: number, r: number) => { arcs.push({ x, y, r }); };
         case 'save': case 'restore': case 'closePath':
-        case 'fill': case 'stroke': case 'moveTo': case 'lineTo':
+        case 'stroke':
+          return () => paintEvents.push({ kind: 'stroke', strokeStyle: String(state.strokeStyle) });
+        case 'fill': case 'moveTo': case 'lineTo':
         case 'bezierCurveTo': case 'quadraticCurveTo':
-        case 'clearRect': case 'strokeText': case 'setLineDash':
+          return () => undefined;
+        case 'setLineDash':
+          return (value: number[] = []) => { dash = [...value]; };
+        case 'getLineDash':
+          return () => [...dash];
+        case 'clearRect': case 'strokeText':
         case 'translate': case 'rotate': case 'scale':
         case 'setTransform': case 'resetTransform': case 'getTransform':
           return () => undefined;
@@ -130,6 +153,7 @@ function recordingCtx(): Recorded {
     clips,
     gradients,
     arcs,
+    paintEvents,
   };
 }
 
@@ -356,6 +380,59 @@ describe('bar chart authored layout and fills', () => {
     expect(rec.strokeRects.filter(rect => rect.ss === '#595959' && rect.lw === 1)).toHaveLength(2);
   });
 
+  it('keeps a filled legend key at the Office-observed 7pt square and preserves its outline', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredBar',
+      categories: ['A'],
+      series: [series({
+        name: 'Outlined',
+        color: 'FF00FF',
+        values: [1],
+        lineColor: '000000',
+        lineWidthEmu: 12700,
+      })],
+      showLegend: true,
+      legendPos: 'r',
+      legendFontSizeHpt: 1500,
+    }), RECT, 1);
+
+    const key = rec.rects.find(rect =>
+      rect.fs === '#FF00FF' && Math.abs(rect.w - rect.h) < 0.01 && rect.w < 10
+    );
+    expect(key).toMatchObject({ w: 7, h: 7 });
+    expect(rec.strokeRects.some(rect =>
+      rect.ss === '#000000'
+      && rect.lw === 1
+      && Math.abs(rect.w - 6) < 0.01
+      && Math.abs(rect.h - 6) < 0.01
+    )).toBe(true);
+  });
+
+  it('keeps a short top-legend label intact at fractional display metrics', () => {
+    // Aptos Narrow at 13.3333px produces this fractional width in Chromium.
+    // Adding a 7pt key and then subtracting it again loses one ULP; without a
+    // bounded measurement epsilon that false overflow turns `disp` into `di…`.
+    const rec = recordingCtx((text, fontPx) => {
+      if (Math.abs(fontPx - 13.3333) > 0.001) return null;
+      if (text === 'disp') return 24.453475952148438;
+      if (text === 'di…') return 23.704971313476562;
+      if (text === 'dis…') return 30.369964599609375;
+      return null;
+    });
+    renderChart(rec.ctx, baseModel({
+      chartType: 'funnel',
+      title: 'Sales Funnel',
+      categories: ['1', '2', '3', '4', '5'],
+      series: [series({ name: 'disp', values: [3, 3, 2, 4, 5] })],
+      showLegend: true,
+      legendPos: 't',
+    }), { x: 0, y: 0, w: 457.2, h: 292.608 }, 4 / 3);
+
+    expect(rec.texts.some(text => text.text === 'disp')).toBe(true);
+    expect(rec.texts.some(text => text.text.includes('…'))).toBe(false);
+  });
+
   it('wraps a measured top legend into centered in-bounds rows without changing authored text style', () => {
     const names = Array.from({ length: 12 }, (_, index) =>
       `Series ${String(index + 1).padStart(2, '0')} alpha`
@@ -398,10 +475,10 @@ describe('bar chart authored layout and fills', () => {
       showLegend: true,
       legendPos: 't',
       legendFontSizeHpt: 1000,
-    }), { x: 0, y: 0, w: 106, h: 200 }, 1);
+    }), { x: 0, y: 0, w: 96, h: 200 }, 1);
 
-    // At this width the two entries fit inside w - 4 but not the actual
-    // w - 8 content rectangle, so both rows must be reserved and painted.
+    // The fixed 7pt keys leave the pair wider than the actual w - 8 content
+    // rectangle, so both rows must be reserved and painted from the same plan.
     const labels = rec.texts.filter(text => text.text === 'AAAAA' || text.text === 'BBBBB');
     expect(labels.map(label => label.text)).toEqual(['AAAAA', 'BBBBB']);
     expect(labels[1].y).toBeGreaterThan(labels[0].y);
@@ -562,6 +639,92 @@ describe('bar chart authored layout and fills', () => {
     expect(left?.x).toBeLessThan(right?.x ?? 0);
   });
 
+  it('maps a bar/scatter overlay through its independent authored X/Y axes', () => {
+    const rec = recordingCtx();
+    const axis = {
+      title: null,
+      hidden: true,
+      lineHidden: true,
+      majorTickMark: 'none',
+      minorTickMark: 'in',
+    } as const;
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredBarH',
+      categories: ['A', 'B'],
+      series: [
+        series({ seriesType: 'bar', values: [0, 0] }),
+        series({
+          seriesType: 'scatter', categories: ['0.5', '1.5'], values: [2, 8],
+          markerSymbol: 'circle', markerFill: '1696D2', showMarker: true,
+        }),
+      ],
+      secondaryCatAxis: {
+        ...axis, min: 0, max: 2, majorUnit: 0.25, minorUnit: 0.05,
+      },
+      secondaryValAxis: {
+        ...axis, min: 0, max: 10, majorUnit: 2, minorUnit: 0.5,
+      },
+    }), RECT, 1);
+
+    const points = rec.arcs.filter(point => Number.isFinite(point.x) && Number.isFinite(point.y));
+    expect(points).toHaveLength(2);
+    expect(points[0].x).toBeLessThan(points[1].x);
+    expect(points[0].y).toBeGreaterThan(points[1].y);
+  });
+
+  it.each(['clusteredBar', 'clusteredBarH'] as const)(
+    '%s: custom rich bar labels paint bounded inline runs with theme faces',
+    chartType => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType,
+        categories: ['A'],
+        themeMajorFontLatin: 'Major Theme',
+        themeMinorFontLatin: 'Minor Theme',
+        series: [series({
+          values: [10],
+          dataLabelOverrides: [{
+            idx: 0,
+            text: 'Major Minor',
+            position: 'ctr',
+            richRuns: [
+              { text: 'Major', fontFace: '+mj-lt', color: '112233' },
+              { text: ' Minor', fontFace: '+mn-lt', color: '445566' },
+            ],
+          }],
+        })],
+      }), RECT, 1);
+
+      expect(rec.texts.find(call => call.text === 'Major'))
+        .toMatchObject({ fillStyle: '#112233' });
+      expect(rec.texts.find(call => call.text === 'Major')?.font)
+        .toContain('"Major Theme"');
+      expect(rec.texts.find(call => call.text === ' Minor'))
+        .toMatchObject({ fillStyle: '#445566' });
+      expect(rec.texts.find(call => call.text === ' Minor')?.font)
+        .toContain('"Minor Theme"');
+    },
+  );
+
+  it('bar: richRuns do not replace a label composed from show/format flags', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedBarPct',
+      categories: ['A'],
+      series: [series({
+        values: [1],
+        seriesDataLabels: {
+          showVal: false, showCatName: false, showSerName: false, showPercent: true,
+          formatCode: '0.0%',
+        },
+        dataLabelOverrides: [{ idx: 0, text: '', richRuns: [{ text: 'stale custom' }] }],
+      })],
+    }), RECT, 1);
+
+    expect(rec.texts.map(call => call.text)).toContain('100.0%');
+    expect(rec.texts.map(call => call.text)).not.toContain('stale custom');
+  });
+
   it('measures the automatic horizontal category-label gutter instead of eliding long labels', () => {
     const rec = recordingCtx();
     const category = 'San Francisco County, California';
@@ -701,7 +864,7 @@ describe('CH1 — negative bar/column values extend from the zero line', () => {
     const bars = rec.rects;
     expect(bars).toHaveLength(2);
     const totalLength = bars[0].w + bars[1].w;
-    expect(totalLength).toBeCloseTo(RECT.w * 0.8 * (97 / 150), 4);
+    expect(totalLength).toBeCloseTo(RECT.w * 0.8 * (97 / 120), 4);
   });
 
   it('positive-only data keeps the axis anchored at 0 (pre-fix behavior)', () => {
@@ -1667,7 +1830,7 @@ describe('CH3 — labels are locale-independent (§18.8.30)', () => {
     expect(rec.texts.some(text => text.text === 'costs')).toBe(true);
   });
 
-  it('uses the ChartEx dataPointLine role for waterfall connectors', () => {
+  it('uses the ChartEx seriesLine role for waterfall connectors', () => {
     const rec = segRecordingCtx();
     renderChart(rec.ctx, baseModel({
       chartType: 'waterfall',
@@ -1675,11 +1838,87 @@ describe('CH3 — labels are locale-independent (§18.8.30)', () => {
       series: [series({ name: 'W', values: [10, -2, 8] })],
       subtotalIndices: [2],
       chartexDataPointStyle: { lineColors: ['C00000'] },
-      chartexDataPointLineStyle: { lineColors: ['0070C0'], lineWidthEmu: 25400 },
+      chartexDataPointLineStyle: { lineColors: ['70AD47'], lineWidthEmu: 12700 },
+      chartexSeriesLineStyle: { lineColors: ['0070C0'], lineWidthEmu: 25400 },
     }), RECT, 1);
     const connectors = rec.segs.filter(segment => segment.ss.toLowerCase() === '#0070c0');
     expect(connectors).toHaveLength(2);
     expect(connectors.every(segment => segment.lw === 2)).toBe(true);
+  });
+
+  it('uses the linked seriesLine color and 0.75pt width for waterfall connectors', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'waterfall',
+      categories: ['Start', 'Change', 'End'],
+      series: [series({ name: 'W', values: [10, -2, 8] })],
+      subtotalIndices: [2],
+      chartexSeriesLineStyle: {
+        lineColors: ['D9D9D9'],
+        lineWidthEmu: 9525,
+        lineCap: 'flat',
+        lineJoin: 'round',
+      },
+    }), RECT, 1);
+
+    const connectors = rec.segs.filter(segment => segment.ss.toLowerCase() === '#d9d9d9');
+    expect(connectors).toHaveLength(2);
+    expect(connectors.every(segment => segment.lw === 0.75)).toBe(true);
+  });
+
+  it('keeps a direct Waterfall connector stroke authoritative over linked NoStyle', () => {
+    const rec = strokedPolylineCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'waterfall',
+      categories: ['Start', 'Change', 'End'],
+      series: [series({
+        name: 'W', values: [10, -2, 8],
+        chartexStyle: {
+          lineColors: ['123456'], lineWidthEmu: 25400,
+          lineDash: 'dash', lineCap: 'rnd', lineJoin: 'bevel',
+        },
+      })],
+      subtotalIndices: [2],
+      chartexSeriesLineStyle: { lineHidden: true, lineNoStyle: true },
+    }), RECT, 1);
+
+    const connectors = rec.strokes.filter(segment => segment.ss.toLowerCase() === '#123456');
+    expect(connectors).toHaveLength(2);
+    expect(connectors.every(segment =>
+      segment.lw === 2 && segment.dash.length > 0
+      && segment.cap === 'round' && segment.join === 'bevel'
+    )).toBe(true);
+  });
+
+  it('keeps direct Waterfall connector noFill authoritative over a linked stroke', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'waterfall',
+      categories: ['Start', 'Change', 'End'],
+      series: [series({
+        name: 'W', values: [10, -2, 8],
+        chartexStyle: { lineHidden: true, lineWidthEmu: 25400, lineDash: 'dash' },
+      })],
+      subtotalIndices: [2],
+      chartexSeriesLineStyle: { lineColors: ['0070C0'], lineWidthEmu: 12700 },
+    }), RECT, 1);
+
+    expect(rec.segs.filter(segment => segment.ss.toLowerCase() === '#0070c0'))
+      .toHaveLength(0);
+  });
+
+  it('uses the Office-observed semantic connector stroke for linked NoStyle', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'waterfall',
+      categories: ['1', '2', '3'],
+      series: [series({ name: 'W', values: [1, 1, 1] })],
+      chartexSeriesLineStyle: { lineHidden: true, lineNoStyle: true },
+    }), RECT, 1);
+
+    const connectors = rec.segs.filter(segment => segment.ss.toLowerCase() === '#000000');
+    expect(connectors).toHaveLength(2);
+    expect(connectors.every(segment => segment.lw === 0.75)).toBe(true);
   });
 
   it('keeps semantic data-point fills when the ChartEx series shape has noFill', () => {
@@ -1709,9 +1948,54 @@ describe('CH3 — labels are locale-independent (§18.8.30)', () => {
       series: [series({ name: 'W', values: [10, -2, 8] })],
       subtotalIndices: [2],
       chartexConnectorLines: false,
-      chartexDataPointLineStyle: { lineColors: ['0070C0'], lineWidthEmu: 25400 },
+      chartexSeriesLineStyle: { lineColors: ['0070C0'], lineWidthEmu: 25400 },
     }), RECT, 1);
     expect(rec.segs.filter(segment => segment.ss.toLowerCase() === '#0070c0')).toHaveLength(0);
+  });
+
+  it('does not invent waterfall value labels when no data-label definition exists', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'waterfall',
+      categories: ['Start', 'Change', 'End'],
+      series: [series({ name: 'W', values: [10, -2, 8] })],
+      subtotalIndices: [2],
+      valAxisHidden: true,
+      catAxisHidden: true,
+    }), RECT, 1);
+
+    expect(rec.texts.map(text => text.text)).not.toEqual(
+      expect.arrayContaining(['10', '-2', '8']),
+    );
+  });
+
+  it('omits automatic value-axis labels for an all-increase bridge without totals', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'waterfall',
+      categories: ['A', 'B', 'C'],
+      series: [series({ values: [10, 20, 30] })],
+      subtotalIndices: [],
+      valAxisMajorGridlines: true,
+      valAxisGridlineColor: 'D9D9D9',
+      valAxisLineColor: '000000',
+    }), RECT, 1);
+
+    expect(rec.texts.map(text => text.text)).toEqual(['A', 'B', 'C']);
+    expect(rec.segs.some(segment =>
+      segment.ss.toLowerCase() === '#d9d9d9'
+      && Math.abs(segment.y1 - segment.y0) < 0.01
+      && Math.abs(segment.x1 - segment.x0) > 100
+    )).toBe(true);
+    const gridline = rec.segs.find(segment =>
+      Math.abs(segment.y1 - segment.y0) < 0.01
+      && Math.abs(segment.x1 - segment.x0) > 100
+      && segment.ss.toLowerCase() === '#d9d9d9'
+      && segment.y0 > RECT.y
+    );
+    // Office keeps a visible axis rule off the chart-object edge even when its
+    // implicit numeric labels are suppressed for this Waterfall layout.
+    expect(gridline?.x0).toBeGreaterThanOrEqual(RECT.w * 0.03 - 0.01);
   });
 
   it('draws authored waterfall minor ticks', () => {
@@ -1897,6 +2181,22 @@ describe('ChartEx flat layouts dispatch to semantic renderers', () => {
     expect(rec.rects).toHaveLength(2);
   });
 
+  it('keeps dense one- and two-digit category labels on one line across fallback font metrics', () => {
+    const categories = Array.from({ length: 29 }, (_, index) => String(index + 1));
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredColumn',
+      categories,
+      catAxisFontSizeHpt: 1000,
+      series: [series({ name: 'cyl', values: categories.map(() => 6) })],
+    }), { x: 0, y: 0, w: 494, h: 288 }, 4 / 3);
+
+    const categoryTexts = rec.texts
+      .filter(text => text.baseline === 'top')
+      .map(text => text.text);
+    expect(categoryTexts).toEqual(expect.arrayContaining(categories));
+  });
+
   it('rejects histogram input beyond the ChartEx cache ceiling', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, baseModel({
@@ -2039,6 +2339,19 @@ describe('ChartEx flat layouts dispatch to semantic renderers', () => {
     )).toBe(true);
   });
 
+  it('uses the ordinary linear value axis for a standalone Pareto line', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'paretoLine',
+      categories: [],
+      series: [series({ values: [5, 3, 2] })],
+    }), { x: 0, y: 0, w: 371, h: 198 }, 1);
+
+    const texts = rec.texts.map(text => text.text);
+    expect(texts).toEqual(expect.arrayContaining(['0', '0.2', '0.4', '0.6', '0.8', '1', '1.2']));
+    expect(texts.some(text => text.includes('%'))).toBe(false);
+  });
+
   it('renders owner-backed Pareto bars in sorted source identity order with a 0-100% line axis', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, baseModel({
@@ -2075,6 +2388,54 @@ describe('ChartEx flat layouts dispatch to semantic renderers', () => {
     }), RECT, 1);
     expect(rec.texts.map(text => text.text)).toContain('(too many data points)');
     expect(rec.rects).toHaveLength(0);
+  });
+
+  it('standalone Pareto line resolves direct and linked ChartEx strokes', () => {
+    const model = (
+      direct: ChartSeries['chartexStyle'],
+      linked: ChartModel['chartexDataPointLineStyle'],
+    ) => baseModel({
+      chartType: 'paretoLine',
+      categories: ['A', 'B', 'C'],
+      chartexDataPointLineStyle: linked,
+      series: [series({ values: [3, 2, 1], chartexStyle: direct })],
+    });
+    const cumulativeStroke = (rec: ReturnType<typeof strokedPolylineCtx>) =>
+      rec.strokes.find(stroke => stroke.points.some((point, index) =>
+        index > 0
+        && point.x !== stroke.points[index - 1].x
+        && point.y !== stroke.points[index - 1].y
+      ));
+
+    const direct = strokedPolylineCtx();
+    renderChart(direct.ctx, model(
+      {
+        lineColors: ['123456'], lineWidthEmu: 25400, lineDash: 'dash',
+        lineCap: 'rnd', lineJoin: 'bevel',
+      },
+      { lineColors: ['AA0000'], lineWidthEmu: 12700 },
+    ), RECT, 1);
+    expect(cumulativeStroke(direct)).toMatchObject({
+      ss: '#123456', lw: 2, cap: 'round', join: 'bevel',
+    });
+    expect(cumulativeStroke(direct)?.dash.length).toBeGreaterThan(0);
+
+    const linkedNoFill = strokedPolylineCtx();
+    renderChart(linkedNoFill.ctx, model(null, { lineHidden: true }), RECT, 1);
+    expect(cumulativeStroke(linkedNoFill)).toBeUndefined();
+
+    const directNoFill = strokedPolylineCtx();
+    renderChart(
+      directNoFill.ctx,
+      model({ lineHidden: true }, { lineHidden: true, lineNoStyle: true }),
+      RECT,
+      1,
+    );
+    expect(cumulativeStroke(directNoFill)).toBeUndefined();
+
+    const linkedNoStyle = strokedPolylineCtx();
+    renderChart(linkedNoStyle.ctx, model(null, { lineHidden: true, lineNoStyle: true }), RECT, 1);
+    expect(cumulativeStroke(linkedNoStyle)).toBeDefined();
   });
 
   it('honors direct Pareto cumulative-line width/color and noFill', () => {
@@ -2271,6 +2632,120 @@ describe('ChartEx flat layouts dispatch to semantic renderers', () => {
       .map(text => text.text)
       .filter(text => ['Increase', 'Decrease', 'Total'].includes(text));
     expect(semanticLabels).toEqual(['Increase', 'Decrease', 'Total']);
+  });
+
+  const chartExLegendModel = (
+    chartType: string,
+    localStyle: ChartSeries['chartexStyle'],
+    linkedStyle: ChartModel['chartexDataPointStyle'] = {
+      lineColors: ['AA0000'], lineWidthEmu: 12700,
+    },
+  ): ChartModel => {
+    const owner = series({
+      name: 'Authored', values: [3, 2, 1], chartexStyle: localStyle,
+    });
+    const common = {
+      showLegend: true,
+      legendPos: 'r' as const,
+      chartexDataPointStyle: linkedStyle,
+    };
+    switch (chartType) {
+      case 'histogram':
+        return baseModel({
+          ...common, chartType, series: [owner], chartexHistogramBinning: { binCount: 2 },
+        });
+      case 'waterfall':
+        return baseModel({
+          ...common, chartType, categories: ['A', 'B', 'C'], series: [owner], subtotalIndices: [2],
+        });
+      case 'funnel':
+        return baseModel({
+          ...common, chartType, categories: ['A', 'B', 'C'], series: [owner],
+        });
+      case 'boxWhisker':
+        return baseModel({
+          ...common,
+          chartType,
+          series: [series({ name: 'Authored', values: [] })],
+          chartexBox: {
+            categories: ['A'],
+            series: [{
+              name: 'Authored', color: '4472C4', chartexStyle: localStyle,
+              valuesByCategory: [[1, 2, 3]], meanMarker: false, meanLine: false,
+              showOutliers: false, showNonoutliers: false, quartileMethod: 'inclusive',
+            }],
+          },
+        });
+      case 'sunburst':
+        return baseModel({
+          ...common,
+          chartType,
+          series: [owner],
+          chartexSunburst: { rows: [{ path: ['Branch', 'Leaf'], size: 3 }] },
+        });
+      case 'treemap':
+        return baseModel({
+          ...common,
+          chartType,
+          series: [owner],
+          chartexTreemap: {
+            parentLabelLayout: 'none', rows: [{ path: ['Branch', 'Leaf'], size: 3 }],
+          },
+        });
+      default:
+        return baseModel({
+          ...common, chartType: 'clusteredColumn', categories: ['A'], series: [owner],
+        });
+    }
+  };
+
+  it.each([
+    'clusteredColumn', 'histogram', 'waterfall', 'funnel',
+    'boxWhisker', 'sunburst', 'treemap',
+  ])('%s legend uses the same direct ChartEx outline as its plotted mark', chartType => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, chartExLegendModel(chartType, {
+      lineColors: ['123456'], lineWidthEmu: 25400, lineDash: 'dash',
+      lineCap: 'rnd', lineJoin: 'bevel',
+    }), RECT, 1);
+
+    const keys = rec.strokeRects.filter(rect => rect.w <= 7 && rect.h <= 7);
+    expect(keys.length).toBeGreaterThan(0);
+    expect(keys.every(rect =>
+      rect.ss.toLowerCase() === '#123456'
+      && rect.lw === 2
+      && rect.dash.length > 0
+      && rect.cap === 'round'
+      && rect.join === 'bevel'
+    )).toBe(true);
+  });
+
+  it.each([
+    'clusteredColumn', 'histogram', 'waterfall', 'funnel',
+    'boxWhisker', 'sunburst', 'treemap',
+  ])('%s legend keeps a direct ChartEx outline noFill authoritative', chartType => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, chartExLegendModel(chartType, { lineHidden: true }), RECT, 1);
+    expect(rec.strokeRects.filter(rect => rect.w <= 7 && rect.h <= 7)).toHaveLength(0);
+  });
+
+  it.each([
+    ['clusteredColumn', false],
+    ['histogram', false],
+    ['waterfall', false],
+    ['funnel', false],
+    ['boxWhisker', true],
+    ['sunburst', false],
+    ['treemap', true],
+  ] as const)('%s legend preserves its semantic rule for linked NoStyle: %s', (chartType, expected) => {
+    const rec = recordingCtx();
+    renderChart(
+      rec.ctx,
+      chartExLegendModel(chartType, null, { lineHidden: true, lineNoStyle: true }),
+      RECT,
+      1,
+    );
+    expect(rec.strokeRects.some(rect => rect.w <= 7 && rect.h <= 7)).toBe(expected);
   });
 });
 
@@ -2541,7 +3016,7 @@ describe('CH7 — line/area series honor a secondary value axis (§21.2.2.*)', (
 // smooth (`<c:ser><c:smooth>`), and honors the chartSpace `dispBlanksAs` value
 // when deciding how null cells break/span/zero the plotted line.
 
-interface ArcCall { x: number; y: number; r: number }
+interface ArcCall { x: number; y: number; r: number; fillStyle: string }
 interface FillRectCall { x: number; y: number; w: number; h: number }
 
 /** Recording context that captures the primitives markers / smooth / error
@@ -2602,7 +3077,10 @@ function markerRecordingCtx(): {
         case 'lineTo':
           return (x: number, y: number) => push(x, y);
         case 'arc':
-          return (x: number, y: number, rad: number) => { arcs.push({ x, y, r: rad }); push(x, y); };
+          return (x: number, y: number, rad: number) => {
+            arcs.push({ x, y, r: rad, fillStyle: String(state.fillStyle) });
+            push(x, y);
+          };
         case 'fillRect':
           return (x: number, y: number, w: number, h: number) => fillRects.push({ x, y, w, h });
         case 'fill':
@@ -2677,6 +3155,63 @@ describe('CH9 — line/area consume marker detail (§21.2.2.32)', () => {
       expect(markerArcs.length).toBe(3);
     });
   }
+
+  it('uses the authored marker-outline width independently from marker size', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: ['A', 'B'],
+      catAxisHidden: true,
+      valAxisHidden: true,
+      series: [series({
+        values: [3, 5],
+        showMarker: true,
+        markerSymbol: 'circle',
+        markerSize: 7,
+        markerFill: 'FFFFFF',
+        markerLine: '1696D2',
+        markerLineWidthEmu: 25400,
+        lineColor: '1696D2',
+        lineWidthEmu: 25400,
+      })],
+    }), RECT, 1);
+
+    const blueStrokes = rec.strokes.filter(stroke =>
+      stroke.strokeStyle.toLowerCase() === '#1696d2'
+    );
+    // The series path and both marker outlines share the authored 2pt stroke.
+    expect(blueStrokes.length).toBe(3);
+    expect(blueStrokes.every(stroke => stroke.lineWidth === 2)).toBe(true);
+  });
+
+  it('does not revive a noFill series line in the legend from its width or dash', () => {
+    const rec = strokedPolylineCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: ['A', 'B'],
+      showLegend: true,
+      legendPos: 'r',
+      catAxisHidden: true,
+      valAxisHidden: true,
+      catAxisLineHidden: true,
+      valAxisLineHidden: true,
+      series: [series({
+        name: 'Hidden stroke',
+        values: [3, 5],
+        lineHidden: true,
+        lineWidthEmu: 25400,
+        chartexStyle: {
+          lineHidden: true,
+          lineWidthEmu: 25400,
+          lineDash: 'dash',
+          lineCap: 'rnd',
+          lineJoin: 'bevel',
+        },
+      })],
+    }), RECT, 1);
+
+    expect(rec.strokes).toHaveLength(0);
+  });
 });
 
 describe('CH9 — stacked-area markers/labels sit on the fill\'s band top (§21.2.2.32)', () => {
@@ -2831,6 +3366,67 @@ describe('CH9 — scatter axis crossing and tick-label position (§21.2.2.207)',
 });
 
 describe('CH9 — bubble scale and numeric-X trendlines', () => {
+  it('uses the parsed per-point palette for a single bubble series', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'bubble',
+      categories: ['1', '2', '3'],
+      series: [series({
+        values: [1, 2, 3],
+        bubbleSizes: [100, 400, 900],
+        dataPointColors: ['4472C4', 'ED7D31', 'A5A5A5'],
+      })],
+      catAxisMin: 0,
+      catAxisMax: 4,
+      valMin: 0,
+      valMax: 4,
+    }), RECT, 1);
+
+    expect(rec.arcs.map(arc => arc.fillStyle)).toEqual(['#4472C4', '#ED7D31', '#A5A5A5']);
+  });
+
+  it('keeps series noFill over varyColors while point formatting stays more specific', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'bubble',
+      categories: ['1', '2', '3'],
+      series: [series({
+        name: 'Hidden fill',
+        color: '00000000',
+        values: [1, 2, 3],
+        bubbleSizes: [100, 400, 900],
+        dataPointColors: [null, 'FF0000', '00000000'],
+      })],
+      showLegend: true,
+      legendPos: 'r',
+      catAxisMin: 0,
+      catAxisMax: 4,
+      valMin: 0,
+      valMax: 4,
+    }), RECT, 1);
+
+    expect(rec.arcs.slice(0, 3).map(arc => arc.fillStyle))
+      .toEqual(['#00000000', '#FF0000', '#00000000']);
+    // The one-series legend key uses the same authored transparent series fill;
+    // varyColors does not silently revive it with a theme accent.
+    expect(rec.arcs.at(-1)?.fillStyle).toBe('#00000000');
+  });
+
+  it('uses one automatic numeric-axis density for equal X and Y bubble ranges', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'bubble',
+      categories: ['1', '2', '3'],
+      series: [series({ values: [1, 2, 3], bubbleSizes: [100, 400, 900] })],
+    }), { x: 0, y: 0, w: 600, h: 360 }, 1);
+
+    // Both automatic numeric axes use 0..3.5 at 0.5 intervals. Previously the
+    // horizontal axis ended at 3.5 while the vertical axis independently chose
+    // 0..4, despite having the same source range.
+    expect(rec.texts.filter(text => text.text === '3.5')).toHaveLength(2);
+    expect(rec.texts.some(text => text.text === '4')).toBe(false);
+  });
+
   it('applies bubbleScale to the default maximum bubble diameter', () => {
     const render = (bubbleScale: number) => {
       const rec = markerRecordingCtx();
@@ -3240,6 +3836,267 @@ describe('CH11 — line/area/scatter data labels honor <c:dLblPos> (§21.2.2.48)
     const lbl = valLabel(rec);
     expect(lbl.align).toBe('center');  // 't' wins over series 'r'
     expect(lbl.baseline).toBe('bottom');
+  });
+
+  it('line: endpoint labels stay outside the plot and clear authored markers', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: ['Start', 'End'],
+      catAxisCrossBetween: 'midCat',
+      plotAreaManualLayout: {
+        layoutTarget: 'inner', xMode: 'edge', yMode: 'edge',
+        x: 0.2, y: 0.2, w: 0.6, h: 0.6,
+      },
+      series: [series({
+        name: 'Slope', values: [40, 60], showMarker: true,
+        markerSymbol: 'circle', markerSize: 7,
+        dataLabelOverrides: [
+          { idx: 0, text: 'Left endpoint', position: 'l', fontSizeHpt: 1200 },
+          { idx: 1, text: 'Right endpoint', position: 'r', fontSizeHpt: 1200 },
+        ],
+      })],
+    }), RECT, 1);
+
+    const markers = rec.arcs.filter(arc => Math.abs(arc.r - 3.5) < 1e-6);
+    expect(markers).toHaveLength(2);
+    const left = rec.texts.find(call => call.text === 'Left endpoint');
+    const right = rec.texts.find(call => call.text === 'Right endpoint');
+    expect(left).toBeDefined();
+    expect(right).toBeDefined();
+    // fillText x is the text's right edge for `l`, left edge for `r`.
+    // Office separates each label from the marker center by marker radius +
+    // half an em: 3.5pt + 6pt at the authored 12pt label size.
+    expect(left?.x).toBeCloseTo(markers[0].x - 9.5, 4);
+    expect(right?.x).toBeCloseTo(markers[1].x + 9.5, 4);
+    expect(left?.x).toBeLessThan(RECT.w * 0.2);
+    expect(right?.x).toBeGreaterThan(RECT.w * 0.8);
+  });
+
+  it('line: custom rich label runs stay inline with per-run size and weight', () => {
+    const rich = recordingCtx();
+    const model = baseModel({
+      chartType: 'line',
+      categories: ['Start'],
+      series: [series({
+        name: 'Employer', values: [36], showMarker: true,
+        markerSymbol: 'circle', markerSize: 7,
+        dataLabelOverrides: [{
+          idx: 0,
+          text: 'Employer 36.0%',
+          position: 'l',
+          fontColor: '111111',
+          fontSizeHpt: 1200,
+          fontBold: true,
+          richRuns: [
+            {
+              text: 'Employer', fontSizeHpt: 1200, bold: true,
+              color: '1696D2', fontFace: 'Lato',
+            },
+            { text: ' 36.0%', fontSizeHpt: 1100, bold: false, color: '333333' },
+          ],
+        }],
+      })],
+    });
+    renderChart(rich.ctx, model, RECT, 1);
+
+    const employer = rich.texts.find(text => text.text === 'Employer');
+    const value = rich.texts.find(text => text.text === ' 36.0%');
+    expect(employer).toMatchObject({ fillStyle: '#1696D2', align: 'left', baseline: 'middle' });
+    expect(value).toMatchObject({ fillStyle: '#333333', align: 'left', baseline: 'middle' });
+    expect(employer?.font).toContain('bold 12px "Lato"');
+    expect(value?.font).toContain('11px sans-serif');
+    expect(value?.font).not.toContain('bold ');
+    expect(value?.x).toBeCloseTo((employer?.x ?? 0) + (employer?.width ?? 0), 6);
+
+    // The rich line is measured as one object. Its final right edge stays at
+    // the exact point-label anchor used by the established flattened path.
+    const plain = recordingCtx();
+    const plainModel = structuredClone(model);
+    delete plainModel.series[0].dataLabelOverrides?.[0].richRuns;
+    renderChart(plain.ctx, plainModel, RECT, 1);
+    const flattened = plain.texts.find(text => text.text === 'Employer 36.0%');
+    expect((value?.x ?? 0) + (value?.width ?? 0)).toBeCloseTo(flattened?.x ?? 0, 6);
+  });
+
+  it('line: custom rich labels are bounded to 4096 scalars and four lines', () => {
+    const paragraph = 'x'.repeat(1100);
+    const text = Array.from({ length: 5 }, () => paragraph).join('\n');
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line', categories: ['A'],
+      series: [series({
+        values: [1],
+        dataLabelOverrides: [{
+          idx: 0, text, position: 'ctr',
+          richRuns: [{ text, fontSizeHpt: 1000 }],
+        }],
+      })],
+    }), RECT, 1);
+
+    const painted = rec.texts.filter(call => /^x+$/.test(call.text));
+    expect(painted).toHaveLength(4);
+    expect(painted.reduce((count, call) => count + Array.from(call.text).length, 0))
+      .toBeLessThanOrEqual(4096);
+  });
+
+  it('line: bounds a public rich label before whole-string normalization', () => {
+    const guarded = new String('x'.repeat(5000));
+    Object.defineProperty(guarded, 'replace', {
+      value: () => { throw new Error('must not normalize the unbounded source'); },
+    });
+    const rec = recordingCtx();
+    expect(() => renderChart(rec.ctx, baseModel({
+      chartType: 'line', categories: ['A'],
+      series: [series({
+        values: [1],
+        dataLabelOverrides: [{
+          idx: 0, text: 'bounded', position: 'ctr',
+          richRuns: [{ text: guarded as unknown as string, fontSizeHpt: 1000 }],
+        }],
+      })],
+    }), RECT, 1)).not.toThrow();
+
+    expect(rec.texts.filter(call => /^x+$/.test(call.text)))
+      .toHaveLength(1);
+    expect(rec.texts.find(call => /^x+$/.test(call.text))?.text)
+      .toHaveLength(4096);
+  });
+
+  it('line: caps an adversarial public rich-run array before scanning empty runs', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line', categories: ['A'],
+      series: [series({
+        values: [1],
+        dataLabelOverrides: [{
+          idx: 0, text: 'bounded', position: 'ctr',
+          richRuns: [
+            ...Array.from({ length: 4096 }, () => ({ text: '' })),
+            { text: 'must-not-be-scanned' },
+          ],
+        }],
+      })],
+    }), RECT, 1);
+
+    expect(rec.texts.map(call => call.text)).not.toContain('must-not-be-scanned');
+  });
+
+  it.each([
+    [99, '10px'],
+    [100, '1px'],
+    [400001, '10px'],
+  ] as const)('line: safely resolves public rich-run font size %i', (fontSizeHpt, expectedFont) => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line', categories: ['A'],
+      series: [series({
+        values: [1],
+        dataLabelOverrides: [{
+          idx: 0, text: 'Safe', position: 'ctr', fontSizeHpt: 1000,
+          richRuns: [{ text: 'Safe', fontSizeHpt }],
+        }],
+      })],
+    }), RECT, 1);
+
+    expect(rec.texts.find(call => call.text === 'Safe')?.font).toContain(expectedFont);
+  });
+
+  it('line: accepts the ST_TextFontSize upper bound exactly', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line', categories: ['A'],
+      series: [series({
+        values: [1],
+        dataLabelOverrides: [{
+          idx: 0, text: 'Huge', position: 'ctr', fontSizeHpt: 1000,
+          richRuns: [{ text: 'Huge', fontSizeHpt: 400000 }],
+        }],
+      })],
+    }), RECT, 1);
+
+    expect(rec.texts.find(call => call.text === 'Huge')?.font).toContain('4000px');
+  });
+
+  it('scatter: custom rich label runs use the shared bounded point-label path', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'scatter', categories: ['2'],
+      series: [series({
+        values: [3],
+        dataLabelOverrides: [{
+          idx: 0, text: 'A 3', position: 'r',
+          richRuns: [
+            { text: 'A', fontSizeHpt: 1200, bold: true },
+            { text: ' 3', fontSizeHpt: 1100, bold: false },
+          ],
+        }],
+      })],
+    }), RECT, 1);
+
+    expect(rec.texts.find(call => call.text === 'A')?.font).toContain('bold 12px');
+    expect(rec.texts.find(call => call.text === ' 3')?.font).toContain('11px');
+  });
+
+  it.each(['line', 'area', 'scatter'] as const)(
+    '%s: rich label run faces resolve major/minor theme references and concrete faces',
+    (chartType) => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType,
+        categories: ['1'],
+        themeMajorFontLatin: 'Major Theme',
+        themeMinorFontLatin: 'Minor Theme',
+        dataLabelFontFace: '+mn-lt',
+        series: [series({
+          values: [1],
+          dataLabelOverrides: [{
+            idx: 0,
+            text: 'Major Minor Concrete',
+            position: 'ctr',
+            richRuns: [
+              { text: 'Major', fontFace: '+mj-lt' },
+              { text: ' Minor', fontFace: '+mn-lt' },
+              { text: ' Concrete', fontFace: 'Direct Face' },
+            ],
+          }],
+        })],
+      }), RECT, 1);
+
+      expect(rec.texts.find(call => call.text === 'Major')?.font)
+        .toContain('"Major Theme"');
+      expect(rec.texts.find(call => call.text === ' Minor')?.font)
+        .toContain('"Minor Theme"');
+      expect(rec.texts.find(call => call.text === ' Concrete')?.font)
+        .toContain('"Direct Face"');
+    },
+  );
+
+  it('line: all series geometry is painted before the chart-wide label layer', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: ['A', 'B'],
+      series: [
+        series({
+          name: 'Earlier', values: [40, 60], lineColor: 'FF0000',
+          dataLabelOverrides: [{ idx: 0, text: 'Earlier label', position: 'l' }],
+        }),
+        series({
+          name: 'Later', values: [60, 40], lineColor: '0000FF',
+          dataLabelOverrides: [{ idx: 0, text: 'Later label', position: 'l' }],
+        }),
+      ],
+    }), RECT, 1);
+
+    const blueSeriesStroke = rec.paintEvents.findIndex(
+      event => event.kind === 'stroke' && event.strokeStyle === '#0000FF',
+    );
+    const firstDataLabel = rec.paintEvents.findIndex(
+      event => event.kind === 'text' && event.text.endsWith('label'),
+    );
+    expect(blueSeriesStroke).toBeGreaterThanOrEqual(0);
+    expect(firstDataLabel).toBeGreaterThan(blueSeriesStroke);
   });
 
   it('area: the default position is ctr (centered on the point) per the areaChart group', () => {
@@ -3746,6 +4603,40 @@ describe('CH8 — pie / doughnut geometry', () => {
       .toBe(true);
   });
 
+  it.each(['pie', 'doughnut'] as const)(
+    '%s custom rich labels paint inline runs with theme-resolved faces',
+    chartType => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType,
+        categories: ['A'],
+        themeMajorFontLatin: 'Major Theme',
+        themeMinorFontLatin: 'Minor Theme',
+        series: [series({
+          values: [1],
+          dataLabelOverrides: [{
+            idx: 0,
+            text: 'Major Minor',
+            position: 'ctr',
+            richRuns: [
+              { text: 'Major', fontFace: '+mj-lt', color: '112233' },
+              { text: ' Minor', fontFace: '+mn-lt', color: '445566' },
+            ],
+          }],
+        })],
+      }), RECT, 1);
+
+      expect(rec.texts.find(call => call.text === 'Major'))
+        .toMatchObject({ fillStyle: '#112233' });
+      expect(rec.texts.find(call => call.text === 'Major')?.font)
+        .toContain('"Major Theme"');
+      expect(rec.texts.find(call => call.text === ' Minor'))
+        .toMatchObject({ fillStyle: '#445566' });
+      expect(rec.texts.find(call => call.text === ' Minor')?.font)
+        .toContain('"Minor Theme"');
+    },
+  );
+
   it('inside pie labels respect tiny-slice capacity', () => {
     const rec = ringRecordingCtx();
     renderChart(rec.ctx, pieModel({
@@ -3857,13 +4748,21 @@ interface SegRecorded { ctx: CanvasRenderingContext2D; segs: Seg[]; texts: TextC
 
 function strokedPolylineCtx(): {
   ctx: CanvasRenderingContext2D;
-  strokes: Array<{ points: Array<{ x: number; y: number }>; ss: string; lw: number }>;
+  strokes: Array<{
+    points: Array<{ x: number; y: number }>; ss: string; lw: number; dash: number[];
+    cap: string; join: string;
+  }>;
 } {
-  const strokes: Array<{ points: Array<{ x: number; y: number }>; ss: string; lw: number }> = [];
+  const strokes: Array<{
+    points: Array<{ x: number; y: number }>; ss: string; lw: number; dash: number[];
+    cap: string; join: string;
+  }> = [];
   let path: Array<{ x: number; y: number }> = [];
+  let dash: number[] = [];
   const state: Record<string, unknown> = {
     font: '10px sans-serif', fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
     textAlign: 'start', textBaseline: 'alphabetic', globalAlpha: 1,
+    lineCap: 'butt', lineJoin: 'miter',
   };
   const handler: ProxyHandler<Record<string, unknown>> = {
     get(_target, prop: string) {
@@ -3879,9 +4778,14 @@ function strokedPolylineCtx(): {
               points: path.map(point => ({ ...point })),
               ss: String(state.strokeStyle),
               lw: Number(state.lineWidth),
+              dash: [...dash],
+              cap: String(state.lineCap),
+              join: String(state.lineJoin),
             });
           }
         };
+        case 'setLineDash': return (value: number[]) => { dash = [...value]; };
+        case 'getLineDash': return () => [...dash];
         case 'createLinearGradient': case 'createRadialGradient':
           return () => ({ addColorStop() {} });
         default: return () => undefined;
@@ -4298,6 +5202,19 @@ describe('automatic linear-axis bounds reach the shared planner', () => {
   it('keeps an exact 1.2 positive line range offset and pins just above it to zero', () => {
     expect(Math.min(...numericLabels([10, 12]))).toBeGreaterThan(0);
     expect(numericLabels([10, 12.000_001])).toContain(0);
+  });
+
+  it('line charts use the shared explicit-span unit when vertical bounds omit majorUnit', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line', categories: ['A', 'B'],
+      series: [series({ values: [0.5, 4.5] })],
+      valMin: 0, valMax: 5, valAxisMajorUnit: null,
+      valAxisMajorGridlines: false,
+    }), RECT, 1);
+    const numeric = rec.texts.map(item => Number(item.text)).filter(Number.isFinite);
+    expect(numeric).toContain(0.5);
+    expect(numeric).toContain(4.5);
   });
 
   it('area geometry uses an authored non-zero minimum', () => {
@@ -5194,6 +6111,38 @@ function pieCalloutModel(over: Partial<ChartModel> = {}): ChartModel {
 }
 
 describe('CH14 — pie callout data labels', () => {
+  it('paints a custom rich callout from the same measured inline block', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'pie',
+      categories: ['Only'],
+      themeMajorFontLatin: 'Major Theme',
+      themeMinorFontLatin: 'Minor Theme',
+      series: [series({
+        values: [1],
+        dataLabelOverrides: [{
+          idx: 0,
+          text: 'Rich Callout',
+          richRuns: [
+            { text: 'Rich', fontFace: '+mj-lt', color: '112233' },
+            { text: ' Callout', fontFace: '+mn-lt', color: '445566' },
+          ],
+          manualLayout: { xMode: 'edge', yMode: 'edge', x: 0.25, y: 0.25, w: 0.2, h: 0.1 },
+          labelBox: { fill: 'ABCDEF', borderColor: '123456' },
+        }],
+      })],
+    }), RECT, 1);
+
+    expect(rec.rects.some(box => box.fs === '#ABCDEF' && box.w === 128 && box.h === 36))
+      .toBe(true);
+    expect(rec.texts.find(call => call.text === 'Rich'))
+      .toMatchObject({ fillStyle: '#112233' });
+    expect(rec.texts.find(call => call.text === 'Rich')?.font)
+      .toContain('"Major Theme"');
+    expect(rec.texts.find(call => call.text === ' Callout'))
+      .toMatchObject({ fillStyle: '#445566' });
+  });
+
   it('enters rich pie label layout for a per-point label without series defaults', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, baseModel({
@@ -5620,6 +6569,93 @@ describe('CH15 — chartEx box-and-whisker', () => {
     });
   }
 
+  it('preserves the authored box-series outline on the filled legend key', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, boxModel({
+      showLegend: true,
+      legendPos: 'r',
+      legendFontSizeHpt: 1500,
+      chartexBox: {
+        categories: ['6'],
+        series: [{
+          name: 'Super Duper MPG',
+          color: 'FF00FF',
+          lineColor: '000000',
+          lineWidthEmu: 12700,
+          valuesByCategory: [[10, 20, 30]],
+          meanMarker: true,
+          meanLine: false,
+          showOutliers: true,
+          showNonoutliers: false,
+          quartileMethod: 'exclusive',
+        }],
+      },
+    }), RECT, 1);
+
+    const key = rec.rects.find(rect =>
+      rect.fs === '#FF00FF' && Math.abs(rect.w - 7) < 0.01 && Math.abs(rect.h - 7) < 0.01
+    );
+    expect(key).toBeDefined();
+    expect(rec.strokeRects.some(rect =>
+      rect.ss === '#000000'
+      && rect.lw === 1
+      && Math.abs(rect.w - 6) < 0.01
+      && Math.abs(rect.h - 6) < 0.01
+    )).toBe(true);
+  });
+
+  it('wraps a long side-legend series name into the measured two-line band', () => {
+    // Approximate a narrow Office theme face: the first two words fit the
+    // bounded side column while the complete quoted name does not.
+    const rec = recordingCtx((text, fontPx) => Array.from(text).length * fontPx * 0.48);
+    renderChart(rec.ctx, boxModel({
+      showLegend: true,
+      legendPos: 'r',
+      legendFontSizeHpt: 1500,
+      chartexBox: {
+        categories: ['6'],
+        series: [{
+          name: '"Super Duper MPG"',
+          color: 'FF00FF',
+          valuesByCategory: [[10, 20, 30]],
+          meanMarker: true,
+          meanLine: false,
+          showOutliers: true,
+          showNonoutliers: false,
+          quartileMethod: 'exclusive',
+        }],
+      },
+    }), { x: 0, y: 0, w: 494, h: 288 }, 4 / 3);
+
+    const legendText = rec.texts
+      .filter(text => text.text.includes('Super') || text.text.includes('MPG'))
+      .map(text => text.text);
+    expect(legendText).toEqual(['"Super Duper', 'MPG"']);
+    expect(legendText.some(text => text.includes('…'))).toBe(false);
+  });
+
+  it('keeps Chart Style NoStyle distinct from an explicit noFill on the box legend key', () => {
+    const noStyle = recordingCtx();
+    renderChart(noStyle.ctx, boxModel({
+      showLegend: true,
+      legendPos: 'r',
+      chartexDataPointStyle: { lineHidden: true, lineNoStyle: true },
+    }), RECT, 1);
+    expect(noStyle.strokeRects.some(rect =>
+      Math.abs(rect.w - 6) < 0.01 && Math.abs(rect.h - 6) < 0.01
+    )).toBe(true);
+
+    const explicitNoFill = recordingCtx();
+    renderChart(explicitNoFill.ctx, boxModel({
+      showLegend: true,
+      legendPos: 'r',
+      chartexDataPointStyle: { lineHidden: true },
+    }), RECT, 1);
+    expect(explicitNoFill.strokeRects.some(rect =>
+      Math.abs(rect.w - 6) < 0.01 && Math.abs(rect.h - 6) < 0.01
+    )).toBe(false);
+  });
+
   it('labels the value axis with Excel nice-rounded gridline values including a negative bound', () => {
     const rec = markerRecordingCtx();
     renderChart(rec.ctx, boxModel(), RECT, 1);
@@ -5631,6 +6667,39 @@ describe('CH15 — chartEx box-and-whisker', () => {
     expect(labels).toContain('0');
     expect(labels.some(l => l.startsWith('-'))).toBe(true);
     expect(labels.some(l => Number(l) >= 130)).toBe(true);
+  });
+
+  it.each([
+    { name: 'wide range', values: [10, 466], rect: { x: 0, y: 0, w: 371, h: 216 }, step: 50, max: 500 },
+    { name: 'ordinary range', values: [0, 27], rect: { x: 0, y: 0, w: 530, h: 396 }, step: 5, max: 30 },
+    { name: 'fence boundary', values: [0, 12.0001], rect: { x: 0, y: 0, w: 530, h: 396 }, step: 2, max: 14 },
+  ])('uses the compact Office-observed automatic box axis for $name', ({ values, rect, step, max }) => {
+    const rec = markerRecordingCtx();
+    const model = boxModel({
+      title: null,
+      chartexBox: {
+        categories: ['A'],
+        series: [{
+          name: 'S1',
+          color: 'ED7D31',
+          valuesByCategory: [values],
+          meanMarker: false,
+          meanLine: false,
+          showOutliers: false,
+          showNonoutliers: false,
+          quartileMethod: 'exclusive',
+        }],
+      },
+    });
+    renderChart(rec.ctx, model, rect, 1);
+
+    const ticks = rec.texts
+      .map(text => Number(text.text))
+      .filter(Number.isFinite)
+      .sort((left, right) => left - right);
+    expect(ticks[0]).toBe(0);
+    expect(ticks.at(-1)).toBe(max);
+    expect(ticks[1] - ticks[0]).toBeCloseTo(step, 8);
   });
 
   it('draws the authored value-axis title, rule, gridline style, and explicit 0.2 major unit', () => {
@@ -5668,6 +6737,20 @@ describe('CH15 — chartEx box-and-whisker', () => {
     ).length).toBeGreaterThanOrEqual(10);
   });
 
+  it('derives the omitted box-axis major unit from authored min/max bounds', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, boxModel({
+      valMin: 1,
+      valMax: 3,
+      valAxisMajorUnit: null,
+      valAxisFormatCode: '0.0',
+    }), RECT, 1);
+
+    expect(rec.texts.map(text => text.text)).toEqual(
+      expect.arrayContaining(['1.0', '1.2', '1.4', '1.6', '1.8', '2.0', '2.2', '2.4', '2.6', '2.8', '3.0']),
+    );
+  });
+
   it('uses the authored ChartEx value-axis font size for numeric tick labels', () => {
     const rec = ringRecordingCtx();
     renderChart(rec.ctx, boxModel({
@@ -5677,12 +6760,69 @@ describe('CH15 — chartEx box-and-whisker', () => {
       valAxisFormatCode: '0.0',
       valAxisFontSizeHpt: 900,
       valAxisFontFace: 'Calibri',
+      valAxisFontItalic: true,
+      valAxisTitle: 'Miles per Gallon',
+      valAxisTitleFontSizeHpt: 1200,
+      valAxisTitleFontBold: false,
+      valAxisTitleFontItalic: true,
     }), RECT, 1);
 
     const tick = rec.fontTexts.find(text => text.text === '1.0');
     expect(tick).toBeDefined();
     expect(tick?.font).toContain('9px');
     expect(tick?.font).toContain('Calibri');
+    expect(tick?.font).toContain('italic');
+    const title = rec.fontTexts.find(text => text.text === 'Miles per Gallon');
+    expect(title?.font).toContain('italic');
+    expect(title?.font).not.toContain('bold');
+  });
+
+  it('uses the authored category-axis rule and keeps both axis labels clear of cross ticks', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, boxModel({
+      valMin: 0,
+      valMax: 500,
+      valAxisMajorUnit: 50,
+      valAxisFormatCode: '0.0',
+      valAxisFontSizeHpt: 1200,
+      valAxisLineColor: '000000',
+      valAxisLineWidthEmu: 12700,
+      valAxisMajorTickMark: 'cross',
+      catAxisFontSizeHpt: 1000,
+      catAxisLineColor: '000000',
+      catAxisLineWidthEmu: 12700,
+      catAxisMajorTickMark: 'cross',
+    }), RECT, 1);
+
+    const horizontalAxis = rec.segs.find(segment =>
+      Math.abs(segment.y0 - segment.y1) < 0.5 &&
+      Math.abs(segment.x1 - segment.x0) > 100 &&
+      segment.ss.toLowerCase() === '#000000'
+    );
+    const verticalAxis = rec.segs.find(segment =>
+      Math.abs(segment.x0 - segment.x1) < 0.5 &&
+      Math.abs(segment.y1 - segment.y0) > 100 &&
+      segment.ss.toLowerCase() === '#000000'
+    );
+    expect(horizontalAxis).toBeDefined();
+    expect(verticalAxis).toBeDefined();
+    expect(horizontalAxis?.lw).toBe(1);
+
+    const categoryTicks = rec.segs.filter(segment =>
+      Math.abs(segment.x0 - segment.x1) < 0.5 &&
+      Math.abs(segment.y1 - segment.y0) >= 11.5 &&
+      Math.abs((segment.y0 + segment.y1) / 2 - (horizontalAxis?.y0 ?? 0)) < 0.5 &&
+      segment.ss.toLowerCase() === '#000000'
+    );
+    expect(categoryTicks.length).toBeGreaterThanOrEqual(1);
+
+    const categoryLabel = rec.texts.find(text => text.text === 'Category 1');
+    expect(categoryLabel).toBeDefined();
+    expect((categoryLabel?.y ?? 0) - (horizontalAxis?.y0 ?? 0)).toBeGreaterThanOrEqual(8);
+
+    const zeroLabel = rec.texts.find(text => text.text === '0.0');
+    expect(zeroLabel).toBeDefined();
+    expect((verticalAxis?.x0 ?? 0) - (zeroLabel?.x ?? 0)).toBeCloseTo(12);
   });
 
   it('places the value axis from measured tick-label width instead of a fixed chart-width gutter', () => {
@@ -5837,7 +6977,33 @@ describe('CH15 — chartEx box-and-whisker', () => {
     expect(count('cross') - count('none')).toBe(4);
   });
 
-  it('uses the Chart Style marker size in points for box sample dots', () => {
+  it('draws 6pt major ticks and shorter 4pt minor ticks', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, boxModel({
+      valMin: 3,
+      valMax: 23,
+      valAxisMajorUnit: 10,
+      valAxisMinorUnit: 4,
+      valAxisMajorGridlines: false,
+      valAxisMinorGridlines: false,
+      valAxisMajorTickMark: 'out',
+      valAxisMinorTickMark: 'out',
+      valAxisLineColor: 'FF00FF',
+      valAxisLineWidthEmu: 9525,
+    }), RECT, 2);
+
+    const tickLengths = rec.segs
+      .filter(segment =>
+        segment.ss.toLowerCase() === '#ff00ff'
+        && Math.abs(segment.y1 - segment.y0) < 0.01
+        && Math.abs(segment.x1 - segment.x0) <= 20
+      )
+      .map(segment => Math.abs(segment.x1 - segment.x0));
+    expect(tickLengths).toContain(12);
+    expect(tickLengths).toContain(8);
+  });
+
+  it('uses Excel box-and-whisker semantic sizes for sample dots and the mean marker', () => {
     const rec = markerRecordingCtx();
     renderChart(rec.ctx, boxModel({
       chartexMarkerSizePt: 6,
@@ -5845,14 +7011,28 @@ describe('CH15 — chartEx box-and-whisker', () => {
         categories: ['Category 1'],
         series: [{
           name: 'S1', color: 'ED7D31', valuesByCategory: [[1, 2, 3]],
-          meanMarker: false, meanLine: false, showOutliers: true, showNonoutliers: true,
+          meanMarker: true, meanLine: false, showOutliers: true, showNonoutliers: true,
           quartileMethod: 'exclusive',
         }],
       },
     }), RECT, 2);
 
     expect(rec.arcs).toHaveLength(3);
-    expect(rec.arcs.every(arc => arc.r === 6)).toBe(true);
+    // Office's vector output uses 3pt-diameter observation dots even though
+    // the linked Chart Style's generic marker layout says size=6 here.
+    expect(rec.arcs.every(arc => arc.r === 3)).toBe(true);
+    const meanCross = rec.segments.find(segment =>
+      segment.length === 4
+      && segment.every((point, index) => index === 0
+        || Math.abs(point.x - segment[0].x) > 0
+        || Math.abs(point.y - segment[0].y) > 0)
+    );
+    expect(meanCross).toBeDefined();
+    // The semantic mean marker is a fixed 6pt square (12px at 2px/pt).
+    expect(Math.abs((meanCross as Array<{ x: number; y: number }>)[1].x - (meanCross as Array<{ x: number; y: number }>)[0].x)).toBe(12);
+    expect(Math.abs((meanCross as Array<{ x: number; y: number }>)[1].y - (meanCross as Array<{ x: number; y: number }>)[0].y)).toBe(12);
+    expect(Math.abs((meanCross as Array<{ x: number; y: number }>)[3].x - (meanCross as Array<{ x: number; y: number }>)[2].x)).toBe(12);
+    expect(Math.abs((meanCross as Array<{ x: number; y: number }>)[3].y - (meanCross as Array<{ x: number; y: number }>)[2].y)).toBe(12);
   });
 
   it('uses the authored Chart Style marker symbol for box sample points', () => {
@@ -6408,6 +7588,29 @@ describe('CH15 — chartEx sunburst', () => {
     });
   }
 
+  it('rejects oversized hierarchy rows and paths before allocating the tree', () => {
+    for (const rows of [
+      Array.from({ length: 10_001 }, (_, index) => ({ path: [`N${index}`], size: 1 })),
+      [{ path: Array.from({ length: 10_001 }, (_, index) => `D${index}`), size: 1 }],
+      [{ path: Array.from({ length: 513 }, (_, index) => `D${index}`), size: 1 }],
+    ]) {
+      const rec = ringRecordingCtx();
+      expect(() => renderChart(rec.ctx, sunburstModel({ chartexSunburst: { rows } }), RECT, 1))
+        .not.toThrow();
+      expect(rec.fontTexts.map(text => text.text)).toContain('(too many data points)');
+      expect(rec.arcs).toEqual([]);
+    }
+  });
+
+  it('handles the bounded wide-tree limit without argument or recursion overflow', () => {
+    const rec = ringRecordingCtx();
+    const rows = Array.from({ length: 10_000 }, (_, index) => ({ path: [`N${index}`], size: 1 }));
+    expect(() => renderChart(rec.ctx, sunburstModel({ chartexSunburst: { rows } }), RECT, 1))
+      .not.toThrow();
+    expect(rec.fontTexts.map(text => text.text)).not.toContain('(too many data points)');
+    expect(rec.arcs.length).toBeGreaterThan(0);
+  });
+
   it('draws three concentric rings (Branch / Stem / Leaf) with distinct radii', () => {
     const rec = ringRecordingCtx();
     renderChart(rec.ctx, sunburstModel(), RECT, 1);
@@ -6655,6 +7858,20 @@ describe('CH15 — chartEx treemap', () => {
       },
     });
   }
+
+  it('atomically rejects a hierarchy whose total path segments exceed the paint cap', () => {
+    const rec = recordingCtx();
+    const model = treemapModel();
+    model.chartexTreemap = {
+      ...model.chartexTreemap,
+      rows: Array.from({ length: 5_001 }, (_, index) => ({
+        path: [`P${index}`, `L${index}`], size: 1,
+      })),
+    };
+    expect(() => renderChart(rec.ctx, model, RECT, 1)).not.toThrow();
+    expect(rec.texts.map(text => text.text)).toContain('(too many data points)');
+    expect(rec.rects).toEqual([]);
+  });
 
   it('draws nested branch and leaf rectangles instead of the unsupported-chart placeholder', () => {
     const rec = recordingCtx();
@@ -6912,6 +8129,106 @@ describe('CH15 — chartEx treemap', () => {
     const labels = rec.texts.map(text => text.text);
     expect(labels).toEqual(expect.arrayContaining(['Group A', 'Group B']));
     expect(labels).not.toEqual(expect.arrayContaining(['Subgroup A1', 'Subgroup B1']));
+  });
+
+  it('separates overlapping parent captions from authored inEnd leaves in a two-level treemap', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'treemap',
+      series: [series({
+        seriesDataLabels: {
+          showVal: false,
+          showCatName: true,
+          showSerName: false,
+          showPercent: false,
+          position: 'inEnd',
+          fontSizeHpt: 900,
+        },
+      })],
+      chartexTreemap: {
+        parentLabelLayout: 'overlapping',
+        rows: [
+          { path: ['Female', 'California'], size: 81_400 },
+          { path: ['Female', 'Indiana'], size: 62_000 },
+          { path: ['Female', 'Pennsylvania'], size: 59_900 },
+          { path: ['Male', 'California'], size: 97_500 },
+          { path: ['Male', 'Indiana'], size: 45_200 },
+          { path: ['Male', 'Pennsylvania'], size: 45_900 },
+        ],
+      },
+    }), RECT, 1);
+
+    const parents = rec.texts.filter(text => text.text === 'Female' || text.text === 'Male');
+    const leaves = rec.texts.filter(text =>
+      text.text === 'California' || text.text === 'Indiana' || text.text === 'Pennsylvania'
+    );
+    expect(parents).toHaveLength(2);
+    expect(leaves).toHaveLength(6);
+    expect(parents.every(text => text.align === 'left' && text.baseline === 'top')).toBe(true);
+    expect(leaves.every(text => text.align === 'left' && text.baseline === 'bottom')).toBe(true);
+    expect([...parents, ...leaves].every(text => text.font?.includes('9px '))).toBe(true);
+    // The top caption band and the lowest available leaf edge are disjoint;
+    // this locks the hierarchy-role split that prevents two labels occupying
+    // the same lower-left anchor.
+    expect(Math.max(...parents.map(text => text.y + 9)))
+      .toBeLessThanOrEqual(Math.min(...leaves.map(text => text.y - 9)));
+  });
+
+  it('maps a treemap outEnd value label to the Office-observed lower-left tile anchor', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'treemap',
+      series: [series({
+        seriesDataLabels: {
+          showVal: true,
+          showCatName: false,
+          showSerName: false,
+          showPercent: false,
+          position: 'outEnd',
+          fontSizeHpt: 1000,
+        },
+      })],
+      chartexTreemap: {
+        parentLabelLayout: 'none',
+        rows: [{ path: ['472'], size: 472 }],
+      },
+    }), RECT, 1);
+
+    const value = rec.texts.find(text => text.text === '472');
+    expect(value).toBeDefined();
+    expect(value).toMatchObject({ align: 'left', baseline: 'bottom' });
+    expect((value as TextCall).x).toBeLessThan(RECT.w / 4);
+    expect((value as TextCall).y).toBeGreaterThan(RECT.h * 0.7);
+  });
+
+  it('keeps an authored 10pt bold treemap leaf label at the DrawingML point-to-pixel size', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'treemap',
+      dataLabelFontFace: 'Aptos Narrow',
+      series: [series({
+        seriesDataLabels: {
+          showVal: true,
+          showCatName: false,
+          showSerName: false,
+          showPercent: false,
+          position: 'outEnd',
+          fontSizeHpt: 1000,
+          fontBold: true,
+        },
+      })],
+      chartexTreemap: {
+        parentLabelLayout: 'none',
+        rows: [{ path: ['42'], size: 42 }],
+      },
+    }), RECT, 4 / 3);
+
+    const label = rec.texts.find(text => text.text === '42');
+    expect(label).toBeDefined();
+    expect(label?.font).toContain('bold ');
+    expect(label?.font).toContain('"Aptos Narrow", Calibri, Arial, sans-serif');
+    const px = Number.parseFloat(/(\d+(?:\.\d+)?)px/.exec(label?.font ?? '')?.[1] ?? '0');
+    expect(px).toBeCloseTo(1000 / 100 * 4 / 3, 6);
   });
 
   it('uses the ChartEx data-point outline on the exact tile boundary', () => {
@@ -7356,9 +8673,9 @@ describe('CH — combo bar+line primary value axis spans BOTH the bars and the p
       ],
     }), RECT, 1);
     const axisMax = Math.max(...numericValLabels(rec));
-    // Bars alone: max category sum 150 → symmetric padding and the ceiling
-    // 1/2/5 ladder produce an axis top of 200.
-    expect(axisMax).toBe(200);
+    // Bars alone: max category sum 150 → the measured ten-interval policy
+    // chooses 20-unit steps and an axis top of 160.
+    expect(axisMax).toBe(160);
   });
 
   it('a negative primary-axis line pulls the axis minimum below the bars', () => {

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -3,7 +3,7 @@
 // scatter, waterfall). Ported from the xlsx implementation with pptx
 // extensions (valMin-aware axis, plotAreaBg, dataPointColors, waterfall).
 
-import type { ChartDataLabelOverride, ChartManualLayout, ChartModel, ChartRect, ChartSeries, ChartSeriesDataLabels, ChartTextBox, ChartTrendline, SecondaryValueAxis } from '../types/chart';
+import type { ChartDataLabelOverride, ChartManualLayout, ChartModel, ChartRect, ChartSeries, ChartSeriesDataLabels, ChartTextBox, ChartTextRun, ChartTrendline, SecondaryValueAxis } from '../types/chart';
 import type { Fill } from '../types/common';
 import {
   AXIS_OUTER_TEXT_MARGIN_PT,
@@ -26,7 +26,7 @@ import {
 } from './layout.js';
 import {
   axisLengthNiceStep,
-  valueAxisScale,
+  niceStep,
   planLinearValueAxis,
   axisFraction,
   logAxisScale,
@@ -120,6 +120,15 @@ function chartFontFamily(
   return face ? `"${face}", Calibri, Arial, sans-serif` : 'sans-serif';
 }
 
+function chartFontCss(
+  fontSizePx: number,
+  fontFamily: string,
+  bold = false,
+  italic = false,
+): string {
+  return `${italic ? 'italic ' : ''}${bold ? 'bold ' : ''}${fontSizePx}px ${fontFamily}`;
+}
+
 /** Chart types whose legend lists one entry per category (data point of the
  *  first series) rather than one entry per series. Excel/PowerPoint draw pie
  *  and doughnut legends this way: each slice gets its own row, colored with
@@ -185,6 +194,7 @@ function drawAxisTitle(
   side: ChartAxisTitleSide,
   fontSizePx: number,
   bold: boolean,
+  italic: boolean,
   color: string,
   // Available run length along the axis (plot width for the bottom cat title,
   // plot height for the rotated val title). Titles longer than the axis are
@@ -198,21 +208,30 @@ function drawAxisTitle(
   chartRect?: ChartRect,
 ): void {
   ctx.save();
-  ctx.font = `${bold ? 'bold ' : ''}${fontSizePx}px ${fontFamily}`;
+  ctx.font = chartFontCss(fontSizePx, fontFamily, bold, italic);
   ctx.fillStyle = color;
   // Automatic titles stay bounded to the axis run. An authored title layout
   // is authoritative and keeps its complete text rather than being elided by
   // the automatic plot-width estimate.
   const label = manualLayout ? text : elideToWidth(ctx, text, maxPx);
+  const rotation = axisTitleRotationRad(side, authoredRotation, authoredVerticalMode);
   let resolvedAnchorX = anchorX;
   let resolvedAnchorY = anchorY;
   if (manualLayout && chartRect) {
     const textWidth = ctx.measureText(label).width;
+    // CT_Title manual-layout x/y position the title's axis-aligned box after
+    // DrawingML rotation. A vertical title therefore has a box approximately
+    // one font line wide and one text run tall; using the unrotated dimensions
+    // shifts it into the tick-label/plot bands by half the text length.
+    const cos = Math.abs(Math.cos(rotation));
+    const sin = Math.abs(Math.sin(rotation));
+    const fittedWidth = textWidth * cos + fontSizePx * sin;
+    const fittedHeight = textWidth * sin + fontSizePx * cos;
     const automatic = {
-      x: anchorX - textWidth / 2,
-      y: anchorY - fontSizePx / 2,
-      w: textWidth,
-      h: fontSizePx,
+      x: anchorX - fittedWidth / 2,
+      y: anchorY - fittedHeight / 2,
+      w: fittedWidth,
+      h: fittedHeight,
     };
     // CT_Title manual layout positions the title box, while Office keeps the
     // box fitted to its text. Match the existing chart-title rule: x/y win,
@@ -228,7 +247,6 @@ function drawAxisTitle(
     }
   }
   ctx.translate(resolvedAnchorX, resolvedAnchorY);
-  const rotation = axisTitleRotationRad(side, authoredRotation, authoredVerticalMode);
   if (rotation !== 0) ctx.rotate(rotation);
   ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
   ctx.fillText(label, 0, 0);
@@ -247,12 +265,11 @@ function axisTitleColor(hex: string | null | undefined): string {
  *  to size `catTitleH`/`valTitleW`; the anchor centers each title within its
  *  band. Column/line/area/scatter use cat-bottom + val-left. Horizontal bars
  *  use cat-left + val-bottom because their value axis runs horizontally.
- *  Axis titles default to BOLD — ECMA-376 Part 1 (ST_Style, chart-style
- *  defaults) states "Axis titles and chart titles are bold by default, while
- *  all other chart elements are normal". So an unspecified weight renders
- *  bold; only an explicit `b="0"` un-bolds. The separate 10pt size fallback
- *  is the product compatibility policy in #1228, not a normative OOXML size.
- *  This remains consistent with drawChartTitle's bold resolution. */
+ *  Bold and italic are independent DrawingML character properties. The parser
+ *  resolves authored/inherited OOXML values, including the regular-weight
+ *  DrawingML base fallback. A hand-built public model that leaves bold unset
+ *  retains the renderer's established bold compatibility fallback. The
+ *  separate 10pt size fallback is the product policy in #1228. */
 function drawAxisTitles(
   ctx: CanvasRenderingContext2D,
   chart: ChartModel,
@@ -267,6 +284,7 @@ function drawAxisTitles(
     side: ChartAxisTitleSide,
     fontSizePx: number,
     bold: boolean,
+    italic: boolean,
     color: string,
     fontFamily: string,
     authoredRotation: number | null | undefined,
@@ -278,7 +296,7 @@ function drawAxisTitles(
         ctx, text,
         x + legLeftW + axisTitleMargin(w) + fontSizePx / 2,
         py0 + ph / 2,
-        side, fontSizePx, bold, color, ph, fontFamily, authoredRotation,
+        side, fontSizePx, bold, italic, color, ph, fontFamily, authoredRotation,
         authoredVerticalMode, manualLayout, { x, y, w, h },
       );
       return;
@@ -287,14 +305,15 @@ function drawAxisTitles(
       ctx, text,
       px0 + pw / 2,
       y + h - legBottomH - axisTitleMargin(h) - fontSizePx / 2,
-      side, fontSizePx, bold, color, pw, fontFamily, authoredRotation,
+      side, fontSizePx, bold, italic, color, pw, fontFamily, authoredRotation,
       authoredVerticalMode, manualLayout, { x, y, w, h },
     );
   };
   if (chart.valAxisTitle) {
     drawPrimaryTitle(
       chart.valAxisTitle, horizontalValueAxis ? 'horizontal' : 'left',
-      valTitlePx, chart.valAxisTitleFontBold ?? true, axisTitleColor(chart.valAxisTitleFontColor),
+      valTitlePx, chart.valAxisTitleFontBold ?? true, chart.valAxisTitleFontItalic ?? false,
+      axisTitleColor(chart.valAxisTitleFontColor),
       chartFontFamily(chart, chart.valAxisTitleFontFace, 'major'), chart.valAxisTitleRotation,
       chart.valAxisTitleVerticalMode,
       chart.valAxisTitleManualLayout,
@@ -303,7 +322,8 @@ function drawAxisTitles(
   if (chart.catAxisTitle) {
     drawPrimaryTitle(
       chart.catAxisTitle, horizontalValueAxis ? 'left' : 'horizontal',
-      catTitlePx, chart.catAxisTitleFontBold ?? true, axisTitleColor(chart.catAxisTitleFontColor),
+      catTitlePx, chart.catAxisTitleFontBold ?? true, chart.catAxisTitleFontItalic ?? false,
+      axisTitleColor(chart.catAxisTitleFontColor),
       chartFontFamily(chart, chart.catAxisTitleFontFace, 'major'), chart.catAxisTitleRotation,
       chart.catAxisTitleVerticalMode,
       chart.catAxisTitleManualLayout,
@@ -337,6 +357,7 @@ interface LegendMarker {
   symbol: string;
   fill: string;
   line: string | null;
+  lineWidthEmu: number | null;
   /** True when the plotted series draws both a connecting line and markers. */
   withLine: boolean;
 }
@@ -389,7 +410,13 @@ function legendMarkerFor(
   const withLine = isScatter
     ? scatterSeriesDrawsLine('scatter', scatterStyle, s)
     : s.lineHidden !== true;
-  return { symbol, fill, line: s.markerLine ?? null, withLine };
+  return {
+    symbol,
+    fill,
+    line: s.markerLine ?? null,
+    lineWidthEmu: s.markerLineWidthEmu ?? null,
+    withLine,
+  };
 }
 
 function drawLegendSwatch(
@@ -403,6 +430,9 @@ function drawLegendSwatch(
   fillPaint: Fill | null | undefined = undefined,
   outlineColor: string | null = null,
   outlineWidthEmu: number | null = null,
+  outlineDash: string | null = null,
+  outlineCap: string | null = null,
+  outlineJoin: string | null = null,
   ptToPx = 1,
   shapeRotationDeg = 0,
 ): void {
@@ -412,25 +442,61 @@ function drawLegendSwatch(
   if (marker && !marker.withLine) {
     // Excel's legend marker is about 7pt beside a 12pt label; keeping it near
     // 0.58× the row height also leaves the surrounding key visually balanced.
-    drawMarker(ctx, x + w / 2, y + h / 2, marker.symbol, h * 0.58, marker.fill, marker.line, 1);
+    drawMarker(
+      ctx, x + w / 2, y + h / 2, marker.symbol, h * 0.58, marker.fill, marker.line, 1,
+      marker.lineWidthEmu != null ? axisLineWidthPx(marker.lineWidthEmu, ptToPx) : undefined,
+    );
     return;
   }
   ctx.fillStyle = color;
   if (style === 'line') {
-    // Horizontal stroke centered vertically inside the swatch slot. 2 px
-    // weight matches Excel's default 2.25 pt line at typical legend sizes.
-    ctx.strokeStyle = color;
-    const prevW = ctx.lineWidth;
-    ctx.lineWidth = Math.max(1.5, h * 0.15);
+    // A line key is the same authored stroke as the plotted series. Only the
+    // fully automatic key retains the historical font-relative fallback.
+    const hasAuthoredStroke = outlineColor != null
+      || outlineWidthEmu != null
+      || outlineDash != null
+      || outlineCap != null
+      || outlineJoin != null;
+    if (!hasAuthoredStroke) {
+      ctx.strokeStyle = color;
+      const previousWidth = ctx.lineWidth;
+      ctx.lineWidth = Math.max(1.5, h * 0.15);
+      ctx.beginPath();
+      const ly = y + h / 2;
+      ctx.moveTo(x, ly);
+      ctx.lineTo(x + w, ly);
+      ctx.stroke();
+      ctx.lineWidth = previousWidth;
+      if (marker) {
+        drawMarker(
+          ctx, x + w / 2, y + h / 2, marker.symbol, h * 0.58, marker.fill, marker.line, 1,
+          marker.lineWidthEmu != null ? axisLineWidthPx(marker.lineWidthEmu, ptToPx) : undefined,
+        );
+      }
+      return;
+    }
+    ctx.save();
+    ctx.strokeStyle = outlineColor ? `#${outlineColor}` : color;
+    ctx.lineWidth = outlineWidthEmu != null
+      ? axisLineWidthPx(outlineWidthEmu, ptToPx)
+      : Math.max(1.5, h * 0.15);
+    ctx.setLineDash(dashPatternForPreset(outlineDash ?? undefined));
+    ctx.lineCap = outlineCap === 'rnd' ? 'round' : outlineCap === 'sq' ? 'square' : 'butt';
+    ctx.lineJoin = outlineJoin === 'round' || outlineJoin === 'bevel'
+      ? outlineJoin
+      : 'miter';
     ctx.beginPath();
     const ly = y + h / 2;
     ctx.moveTo(x, ly);
     ctx.lineTo(x + w, ly);
     ctx.stroke();
-    ctx.lineWidth = prevW;
     if (marker) {
-      drawMarker(ctx, x + w / 2, y + h / 2, marker.symbol, h * 0.58, marker.fill, marker.line, 1);
+      drawMarker(
+        ctx, x + w / 2, y + h / 2, marker.symbol, h * 0.58, marker.fill, marker.line, 1,
+        marker.lineWidthEmu != null ? axisLineWidthPx(marker.lineWidthEmu, ptToPx) : undefined,
+      );
     }
+    ctx.restore();
   } else {
     if (fillPaint !== null) {
       if (fillPaint) {
@@ -445,6 +511,11 @@ function drawLegendSwatch(
       ctx.save();
       ctx.strokeStyle = `#${outlineColor}`;
       ctx.lineWidth = outlineWidth;
+      ctx.setLineDash(dashPatternForPreset(outlineDash ?? undefined));
+      ctx.lineCap = outlineCap === 'rnd' ? 'round' : outlineCap === 'sq' ? 'square' : 'butt';
+      ctx.lineJoin = outlineJoin === 'round' || outlineJoin === 'bevel'
+        ? outlineJoin
+        : 'miter';
       ctx.strokeRect(
         x + outlineWidth / 2,
         y + outlineWidth / 2,
@@ -468,6 +539,9 @@ interface LegendEntry {
   fillPaint: Fill | null | undefined;
   outlineColor: string | null;
   outlineWidthEmu: number | null;
+  outlineDash: string | null;
+  outlineCap: string | null;
+  outlineJoin: string | null;
 }
 
 /** Build the legend entries for a chart. Pie/doughnut legends are
@@ -496,19 +570,35 @@ function buildLegendEntries(
       fillPaint: i < fillPaints.length ? fillPaints[i] : undefined,
       outlineColor: null,
       outlineWidthEmu: null,
+      outlineDash: null,
+      outlineCap: null,
+      outlineJoin: null,
     }));
   }
-  return series.map((s, i) => ({
-    label: s.name || `Series ${i + 1}`,
-    color: legendEntryColor(chartType, series, i),
-    marker: legendMarkerFor(chartType, scatterStyle, series, i),
+  return series.map((s, i) => {
     // A combo chart has multiple chart groups under one plotArea. The legend
     // key describes the individual series' group, not the first/primary group.
-    swatchStyle: legendSwatchStyle(s.seriesType ?? chartType),
-    fillPaint: i < fillPaints.length ? fillPaints[i] : (s.fillPattern ?? undefined),
-    outlineColor: s.lineHidden === true ? null : (s.lineColor ?? null),
-    outlineWidthEmu: s.lineWidthEmu ?? null,
-  }));
+    const swatchStyle = legendSwatchStyle(s.seriesType ?? chartType);
+    const lineVisible = s.lineHidden !== true;
+    const lineColor = lineVisible ? (s.lineColor ?? null) : null;
+    return {
+      label: s.name || `Series ${i + 1}`,
+      color: swatchStyle === 'line' && lineColor
+        ? `#${lineColor}`
+        : legendEntryColor(chartType, series, i),
+      marker: legendMarkerFor(chartType, scatterStyle, series, i),
+      swatchStyle,
+      fillPaint: i < fillPaints.length ? fillPaints[i] : (s.fillPattern ?? undefined),
+      outlineColor: lineColor,
+      // A DrawingML noFill line may still carry width/dash/cap/join. Those
+      // geometry attributes do not make the stroke visible and must not revive
+      // it in the legend through the automatic-color fallback.
+      outlineWidthEmu: lineVisible ? (s.lineWidthEmu ?? null) : null,
+      outlineDash: lineVisible ? (s.chartexStyle?.lineDash ?? null) : null,
+      outlineCap: lineVisible ? (s.chartexStyle?.lineCap ?? null) : null,
+      outlineJoin: lineVisible ? (s.chartexStyle?.lineJoin ?? null) : null,
+    };
+  });
 }
 
 /** Resolved legend text styling (CH10). `fontFamily` already carries the
@@ -535,15 +625,54 @@ const LEGEND_HORIZONTAL_INSET = 4;
 const LEGEND_HORIZONTAL_PADDING = LEGEND_HORIZONTAL_INSET * 2;
 const LEGEND_VERTICAL_PADDING = 4;
 const LEGEND_SIDE_PADDING = 8;
+// The item width is measured as key + gap + text, then split back into those
+// components for paint. Fractional Canvas metrics can lose one ULP in that
+// subtraction (e.g. 24.453475952148438 becomes 24.453475952148434), falsely
+// eliding a label that was already proven to fit. A hundredth of a CSS pixel is
+// safely below a visible/device-pixel overflow while absorbing that arithmetic
+// roundoff.
+const LEGEND_MEASUREMENT_EPSILON_PX = 0.01;
+// Office vector output keeps a filled legend key at roughly 7pt square even
+// when the legend text is larger (for example, a 15pt legend still has a 7pt
+// box). Line/marker keys remain font-relative because their glyph geometry is
+// tied to the legend row rather than a filled-area key.
+const FILLED_LEGEND_KEY_PT = 7;
 
 function legendFontSizePx(style: LegendTextStyle, ptToPx: number): number {
   return style.sizePx ?? 10 * ptToPx;
 }
 
-function legendSwatchWidths(entries: readonly LegendEntry[], fontSize: number): number[] {
+function legendSwatchWidths(
+  entries: readonly LegendEntry[],
+  fontSize: number,
+  ptToPx: number,
+): number[] {
   return entries.map(entry =>
-    entry.swatchStyle === 'line' ? fontSize * 1.6 : Math.min(10, fontSize)
+    entry.swatchStyle === 'line' ? fontSize * 1.6 : FILLED_LEGEND_KEY_PT * ptToPx
   );
+}
+
+function legendSwatchHeight(entry: LegendEntry, fontSize: number, ptToPx: number): number {
+  return entry.swatchStyle === 'line' ? fontSize : FILLED_LEGEND_KEY_PT * ptToPx;
+}
+
+/** Resolve side-legend text into the same bounded lines that paint consumes.
+ * Office wraps a long series name at word boundaries in a left/right legend
+ * (rather than replacing the whole second half with an ellipsis). Two lines
+ * keep the automatic side band bounded; only text that still exceeds that
+ * contract is elided on the final line. */
+function sideLegendLabelLines(
+  ctx: CanvasRenderingContext2D,
+  label: string,
+  maxWidth: number,
+): string[] {
+  if (!(maxWidth > 0)) return [];
+  const wrapped = wrapMeasuredText(ctx, label, maxWidth);
+  if (wrapped.length <= 2) return wrapped;
+  return [
+    wrapped[0],
+    elideToWidth(ctx, wrapped.slice(1).join(' '), maxWidth),
+  ];
 }
 
 /** Resolve the shared automatic legend reserve from real Canvas text metrics. */
@@ -565,7 +694,7 @@ function measuredLegendReserve(
     chart.categories,
   );
   const fontSize = legendFontSizePx(style, ptToPx);
-  const swatches = legendSwatchWidths(entries, fontSize);
+  const swatches = legendSwatchWidths(entries, fontSize, ptToPx);
   ctx.save();
   ctx.font = `${style.bold ? 'bold ' : ''}${fontSize}px ${style.fontFamily}`;
   const itemWidths = entries.map((entry, index) =>
@@ -611,7 +740,7 @@ function drawLegend(
   ctx.font = `${boldPrefix}${fontSize}px ${style.fontFamily}`;
   ctx.textBaseline = 'middle';
   const rowH = fontSize + LEGEND_ROW_EXTRA_PX;
-  const swatches = legendSwatchWidths(entries, fontSize);
+  const swatches = legendSwatchWidths(entries, fontSize, ptToPx);
   const itemWidths = entries.map((entry, index) =>
     swatches[index] + gap + ctx.measureText(entry.label).width
   );
@@ -637,13 +766,18 @@ function drawLegend(
           rx += effectiveWidth + LEGEND_ITEM_GAP;
           continue;
         }
-        const maxTextPx = Math.max(0, effectiveWidth - sw - gap);
+        const maxTextPx = Math.max(
+          0,
+          effectiveWidth - sw - gap + LEGEND_MEASUREMENT_EPSILON_PX,
+        );
         const label = elideToWidth(ctx, entries[index].label, maxTextPx);
+        const swatchH = legendSwatchHeight(entries[index], fontSize, ptToPx);
         drawLegendSwatch(
           ctx, entries[index].swatchStyle, entries[index].color,
-          rx, ry - fontSize / 2, sw, fontSize,
+          rx, ry - swatchH / 2, sw, swatchH,
           entries[index].marker, entries[index].fillPaint,
           entries[index].outlineColor, entries[index].outlineWidthEmu,
+          entries[index].outlineDash, entries[index].outlineCap, entries[index].outlineJoin,
           ptToPx, shapeRotationDeg,
         );
         ctx.fillStyle = style.color;
@@ -655,27 +789,52 @@ function drawLegend(
     return;
   }
   // Vertical legend: each label runs from just after the swatch to the right
-  // edge of the reserved legend column, so cap it at that remaining width.
+  // edge of the reserved legend column. Long series names wrap to at most two
+  // measured lines; use those same lines to plan row heights and to paint, so
+  // reserve and draw cannot disagree about which words fit.
   const maxTextPx = lw - Math.max(...swatches, 0) - gap;
-  const visibleCount = Math.min(entries.length, Math.max(0, Math.floor(lh / rowH)));
+  // Point/category legends can contain dozens of independent keys; keep their
+  // historical one-line/elided rows so wrapping one category cannot starve
+  // later entries. Series-driven legends are the bounded multi-line case.
+  const wrapSeriesNames = !varyByPoint && !legendIsCategoryDriven(chartType);
+  const labelLines = entries.map(entry => wrapSeriesNames
+    ? sideLegendLabelLines(ctx, entry.label, maxTextPx)
+    : [elideToWidth(ctx, entry.label, maxTextPx)]
+  );
+  const entryHeights = labelLines.map(lines => lines.length * fontSize + LEGEND_ROW_EXTRA_PX);
+  let visibleCount = 0;
+  let visibleHeight = 0;
+  while (visibleCount < entries.length
+    && visibleHeight + entryHeights[visibleCount] <= lh) {
+    visibleHeight += entryHeights[visibleCount];
+    visibleCount++;
+  }
   let ry = visibleCount === entries.length
-    ? ly + (lh - rowH * visibleCount) / 2
+    ? ly + (lh - visibleHeight) / 2
     : ly;
   for (let i = 0; i < visibleCount; i++) {
     const sw = swatches[i];
+    const entryH = entryHeights[i];
     if (lw < sw) {
-      ry += rowH;
+      ry += entryH;
       continue;
     }
+    const swatchH = legendSwatchHeight(entries[i], fontSize, ptToPx);
     drawLegendSwatch(
       ctx, entries[i].swatchStyle, entries[i].color,
-      lx, ry, sw, fontSize,
+      lx, ry + (entryH - swatchH) / 2, sw, swatchH,
       entries[i].marker, entries[i].fillPaint,
-      entries[i].outlineColor, entries[i].outlineWidthEmu, ptToPx, shapeRotationDeg,
+      entries[i].outlineColor, entries[i].outlineWidthEmu,
+      entries[i].outlineDash, entries[i].outlineCap, entries[i].outlineJoin,
+      ptToPx, shapeRotationDeg,
     );
     ctx.fillStyle = style.color; ctx.textAlign = 'left';
-    ctx.fillText(elideToWidth(ctx, entries[i].label, maxTextPx), lx + sw + gap, ry + fontSize / 2);
-    ry += rowH;
+    labelLines[i].forEach((line, lineIndex) =>
+      // Preserve the established single-line baseline byte-for-byte. Extra
+      // wrapped lines continue at one authored font-size interval.
+      ctx.fillText(line, lx + sw + gap, ry + fontSize * (lineIndex + 0.5))
+    );
+    ry += entryH;
   }
 }
 
@@ -774,16 +933,17 @@ function drawAxisTick(
   // right — pass `opposite` to flip the out/in direction.
   opposite = false,
   lineHidden = false,
+  level: 'major' | 'minor' = 'major',
+  ptToPx = 1,
 ): void {
   // Axis shape properties style both the rule and its tick marks. An authored
   // `<a:ln><a:noFill/>` therefore suppresses the ticks too, while labels and
   // gridlines remain independently visible.
   if (lineHidden || mode === 'none' || !mode) return;
-  // Tick length scales mildly with the axis line weight so a thick
-  // ruler-style axis (e.g. Vertex42 Gantt 5 pt) produces ticks that
-  // are visible without being huge.
-  const baseLen = 4;
-  const len = lineWidth ? Math.max(baseLen, lineWidth + 2) : baseLen;
+  // Office's vector output uses 6pt major ticks and 4pt minor ticks. Tick
+  // length still scales mildly with an unusually thick authored axis rule.
+  const baseLen = (level === 'minor' ? 4 : 6) * ptToPx;
+  const len = lineWidth ? Math.max(baseLen, lineWidth + 2 * ptToPx) : baseLen;
   const prevS = ctx.strokeStyle;
   const prevW = ctx.lineWidth;
   ctx.strokeStyle = color ?? '#888';
@@ -1062,6 +1222,7 @@ function planValueAxis(
   dataMax: number,
   axisLenPt?: number,
   percentStacked = false,
+  axisOrientation: 'vertical' | 'horizontal' = 'vertical',
 ): ValueAxisPlan {
   const reversed = valAxisReversed(chart);
   const logBase = chart.valAxisLogBase;
@@ -1121,6 +1282,7 @@ function planValueAxis(
     explicitMin,
     explicitMax,
     axisLenPt,
+    axisOrientation,
     majorUnit,
     minorUnit: mu,
     needMinor: chart.valAxisMinorGridlines === true || needsMinorTicks,
@@ -1326,6 +1488,7 @@ function wrapMeasuredText(
   ctx: CanvasRenderingContext2D,
   text: string,
   maxWidth: number,
+  singleTokenOverhangPx = 0,
 ): string[] {
   const words = text.trim().split(/\s+/).filter(Boolean);
   if (words.length === 0) return [''];
@@ -1341,7 +1504,7 @@ function wrapMeasuredText(
       lines.push(line);
       line = '';
     }
-    if (ctx.measureText(token).width <= maxWidth) {
+    if (ctx.measureText(token).width <= maxWidth + singleTokenOverhangPx) {
       line = token;
       return;
     }
@@ -1371,6 +1534,17 @@ function wrapMeasuredText(
   for (const word of words) pushToken(word);
   if (line) lines.push(line);
   return lines.length ? lines : [''];
+}
+
+/** Office keeps short numeric category labels on one line when its native
+ * theme-font metrics fit the slot. A browser without that Office font may use
+ * a slightly wider fallback and otherwise split `10` into `1` / `0`. Permit a
+ * small metric-only overhang for numeric tokens; ordinary text still obeys the
+ * exact measured slot and genuinely over-wide numbers continue to wrap. */
+function numericCategoryMetricTolerance(text: string, fontPx: number): number {
+  return /^[+-]?(?:\d+(?:[.,]\d*)?|[.,]\d+)%?$/.test(text)
+    ? fontPx * 0.15
+    : 0;
 }
 
 /** Whether the CATEGORY tick labels should be drawn. `<c:catAx><c:tickLblPos
@@ -1483,6 +1657,7 @@ function computeSecondaryAxis(
     explicitMin: sec.min,
     explicitMax: sec.max,
     axisLenPt: plotHeightPt,
+    axisOrientation: 'vertical',
     majorUnit: sec.majorUnit,
     minorUnit: sec.minorUnit,
     needMinor: sec.minorGridlines === true
@@ -1547,12 +1722,12 @@ function drawSecondaryValueAxis(
     for (const sval of secScale.majorLines) {
       const gy = toYSecondary(sval);
       // Same tick geometry as the left axis, mirrored to the right edge.
-      drawAxisTick(ctx, sec.majorTickMark, 'val', axX, gy, secLineColor, secLineW, true, sec.lineHidden);
+      drawAxisTick(ctx, sec.majorTickMark, 'val', axX, gy, secLineColor, secLineW, true, sec.lineHidden, 'major', ptToPx);
       ctx.fillText(formatChartValWithCode(sval, sec.formatCode ?? null, date1904), axX + 14, gy);
     }
     if (sec.minorTickMark && sec.minorTickMark !== 'none') {
       for (const value of secScale.minorTicks) {
-        drawAxisTick(ctx, sec.minorTickMark, 'val', axX, toYSecondary(value), secLineColor, secLineW, true, sec.lineHidden);
+        drawAxisTick(ctx, sec.minorTickMark, 'val', axX, toYSecondary(value), secLineColor, secLineW, true, sec.lineHidden, 'minor', ptToPx);
       }
     }
   }
@@ -1588,6 +1763,7 @@ function drawSecondaryAxisTitle(
     'right',
     fontSizePx,
     sec.titleFontBold ?? true,
+    sec.titleFontItalic ?? false,
     color,
     ph,
     chartFontFamily(chart, sec.titleFontFace, 'major'),
@@ -1737,6 +1913,7 @@ function drawBarDataLabel(
   layoutReferenceRect: DataLabelRect,
   manualLayout?: ChartDataLabelOverride['manualLayout'],
   negative = false,
+  rich?: RichDataLabelOptions,
 ): void {
   const rect = orient === 'vertical'
     ? { x: bx, y: by, w: barW, h: barL }
@@ -1750,6 +1927,7 @@ function drawBarDataLabel(
     color ? `#${color}` : '#333',
     manualLayout,
     layoutReferenceRect,
+    rich,
   );
 }
 
@@ -1814,37 +1992,17 @@ function renderBarChart(
       ...chart,
       series: barSeries.map((series, index) => {
         const styleIndex = barStyleIndices[index];
-        const linkedStyle = chart.chartexDataPointStyle;
-        const localStyle = series.chartexStyle;
-        const localHasLine = localStyle?.lineHidden != null
-          || localStyle?.lineColors?.some(Boolean)
-          || localStyle?.lineWidthEmu != null
-          || localStyle?.lineDash != null;
-        const useLocalLine = localHasLine && !(localStyle?.lineHidden && localStyle.lineNoStyle);
-        const useLegacyLine = !useLocalLine && (
-          series.lineHidden != null || series.lineColor != null || series.lineWidthEmu != null
+        const fill = series.color
+          ?? chartExDataPointFill(chart, styleIndex, barSeries.length, series.chartexStyle);
+        return chartExLegendSeries(
+          chart,
+          series.name,
+          series,
+          chart.chartexDataPointStyle,
+          styleIndex,
+          barSeries.length,
+          fill,
         );
-        const effectiveLineStyle = useLocalLine
-          ? localStyle
-          : useLegacyLine ? null : linkedStyle;
-        return {
-          ...series,
-          color: series.color
-            ?? chartExDataPointFill(chart, styleIndex, barSeries.length, localStyle),
-          lineHidden: useLocalLine
-            ? localStyle?.lineHidden === true
-            : useLegacyLine
-              ? series.lineHidden
-              : effectiveLineStyle?.lineHidden ?? false,
-          lineColor: useLegacyLine
-            ? series.lineColor
-            : chartExStyleColor(
-              chart, effectiveLineStyle, 'line', styleIndex, barSeries.length,
-            ),
-          lineWidthEmu: useLegacyLine
-            ? series.lineWidthEmu
-            : effectiveLineStyle?.lineWidthEmu ?? null,
-        };
       }),
     }
     : chart;
@@ -2005,7 +2163,14 @@ function renderBarChart(
   if (dataMax === 0 && dataMin === 0) dataMax = 1;
   // `planValueAxis` folds in the CH6 major unit / logBase / orientation; with
   // none set it is byte-identical to `valueAxisScale` + a linear map.
-  const plan = planValueAxis(chart, dataMin, dataMax, valAxisLenPt, pct);
+  const plan = planValueAxis(
+    chart,
+    dataMin,
+    dataMax,
+    valAxisLenPt,
+    pct,
+    isH ? 'horizontal' : 'vertical',
+  );
   const { step } = plan;
 
   // Secondary value-axis scale (combo charts). INDEPENDENT of the primary: its
@@ -2138,12 +2303,23 @@ function renderBarChart(
       ? catAxFontPx
       : Math.max(8, Math.min(11, slotW * 0.5));
     ctx.save();
-    ctx.font = `${chart.catAxisFontBold ? 'bold ' : ''}${wrapFontPx}px ${chartFontFamily(chart, chart.catAxisFontFace, 'minor')}`;
+    ctx.font = chartFontCss(
+      wrapFontPx,
+      chartFontFamily(chart, chart.catAxisFontFace, 'minor'),
+      chart.catAxisFontBold ?? false,
+      chart.catAxisFontItalic ?? false,
+    );
     for (const category of cats) {
+      const formattedCategory = formatCategoryLabel(
+        category,
+        chart.catAxisFormatCode,
+        chart.date1904,
+      );
       wrappedColumnCategories.push(wrapMeasuredText(
         ctx,
-        formatCategoryLabel(category, chart.catAxisFormatCode, chart.date1904),
+        formattedCategory,
         Math.max(1, slotW),
+        numericCategoryMetricTolerance(formattedCategory, wrapFontPx),
       ));
     }
     ctx.restore();
@@ -2319,18 +2495,18 @@ function renderBarChart(
     if (!chart.valAxisHidden && chart.valAxisMajorTickMark && chart.valAxisMajorTickMark !== 'none') {
       for (const val of plan.majorLines) {
         if (!isH) {
-          drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, valY(val), valLineColor, valLineW, false, chart.valAxisLineHidden);
+          drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, valY(val), valLineColor, valLineW, false, chart.valAxisLineHidden, 'major', ptToPx);
         } else {
-          drawAxisTick(ctx, chart.valAxisMajorTickMark, 'cat', py0 + ph, valX(val), valLineColor, valLineW, false, chart.valAxisLineHidden);
+          drawAxisTick(ctx, chart.valAxisMajorTickMark, 'cat', py0 + ph, valX(val), valLineColor, valLineW, false, chart.valAxisLineHidden, 'major', ptToPx);
         }
       }
     }
     if (!chart.valAxisHidden && chart.valAxisMinorTickMark && chart.valAxisMinorTickMark !== 'none') {
       for (const value of plan.minorTicks) {
         if (!isH) {
-          drawAxisTick(ctx, chart.valAxisMinorTickMark, 'val', px0, valY(value), valLineColor, valLineW, false, chart.valAxisLineHidden);
+          drawAxisTick(ctx, chart.valAxisMinorTickMark, 'val', px0, valY(value), valLineColor, valLineW, false, chart.valAxisLineHidden, 'minor', ptToPx);
         } else {
-          drawAxisTick(ctx, chart.valAxisMinorTickMark, 'cat', py0 + ph, valX(value), valLineColor, valLineW, false, chart.valAxisLineHidden);
+          drawAxisTick(ctx, chart.valAxisMinorTickMark, 'cat', py0 + ph, valX(value), valLineColor, valLineW, false, chart.valAxisLineHidden, 'minor', ptToPx);
         }
       }
     }
@@ -2343,9 +2519,9 @@ function renderBarChart(
       for (let ci = 0; ci <= last; ci++) {
         const frac = onBoundary ? ci / n : (n === 1 ? 0.5 : ci / (n - 1));
         if (!isH) {
-          drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, px0 + frac * pw, catLineColor, catLineW, false, chart.catAxisLineHidden);
+          drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, px0 + frac * pw, catLineColor, catLineW, false, chart.catAxisLineHidden, 'major', ptToPx);
         } else {
-          drawAxisTick(ctx, chart.catAxisMajorTickMark, 'val', px0, py0 + frac * ph, catLineColor, catLineW, false, chart.catAxisLineHidden);
+          drawAxisTick(ctx, chart.catAxisMajorTickMark, 'val', px0, py0 + frac * ph, catLineColor, catLineW, false, chart.catAxisLineHidden, 'major', ptToPx);
         }
       }
     }
@@ -2527,6 +2703,13 @@ function renderBarChart(
             { x, y, w, h },
             authoredLabel?.manualLayout,
             negative,
+            customRichDataLabelOptions(
+              chart,
+              authoredLabel,
+              ptToPx,
+              chartFontFamily(chart, chart.dataLabelFontFace, 'minor'),
+              bold,
+            ),
           );
         }
       } else {
@@ -2591,6 +2774,13 @@ function renderBarChart(
             { x, y, w, h },
             authoredLabel?.manualLayout,
             negative,
+            customRichDataLabelOptions(
+              chart,
+              authoredLabel,
+              ptToPx,
+              chartFontFamily(chart, chart.dataLabelFontFace, 'minor'),
+              bold,
+            ),
           );
         }
       }
@@ -2729,14 +2919,31 @@ function renderBarChart(
     if (allX.length && allY.length) {
       const xAxis = chart.secondaryCatAxis;
       const yAxis = chart.secondaryValAxis;
-      const xScale = valueAxisScale(
-        Math.min(...allX), Math.max(...allX),
-        xAxis?.min, xAxis?.max, pw / ptToPx, xAxis?.majorUnit,
-      );
-      const yScale = valueAxisScale(
-        Math.min(...allY), Math.max(...allY),
-        yAxis?.min, yAxis?.max, ph / ptToPx, yAxis?.majorUnit,
-      );
+      const needsMinor = (axis: SecondaryValueAxis | null | undefined): boolean =>
+        axis?.minorGridlines === true
+        || (axis?.minorTickMark != null && axis.minorTickMark !== 'none');
+      const xScale = planLinearValueAxis({
+        dataMin: Math.min(...allX),
+        dataMax: Math.max(...allX),
+        explicitMin: xAxis?.min,
+        explicitMax: xAxis?.max,
+        axisLenPt: pw / ptToPx,
+        axisOrientation: 'horizontal',
+        majorUnit: xAxis?.majorUnit,
+        minorUnit: xAxis?.minorUnit,
+        needMinor: needsMinor(xAxis),
+      });
+      const yScale = planLinearValueAxis({
+        dataMin: Math.min(...allY),
+        dataMax: Math.max(...allY),
+        explicitMin: yAxis?.min,
+        explicitMax: yAxis?.max,
+        axisLenPt: ph / ptToPx,
+        axisOrientation: 'vertical',
+        majorUnit: yAxis?.majorUnit,
+        minorUnit: yAxis?.minorUnit,
+        needMinor: needsMinor(yAxis),
+      });
       const scatterToX = (value: number): number =>
         px0 + axisFraction(value, xScale.min, xScale.max) * pw;
       const scatterToY = (value: number): number =>
@@ -2787,12 +2994,12 @@ function renderBarChart(
       for (const sval of secScale?.majorLines ?? majorAxisValues(sMin, sMax, sStep)) {
         const gy = toYSecondary(sval);
         // Same tick geometry as the left axis, mirrored to the right edge.
-        drawAxisTick(ctx, sec.majorTickMark, 'val', axX, gy, secLineColor, secLineW, true, sec.lineHidden);
+        drawAxisTick(ctx, sec.majorTickMark, 'val', axX, gy, secLineColor, secLineW, true, sec.lineHidden, 'major', ptToPx);
         ctx.fillText(formatChartValWithCode(sval, sec.formatCode ?? null, chart.date1904), axX + 14, gy);
       }
       if (sec.minorTickMark && sec.minorTickMark !== 'none') {
         for (const value of secScale?.minorTicks ?? minorAxisValues(sMin, sMax, sStep, sec.minorUnit)) {
-          drawAxisTick(ctx, sec.minorTickMark, 'val', axX, toYSecondary(value), secLineColor, secLineW, true, sec.lineHidden);
+          drawAxisTick(ctx, sec.minorTickMark, 'val', axX, toYSecondary(value), secLineColor, secLineW, true, sec.lineHidden, 'minor', ptToPx);
         }
       }
     }
@@ -2944,7 +3151,12 @@ function renderLineChart(
   let secLabelBandW = 0;
   if (sec && secScale && !sec.hidden) {
     const prevFont = ctx.font;
-    ctx.font = `${secFontPx}px ${chartFontFamily(chart, sec.fontFace, 'minor')}`;
+    ctx.font = chartFontCss(
+      secFontPx,
+      chartFontFamily(chart, sec.fontFace, 'minor'),
+      false,
+      sec.fontItalic ?? false,
+    );
     let wmax = 0;
     for (const value of secScale.majorLines) {
       wmax = Math.max(wmax, ctx.measureText(formatChartValWithCode(value, sec.formatCode ?? null, chart.date1904)).width);
@@ -3060,7 +3272,7 @@ function renderLineChart(
     for (const v of plan.majorLines) {
       const gy = toY(v);
       if (drawMajorGrid) strokeValueGridlineH(ctx, px0, pw, gy, v === 0, grid);
-      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, primaryValTickColor, primaryValTickWidth, false, chart.valAxisLineHidden);
+      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, primaryValTickColor, primaryValTickWidth, false, chart.valAxisLineHidden, 'major', ptToPx);
       if (drawLabels) {
         ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
         ctx.textAlign = 'right';
@@ -3072,7 +3284,7 @@ function renderLineChart(
     }
     if (chart.valAxisMinorTickMark && chart.valAxisMinorTickMark !== 'none') {
       for (const value of plan.minorTicks) {
-        drawAxisTick(ctx, chart.valAxisMinorTickMark, 'val', px0, toY(value), primaryValTickColor, primaryValTickWidth, false, chart.valAxisLineHidden);
+        drawAxisTick(ctx, chart.valAxisMinorTickMark, 'val', px0, toY(value), primaryValTickColor, primaryValTickWidth, false, chart.valAxisLineHidden, 'minor', ptToPx);
       }
     }
   }
@@ -3107,19 +3319,34 @@ function renderLineChart(
   }
 
   // Line width and marker size come from OOXML in points (<a:ln w=EMU> /
-  // <c:marker><c:size val=pt>). We don't parse per-series overrides yet so
-  // use the PowerPoint defaults (2.25pt line, 5pt marker diameter) scaled to
-  // the current slide pt-per-px so both shrink with the viewport.
+  // <c:marker><c:size val=pt>). Omitted series strokes keep the PowerPoint
+  // defaults (2.25pt line, 5pt marker diameter) scaled to the viewport.
   const lineWidthPx = Math.max(1, 2.25 * ptToPx);
   const markerR = Math.max(2, 2.5 * ptToPx);
   const dataLabelPx = axisLabelPx(chart.dataLabelFontSizeHpt, h, ptToPx);
+  // Data labels are a chart-wide foreground layer. Painting them inside the
+  // per-series loop lets a later series line (or trendline) cross labels that
+  // belong to an earlier series. Excel keeps every series label above all
+  // series geometry, so collect the label painters and flush them only after
+  // every line, error bar, marker, and trendline has been painted.
+  const deferredDataLabels: Array<() => void> = [];
   for (let si = 0; si < chart.series.length; si++) {
     const s = chart.series[si];
     const color = chartColor(si, s);
     // Secondary series ride their own vertical scale; primary series (and every
     // series when there is no secondary axis) map through the primary `toY`.
     const yOf = yMapFor(s);
-    ctx.strokeStyle = color; ctx.lineWidth = lineWidthPx; ctx.setLineDash([]);
+    ctx.strokeStyle = s.lineColor ? `#${s.lineColor}` : color;
+    ctx.lineWidth = s.lineWidthEmu != null
+      ? axisLineWidthPx(s.lineWidthEmu, ptToPx)
+      : lineWidthPx;
+    ctx.setLineDash(dashPatternForPreset(s.chartexStyle?.lineDash ?? undefined));
+    ctx.lineCap = s.chartexStyle?.lineCap === 'rnd'
+      ? 'round'
+      : s.chartexStyle?.lineCap === 'sq' ? 'square' : 'butt';
+    ctx.lineJoin = s.chartexStyle?.lineJoin === 'round' || s.chartexStyle?.lineJoin === 'bevel'
+      ? s.chartexStyle.lineJoin
+      : 'miter';
     ctx.beginPath();
     // Collect runs of consecutive present points (a null breaks the line into a
     // fresh run; stacked charts have no nulls in the plotted sum). Each run is
@@ -3147,7 +3374,7 @@ function renderLineChart(
       run.push({ x: toX(ci), y: yOf(plotted(si, ci)) });
     }
     flushRun();
-    ctx.stroke();
+    if (s.lineHidden !== true) ctx.stroke();
 
     // Error bars (`<c:errBars>`, §21.2.2.20) — drawn under the markers so the
     // dots overlay the bar tips. Only fires for series that carry them.
@@ -3167,25 +3394,43 @@ function renderLineChart(
     // (byte-stable). `markerSymbol: "none"` is caught by the showMarker gate.
     const hasMarkerDetail = seriesHasMarkerDetail(s);
     // Per-point / series-level data labels (`<c:dLbl idx>` / `<c:dLbls>`) take
-    // precedence over the family's simple `showDataLabels` value dump.
-    const perPointLabels = drawCategoryDataLabels(
-      ctx, s, cats, n, toX, yOf, plottedOf, ph, ptToPx, chart.date1904 ?? false,
-      // Mirror the marker loop's gate just below: stacked series never see a
-      // plotted null (a stacked sum already reads null as 0), and unstacked
-      // "zero" mode plots the null at 0 — both cases get a label too.
-      stacked || dispBlanks === 'zero',
-      chartFontFamily(chart, chart.dataLabelFontFace, 'minor'),
-      // §21.2.2.48 `<c:dLblPos>` precedence: per-point/series positions win, else
-      // the chart-level position, else PowerPoint's line-chart default `'r'`
-      // (right of the point).
-      chart.dataLabelPosition ?? 'r',
-      { x: px0, y: py0, w: pw, h: ph },
-      { x, y, w, h },
-      pct && pctTotals
-        ? ci => (s.values[ci] ?? 0) / pctTotals[ci]
-        : undefined,
-    );
-    if (perPointLabels) ctx.fillStyle = color;
+    // precedence over the family's simple `showDataLabels` value dump. Merely
+    // decide the route here; painting is deferred until all series geometry is
+    // complete so labels remain the chart-wide foreground layer.
+    const perPointLabels = (s.dataLabelOverrides?.length ?? 0) > 0 || s.seriesDataLabels != null;
+    if (perPointLabels) {
+      deferredDataLabels.push(() => {
+        drawCategoryDataLabels(
+          ctx, s, cats, n, toX, yOf, plottedOf, ph, ptToPx, chart.date1904 ?? false,
+          // Mirror the marker loop's gate just below: stacked series never see a
+          // plotted null (a stacked sum already reads null as 0), and unstacked
+          // "zero" mode plots the null at 0 — both cases get a label too.
+          stacked || dispBlanks === 'zero',
+          chartFontFamily(chart, chart.dataLabelFontFace, 'minor'),
+          // §21.2.2.48 `<c:dLblPos>` precedence: per-point/series positions win,
+          // else the chart-level position, else the line-chart default `'r'`.
+          chart.dataLabelPosition ?? 'r',
+          // Automatic endpoint labels may occupy the chart gutter outside the
+          // plot area (the plot's manual layout often reserves that space).
+          // Keep vertical clipping aligned to the plot, but clamp horizontally
+          // to the chart rectangle so `l`/`r` remain outside the end markers.
+          { x, y: py0, w, h: ph },
+          { x, y, w, h },
+          pct && pctTotals
+            ? ci => (s.values[ci] ?? 0) / pctTotals[ci]
+            : undefined,
+          ci => {
+            if (!drawMarkers) return 0;
+            if (!hasMarkerDetail) return markerR;
+            const dpt = (s.dataPointOverrides ?? []).find(point => point.idx === ci);
+            const symbol = dpt?.markerSymbol ?? s.markerSymbol ?? 'circle';
+            if (symbol === 'none') return 0;
+            return ((dpt?.markerSize ?? s.markerSize ?? 5) / 2) * ptToPx;
+          },
+          face => chartFontFamily(chart, face, 'minor'),
+        );
+      });
+    }
     for (let ci = 0; ci < n; ci++) {
       // A null point gets a marker/label only in "zero" mode (plotted at 0);
       // "gap"/"span" leave the hole empty.
@@ -3199,28 +3444,35 @@ function renderLineChart(
             const sizePt = dpt?.markerSize ?? s.markerSize ?? 5;
             const fill = dpt?.markerFill ?? dpt?.color ?? s.markerFill ?? color;
             const line = dpt?.markerLine ?? s.markerLine ?? null;
-            drawMarker(ctx, toX(ci), yOf(pv), symbol, sizePt, fill, line, ptToPx);
+            const lineWidthEmu = dpt?.markerLineWidthEmu ?? s.markerLineWidthEmu;
+            drawMarker(
+              ctx, toX(ci), yOf(pv), symbol, sizePt, fill, line, ptToPx,
+              lineWidthEmu != null ? axisLineWidthPx(lineWidthEmu, ptToPx) : undefined,
+            );
           }
         } else {
           ctx.beginPath(); ctx.arc(toX(ci), yOf(pv), markerR, 0, Math.PI * 2); ctx.fill();
         }
       }
-      if (chart.showDataLabels && !perPointLabels) {
-        // §21.2.2.48 `<c:dLblPos>`: the family-level `showDataLabels` value dump
-        // honors the chart-level position (else PowerPoint's line default `'r'`,
-        // right of the point) instead of the old fixed "above the point". Offset
-        // in the label's direction by the marker radius + 1px gap so the text
-        // clears the dot (2px when there is no marker), matching the prior clear
-        // distance but now direction-aware.
-        drawDataLabelText(
-          ctx, toX(ci), yOf(pv), formatChartVal(s.values[ci] ?? 0),
-          chart.dataLabelPosition ?? 'r', dataLabelPx, undefined, false,
-          chartFontFamily(chart, chart.dataLabelFontFace, 'minor'),
-          drawMarkers ? markerR + 1 : 2,
-          { x: px0, y: py0, w: pw, h: ph },
-        );
-        ctx.fillStyle = color;
-      }
+    }
+
+    if (chart.showDataLabels && !perPointLabels) {
+      deferredDataLabels.push(() => {
+        for (let ci = 0; ci < n; ci++) {
+          if (!stacked && s.values[ci] == null && dispBlanks !== 'zero') continue;
+          const pv = plotted(si, ci);
+          // §21.2.2.48 `<c:dLblPos>`: the family-level value dump honors the
+          // chart-level position (else the line default `'r'`). The marker gap
+          // stays directional while the whole label layer is painted last.
+          drawDataLabelText(
+            ctx, toX(ci), yOf(pv), formatChartVal(s.values[ci] ?? 0),
+            chart.dataLabelPosition ?? 'r', dataLabelPx, undefined, false,
+            chartFontFamily(chart, chart.dataLabelFontFace, 'minor'),
+            drawMarkers ? markerR + 1 : 2,
+            { x: px0, y: py0, w: pw, h: ph },
+          );
+        }
+      });
     }
 
     // Trendlines (`<c:trendline>`, §21.2.2.211) over this series' points —
@@ -3232,6 +3484,8 @@ function renderLineChart(
     );
   }
 
+  for (const drawLabels of deferredDataLabels) drawLabels();
+
   if (!chart.catAxisHidden) {
     const catLabelColor = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#555';
     ctx.fillStyle = catLabelColor; ctx.textAlign = 'center'; ctx.textBaseline = 'top';
@@ -3242,7 +3496,7 @@ function renderLineChart(
     // indices to author intervals such as every second year.
     const tickInterval = Math.max(1, Math.floor(chart.catAxisTickMarkSkip ?? 1));
     for (let ci = 0; ci < n; ci += tickInterval) {
-      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, toX(ci), primaryCatTickColor, primaryCatTickWidth, false, chart.catAxisLineHidden);
+      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, toX(ci), primaryCatTickColor, primaryCatTickWidth, false, chart.catAxisLineHidden, 'major', ptToPx);
     }
     const showLabels = catLabelsVisible(chart);
     const labelInterval = Math.max(1, Math.floor(chart.catAxisTickLabelSkip ?? 1));
@@ -3399,7 +3653,7 @@ function renderStockChart(
     for (const v of plan.majorLines) {
       const gy = toY(v);
       if (drawMajorGrid) strokeValueGridlineH(ctx, px0, pw, gy, v === 0, grid);
-      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, undefined, undefined, false, chart.valAxisLineHidden);
+      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, undefined, undefined, false, chart.valAxisLineHidden, 'major', ptToPx);
       if (drawLabels) {
         ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
         ctx.textAlign = 'right';
@@ -3409,7 +3663,7 @@ function renderStockChart(
     for (const v of plan.minorTicks) {
       drawAxisTick(
         ctx, chart.valAxisMinorTickMark, 'val', px0, toY(v),
-        undefined, undefined, false, chart.valAxisLineHidden,
+        undefined, undefined, false, chart.valAxisLineHidden, 'minor', ptToPx,
       );
     }
   }
@@ -3466,6 +3720,7 @@ function renderStockChart(
         drawMarker(
           ctx, cx, cy, symbol as string,
           s.markerSize ?? 3, s.markerFill ?? color, s.markerLine ?? null, ptToPx,
+          s.markerLineWidthEmu != null ? axisLineWidthPx(s.markerLineWidthEmu, ptToPx) : undefined,
         );
         continue;
       }
@@ -3503,7 +3758,7 @@ function renderStockChart(
     const rotRad = catLabelRotationRad(chart);
     for (let ci = 0; ci < n; ci += labelInterval) {
       const tx = toX(ci);
-      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, tx, undefined, undefined, false, chart.catAxisLineHidden);
+      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, tx, undefined, undefined, false, chart.catAxisLineHidden, 'major', ptToPx);
       if (!showLabels) continue;
       ctx.fillStyle = catLabelColor;
       const label = formatCategoryLabel((cats[ci] ?? '').toString(), chart.catAxisFormatCode, chart.date1904);
@@ -3902,7 +4157,11 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
             const sizePt = dpt?.markerSize ?? s.markerSize ?? 5;
             const fill = dpt?.markerFill ?? dpt?.color ?? s.markerFill ?? color;
             const line = dpt?.markerLine ?? s.markerLine ?? null;
-            drawMarker(ctx, px, py, symbol, sizePt, fill, line, ptToPx);
+            const lineWidthEmu = dpt?.markerLineWidthEmu ?? s.markerLineWidthEmu;
+            drawMarker(
+              ctx, px, py, symbol, sizePt, fill, line, ptToPx,
+              lineWidthEmu != null ? axisLineWidthPx(lineWidthEmu, ptToPx) : undefined,
+            );
           } else {
             ctx.fillStyle = color;
             ctx.beginPath(); ctx.arc(px, py, areaMarkerR, 0, Math.PI * 2); ctx.fill();
@@ -3926,6 +4185,8 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
         pct && pctTotals
           ? ci => (s.values[ci] ?? 0) / pctTotals[ci]
           : undefined,
+        undefined,
+        face => chartFontFamily(chart, face, 'minor'),
       );
     }
   }
@@ -3976,6 +4237,9 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
           ctx, toX(ci), yOf(value), symbol, dpt?.markerSize ?? s.markerSize ?? 5,
           dpt?.markerFill ?? dpt?.color ?? s.markerFill ?? stroke,
           dpt?.markerLine ?? s.markerLine ?? null, ptToPx,
+          (dpt?.markerLineWidthEmu ?? s.markerLineWidthEmu) != null
+            ? axisLineWidthPx((dpt?.markerLineWidthEmu ?? s.markerLineWidthEmu) as number, ptToPx)
+            : undefined,
         );
       }
     }
@@ -3984,6 +4248,9 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
       chartFontFamily(chart, chart.dataLabelFontFace, 'minor'), chart.dataLabelPosition ?? 'r',
       { x: px0, y: py0, w: pw, h: ph },
       { x, y, w, h },
+      undefined,
+      undefined,
+      face => chartFontFamily(chart, face, 'minor'),
     );
     drawSeriesTrendlines(
       ctx, s, stroke, toX, yOf, ptToPx, undefined,
@@ -4002,7 +4269,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     ctx.textBaseline = 'middle';
     for (const v of areaPlan.majorLines) {
       const gy = toY(v);
-      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, valLineColor, valLineW, false, chart.valAxisLineHidden);
+      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, valLineColor, valLineW, false, chart.valAxisLineHidden, 'major', ptToPx);
       ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
       ctx.textAlign = 'right';
       const gap = chart.valAxisFontSizeHpt != null
@@ -4012,7 +4279,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     }
     if (chart.valAxisMinorTickMark && chart.valAxisMinorTickMark !== 'none') {
       for (const value of areaPlan.minorTicks) {
-        drawAxisTick(ctx, chart.valAxisMinorTickMark, 'val', px0, toY(value), valLineColor, valLineW, false, chart.valAxisLineHidden);
+        drawAxisTick(ctx, chart.valAxisMinorTickMark, 'val', px0, toY(value), valLineColor, valLineW, false, chart.valAxisLineHidden, 'minor', ptToPx);
       }
     }
   }
@@ -4034,11 +4301,11 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     const tickSkip = Math.max(1, Math.floor(chart.catAxisTickMarkSkip ?? 1));
     if (between) {
       for (let ci = 0; ci <= n; ci += tickSkip) {
-        drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, px0 + (ci / n) * pw, catLineColor, catLineW, false, chart.catAxisLineHidden);
+        drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, px0 + (ci / n) * pw, catLineColor, catLineW, false, chart.catAxisLineHidden, 'major', ptToPx);
       }
     } else {
       for (let ci = 0; ci < n; ci += tickSkip) {
-        drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, toX(ci), catLineColor, catLineW, false, chart.catAxisLineHidden);
+        drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, toX(ci), catLineColor, catLineW, false, chart.catAxisLineHidden, 'major', ptToPx);
       }
     }
   }
@@ -4357,6 +4624,7 @@ function drawPieRichLabels(
     const sizePx = sizeHpt ? (sizeHpt / 100) * ptToPx : Math.max(8, outerR * 0.1);
     const bold = ov?.fontBold ?? def.fontBold;
     const fontColor = ov?.fontColor ?? def.fontColor;
+    const rich = customRichDataLabelOptions(chart, ov, ptToPx, font, bold ?? false);
     const automaticLabelR = innerR > 0.01
       ? (innerR + outerR) / 2
       : outerR * PIE_CTR_LABEL_RADIUS_FRAC;
@@ -4376,28 +4644,34 @@ function drawPieRichLabels(
         fontColor ? `#${fontColor}` : '#fff',
         ov.manualLayout,
         { x: chartX, y: chartY, w: chartW, h: chartH },
+        rich,
       );
       continue;
     }
     if (outside) {
       ctx.font = `${bold ? 'bold ' : ''}${sizePx}px ${font}`;
+      const richBlock = rich
+        ? resolveRichDataLabelBlock(ctx, rich, sizePx, fontColor ? `#${fontColor}` : '#333')
+        : null;
       const lineHeight = sizePx * 1.15;
-      const fittedLines = fitDataLabelLines(
-        text,
-        Math.max(0, chartW - sizePx),
-        Math.max(0, chartH - sizePx),
-        lineHeight,
-        value => ctx.measureText(value).width,
+      const fittedLines = richBlock ? [] : fitDataLabelLines(
+        text, Math.max(0, chartW - sizePx), Math.max(0, chartH - sizePx),
+        lineHeight, value => ctx.measureText(value).width,
       );
-      if (fittedLines.length === 0) continue;
-      const textW = fittedLines.reduce(
+      if (rich && !richBlock) continue;
+      if (!richBlock && fittedLines.length === 0) continue;
+      const textW = richBlock?.width ?? fittedLines.reduce(
         (max, line) => Math.max(max, ctx.measureText(line).width), 0,
       );
-      const textH = sizePx + Math.max(0, fittedLines.length - 1) * lineHeight;
+      const textH = richBlock?.height
+        ?? (sizePx + Math.max(0, fittedLines.length - 1) * lineHeight);
       outsideLabels.push(createPieOutsideLabel(
         fittedLines, midAngle, cx2, cy2, outerR,
-        textW, textH, lineHeight, sizePx, bold ?? false,
+        Math.min(textW, Math.max(0, chartW - sizePx)),
+        Math.min(textH, Math.max(0, chartH - sizePx)),
+        lineHeight, sizePx, bold ?? false,
         fontColor ? `#${fontColor}` : '#333',
+        richBlock ?? undefined,
       ));
       continue;
     }
@@ -4446,6 +4720,7 @@ function drawPieRichLabels(
       fontColor ? `#${fontColor}` : '#fff',
       undefined,
       { x: chartX, y: chartY, w: chartW, h: chartH },
+      rich,
     );
   }
 
@@ -4461,6 +4736,7 @@ function drawPieRichLabels(
  * long category names overlap the slices. */
 interface PieOutsideLabel {
   lines: string[];
+  rich?: RichDataLabelBlock;
   rimX: number;
   rimY: number;
   boxW: number;
@@ -4522,6 +4798,7 @@ function createPieOutsideLabel(
   fontPx: number,
   bold: boolean,
   fontColor: string,
+  rich?: RichDataLabelBlock,
 ): PieOutsideLabel {
   const clearance = fontPx * 0.5;
   const distance = outsideLabelRadialDistance(
@@ -4530,7 +4807,7 @@ function createPieOutsideLabel(
   const cxBox = pieCx + Math.cos(midAngle) * distance;
   const cyBox = pieCy + Math.sin(midAngle) * distance;
   return {
-    lines,
+    lines, rich,
     rimX: pieCx + Math.cos(midAngle) * outerR,
     rimY: pieCy + Math.sin(midAngle) * outerR,
     boxW, boxH, lineHeight, fontPx, bold, fontColor,
@@ -4625,6 +4902,10 @@ function drawPieOutsideLabels(
   }
 
   for (const label of labels) {
+    if (label.rich) {
+      paintRichDataLabelBlock(ctx, label.rich, label.cxBox, label.cyBox);
+      continue;
+    }
     ctx.font = `${label.bold ? 'bold ' : ''}${label.fontPx}px ${font}`;
     ctx.fillStyle = label.fontColor;
     ctx.textAlign = 'center';
@@ -4641,6 +4922,7 @@ function drawPieOutsideLabels(
  *  rim anchor point on its slice, and the resolved per-point style. */
 interface PieCalloutLabel {
   lines: string[];
+  rich?: RichDataLabelBlock;
   lineHeight: number;
   /** Slice mid-angle (canvas radians) — the leader-line target direction. */
   midAngle: number;
@@ -4756,24 +5038,30 @@ function drawPieCalloutLabels(
       defaultSeparator: '\n',
     });
     if (!text) continue;
+    const richOptions = customRichDataLabelOptions(chart, ov, ptToPx, font, bold);
 
     const padX = Math.max(4, fontPx * 0.45);
     const padY = Math.max(2, fontPx * 0.28);
     const lineGap = fontPx * 0.22;
     const lineH = fontPx + lineGap;
     ctx.font = `${bold ? 'bold ' : ''}${fontPx}px ${font}`;
-    let lines = fitDataLabelLines(
+    const rich = richOptions
+      ? resolveRichDataLabelBlock(ctx, richOptions, fontPx, fontColor)
+      : null;
+    if (richOptions && !rich) continue;
+    let lines = rich ? [] : fitDataLabelLines(
       text,
       Math.max(0, boundsW - padX * 2),
       Math.max(0, boundsH - padY * 2),
       lineH,
       value => ctx.measureText(value).width,
     );
-    if (lines.length === 0) continue;
-    let textW = 0;
-    for (const ln of lines) textW = Math.max(textW, ctx.measureText(ln).width);
-    let boxW = textW + padX * 2;
-    let boxH = lines.length * lineH - lineGap + padY * 2;
+    if (!rich && lines.length === 0) continue;
+    let textW = rich?.width ?? 0;
+    if (!rich) for (const ln of lines) textW = Math.max(textW, ctx.measureText(ln).width);
+    let boxW = Math.min(textW + padX * 2, boundsW);
+    let boxH = rich?.height ?? (lines.length * lineH - lineGap);
+    boxH = Math.min(boxH + padY * 2, boundsH);
 
     const rimX = cx2 + Math.cos(midAngle) * outerR;
     const rimY = cy2 + Math.sin(midAngle) * outerR;
@@ -4798,14 +5086,16 @@ function drawPieCalloutLabels(
       if (!manual) continue;
       boxW = manual.rect.w;
       boxH = manual.rect.h;
-      lines = fitDataLabelLines(
-        text,
-        Math.max(0, boxW - padX * 2),
-        Math.max(0, boxH - padY * 2),
-        lineH,
-        value => ctx.measureText(value).width,
-      );
-      if (lines.length === 0) continue;
+      if (!rich) {
+        lines = fitDataLabelLines(
+          text,
+          Math.max(0, boxW - padX * 2),
+          Math.max(0, boxH - padY * 2),
+          lineH,
+          value => ctx.measureText(value).width,
+        );
+        if (lines.length === 0) continue;
+      }
       cxBox = manual.rect.x + manual.rect.w / 2;
       cyBox = manual.rect.y + manual.rect.h / 2;
       leftSide = cxBox < cx2;
@@ -4831,17 +5121,22 @@ function drawPieCalloutLabels(
         { x: boundsX, y: boundsY, w: boundsW, h: boundsH },
       );
       if (!sliceBounds) continue;
-      lines = fitDataLabelLines(
-        text,
-        Math.max(0, sliceBounds.w - padX * 2),
-        Math.max(0, sliceBounds.h - padY * 2),
-        lineH,
-        value => ctx.measureText(value).width,
-      );
-      if (lines.length === 0) continue;
-      textW = lines.reduce((width, line) => Math.max(width, ctx.measureText(line).width), 0);
-      boxW = textW + padX * 2;
-      boxH = lines.length * lineH - lineGap + padY * 2;
+      if (!rich) {
+        lines = fitDataLabelLines(
+          text,
+          Math.max(0, sliceBounds.w - padX * 2),
+          Math.max(0, sliceBounds.h - padY * 2),
+          lineH,
+          value => ctx.measureText(value).width,
+        );
+        if (lines.length === 0) continue;
+        textW = lines.reduce((width, line) => Math.max(width, ctx.measureText(line).width), 0);
+        boxW = textW + padX * 2;
+        boxH = lines.length * lineH - lineGap + padY * 2;
+      } else {
+        boxW = Math.min(boxW, sliceBounds.w);
+        boxH = Math.min(boxH, sliceBounds.h);
+      }
       const anchorPosition = position === 'inBase' || position === 'inEnd'
         ? 'ctr'
         : position;
@@ -4868,7 +5163,7 @@ function drawPieCalloutLabels(
     }
 
     labels.push({
-      lines, lineHeight: lineH, midAngle, rimX, rimY, boxW, boxH, cxBox, cyBox,
+      lines, rich: rich ?? undefined, lineHeight: lineH, midAngle, rimX, rimY, boxW, boxH, cxBox, cyBox,
       leftSide, fontColor, boxFill, boxBorder, boxBorderPx, fontPx, bold, inside, manualClip,
     });
   }
@@ -5014,7 +5309,18 @@ function drawPieCalloutLabels(
       ctx.lineWidth = l.boxBorderPx;
       ctx.strokeRect(bx, by, l.boxW, l.boxH);
     }
-    // Text: centred, stacked lines.
+    // Text: centred, stacked lines. A custom rich body uses the same bounded
+    // inline block that measured the box, keeping measurement and paint exact.
+    if (l.rich) {
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(bx, by, l.boxW, l.boxH);
+      ctx.clip();
+      paintRichDataLabelBlock(ctx, l.rich, l.cxBox, l.cyBox);
+      ctx.restore();
+      if (l.manualClip) ctx.restore();
+      continue;
+    }
     ctx.font = `${l.bold ? 'bold ' : ''}${l.fontPx}px ${font}`;
     ctx.fillStyle = l.fontColor;
     ctx.textAlign = 'center';
@@ -5154,6 +5460,8 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
           valAxisLine.width,
           false,
           chart.valAxisLineHidden,
+          'minor',
+          ptToPx,
         );
       }
     }
@@ -5286,6 +5594,19 @@ type ScatterSeriesLayer = {
   cats: string[];
   pointOverrides: Map<number, NonNullable<ChartSeries['dataPointOverrides']>[number]>;
 };
+
+function scatterPointFill(
+  series: ChartSeries,
+  point: NonNullable<ChartSeries['dataPointOverrides']>[number] | undefined,
+  index: number,
+  fallbackColor: string,
+): string {
+  return point?.markerFill
+    ?? point?.color
+    ?? series.dataPointColors?.[index]
+    ?? series.markerFill
+    ?? fallbackColor;
+}
 
 function makeScatterSeriesLayer(
   chart: ChartModel,
@@ -5435,13 +5756,16 @@ function drawScatterSeriesLayer(
           if (bubbleSize == null) continue;
           sizePt = (bubbleSizeMagnitude(chart, bubbleSize) * bubbleScale) / ptToPx;
         }
-        const fill = dpt?.markerFill ?? dpt?.color ?? s.markerFill ?? fallbackColor;
+        const fill = scatterPointFill(s, dpt, ci, fallbackColor);
         // Bubble geometry is the series shape itself, so its outline comes from
         // `<c:ser><c:spPr><a:ln>` rather than a `<c:marker>` block. Ordinary
         // scatter markers continue to use markerLine only.
         const line = dpt?.markerLine ?? s.markerLine ?? (isBubble ? s.lineColor : null) ?? null;
-        const lineWidthPx = isBubble && s.lineWidthEmu != null
-          ? Math.max(0.5, (s.lineWidthEmu / EMU_PER_PT) * ptToPx)
+        const markerLineWidthEmu = dpt?.markerLineWidthEmu ?? s.markerLineWidthEmu;
+        const bubbleLineWidthEmu = dpt?.lineWidthEmu ?? s.lineWidthEmu;
+        const lineWidthEmu = isBubble ? bubbleLineWidthEmu : markerLineWidthEmu;
+        const lineWidthPx = lineWidthEmu != null
+          ? axisLineWidthPx(lineWidthEmu, ptToPx)
           : undefined;
         drawMarker(ctx, toX(xv), toY(yv), symbol, sizePt, fill, line, ptToPx, lineWidthPx);
       }
@@ -5463,6 +5787,7 @@ function drawScatterSeriesLayer(
       chart.dataLabelPosition ?? 'r',
       { x: px0, y: py0, w: pw, h: ph },
       layoutReferenceRect,
+      face => chartFontFamily(chart, face, 'minor'),
     );
   }
 
@@ -5561,8 +5886,13 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
   // Omitted Y bounds, including point ranges, flow through the shared planner.
   if (chart.valMin != null) yMin = chart.valMin;
   if (chart.valMax != null) yMax = chart.valMax;
-  // Scatter/bubble retain their fixed-density target (axis length omitted),
-  // while using the same bounds, authored-unit precedence, and safety policy.
+  // Preserve the legacy density input unless the new explicit-bounds policy
+  // actually applies. This keeps automatic ranges and authored units byte-for-
+  // byte compatible while giving an explicit vertical axis its physical height.
+  const numericAxisDensityLengthPt = Math.max(pw, ph) / ptToPx;
+  const explicitAutomaticYAxis = chart.valMin != null
+    && chart.valMax != null
+    && chart.valAxisMajorUnit == null;
   const yNeedsMinor = chart.valAxisMinorGridlines === true
     || (chart.valAxisMinorTickMark != null && chart.valAxisMinorTickMark !== 'none');
   const yAxisPlan = planLinearValueAxis({
@@ -5570,6 +5900,8 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     dataMax: yMax,
     explicitMin: chart.valMin,
     explicitMax: chart.valMax,
+    axisLenPt: explicitAutomaticYAxis ? ph / ptToPx : numericAxisDensityLengthPt,
+    axisOrientation: 'vertical',
     majorUnit: chart.valAxisMajorUnit,
     minorUnit: chart.valAxisMinorUnit,
     needMinor: yNeedsMinor,
@@ -5583,7 +5915,8 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     dataMax: xMax,
     explicitMin: chart.catAxisMin,
     explicitMax: chart.catAxisMax,
-    axisLenPt: pw / ptToPx,
+    axisLenPt: numericAxisDensityLengthPt,
+    axisOrientation: 'horizontal',
     majorUnit: chart.catAxisMajorUnit,
     minorUnit: chart.catAxisMinorUnit,
     needMinor: xNeedsMinor,
@@ -5630,7 +5963,12 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     const yTickGap = chart.valAxisFontSizeHpt != null
       ? valueTickLabelGapPx(yTickFontPx)
       : 4;
-    ctx.font = `${chart.valAxisFontBold ? 'bold ' : ''}${yTickFontPx}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
+    ctx.font = chartFontCss(
+      yTickFontPx,
+      chartFontFamily(chart, chart.valAxisFontFace, 'minor'),
+      chart.valAxisFontBold ?? false,
+      chart.valAxisFontItalic ?? false,
+    );
     if (chart.valAxisMinorGridlines) {
       const minorGrid = valMinorGridStroke(chart, ptToPx);
       for (const value of yMinorTicks) {
@@ -5664,12 +6002,12 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       // so only the width formula is shared. `axisLineWidthPx`'s 1 px fallback is
       // equivalent to undefined here (drawAxisTick treats both as a hairline).
       const yAxisLineColor = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : undefined;
-      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', yAxisX, gy, yAxisLineColor, axisLineWidthPx(chart.valAxisLineWidthEmu, ptToPx), false, chart.valAxisLineHidden);
+      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', yAxisX, gy, yAxisLineColor, axisLineWidthPx(chart.valAxisLineWidthEmu, ptToPx), false, chart.valAxisLineHidden, 'major', ptToPx);
     }
     if (chart.valAxisMinorTickMark && chart.valAxisMinorTickMark !== 'none') {
       const yAxisLineColor = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : undefined;
       for (const value of yMinorTicks) {
-        drawAxisTick(ctx, chart.valAxisMinorTickMark, 'val', yAxisX, toY(value), yAxisLineColor, axisLineWidthPx(chart.valAxisLineWidthEmu, ptToPx), false, chart.valAxisLineHidden);
+        drawAxisTick(ctx, chart.valAxisMinorTickMark, 'val', yAxisX, toY(value), yAxisLineColor, axisLineWidthPx(chart.valAxisLineWidthEmu, ptToPx), false, chart.valAxisLineHidden, 'minor', ptToPx);
       }
     }
   }
@@ -5737,7 +6075,12 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     const tickGap = chart.catAxisFontSizeHpt != null
       ? categoryTickLabelGapPx(tickFontPx)
       : 4;
-    ctx.font = `${chart.catAxisFontBold ? 'bold ' : ''}${tickFontPx}px ${chartFontFamily(chart, chart.catAxisFontFace, 'minor')}`;
+    ctx.font = chartFontCss(
+      tickFontPx,
+      chartFontFamily(chart, chart.catAxisFontFace, 'minor'),
+      chart.catAxisFontBold ?? false,
+      chart.catAxisFontItalic ?? false,
+    );
     ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#555';
     ctx.textAlign = 'center';
     const labelPos = chart.catAxisTickLabelPos ?? 'nextTo';
@@ -5751,12 +6094,12 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
         ctx.fillText(formatChartValWithCode(v, chart.catAxisFormatCode, chart.date1904), gx, labelY);
       }
       const xAxisLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : undefined;
-      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', xAxisY, gx, xAxisLineColor, axisLineWidthPx(chart.catAxisLineWidthEmu, ptToPx), false, chart.catAxisLineHidden);
+      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', xAxisY, gx, xAxisLineColor, axisLineWidthPx(chart.catAxisLineWidthEmu, ptToPx), false, chart.catAxisLineHidden, 'major', ptToPx);
     }
     if (chart.catAxisMinorTickMark && chart.catAxisMinorTickMark !== 'none') {
       const xAxisLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : undefined;
       for (const value of xMinorTicks) {
-        drawAxisTick(ctx, chart.catAxisMinorTickMark, 'cat', xAxisY, toX(value), xAxisLineColor, axisLineWidthPx(chart.catAxisLineWidthEmu, ptToPx), false, chart.catAxisLineHidden);
+        drawAxisTick(ctx, chart.catAxisMinorTickMark, 'cat', xAxisY, toX(value), xAxisLineColor, axisLineWidthPx(chart.catAxisLineWidthEmu, ptToPx), false, chart.catAxisLineHidden, 'minor', ptToPx);
       }
     }
   }
@@ -5849,16 +6192,16 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
           // ptToPx multiplication gives the same px size.
           sizePt = (bubbleSizeMagnitude(chart, bsz) * bubbleScale) / ptToPx;
         }
-        const fill = dpt?.markerFill
-          ?? dpt?.color
-          ?? s.markerFill
-          ?? fallbackColor;
+        const fill = scatterPointFill(s, dpt, ci, fallbackColor);
         // Bubble geometry is the series shape itself, so its outline comes from
         // `<c:ser><c:spPr><a:ln>` rather than a `<c:marker>` block. Ordinary
         // scatter markers continue to use markerLine only.
         const line = dpt?.markerLine ?? s.markerLine ?? (isBubble ? s.lineColor : null) ?? null;
-        const lineWidthPx = isBubble && s.lineWidthEmu != null
-          ? Math.max(0.5, (s.lineWidthEmu / EMU_PER_PT) * ptToPx)
+        const markerLineWidthEmu = dpt?.markerLineWidthEmu ?? s.markerLineWidthEmu;
+        const bubbleLineWidthEmu = dpt?.lineWidthEmu ?? s.lineWidthEmu;
+        const lineWidthEmu = isBubble ? bubbleLineWidthEmu : markerLineWidthEmu;
+        const lineWidthPx = lineWidthEmu != null
+          ? axisLineWidthPx(lineWidthEmu, ptToPx)
           : undefined;
         drawMarker(ctx, toX(xv), toY(yv), symbol, sizePt, fill, line, ptToPx, lineWidthPx);
       }
@@ -5873,6 +6216,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       chart.dataLabelPosition ?? 'r',
       { x: px0, y: py0, w: pw, h: ph },
       { x, y, w, h },
+      face => chartFontFamily(chart, face, 'minor'),
     );
 
     if (s.trendLines && s.trendLines.length > 0) {
@@ -6095,6 +6439,7 @@ function drawSeriesDataLabels(
   defaultPos = 'r',
   bounds: DataLabelRect = { x: -1e6, y: -1e6, w: 2e6, h: 2e6 },
   layoutReferenceRect: DataLabelRect = bounds,
+  richFontFamilyForFace?: (face: string) => string,
 ): void {
   const overrides = s.dataLabelOverrides ?? [];
   if (overrides.length === 0 && !s.seriesDataLabels) return;
@@ -6138,6 +6483,9 @@ function drawSeriesDataLabels(
       ctx, toX(xv), toY(yv), text, pos, fontSizePx, color, bold, fontFamily, 0,
       bounds, ovr?.manualLayout,
       layoutReferenceRect,
+      ovr?.richRuns,
+      ptToPx,
+      richFontFamilyForFace,
     );
   }
 }
@@ -6158,6 +6506,9 @@ function drawDataLabelText(
   bounds: DataLabelRect = { x: -1e6, y: -1e6, w: 2e6, h: 2e6 },
   manualLayout?: ChartDataLabelOverride['manualLayout'],
   layoutReferenceRect: DataLabelRect = bounds,
+  richRuns?: readonly ChartTextRun[],
+  ptToPx = 1,
+  richFontFamilyForFace?: (face: string) => string,
 ): void {
   ctx.save();
   ctx.font = `${bold ? 'bold ' : ''}${fontSizePx}px ${fontFamily}`;
@@ -6170,8 +6521,211 @@ function drawDataLabelText(
     color ? `#${color}` : '#333',
     manualLayout,
     layoutReferenceRect,
+    richRuns && richRuns.length > 0
+      ? {
+          runs: richRuns,
+          ptToPx,
+          fontFamily,
+          fallbackBold: bold,
+          fontFamilyForFace: richFontFamilyForFace,
+        }
+      : undefined,
   );
   ctx.restore();
+}
+
+interface RichDataLabelOptions {
+  runs: readonly ChartTextRun[];
+  ptToPx: number;
+  fontFamily: string;
+  fallbackBold: boolean;
+  /** Resolve a run-local concrete or theme-reference face through the chart's
+   * single font-scheme resolver. Absent retains the established concrete-face
+   * fallback for internal callers that do not carry a chart model. */
+  fontFamilyForFace?: (face: string) => string;
+}
+
+interface RichDataLabelPaintRun {
+  text: string;
+  font: string;
+  fillStyle: string;
+  width: number;
+  fontSizePx: number;
+}
+
+interface RichDataLabelBlock {
+  lines: RichDataLabelPaintRun[][];
+  lineHeights: number[];
+  lineWidths: number[];
+  width: number;
+  height: number;
+}
+
+const MAX_DATA_LABEL_RICH_SCALARS = 4096;
+const MAX_DATA_LABEL_RICH_LINES = 4;
+// A public ChartModel can bypass the Rust parser. At one visible scalar per
+// run, no useful label needs more runs than the scalar ceiling; this also
+// prevents an adversarial array of empty runs from forcing an unbounded scan.
+const MAX_DATA_LABEL_RICH_RUNS = MAX_DATA_LABEL_RICH_SCALARS;
+
+/** Resolve one bounded custom label body into inline paint runs. This is a
+ * renderer-side defence in depth for public models that did not come through
+ * the Rust parser; the parser applies the same 4096-scalar / four-line limits. */
+function resolveRichDataLabelLines(
+  ctx: CanvasRenderingContext2D,
+  options: RichDataLabelOptions,
+  fallbackFontSizePx: number,
+  fallbackColor: string,
+): RichDataLabelPaintRun[][] {
+  const lines: RichDataLabelPaintRun[][] = [[]];
+  let scalarCount = 0;
+  const cleanColor = (value: string | null | undefined): string | null => {
+    if (!value) return null;
+    const hex = value.startsWith('#') ? value.slice(1) : value;
+    return /^[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$/.test(hex) ? `#${hex}` : null;
+  };
+  outer: for (let runIndex = 0;
+    runIndex < options.runs.length && runIndex < MAX_DATA_LABEL_RICH_RUNS;
+    runIndex++) {
+    const source = options.runs[runIndex];
+    const fontSizePx = source.fontSizeHpt != null
+      && Number.isFinite(source.fontSizeHpt)
+      && source.fontSizeHpt >= 100
+      && source.fontSizeHpt <= 400_000
+      ? (source.fontSizeHpt / 100) * options.ptToPx
+      : fallbackFontSizePx;
+    const authoredFace = source.fontFace?.trim().replaceAll('"', '');
+    const safeFace = authoredFace && !authoredFace.startsWith('+')
+      ? authoredFace
+      : null;
+    const fontFamily = authoredFace && options.fontFamilyForFace
+      ? options.fontFamilyForFace(authoredFace)
+      : safeFace
+        ? `"${safeFace}", Calibri, Arial, sans-serif`
+        : options.fontFamily;
+    const font = chartFontCss(fontSizePx, fontFamily, source.bold ?? options.fallbackBold);
+    const fillStyle = cleanColor(source.color) ?? fallbackColor;
+    let chunk = '';
+    const flush = (): void => {
+      if (!chunk) return;
+      ctx.font = font;
+      lines[lines.length - 1].push({
+        text: chunk,
+        font,
+        fillStyle,
+        width: ctx.measureText(chunk).width,
+        fontSizePx,
+      });
+      chunk = '';
+    };
+    // Normalize CR/LF while consuming the bounded prefix. Calling replace() on
+    // the complete source first would allocate and scan an attacker-controlled
+    // string before either public-model ceiling had a chance to apply.
+    let skipLfAfterCr = false;
+    for (const sourceCharacter of source.text) {
+      if (skipLfAfterCr && sourceCharacter === '\n') {
+        skipLfAfterCr = false;
+        continue;
+      }
+      skipLfAfterCr = false;
+      const character = sourceCharacter === '\r' ? '\n' : sourceCharacter;
+      if (sourceCharacter === '\r') skipLfAfterCr = true;
+      if (scalarCount >= MAX_DATA_LABEL_RICH_SCALARS) {
+        flush();
+        break outer;
+      }
+      scalarCount++;
+      if (character === '\n') {
+        flush();
+        if (lines.length >= MAX_DATA_LABEL_RICH_LINES) break outer;
+        lines.push([]);
+      } else {
+        chunk += character;
+      }
+    }
+    flush();
+  }
+  return lines.some(line => line.length > 0) ? lines : [];
+}
+
+function resolveRichDataLabelBlock(
+  ctx: CanvasRenderingContext2D,
+  options: RichDataLabelOptions,
+  fallbackFontSizePx: number,
+  fallbackColor: string,
+): RichDataLabelBlock | null {
+  const lines = resolveRichDataLabelLines(ctx, options, fallbackFontSizePx, fallbackColor);
+  if (lines.length === 0) return null;
+  const lineHeights = lines.map(line =>
+    Math.max(fallbackFontSizePx, ...line.map(run => run.fontSizePx)) * 1.15
+  );
+  const lineWidths = lines.map(line => line.reduce((sum, run) => sum + run.width, 0));
+  return {
+    lines,
+    lineHeights,
+    lineWidths,
+    width: Math.max(0, ...lineWidths),
+    height: lineHeights.reduce((sum, height) => sum + height, 0),
+  };
+}
+
+function paintRichDataLabelBlock(
+  ctx: CanvasRenderingContext2D,
+  block: RichDataLabelBlock,
+  x: number,
+  y: number,
+  textAlign: CanvasTextAlign = 'center',
+  textBaseline: CanvasTextBaseline = 'middle',
+): void {
+  const top = textBaseline === 'top'
+    ? y
+    : textBaseline === 'bottom'
+      ? y - block.height
+      : y - block.height / 2;
+  let lineTop = top;
+  for (let lineIndex = 0; lineIndex < block.lines.length; lineIndex++) {
+    const line = block.lines[lineIndex];
+    const lineWidth = block.lineWidths[lineIndex];
+    let cursorX = textAlign === 'left'
+      ? x
+      : textAlign === 'right'
+        ? x - lineWidth
+        : x - lineWidth / 2;
+    const paintY = textBaseline === 'top'
+      ? lineTop
+      : textBaseline === 'bottom'
+        ? lineTop + block.lineHeights[lineIndex]
+        : lineTop + block.lineHeights[lineIndex] / 2;
+    for (const run of line) {
+      ctx.font = run.font;
+      ctx.fillStyle = run.fillStyle;
+      ctx.textAlign = 'left';
+      ctx.textBaseline = textBaseline;
+      ctx.fillText(run.text, cursorX, paintY);
+      cursorX += run.width;
+    }
+    lineTop += block.lineHeights[lineIndex];
+  }
+}
+
+/** A `<c:tx><c:rich>` body is authoritative only with non-empty custom text.
+ * Empty override text means the visible label is composed from show/format
+ * flags, so stale/empty rich payload must not replace that composition. */
+function customRichDataLabelOptions(
+  chart: ChartModel,
+  override: ChartDataLabelOverride | undefined,
+  ptToPx: number,
+  fontFamily: string,
+  fallbackBold: boolean,
+): RichDataLabelOptions | undefined {
+  if (!override?.text || !override.richRuns || override.richRuns.length === 0) return undefined;
+  return {
+    runs: override.richRuns,
+    ptToPx,
+    fontFamily,
+    fallbackBold,
+    fontFamilyForFace: face => chartFontFamily(chart, face, 'minor'),
+  };
 }
 
 /** Measure, fit, clip, and paint one label through the shared pure resolver. */
@@ -6184,8 +6738,28 @@ function drawBoundedDataLabelText(
   color: string,
   manualLayout?: ChartDataLabelOverride['manualLayout'],
   layoutReferenceRect: DataLabelRect = bounds,
+  rich?: RichDataLabelOptions,
 ): void {
   if (!text || !Number.isFinite(fontSizePx) || fontSizePx <= 0) return;
+  if (rich) {
+    const block = resolveRichDataLabelBlock(ctx, rich, fontSizePx, color);
+    if (!block) return;
+    const placement = resolveDataLabelPlacement(
+      anchor, bounds, { w: block.width, h: block.height }, fontSizePx, manualLayout,
+      layoutReferenceRect,
+    );
+    if (!placement) return;
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(placement.clip.x, placement.clip.y, placement.clip.w, placement.clip.h);
+    ctx.clip();
+    paintRichDataLabelBlock(
+      ctx, block, placement.x, placement.y, placement.textAlign, placement.textBaseline,
+    );
+    ctx.restore();
+    return;
+  }
   const lineHeight = fontSizePx * 1.15;
   const sourceLines = boundDataLabelText(text).value.split(/\r?\n/);
   const measuredW = sourceLines.reduce((max, line) => Math.max(max, ctx.measureText(line).width), 0);
@@ -6275,7 +6849,7 @@ function dashPatternForPreset(preset: string | undefined): number[] {
 }
 
 /** True when the series carries any explicit `<c:marker>` detail (symbol, size,
- *  fill, line) or per-point `<c:dPt>` marker overrides — i.e. a reason to route
+ *  fill, line, line width) or per-point `<c:dPt>` marker overrides — i.e. a reason to route
  *  through {@link drawMarker} instead of the line/area family's historical
  *  fixed-circle fast path. A series without any of these keeps the exact prior
  *  circle marker (byte-stable), so charts that never parsed marker detail are
@@ -6287,6 +6861,7 @@ function seriesHasMarkerDetail(s: ChartSeries): boolean {
     s.markerSize != null ||
     s.markerFill != null ||
     s.markerLine != null ||
+    s.markerLineWidthEmu != null ||
     (s.dataPointOverrides != null && s.dataPointOverrides.length > 0)
   );
 }
@@ -6376,6 +6951,8 @@ function drawCategoryDataLabels(
   bounds: DataLabelRect = { x: -1e6, y: -1e6, w: 2e6, h: 2e6 },
   layoutReferenceRect: DataLabelRect = bounds,
   percentRatioAt?: (index: number) => number,
+  markerGapAt?: (index: number) => number,
+  richFontFamilyForFace?: (face: string) => string,
 ): boolean {
   const overrides = s.dataLabelOverrides ?? [];
   const seriesDef = s.seriesDataLabels;
@@ -6414,9 +6991,13 @@ function drawCategoryDataLabels(
     const color = ovr?.fontColor ?? seriesDef?.fontColor;
     const bold = ovr?.fontBold ?? seriesDef?.fontBold ?? false;
     drawDataLabelText(
-      ctx, xAt(ci), yAt(anchorValue), text, pos, fontSizePx, color, bold, fontFamily, 0,
+      ctx, xAt(ci), yAt(anchorValue), text, pos, fontSizePx, color, bold, fontFamily,
+      markerGapAt?.(ci) ?? 0,
       bounds, ovr?.manualLayout,
       layoutReferenceRect,
+      ovr?.richRuns,
+      ptToPx,
+      richFontFamilyForFace,
     );
   }
   return true;
@@ -6449,8 +7030,7 @@ function chartExSeriesFormatIndex(
 
 /** Resolve CT_DataLabels + indexed CT_DataLabel/dataLabelHidden without
  * renderer-specific precedence. Defaults describe the semantic label layer of
- * the chart type (waterfall values remain visible when no dataLabels element
- * exists); authored visibility always overrides those defaults. */
+ * the chart type; authored visibility always overrides those defaults. */
 function resolveChartExLabel(
   chart: ChartModel,
   series: ChartSeries | null | undefined,
@@ -6642,26 +7222,86 @@ function chartExFillStyle(
   return resolveFill(paint, ctx, x, y, w, h, shapeRotationDeg) ?? fallbackColor;
 }
 
-function applyChartExLineStyle(
-  ctx: CanvasRenderingContext2D,
+interface ResolvedChartExLineStyle {
+  visible: boolean;
+  color: string;
+  widthEmu: number | null;
+  dash: string | null;
+  cap: string | null;
+  join: string | null;
+}
+
+type ChartExSeriesStyleCarrier = Pick<
+  ChartSeries,
+  'chartexStyle' | 'lineHidden' | 'lineColor' | 'lineWidthEmu'
+>;
+
+/** Resolve a ChartEx mark's effective outline once for both plot and legend.
+ * Direct CT_Series formatting wins over the linked Chart Style role. `NoStyle`
+ * is absence of decoration (and may expose a family semantic outline), while
+ * an explicit noFill suppresses the outline. */
+function resolveChartExSeriesLineStyle(
   chart: ChartModel,
-  style: ChartExStyle | null | undefined,
+  linkedStyle: ChartExStyle | null | undefined,
+  series: Partial<ChartExSeriesStyleCarrier> | null | undefined,
   index: number,
   count: number,
   fallbackColor: string,
+  options: { linkedNoStyleFallback?: boolean } = {},
+): ResolvedChartExLineStyle {
+  const resolved = (
+    style: ChartExStyle | null | undefined,
+    fallback: string,
+  ): ResolvedChartExLineStyle => ({
+    visible: style?.lineHidden !== true,
+    color: chartExStyleColor(chart, style, 'line', index, count) ?? fallback,
+    widthEmu: style?.lineWidthEmu ?? null,
+    dash: style?.lineDash ?? null,
+    cap: style?.lineCap ?? null,
+    join: style?.lineJoin ?? null,
+  });
+  const local = series?.chartexStyle;
+  const localHasLine = local?.lineHidden != null
+    || local?.lineColors?.some(Boolean)
+    || local?.lineWidthEmu != null
+    || local?.lineDash != null
+    || local?.lineCap != null
+    || local?.lineJoin != null;
+  if (localHasLine && !(local?.lineHidden && local.lineNoStyle)) {
+    return resolved(local, fallbackColor);
+  }
+  const hasLegacyLocalLine = series?.lineHidden != null
+    || series?.lineColor != null
+    || series?.lineWidthEmu != null;
+  if (hasLegacyLocalLine) {
+    return {
+      visible: series?.lineHidden !== true,
+      color: series?.lineColor ?? fallbackColor,
+      widthEmu: series?.lineWidthEmu ?? null,
+      dash: null,
+      cap: null,
+      join: null,
+    };
+  }
+  if (linkedStyle?.lineNoStyle && options.linkedNoStyleFallback) {
+    return resolved(null, fallbackColor);
+  }
+  return resolved(linkedStyle, fallbackColor);
+}
+
+function applyResolvedChartExLineStyle(
+  ctx: CanvasRenderingContext2D,
+  line: ResolvedChartExLineStyle,
   ptToPx: number,
 ): boolean {
-  if (style?.lineHidden) return false;
-  const color = chartExStyleColor(chart, style, 'line', index, count) ?? fallbackColor;
-  ctx.strokeStyle = color.startsWith('#') ? color : `#${color}`;
-  ctx.lineWidth = style?.lineWidthEmu != null
-    ? axisLineWidthPx(style.lineWidthEmu, ptToPx)
+  if (!line.visible) return false;
+  ctx.strokeStyle = line.color.startsWith('#') ? line.color : `#${line.color}`;
+  ctx.lineWidth = line.widthEmu != null
+    ? axisLineWidthPx(line.widthEmu, ptToPx)
     : 1;
-  ctx.setLineDash(dashPatternForPreset(style?.lineDash ?? undefined));
-  ctx.lineCap = style?.lineCap === 'rnd' ? 'round' : style?.lineCap === 'sq' ? 'square' : 'butt';
-  ctx.lineJoin = style?.lineJoin === 'round' || style?.lineJoin === 'bevel'
-    ? style.lineJoin
-    : 'miter';
+  ctx.setLineDash(dashPatternForPreset(line.dash ?? undefined));
+  ctx.lineCap = line.cap === 'rnd' ? 'round' : line.cap === 'sq' ? 'square' : 'butt';
+  ctx.lineJoin = line.join === 'round' || line.join === 'bevel' ? line.join : 'miter';
   return true;
 }
 
@@ -6680,38 +7320,50 @@ function applyChartExSeriesLineStyle(
   ptToPx: number,
   options: { linkedNoStyleFallback?: boolean } = {},
 ): boolean {
-  const local = series?.chartexStyle;
-  const localHasLine = local?.lineHidden != null
-    || local?.lineColors?.some(Boolean)
-    || local?.lineWidthEmu != null
-    || local?.lineDash != null
-    || local?.lineCap != null
-    || local?.lineJoin != null;
-  if (localHasLine && !(local?.lineHidden && local.lineNoStyle)) {
-    return applyChartExLineStyle(ctx, chart, local, index, count, fallbackColor, ptToPx);
-  }
-  const hasLegacyLocalLine = series?.lineHidden != null
-    || series?.lineColor != null
-    || series?.lineWidthEmu != null;
-  if (!hasLegacyLocalLine) {
-    // NoStyle means the linked role supplies no decorative override. Layouts
-    // with a semantic line may opt back into their automatic fallback; an
-    // explicit linked noFill remains authoritative because lineNoStyle is false.
-    if (style?.lineNoStyle && options.linkedNoStyleFallback) {
-      return applyChartExLineStyle(ctx, chart, null, index, count, fallbackColor, ptToPx);
-    }
-    return applyChartExLineStyle(ctx, chart, style, index, count, fallbackColor, ptToPx);
-  }
-  if (series?.lineHidden) return false;
-  const color = series?.lineColor ?? fallbackColor;
-  ctx.strokeStyle = color.startsWith('#') ? color : `#${color}`;
-  ctx.lineWidth = series?.lineWidthEmu != null
-    ? axisLineWidthPx(series.lineWidthEmu, ptToPx)
-    : 1;
-  ctx.setLineDash([]);
-  ctx.lineCap = 'butt';
-  ctx.lineJoin = 'miter';
-  return true;
+  return applyResolvedChartExLineStyle(
+    ctx,
+    resolveChartExSeriesLineStyle(
+      chart, style, series, index, count, fallbackColor, options,
+    ),
+    ptToPx,
+  );
+}
+
+/** Build a synthetic legend series from the same resolved line contract used
+ * by plot paint. `chartexStyle` carries dash/cap/join through the generic
+ * legend pipeline without widening the public ChartSeries surface. */
+function chartExLegendSeries(
+  chart: ChartModel,
+  name: string,
+  series: Partial<ChartExSeriesStyleCarrier> | null | undefined,
+  linkedStyle: ChartExStyle | null | undefined,
+  index: number,
+  count: number,
+  fillColor: string,
+  semanticNoStyleFallback = false,
+): ChartSeries {
+  const line = resolveChartExSeriesLineStyle(
+    chart,
+    linkedStyle,
+    series,
+    index,
+    count,
+    fillColor,
+    { linkedNoStyleFallback: semanticNoStyleFallback },
+  );
+  return {
+    name,
+    values: [],
+    color: fillColor.replace(/^#/, ''),
+    lineHidden: !line.visible,
+    lineColor: line.visible ? line.color.replace(/^#/, '') : null,
+    lineWidthEmu: line.widthEmu,
+    chartexStyle: {
+      lineDash: line.dash,
+      lineCap: line.cap,
+      lineJoin: line.join,
+    },
+  };
 }
 
 // The parser may preserve up to the OOXML cache ceiling, but expanding every
@@ -6719,6 +7371,9 @@ function applyChartExSeriesLineStyle(
 // Refuse an oversized paint atomically instead of drawing a misleading prefix.
 // This is an availability boundary, not an automatic chart-layout heuristic.
 const MAX_CANVAS_CHART_POINTS = 10_000;
+// The package parser already applies its XML-depth ceiling. Keep the same kind
+// of stack-safety boundary for caller-constructed public ChartModel objects.
+const MAX_CANVAS_HIERARCHY_DEPTH = 512;
 
 function rejectOversizedCanvasChart(
   ctx: CanvasRenderingContext2D,
@@ -6837,6 +7492,16 @@ function renderWaterfallChart(
 
   if (rawMax <= rawMin) return;
 
+  // Office-observed ChartEx compatibility: an all-increase bridge with no
+  // subtotal/total points keeps its value grid and rule but omits numeric tick
+  // labels. The axis XML is otherwise the same as a subtotal bridge, so keep
+  // this narrow family policy out of the shared linear-axis planner.
+  const suppressImplicitValueTickLabels = subSet.size === 0
+    && bars.every((bar, index) => !bar.hasValue || (vals[index] as number) >= 0);
+  const valueTickLabelsVisible = !chart.valAxisHidden
+    && chart.valAxisTickLabelPos !== 'none'
+    && !suppressImplicitValueTickLabels;
+
   const titleBand = cartesianTitleBand(chart, h, ptToPx);
   const axBands = chartAxisTitleBands(chart, w, h, ptToPx);
   const valFontPx = axisLabelPx(chart.valAxisFontSizeHpt, h, ptToPx);
@@ -6847,8 +7512,13 @@ function renderWaterfallChart(
 
   ctx.save();
   let valLabelBandW = 0;
-  if (!chart.valAxisHidden) {
-    ctx.font = `${chart.valAxisFontBold ? 'bold ' : ''}${valFontPx}px ${valFont}`;
+  if (valueTickLabelsVisible) {
+    ctx.font = chartFontCss(
+      valFontPx,
+      valFont,
+      chart.valAxisFontBold ?? false,
+      chart.valAxisFontItalic ?? false,
+    );
     let maxWidth = 0;
     for (const value of provisionalPlan.majorLines) {
       maxWidth = Math.max(
@@ -6867,7 +7537,12 @@ function renderWaterfallChart(
     w - axBands.valBandW - valLabelBandW - w * 0.02,
   );
   const estimatedSlotW = estimatedPlotW / n;
-  ctx.font = `${chart.catAxisFontBold ? 'bold ' : ''}${catFontPx}px ${catFont}`;
+  ctx.font = chartFontCss(
+    catFontPx,
+    catFont,
+    chart.catAxisFontBold ?? false,
+    chart.catAxisFontItalic ?? false,
+  );
   const wrappedCategories = cats.slice(0, n).map(category =>
     wrapMeasuredText(
       ctx,
@@ -6895,9 +7570,15 @@ function renderWaterfallChart(
     ...chart,
     chartType: 'clusteredBar',
     series: [
-      { name: 'Increase', values: [], color: colorPos.slice(1) },
-      { name: 'Decrease', values: [], color: colorNeg.slice(1) },
-      { name: 'Total', values: [], color: colorSub.slice(1) },
+      chartExLegendSeries(
+        chart, 'Increase', series, chart.chartexDataPointStyle, 0, 3, colorPos,
+      ),
+      chartExLegendSeries(
+        chart, 'Decrease', series, chart.chartexDataPointStyle, 1, 3, colorNeg,
+      ),
+      chartExLegendSeries(
+        chart, 'Total', series, chart.chartexDataPointStyle, 2, 3, colorSub,
+      ),
     ],
   };
   const leg = measuredLegendReserve(ctx, legendChart, w, h, 0.22, ptToPx);
@@ -6906,7 +7587,13 @@ function renderWaterfallChart(
     t: titleBand.bandH + legTopH + valFontPx / 2 + 2,
     r: legRightW + w * 0.02,
     b: legBottomH + axBands.catBandH + categoryLabelBandH,
-    l: legLeftW + axBands.valBandW + (chart.valAxisHidden ? w * 0.02 : valLabelBandW),
+    l: legLeftW + axBands.valBandW + (chart.valAxisHidden
+      ? w * 0.02
+      // Office keeps the visible Waterfall value-axis rule roughly 3% inside
+      // the chart object even when this layout suppresses its implicit numeric
+      // labels. A measured label band may be wider, but never collapses that
+      // automatic edge gutter to zero.
+      : Math.max(w * 0.03, valLabelBandW)),
   };
   const frame = computeChartFrame(chart, x, y, w, h, ptToPx, {
     titleBand,
@@ -6936,7 +7623,12 @@ function renderWaterfallChart(
   // This is the canonical PowerPoint look for waterfall analyses where the
   // value scale is implicit in the data labels on each bar.
   if (!chart.valAxisHidden) {
-    ctx.font = `${chart.valAxisFontBold ? 'bold ' : ''}${valFontPx}px ${valFont}`;
+    ctx.font = chartFontCss(
+      valFontPx,
+      valFont,
+      chart.valAxisFontBold ?? false,
+      chart.valAxisFontItalic ?? false,
+    );
     ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#595959';
     ctx.textAlign = 'right';
     ctx.textBaseline = 'middle';
@@ -6957,11 +7649,13 @@ function renderWaterfallChart(
       // Locale-independent §18.8.30 formatting (honoring `<c:valAx><c:numFmt>`),
       // matching the other renderers — `toLocaleString()` grouped by the
       // viewer's OS locale, so the same chart read differently across machines.
-      ctx.fillText(
-        formatChartValWithCode(value, chart.valAxisFormatCode, chart.date1904),
-        px0 - 4,
-        gy,
-      );
+      if (valueTickLabelsVisible) {
+        ctx.fillText(
+          formatChartValWithCode(value, chart.valAxisFormatCode, chart.date1904),
+          px0 - 4,
+          gy,
+        );
+      }
       drawAxisTick(
         ctx,
         chart.valAxisMajorTickMark,
@@ -6972,12 +7666,14 @@ function renderWaterfallChart(
         valAxisLine.width,
         false,
         chart.valAxisLineHidden,
+        'major',
+        ptToPx,
       );
     }
     for (const value of plan.minorTicks) {
       drawAxisTick(
         ctx, chart.valAxisMinorTickMark, 'val', px0, yOf(value),
-        valAxisLine.color, valAxisLine.width, false, chart.valAxisLineHidden,
+        valAxisLine.color, valAxisLine.width, false, chart.valAxisLineHidden, 'minor', ptToPx,
       );
     }
   }
@@ -7041,17 +7737,25 @@ function renderWaterfallChart(
       const nextBx = px0 + gapW * (i + 1) + (gapW - barW) / 2;
       const connY = bar.isPos ? yTop : yBot;
       ctx.save();
-      if (applyChartExSeriesLineStyle(
-        ctx,
+      const connectorLine = resolveChartExSeriesLineStyle(
         chart,
-        chart.chartexDataPointLineStyle,
+        chart.chartexSeriesLineStyle,
         series,
         accentIndex,
         3,
-        '#ccc',
-        ptToPx,
-      )) {
-        if (!chart.chartexDataPointLineStyle?.lineWidthEmu) ctx.lineWidth = 0.8;
+        '#000000',
+        { linkedNoStyleFallback: true },
+      );
+      if (applyResolvedChartExLineStyle(ctx, connectorLine, ptToPx)) {
+        // A linked `seriesLine` NoStyle delegates to Waterfall's semantic
+        // connector rather than suppressing it. Office vector output from
+        // both an unstyled bridge and an explicitly styled bridge establishes
+        // the family default as a 0.75pt rule; authored width/color above stay
+        // authoritative.
+        // Apply the semantic 0.75pt width only when the common direct>linked
+        // resolver found no authored width. Looking only at the linked role
+        // here used to overwrite a direct CT_Series width.
+        if (connectorLine.widthEmu == null) ctx.lineWidth = 0.75 * ptToPx;
         ctx.beginPath();
         ctx.moveTo(bx + barW, connY);
         ctx.lineTo(nextBx, connY);
@@ -7063,7 +7767,7 @@ function renderWaterfallChart(
     const rawVal = bar.hasValue ? vals[i] as number : 0;
     const label = resolveChartExLabel(
       chart, series, i, cats[i] ?? '', rawVal,
-      { visible: true, showVal: true, showCatName: false },
+      { visible: chart.showDataLabels, showVal: true, showCatName: false },
       undefined,
       !bar.hasValue,
     );
@@ -7102,7 +7806,12 @@ function renderWaterfallChart(
   ctx.textBaseline = 'top';
   ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#595959';
   // Category (transaction) labels below the bars → category-axis face.
-  ctx.font = `${chart.catAxisFontBold ? 'bold ' : ''}${catFontPx}px ${catFont}`;
+  ctx.font = chartFontCss(
+    catFontPx,
+    catFont,
+    chart.catAxisFontBold ?? false,
+    chart.catAxisFontItalic ?? false,
+  );
   const labelY = py0 + ph + 4;
   for (let i = 0; i < n && !chart.catAxisHidden; i++) {
     const ccx = px0 + gapW * i + gapW / 2;
@@ -7158,11 +7867,31 @@ function renderFunnelChart(
   if (!(max > 0)) return;
   const { x, y, w, h } = r;
   const titleBand = cartesianTitleBand(chart, h, ptToPx);
-  const leg = measuredLegendReserve(ctx, chart, w, h, 0.22, ptToPx);
+  const series = chart.series[0];
+  const color = `#${series?.color ?? chartExDataPointFill(chart, 0, 1, series?.chartexStyle)}`;
+  const paint = chartExDataPointPaint(chart, 0, 1, series?.chartexStyle, series?.color);
+  const legendChart: ChartModel = {
+    ...chart,
+    series: [chartExLegendSeries(
+      chart,
+      series?.name ?? '',
+      series,
+      chart.chartexDataPointStyle,
+      0,
+      1,
+      color,
+    )],
+  };
+  const leg = measuredLegendReserve(ctx, legendChart, w, h, 0.22, ptToPx);
   const { legRightW, legLeftW, legTopH, legBottomH } = chartLegendBands(leg);
   const catFontPx = axisLabelPx(chart.catAxisFontSizeHpt, h, ptToPx);
   ctx.save();
-  ctx.font = `${chart.catAxisFontBold ? 'bold ' : ''}${catFontPx}px ${chartFontFamily(chart, chart.catAxisFontFace, 'minor')}`;
+  ctx.font = chartFontCss(
+    catFontPx,
+    chartFontFamily(chart, chart.catAxisFontFace, 'minor'),
+    chart.catAxisFontBold ?? false,
+    chart.catAxisFontItalic ?? false,
+  );
   let labelW = 0;
   if (!chart.catAxisHidden) {
     for (let index = 0; index < Math.min(n, chart.categories.length); index++) {
@@ -7187,9 +7916,6 @@ function renderFunnelChart(
   const rowH = ph / n;
   const gapWidthPct = resolveCategoryGapWidthPercent(chart.barGapWidth, 'chartex');
   const barH = rowH / (1 + gapWidthPct / 100);
-  const series = chart.series[0];
-  const color = `#${series?.color ?? chartExDataPointFill(chart, 0, 1, series?.chartexStyle)}`;
-  const paint = chartExDataPointPaint(chart, 0, 1, series?.chartexStyle, series?.color);
   for (let index = 0; index < n; index++) {
     const value = Math.max(0, values[index] ?? 0);
     const barW = pw * value / max;
@@ -7244,7 +7970,7 @@ function renderFunnelChart(
     ctx.lineWidth = line.width;
     ctx.beginPath(); ctx.moveTo(px0, py0); ctx.lineTo(px0, py0 + ph); ctx.stroke();
   }
-  drawLegendForLayout(ctx, chart, leg, x, y, w, h, px0, py0, pw, ph, titleBand.bandH + 2, ptToPx, [paint], shapeRotationDeg);
+  drawLegendForLayout(ctx, legendChart, leg, x, y, w, h, px0, py0, pw, ph, titleBand.bandH + 2, ptToPx, [paint], shapeRotationDeg);
   ctx.restore();
 }
 
@@ -7265,19 +7991,46 @@ function renderParetoLineChart(
   if (rejectOversizedCanvasChart(ctx, r, pointCount)) return;
   const layout = planParetoLayout(source, chart.categories);
   if (layout.points.length === 0) return;
+  const styleIndex = chartExSeriesFormatIndex(source, 0);
+  const paretoLine = resolveChartExSeriesLineStyle(
+    chart,
+    chart.chartexDataPointLineStyle,
+    source,
+    styleIndex,
+    1,
+    chartColor(0, source),
+    { linkedNoStyleFallback: true },
+  );
   renderLineChart(ctx, {
     ...chart,
     chartType: 'line',
     categories: layout.categories,
-    series: [{ ...layout.series, showMarker: false }],
+    series: [{
+      ...layout.series,
+      showMarker: false,
+      lineHidden: !paretoLine.visible,
+      lineColor: paretoLine.color.replace(/^#/, ''),
+      lineWidthEmu: paretoLine.widthEmu,
+      chartexStyle: {
+        lineDash: paretoLine.dash,
+        lineCap: paretoLine.cap,
+        lineJoin: paretoLine.join,
+      },
+    }],
     // Pareto's ordinal category labels are suppressed, but its authored
     // category-axis rule remains visible. Keep those two concerns separate.
     catAxisHidden: false,
     catAxisTickLabelPos: 'none',
     showLegend: false,
-    valMin: 0,
-    valMax: chart.valMax ?? 1,
-    valAxisFormatCode: chart.valAxisFormatCode ?? '0%',
+    // A standalone paretoLine carries cumulative fractions as its actual
+    // values, but Office lays them out on an ordinary decimal axis. Two vector
+    // references at different chart sizes use the same omitted-axis contract:
+    // 0..1.2 in 0.2 steps. Keep authored bounds/major units authoritative and
+    // avoid making this semantic cumulative scale depend on pixel height.
+    // The 0..100% secondary-axis convention belongs to owner-backed Pareto.
+    valMin: chart.valMin ?? 0,
+    valMax: chart.valMax ?? 1.2,
+    valAxisMajorUnit: chart.valAxisMajorUnit ?? 0.2,
   }, r, ptToPx);
 }
 
@@ -7357,6 +8110,40 @@ function renderParetoChart(
 
 // ─── chartEx: box-and-whisker (CH15, MS 2014 chartex ext) ────────────────────
 
+/** Compact omitted-axis policy observed in three independent Office vector
+ * box/whisker outputs (small, ordinary, and wide numeric ranges). OOXML does
+ * not define the automatic major unit. Office consistently chooses the nearest
+ * 1/2/5 ladder to about seven raw-range intervals for this family, then applies the same
+ * 5% padding / zero-threshold rules as the shared planner. */
+function automaticBoxWhiskerAxis(
+  dataMin: number,
+  dataMax: number,
+  explicitMin?: number | null,
+  explicitMax?: number | null,
+): { min: number; max: number; majorUnit: number } | null {
+  // Authored bounds constrain the automatic-unit calculation as well as the
+  // final axis. ChartEx may write min/max while omitting majorUnit; Office then
+  // chooses the box/whisker family unit from that authored span (for example
+  // 1..3 becomes 0.2), rather than deriving a coarse unit from the raw data and
+  // merely clipping it to the authored bounds afterwards.
+  const boundedMin = explicitMin ?? dataMin;
+  const boundedMax = explicitMax ?? dataMax;
+  const span = boundedMax - boundedMin;
+  if (!(span > 0) || !Number.isFinite(span)) return null;
+  const majorUnit = niceStep(span, 7);
+  if (!(majorUnit > 0) || !Number.isFinite(majorUnit)) return null;
+  let paddedMin = dataMin - span * 0.05;
+  let paddedMax = dataMax + span * 0.05;
+  if (dataMin >= 0 && (dataMin === 0 || dataMax > 1.2 * dataMin)) paddedMin = 0;
+  if (dataMax <= 0 && (dataMax === 0 || Math.abs(dataMin) > 1.2 * Math.abs(dataMax))) {
+    paddedMax = 0;
+  }
+  const min = explicitMin ?? Math.floor(paddedMin / majorUnit) * majorUnit;
+  const max = explicitMax ?? Math.ceil(paddedMax / majorUnit) * majorUnit;
+  if (![min, max].every(Number.isFinite) || !(max > min)) return null;
+  return { min, max, majorUnit };
+}
+
 /**
  * Render a chartEx box-and-whisker chart (MS 2014 chartex extension — there is
  * no ECMA-376 section; the structure is Microsoft's `<cx:chartSpace>` with a
@@ -7377,6 +8164,13 @@ function renderBoxWhiskerChart(
   ptToPx: number,
   shapeRotationDeg: number,
 ): void {
+  // ChartEx's linked dataPointMarkerLayout is a generic marker recipe. Office
+  // does not use its size for box-and-whisker observations: vector output uses
+  // 3pt observation/outlier dots and a 6pt mean `x`, independent of box width.
+  // The linked recipe still supplies the marker symbol and paint.
+  const observationMarkerSizePt = 3;
+  const observationMarkerRadiusPx = observationMarkerSizePt * ptToPx / 2;
+  const meanMarkerRadiusPx = 3 * ptToPx;
   const box = chart.chartexBox;
   if (!box || box.categories.length === 0 || box.series.length === 0) return;
   const { x, y, w, h } = r;
@@ -7431,15 +8225,31 @@ function renderBoxWhiskerChart(
     return;
   }
 
+  // Authored bounds/unit always win. An omitted unit still receives the compact
+  // family default inferred from the vector corpus, using authored min/max as
+  // the effective span when present.
+  const automaticBoxAxis = chart.valAxisMajorUnit == null
+    ? automaticBoxWhiskerAxis(dataMin, dataMax, chart.valMin, chart.valMax)
+    : null;
+  const boxAxisChart: ChartModel = automaticBoxAxis
+    ? {
+        ...chart,
+        valMin: automaticBoxAxis.min,
+        valMax: automaticBoxAxis.max,
+        valAxisMajorUnit: automaticBoxAxis.majorUnit,
+      }
+    : chart;
+
   const font = chartFontFamily(chart, chart.valAxisFontFace, 'minor');
   const valFontPx = axisLabelPx(chart.valAxisFontSizeHpt, h, ptToPx);
+  const valTickLabelGap = valueTickLabelGapPx(valFontPx);
   const provisionalScale = planLinearValueAxis({
     dataMin,
     dataMax,
-    explicitMin: chart.valMin,
-    explicitMax: chart.valMax,
+    explicitMin: boxAxisChart.valMin,
+    explicitMax: boxAxisChart.valMax,
     axisLenPt: h / ptToPx,
-    majorUnit: chart.valAxisMajorUnit,
+    majorUnit: boxAxisChart.valAxisMajorUnit,
   });
   if (!usableScale({
     min: provisionalScale.min,
@@ -7452,7 +8262,12 @@ function renderBoxWhiskerChart(
   let valLabelBandW = 0;
   if (!chart.valAxisHidden) {
     const previousFont = ctx.font;
-    ctx.font = `${chart.valAxisFontBold ? 'bold ' : ''}${valFontPx}px ${font}`;
+    ctx.font = chartFontCss(
+      valFontPx,
+      font,
+      chart.valAxisFontBold ?? false,
+      chart.valAxisFontItalic ?? false,
+    );
     let maxLabelW = 0;
     for (const value of provisionalScale.majorTicks) {
       const label = formatChartValWithCode(
@@ -7463,9 +8278,7 @@ function renderBoxWhiskerChart(
       maxLabelW = Math.max(maxLabelW, ctx.measureText(label).width);
     }
     ctx.font = previousFont;
-    // Four pixels are used by fillText's axis gap below; the remaining four
-    // keep the label box clear of the adjacent vertical title band.
-    valLabelBandW = maxLabelW + 8;
+    valLabelBandW = maxLabelW + valTickLabelGap + AXIS_OUTER_TEXT_MARGIN_PT * ptToPx;
   }
 
   // Shared title band + cartesian plot rect. Reserve category/value-axis bands
@@ -7478,15 +8291,25 @@ function renderBoxWhiskerChart(
   const boxStyleIndices = box.series.map((series, index) =>
     chartExSeriesFormatIndex(series, index)
   );
+  const boxLegendSeries = box.series.map((series, index) => {
+    const styleIndex = boxStyleIndices[index];
+    const fill = series.color ?? chartExDataPointFill(
+      chart, styleIndex, nSer, series.chartexStyle,
+    );
+    return chartExLegendSeries(
+      chart,
+      series.name,
+      series,
+      chart.chartexDataPointStyle,
+      styleIndex,
+      nSer,
+      fill,
+      true,
+    );
+  });
   const legendChart: ChartModel = {
     ...chart,
-    series: box.series.map((series, index) => ({
-      name: series.name,
-      values: [],
-      color: series.color ?? chartExDataPointFill(
-        chart, boxStyleIndices[index], nSer, series.chartexStyle,
-      ),
-    })),
+    series: boxLegendSeries,
   };
   const leg = measuredLegendReserve(ctx, legendChart, w, h, 0.22, ptToPx);
   const { legRightW, legLeftW, legTopH, legBottomH } = chartLegendBands(leg);
@@ -7508,7 +8331,7 @@ function renderBoxWhiskerChart(
   const nCat = cats.length;
 
   // Excel's automatic value axis uses nice-rounded bounds and steps.
-  const boxAxisPlan = planValueAxis(chart, dataMin, dataMax, ph / ptToPx);
+  const boxAxisPlan = planValueAxis(boxAxisChart, dataMin, dataMax, ph / ptToPx);
   if (!usableScale(boxAxisPlan)) {
     rejectOutOfRange();
     return;
@@ -7524,7 +8347,12 @@ function renderBoxWhiskerChart(
   // Value-axis gridlines + labels (unless the value axis is hidden).
   ctx.save();
   if (!chart.valAxisHidden) {
-    ctx.font = `${chart.valAxisFontBold ? 'bold ' : ''}${valFontPx}px ${font}`;
+    ctx.font = chartFontCss(
+      valFontPx,
+      font,
+      chart.valAxisFontBold ?? false,
+      chart.valAxisFontItalic ?? false,
+    );
     ctx.textAlign = 'right';
     ctx.textBaseline = 'middle';
     if (chart.valAxisMinorGridlines) {
@@ -7544,7 +8372,11 @@ function renderBoxWhiskerChart(
         if (valGridline.dash.length > 0) ctx.setLineDash(previousDash);
       }
       ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#595959';
-      ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode, chart.date1904), px0 - 4, gy);
+      ctx.fillText(
+        formatChartValWithCode(v, chart.valAxisFormatCode, chart.date1904),
+        px0 - valTickLabelGap,
+        gy,
+      );
       drawAxisTick(
         ctx,
         chart.valAxisMajorTickMark,
@@ -7555,12 +8387,14 @@ function renderBoxWhiskerChart(
         valAxisLine.width,
         false,
         chart.valAxisLineHidden,
+        'major',
+        ptToPx,
       );
     }
     for (const value of boxAxisPlan.minorTicks) {
       drawAxisTick(
         ctx, chart.valAxisMinorTickMark, 'val', px0, yOf(value),
-        valAxisLine.color, valAxisLine.width, false, chart.valAxisLineHidden,
+        valAxisLine.color, valAxisLine.width, false, chart.valAxisLineHidden, 'minor', ptToPx,
       );
     }
     if (!chart.valAxisLineHidden) {
@@ -7569,10 +8403,17 @@ function renderBoxWhiskerChart(
       ctx.beginPath(); ctx.moveTo(px0, py0); ctx.lineTo(px0, py0 + ph); ctx.stroke();
     }
   }
-  // Category-axis baseline.
+  // Category-axis baseline. ChartEx carries the axis rule in the local
+  // `<cx:axis><cx:spPr><a:ln>`; do not replace an authored dark/weighted rule
+  // with the old fixed 1px grey fallback.
+  const catAxisLine = resolveAxisLine(
+    chart.catAxisLineColor,
+    chart.catAxisLineWidthEmu,
+    ptToPx,
+  );
   if (!chart.catAxisHidden && !chart.catAxisLineHidden) {
-    ctx.strokeStyle = '#bfbfbf';
-    ctx.lineWidth = 1;
+    ctx.strokeStyle = catAxisLine.color;
+    ctx.lineWidth = catAxisLine.width;
     ctx.beginPath(); ctx.moveTo(px0, py0 + ph); ctx.lineTo(px0 + pw, py0 + ph); ctx.stroke();
   }
 
@@ -7639,8 +8480,24 @@ function renderBoxWhiskerChart(
     ctx.restore();
   }
   const catFontPx = axisLabelPx(chart.catAxisFontSizeHpt, h, ptToPx);
+  const catTickLabelGap = categoryTickLabelGapPx(catFontPx);
   for (let ci = 0; ci < nCat; ci++) {
     const categoryCenterX = px0 + slotW * (ci + 1);
+    if (!chart.catAxisHidden) {
+      drawAxisTick(
+        ctx,
+        chart.catAxisMajorTickMark,
+        'cat',
+        py0 + ph,
+        categoryCenterX,
+        catAxisLine.color,
+        catAxisLine.width,
+        false,
+        chart.catAxisLineHidden,
+        'major',
+        ptToPx,
+      );
+    }
     for (let si = 0; si < nSer; si++) {
       const s = box.series[si];
       const stats = statsBySeries[si][ci];
@@ -7738,9 +8595,7 @@ function renderBoxWhiskerChart(
       // Interior sample points. Excel overlays the raw non-outlier values on
       // the box/whiskers when cx:visibility@nonoutliers is enabled.
       if (s.showNonoutliers) {
-        const pR = chart.chartexMarkerSizePt != null
-          ? (chart.chartexMarkerSizePt * ptToPx) / 2
-          : Math.max(1.25, boxW * 0.045);
+        const pR = observationMarkerRadiusPx;
         const pointSymbol = chart.chartexMarkerSymbol ?? 'circle';
         for (const point of stats.inner) {
           if (pointSymbol === 'none') continue;
@@ -7769,7 +8624,7 @@ function renderBoxWhiskerChart(
               cx,
               pointY,
               pointSymbol,
-              chart.chartexMarkerSizePt ?? (pR * 2) / ptToPx,
+              observationMarkerSizePt,
               markerFillPaint ? (markerFill ? `#${markerFill}` : fill) : 'transparent',
               markerLineVisible ? (markerEdge ? `#${markerEdge}` : edge) : null,
               ptToPx,
@@ -7782,7 +8637,7 @@ function renderBoxWhiskerChart(
       // Mean `×` marker (same accent×0.8 as the rest of the outline).
       if (s.meanMarker) {
         const mY = yOf(stats.mean);
-        const mR = Math.max(2, boxW * 0.14);
+        const mR = meanMarkerRadiusPx;
         if (applySeriesLine(markerStyle, markerEdge ?? edge)) {
           ctx.beginPath();
           ctx.moveTo(cx - mR, mY - mR); ctx.lineTo(cx + mR, mY + mR);
@@ -7794,9 +8649,7 @@ function renderBoxWhiskerChart(
       // Outlier dots.
       if (s.showOutliers) {
         const pointSymbol = chart.chartexMarkerSymbol ?? 'circle';
-        const oR = chart.chartexMarkerSizePt != null
-          ? (chart.chartexMarkerSizePt * ptToPx) / 2
-          : Math.max(1.5, boxW * 0.06);
+        const oR = observationMarkerRadiusPx;
         for (const o of stats.outliers) {
           if (pointSymbol === 'none') continue;
           const markerLineVisible = applySeriesLine(markerStyle, markerEdge ?? edge);
@@ -7823,7 +8676,7 @@ function renderBoxWhiskerChart(
               cx,
               outlierY,
               pointSymbol,
-              chart.chartexMarkerSizePt ?? (oR * 2) / ptToPx,
+              observationMarkerSizePt,
               markerFillPaint ? (markerFill ? `#${markerFill}` : fill) : 'transparent',
               markerLineVisible ? (markerEdge ? `#${markerEdge}` : edge) : null,
               ptToPx,
@@ -7842,7 +8695,7 @@ function renderBoxWhiskerChart(
       ctx.textAlign = 'center';
       ctx.textBaseline = 'top';
       const label = cats[ci];
-      ctx.fillText(label, categoryCenterX, py0 + ph + 4);
+      ctx.fillText(label, categoryCenterX, py0 + ph + catTickLabelGap);
     }
   }
   ctx.restore();
@@ -7906,6 +8759,20 @@ interface SunburstNode {
   labelIndex: number;
   a0: number;
   a1: number;
+}
+
+/** Preflight flat hierarchy input before allocating the interned tree. Both
+ * rows and path nodes become paint primitives, so either can exhaust the same
+ * synchronous Canvas budget. */
+function hierarchyInputTooLarge(rows: readonly { path: readonly string[] }[]): boolean {
+  if (rows.length > MAX_CANVAS_CHART_POINTS) return true;
+  let segments = 0;
+  for (const row of rows) {
+    if (row.path.length > MAX_CANVAS_HIERARCHY_DEPTH) return true;
+    if (segments > MAX_CANVAS_CHART_POINTS - row.path.length) return true;
+    segments += row.path.length;
+  }
+  return false;
 }
 
 /**
@@ -7975,36 +8842,50 @@ function buildSunburstTree(
   root.layoutWeight = root.children.reduce((sum, child) => sum + child.layoutWeight, 0);
   root.value = root.children.reduce((sum, child) => safeSum(sum, child.value), 0);
   let nextLabelIndex = 0;
-  const assignLabelIndices = (node: SunburstNode): void => {
-    for (const child of node.children) {
-      child.labelIndex = nextLabelIndex++;
-      assignLabelIndices(child);
+  const pending = [...root.children].reverse();
+  while (pending.length > 0) {
+    const node = pending.pop() as SunburstNode;
+    node.labelIndex = nextLabelIndex++;
+    for (let index = node.children.length - 1; index >= 0; index--) {
+      pending.push(node.children[index]);
     }
-  };
-  assignLabelIndices(root);
+  }
   return root;
 }
 
 /** Assign angular spans top-down: each node partitions its `[a0, a1)` range
  *  across its children proportional to their layout weight, in child (source)
  *  order. */
-function layoutSunburstAngles(node: SunburstNode): void {
-  const total = node.children.reduce((sum, child) => sum + child.layoutWeight, 0);
-  if (total <= 0) return;
-  let a = node.a0;
-  for (const child of node.children) {
-    const sweep = ((node.a1 - node.a0) * child.layoutWeight) / total;
-    child.a0 = a;
-    child.a1 = a + sweep;
-    a = child.a1;
-    layoutSunburstAngles(child);
+function layoutSunburstAngles(root: SunburstNode): void {
+  const pending = [root];
+  while (pending.length > 0) {
+    const node = pending.pop() as SunburstNode;
+    let total = 0;
+    for (const child of node.children) total += child.layoutWeight;
+    if (total <= 0) continue;
+    let a = node.a0;
+    for (const child of node.children) {
+      const sweep = ((node.a1 - node.a0) * child.layoutWeight) / total;
+      child.a0 = a;
+      child.a1 = a + sweep;
+      a = child.a1;
+      pending.push(child);
+    }
   }
 }
 
 /** Maximum ring depth (number of levels below the root). */
-function sunburstMaxDepth(node: SunburstNode): number {
-  if (node.children.length === 0) return node.depth;
-  return Math.max(...node.children.map(sunburstMaxDepth));
+function sunburstMaxDepth(root: SunburstNode): number {
+  let maxDepth = root.depth;
+  const pending = [root];
+  while (pending.length > 0) {
+    const node = pending.pop() as SunburstNode;
+    maxDepth = Math.max(maxDepth, node.depth);
+    for (let index = node.children.length - 1; index >= 0; index--) {
+      pending.push(node.children[index]);
+    }
+  }
+  return maxDepth;
 }
 
 /**
@@ -8030,6 +8911,10 @@ function renderSunburstChart(
   const sb = chart.chartexSunburst;
   if (!sb || sb.rows.length === 0) return;
   const { x, y, w, h } = r;
+  if (hierarchyInputTooLarge(sb.rows)) {
+    rejectOversizedCanvasChart(ctx, r, MAX_CANVAS_CHART_POINTS + 1);
+    return;
+  }
   const root = buildSunburstTree(sb.rows);
   if (root.layoutWeight <= 0 || root.children.length === 0) return;
   const series = chart.series[0];
@@ -8039,11 +8924,20 @@ function renderSunburstChart(
   const legendChart: ChartModel = {
     ...chart,
     chartType: 'clusteredBar',
-    series: root.children.map((node, index) => ({
-      name: node.label,
-      values: [],
-      color: chartExDataPointFill(chart, index, root.children.length, series?.chartexStyle),
-    })),
+    series: root.children.map(node => {
+      const fill = chartExDataPointFill(
+        chart, node.branchIndex, root.children.length, series?.chartexStyle,
+      );
+      return chartExLegendSeries(
+        chart,
+        node.label,
+        series,
+        chart.chartexDataPointStyle,
+        node.branchIndex,
+        root.children.length,
+        fill,
+      );
+    }),
   };
   // Reuse the radial frame so an authored top legend reserves space above the
   // rings instead of being painted over the circle.
@@ -8099,11 +8993,14 @@ function renderSunburstChart(
   // Draw every non-root node as a ring segment, deepest-last so borders read on
   // top. Iterate breadth-first by depth.
   const byDepth: SunburstNode[][] = Array.from({ length: ringCount }, () => []);
-  const collect = (n: SunburstNode): void => {
-    if (n.depth >= 0) byDepth[n.depth].push(n);
-    n.children.forEach(collect);
-  };
-  collect(root);
+  const pending = [root];
+  while (pending.length > 0) {
+    const node = pending.pop() as SunburstNode;
+    if (node.depth >= 0) byDepth[node.depth].push(node);
+    for (let index = node.children.length - 1; index >= 0; index--) {
+      pending.push(node.children[index]);
+    }
+  }
 
   ctx.save();
   for (let d = 0; d < ringCount; d++) {
@@ -8323,6 +9220,10 @@ function renderTreemapChart(
 ): void {
   const treemap = chart.chartexTreemap;
   if (!treemap || treemap.rows.length === 0) return;
+  if (hierarchyInputTooLarge(treemap.rows)) {
+    rejectOversizedCanvasChart(ctx, r, MAX_CANVAS_CHART_POINTS + 1);
+    return;
+  }
   // A treemap data point remains a distinct tile even when its terminal label
   // repeats. Only parent path components are grouping keys.
   const root = buildSunburstTree(treemap.rows, true);
@@ -8336,11 +9237,21 @@ function renderTreemapChart(
   const legendChart: ChartModel = {
     ...chart,
     chartType: 'clusteredBar',
-    series: root.children.map((node, index) => ({
-      name: node.label,
-      values: [],
-      color: chartExDataPointFill(chart, index, root.children.length, series?.chartexStyle),
-    })),
+    series: root.children.map(node => {
+      const fill = chartExDataPointFill(
+        chart, node.branchIndex, root.children.length, series?.chartexStyle,
+      );
+      return chartExLegendSeries(
+        chart,
+        node.label,
+        series,
+        chart.chartexDataPointStyle,
+        node.branchIndex,
+        root.children.length,
+        fill,
+        true,
+      );
+    }),
   };
   const leg = measuredLegendReserve(ctx, legendChart, r.w, r.h, 0.22, ptToPx);
   const frame = computeChartFrame(chart, r.x, r.y, r.w, r.h, ptToPx, {
@@ -8435,12 +9346,16 @@ function renderTreemapChart(
           ? { x: tile.x, y: tile.y, w: tile.w, h: bannerH }
           : tile;
         const automaticBounds = labelRect;
+        // The series-level data-label position describes leaf values. Office
+        // keeps overlapping parent captions at the top-left even when leaves
+        // are authored at inEnd; only an indexed parent override changes it.
+        const parentPosition = labelOverride?.position ?? 'inBase';
         drawBoundedDataLabelText(
           ctx,
           parentLabel.text,
           parentLabel.manualLayout
-            ? { kind: 'point', x: tile.x + tile.w / 2, y: tile.y + tile.h / 2, position: parentLabel.position ?? 'inBase' }
-            : { kind: 'box', rect: automaticBounds, position: parentLabel.position ?? 'inBase' },
+            ? { kind: 'point', x: tile.x + tile.w / 2, y: tile.y + tile.h / 2, position: parentPosition }
+            : { kind: 'box', rect: automaticBounds, position: parentPosition },
           parentLabel.manualLayout ? plotBounds : automaticBounds,
           fontPx,
           nodeLabelColor,
@@ -8492,12 +9407,19 @@ function renderTreemapChart(
     if (!leafLabel.manualLayout && (tile.w <= fontPx * 1.2 || tile.h <= fontPx * 1.2)) return;
     ctx.font = `${leafLabel.fontBold ? 'bold ' : ''}${fontPx}px ${fontFamily}`;
     const automaticBounds = tile;
+    // ChartEx uses `outEnd` for treemap value labels but Excel paints that
+    // token inside the tile at its lower-left corner. Keep the family-specific
+    // semantic mapping here; the shared box resolver's generic outEnd remains
+    // right-centred for other chart families.
+    const leafPosition = leafLabel.position === 'outEnd'
+      ? 'inEnd'
+      : (leafLabel.position ?? 'ctr');
     drawBoundedDataLabelText(
       ctx,
       leafLabel.text,
       leafLabel.manualLayout
-        ? { kind: 'point', x: tile.x + tile.w / 2, y: tile.y + tile.h / 2, position: leafLabel.position ?? 'ctr' }
-        : { kind: 'box', rect: automaticBounds, position: leafLabel.position ?? 'ctr' },
+        ? { kind: 'point', x: tile.x + tile.w / 2, y: tile.y + tile.h / 2, position: leafPosition }
+        : { kind: 'box', rect: automaticBounds, position: leafPosition },
       leafLabel.manualLayout ? plotBounds : automaticBounds,
       fontPx,
       leafLabel.fontColor ? `#${leafLabel.fontColor}` : nodeLabelColor,

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -107,6 +107,8 @@ export interface ChartSeries {
   markerFill?: string | null;
   /** `<c:marker><c:spPr><a:ln><a:solidFill>` resolved hex (no `#`). */
   markerLine?: string | null;
+  /** `<c:marker><c:spPr><a:ln w>` marker-outline width in EMU. */
+  markerLineWidthEmu?: number | null;
   /**
    * Per-data-point overrides (ECMA-376 §21.2.2.39 `<c:dPt>`). Keyed by point
    * index. Any unset field falls back to the series-level value.
@@ -232,6 +234,8 @@ export interface ChartDataPointOverride {
   markerSize?: number;
   markerFill?: string;
   markerLine?: string;
+  /** Direct point marker-outline width in EMU. */
+  markerLineWidthEmu?: number;
   /**
    * `<c:dPt><c:explosion val>` (ECMA-376 §21.2.2.61) — the amount this
    * pie/doughnut slice is moved out from the center. The schema type is
@@ -250,6 +254,15 @@ export interface ChartDataLabelOverride {
   idx: number;
   /** Empty string = label deleted (skip drawing). */
   text: string;
+  /** Bounded DrawingML runs from a custom `<c:dLbl><c:tx><c:rich>` body.
+   * Runs in one paragraph remain inline; a dedicated run containing `\n`
+   * marks an authored paragraph break. The parser caps this payload at 4096
+   * Unicode scalars and four lines.
+   * Inline run paint is consumed by the shared bounded label path for classic
+   * line/area/scatter/bubble, bar/column, and pie/doughnut (including callouts).
+   * Family-specific layout still owns each label's anchor, capacity and clip.
+   * undefined keeps the established plain-label path. */
+  richRuns?: ChartTextRun[];
   /** "l"|"r"|"t"|"b"|"ctr"|"outEnd"|"bestFit". undefined = inherit. */
   position?: string;
   fontColor?: string;
@@ -508,13 +521,19 @@ export interface ChartModel {
   titleFontBold?: boolean | null;
   /** `<c:catAx><c:txPr>...defRPr@b>` X-axis tick label bold flag. */
   catAxisFontBold?: boolean | null;
+  /** `<c:catAx><c:txPr>...defRPr@i>` X-axis tick label italic flag. */
+  catAxisFontItalic?: boolean | null;
   /** `<c:valAx><c:txPr>...defRPr@b>` Y-axis tick label bold flag. */
   valAxisFontBold?: boolean | null;
+  /** `<c:valAx><c:txPr>...defRPr@i>` Y-axis tick label italic flag. */
+  valAxisFontItalic?: boolean | null;
   /** `<c:catAx><c:title>` run-prop font size (hpt). Distinct from
    *  `catAxisFontSizeHpt` (tick labels). null = renderer default. */
   catAxisTitleFontSizeHpt?: number | null;
   /** `<c:catAx><c:title>` run-prop bold flag. null = not bold. */
   catAxisTitleFontBold?: boolean | null;
+  /** `<c:catAx><c:title>` run-prop italic flag. */
+  catAxisTitleFontItalic?: boolean | null;
   /** `<c:catAx><c:title>` run-prop color (hex without '#'). null = default. */
   catAxisTitleFontColor?: string | null;
   /** Authored `<c:catAx><c:title>` DrawingML `bodyPr@rot` in raw `ST_Angle`
@@ -537,6 +556,8 @@ export interface ChartModel {
   valAxisTitleFontSizeHpt?: number | null;
   /** `<c:valAx><c:title>` run-prop bold flag. null = not bold. */
   valAxisTitleFontBold?: boolean | null;
+  /** `<c:valAx><c:title>` run-prop italic flag. */
+  valAxisTitleFontItalic?: boolean | null;
   /** `<c:valAx><c:title>` run-prop color (hex without '#'). null = default. */
   valAxisTitleFontColor?: string | null;
   /** Authored `<c:valAx><c:title>` DrawingML `bodyPr@rot` in raw `ST_Angle`
@@ -885,6 +906,8 @@ export interface ChartModel {
   chartexDataPointStyle?: ChartExElementStyle | null;
   /** Effective `<cs:dataPointLine>` style for whiskers/median/connectors. */
   chartexDataPointLineStyle?: ChartExElementStyle | null;
+  /** Effective `<cs:seriesLine>` style for waterfall connector lines. */
+  chartexSeriesLineStyle?: ChartExElementStyle | null;
   /** Effective `<cs:dataPointMarker>` style for raw/outlier/mean markers. */
   chartexDataPointMarkerStyle?: ChartExElementStyle | null;
   /** Chart Style `dataPointMarkerLayout@size`, in points (2..72). */
@@ -1026,6 +1049,8 @@ export interface SecondaryValueAxis {
   fontColor?: string | null;
   /** `<c:txPr>` tick-label font size (hpt). */
   fontSizeHpt?: number | null;
+  /** `<c:txPr>` tick-label italic flag. */
+  fontItalic?: boolean | null;
   /** `<c:txPr>…<a:latin typeface>` tick-label font face. */
   fontFace?: string | null;
   /** `<c:spPr><a:ln><a:solidFill>` axis-line color (hex without '#'). */
@@ -1058,6 +1083,8 @@ export interface SecondaryValueAxis {
   titleFontSizeHpt?: number | null;
   /** `<c:title>` run-prop bold flag. */
   titleFontBold?: boolean | null;
+  /** `<c:title>` run-prop italic flag. */
+  titleFontItalic?: boolean | null;
   /** `<c:title>` run-prop color (hex without '#'). */
   titleFontColor?: string | null;
   titleFontFace?: string | null;

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -58,6 +58,7 @@ export type CellElement = ({
 export interface ChartDataLabelOverride {
     idx: number;
     text: string;
+    richRuns?: ChartTextRun[];
     position?: string;
     fontColor?: string;
     fontSizeHpt?: number;
@@ -84,6 +85,7 @@ export interface ChartDataPointOverride {
     markerSize?: number;
     markerFill?: string;
     markerLine?: string;
+    markerLineWidthEmu?: number;
     explosion?: number;
 }
 export interface ChartErrBars {
@@ -208,15 +210,19 @@ export interface ChartModel {
     dataLabelFormatCode?: string | null;
     titleFontBold?: boolean | null;
     catAxisFontBold?: boolean | null;
+    catAxisFontItalic?: boolean | null;
     valAxisFontBold?: boolean | null;
+    valAxisFontItalic?: boolean | null;
     catAxisTitleFontSizeHpt?: number | null;
     catAxisTitleFontBold?: boolean | null;
+    catAxisTitleFontItalic?: boolean | null;
     catAxisTitleFontColor?: string | null;
     catAxisTitleRotation?: number | null;
     catAxisTitleVerticalMode?: 'horz' | 'vert' | 'vert270' | 'wordArtVert' | 'eaVert' | 'mongolianVert' | 'wordArtVertRtl' | null;
     catAxisTitleManualLayout?: ChartManualLayout | null;
     valAxisTitleFontSizeHpt?: number | null;
     valAxisTitleFontBold?: boolean | null;
+    valAxisTitleFontItalic?: boolean | null;
     valAxisTitleFontColor?: string | null;
     valAxisTitleRotation?: number | null;
     valAxisTitleVerticalMode?: 'horz' | 'vert' | 'vert270' | 'wordArtVert' | 'eaVert' | 'mongolianVert' | 'wordArtVertRtl' | null;
@@ -298,6 +304,7 @@ export interface ChartModel {
     chartexColorStyleMethod?: string | null;
     chartexDataPointStyle?: ChartExElementStyle | null;
     chartexDataPointLineStyle?: ChartExElementStyle | null;
+    chartexSeriesLineStyle?: ChartExElementStyle | null;
     chartexDataPointMarkerStyle?: ChartExElementStyle | null;
     chartexMarkerSizePt?: number | null;
     chartexMarkerSymbol?: string | null;
@@ -353,6 +360,7 @@ export interface ChartSeries {
     markerSize?: number | null;
     markerFill?: string | null;
     markerLine?: string | null;
+    markerLineWidthEmu?: number | null;
     dataPointOverrides?: ChartDataPointOverride[] | null;
     dataLabelOverrides?: ChartDataLabelOverride[] | null;
     seriesDataLabels?: ChartSeriesDataLabels | null;
@@ -1329,6 +1337,7 @@ export interface SecondaryValueAxis {
     formatCode?: string | null;
     fontColor?: string | null;
     fontSizeHpt?: number | null;
+    fontItalic?: boolean | null;
     fontFace?: string | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
@@ -1343,6 +1352,7 @@ export interface SecondaryValueAxis {
     minorUnit?: number | null;
     titleFontSizeHpt?: number | null;
     titleFontBold?: boolean | null;
+    titleFontItalic?: boolean | null;
     titleFontColor?: string | null;
     titleFontFace?: string | null;
     titleRotation?: number | null;

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -226,11 +226,17 @@ pub struct ChartModel {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cat_axis_font_bold: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_font_italic: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub val_axis_font_bold: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_font_italic: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cat_axis_title_font_size_hpt: Option<i32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cat_axis_title_font_bold: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_title_font_italic: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cat_axis_title_font_color: Option<String>,
     /// Authored `<c:catAx><c:title>` `bodyPr@rot` in raw `ST_Angle` units.
@@ -245,6 +251,8 @@ pub struct ChartModel {
     pub val_axis_title_font_size_hpt: Option<i32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub val_axis_title_font_bold: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_title_font_italic: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub val_axis_title_font_color: Option<String>,
     /// Authored `<c:valAx><c:title>` `bodyPr@rot` in raw `ST_Angle` units.
@@ -518,6 +526,8 @@ pub struct ChartModel {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chartex_data_point_line_style: Option<ChartExElementStyle>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chartex_series_line_style: Option<ChartExElementStyle>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chartex_data_point_marker_style: Option<ChartExElementStyle>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chartex_marker_size_pt: Option<u8>,
@@ -655,6 +665,8 @@ pub struct ChartSeries {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub marker_line: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub marker_line_width_emu: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data_point_overrides: Option<Vec<ChartDataPointOverride>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data_label_overrides: Option<Vec<ChartDataLabelOverride>>,
@@ -754,6 +766,8 @@ pub struct ChartDataPointOverride {
     pub marker_fill: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub marker_line: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub marker_line_width_emu: Option<u32>,
     /// `<c:dPt><c:explosion val>` (§21.2.2.61) — pie/doughnut slice pull-out
     /// amount. The schema type is `CT_UnsignedInt` (unbounded `xsd:unsignedInt`);
     /// the spec text itself doesn't define a 0–100 range or "percentage" unit,
@@ -771,6 +785,11 @@ pub struct ChartDataPointOverride {
 pub struct ChartDataLabelOverride {
     pub idx: u32,
     pub text: String,
+    /// Effective DrawingML runs from a custom `<c:dLbl><c:tx><c:rich>` body.
+    /// Paragraph breaks are stored as `\n` runs. The parser bounds the payload
+    /// to 4096 Unicode scalars and four lines before it crosses the WASM wire.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rich_runs: Option<Vec<ChartTextRun>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub position: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -923,6 +942,8 @@ pub struct SecondaryValueAxis {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_size_hpt: Option<i32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub font_italic: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_face: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub line_color: Option<String>,
@@ -952,6 +973,8 @@ pub struct SecondaryValueAxis {
     pub title_font_size_hpt: Option<i32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title_font_bold: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title_font_italic: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title_font_color: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1387,20 +1410,29 @@ fn chart_text_bool_attr(node: Node, name: &str) -> Option<bool> {
 fn chart_text_run_from_node(
     run: Node,
     paragraph_default: Option<Node>,
+    text_body_default: Option<Node>,
     resolver: &dyn ColorResolver,
 ) -> Option<ChartTextRun> {
     let text = child(run, "t")?.text().unwrap_or_default().to_string();
     let run_props = child(run, "rPr");
-    let prop = |name: &str| {
-        run_props
-            .and_then(|node| node.attribute(name))
-            .or_else(|| paragraph_default.and_then(|node| node.attribute(name)))
-    };
+    // ST_TextFontSize is 100..400000 hundredths of a point. Resolve size
+    // property-by-property: an invalid direct value is ignored and the next
+    // paragraph/text-body default remains eligible, just like the other text
+    // properties' independent cascade.
+    let font_size_hpt = [run_props, paragraph_default, text_body_default]
+        .into_iter()
+        .flatten()
+        .find_map(|node| node.attribute("sz").and_then(parse_text_font_size_hpt));
     let color = run_props
         .and_then(|node| child(node, "solidFill"))
         .and_then(|fill| resolver.resolve_solid_fill(fill))
         .or_else(|| {
             paragraph_default
+                .and_then(|node| child(node, "solidFill"))
+                .and_then(|fill| resolver.resolve_solid_fill(fill))
+        })
+        .or_else(|| {
+            text_body_default
                 .and_then(|node| child(node, "solidFill"))
                 .and_then(|fill| resolver.resolve_solid_fill(fill))
         });
@@ -1412,15 +1444,21 @@ fn chart_text_run_from_node(
                 .and_then(|node| child(node, "latin"))
                 .and_then(|latin| latin.attribute("typeface"))
         })
+        .or_else(|| {
+            text_body_default
+                .and_then(|node| child(node, "latin"))
+                .and_then(|latin| latin.attribute("typeface"))
+        })
         .map(str::to_string)
         .filter(|face| !face.is_empty());
 
     Some(ChartTextRun {
         text,
-        font_size_hpt: prop("sz").and_then(|value| value.parse::<i32>().ok()),
+        font_size_hpt,
         bold: run_props
             .and_then(|node| chart_text_bool_attr(node, "b"))
-            .or_else(|| paragraph_default.and_then(|node| chart_text_bool_attr(node, "b"))),
+            .or_else(|| paragraph_default.and_then(|node| chart_text_bool_attr(node, "b")))
+            .or_else(|| text_body_default.and_then(|node| chart_text_bool_attr(node, "b"))),
         color,
         font_face,
     })
@@ -1488,7 +1526,7 @@ pub fn parse_chart_user_shapes(root: Node, resolver: &dyn ColorResolver) -> Vec<
                             node.is_element() && matches!(node.tag_name().name(), "r" | "fld")
                         })
                         .filter_map(|run| {
-                            chart_text_run_from_node(run, paragraph_default, resolver)
+                            chart_text_run_from_node(run, paragraph_default, None, resolver)
                         })
                         .collect();
                     ChartTextParagraph { runs, align }
@@ -1803,6 +1841,24 @@ pub fn extract_axis_tick_label_bold(axis_node: Node) -> Option<bool> {
     })
 }
 
+/// First `<a:defRPr@i>` / `<a:rPr@i>` italic flag inside the axis's
+/// `<c:txPr>`. DrawingML character properties keep italic independent from
+/// bold, so preserve it separately through the chart model.
+pub fn extract_axis_tick_label_italic(axis_node: Node) -> Option<bool> {
+    let txpr = child(axis_node, "txPr")?;
+    txpr.descendants().find_map(|n| {
+        if !n.is_element() {
+            return None;
+        }
+        let tag = n.tag_name().name();
+        if tag != "defRPr" && tag != "rPr" {
+            return None;
+        }
+        n.attribute("i")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    })
+}
+
 /// Plain text of `node`'s direct-child `<c:title>` (ECMA-376 §21.2.2.6
 /// `CT_Title`). Works for the `<c:chart>` element (chart title) or a
 /// `<c:catAx>` / `<c:valAx>` (axis title). Walks `<a:t>` (rich text runs) and
@@ -2037,6 +2093,17 @@ fn extract_axis_title_bold(axis_node: Node) -> Option<bool> {
         .find_map(|props| {
             props
                 .attribute("b")
+                .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        })
+}
+
+fn extract_axis_title_italic(axis_node: Node) -> Option<bool> {
+    let title = child(axis_node, "title")?;
+    title_text_property_nodes(title)
+        .into_iter()
+        .find_map(|props| {
+            props
+                .attribute("i")
                 .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
         })
 }
@@ -3489,6 +3556,10 @@ fn extract_chartex_style_text_props(
     (size, bold, color, face)
 }
 
+fn extract_chartex_style_text_italic(style_node: Option<Node>) -> Option<bool> {
+    child(style_node?, "defRPr").and_then(|props| chart_text_bool_attr(props, "i"))
+}
+
 /// Parse chartEx with a package-supplied resolver for formula-only dimensions.
 /// Excel frequently omits `<cx:lvl>` caches in XLSX and points `<cx:f>` at a
 /// hidden workbook defined name instead; authored levels still take priority.
@@ -3530,6 +3601,7 @@ fn parse_chartex_data_point_overrides(
                 marker_size: None,
                 marker_fill: None,
                 marker_line: None,
+                marker_line_width_emu: None,
                 explosion: None,
             })
         })
@@ -3663,6 +3735,7 @@ fn parse_chartex_series_labels(
             text: tx_pr
                 .map(|node| flatten_rich_text(node, None))
                 .unwrap_or_default(),
+            rich_runs: None,
             position: attr(&label, "pos"),
             font_color,
             font_size_hpt: extract_axis_tick_label_size(label),
@@ -3695,6 +3768,7 @@ fn parse_chartex_series_labels(
             overrides.push(ChartDataLabelOverride {
                 idx,
                 text: String::new(),
+                rich_runs: None,
                 position: None,
                 font_color: None,
                 font_size_hpt: None,
@@ -3886,6 +3960,14 @@ pub fn parse_chartex_part_with_references_and_style_parts(
             chartex_color_style_method.as_deref(),
         )
     });
+    let chartex_series_line_style = style_element("seriesLine").map(|node| {
+        parse_chartex_element_style(
+            node,
+            resolver,
+            style_palette,
+            chartex_color_style_method.as_deref(),
+        )
+    });
     let chartex_data_point_marker_style = style_element("dataPointMarker").map(|node| {
         parse_chartex_element_style(
             node,
@@ -4059,6 +4141,7 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         marker_size: None,
         marker_fill: None,
         marker_line: None,
+        marker_line_width_emu: None,
         data_point_overrides: {
             let overrides = parse_chartex_data_point_overrides(series_node, resolver);
             (!overrides.is_empty()).then_some(overrides)
@@ -4223,6 +4306,7 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         .and_then(chartex_text);
     let inline_cat_title_size = cat_axis.and_then(extract_axis_title_size);
     let inline_cat_title_bold = cat_axis.and_then(extract_axis_title_bold);
+    let inline_cat_title_italic = cat_axis.and_then(extract_axis_title_italic);
     let inline_cat_title_color = cat_axis.and_then(|axis| extract_axis_title_color(axis, resolver));
     let inline_cat_title_face = cat_axis.and_then(extract_axis_title_face);
     let cat_axis_title_rotation = cat_axis.and_then(extract_axis_title_rotation);
@@ -4230,6 +4314,7 @@ pub fn parse_chartex_part_with_references_and_style_parts(
     let cat_axis_title_manual_layout = cat_axis.and_then(extract_axis_title_manual_layout);
     let inline_val_title_size = val_axis.and_then(extract_axis_title_size);
     let inline_val_title_bold = val_axis.and_then(extract_axis_title_bold);
+    let inline_val_title_italic = val_axis.and_then(extract_axis_title_italic);
     let inline_val_title_color = val_axis.and_then(|axis| extract_axis_title_color(axis, resolver));
     let inline_val_title_face = val_axis.and_then(extract_axis_title_face);
     let val_axis_title_rotation = val_axis.and_then(extract_axis_title_rotation);
@@ -4243,19 +4328,32 @@ pub fn parse_chartex_part_with_references_and_style_parts(
     ) = extract_chartex_style_text_props(style_element("axisTitle"), resolver);
     let style_axis_title_size =
         raw_style_axis_title_size.filter(|size| (100..=400_000).contains(size));
+    let style_axis_title_italic = extract_chartex_style_text_italic(style_element("axisTitle"));
     let (style_cat_size, style_cat_bold, style_cat_color, style_cat_face) =
         extract_chartex_style_text_props(style_element("categoryAxis"), resolver);
     let (style_val_size, style_val_bold, style_val_color, style_val_face) =
         extract_chartex_style_text_props(style_element("valueAxis"), resolver);
+    let style_cat_italic = extract_chartex_style_text_italic(style_element("categoryAxis"));
+    let style_val_italic = extract_chartex_style_text_italic(style_element("valueAxis"));
     // Axis-local title runs are authored values and win property-by-property;
     // the associated Chart Style is only the omitted-property fallback.
     let cat_axis_title_font_size_hpt = inline_cat_title_size.or(style_axis_title_size);
-    let cat_axis_title_font_bold = inline_cat_title_bold.or(style_axis_title_bold);
+    let cat_axis_title_font_bold = cat_axis_title.as_ref().map(|_| {
+        inline_cat_title_bold
+            .or(style_axis_title_bold)
+            .unwrap_or(false)
+    });
+    let cat_axis_title_font_italic = inline_cat_title_italic.or(style_axis_title_italic);
     let cat_axis_title_font_color =
         inline_cat_title_color.or_else(|| style_axis_title_color.clone());
     let cat_axis_title_font_face = inline_cat_title_face.or_else(|| style_axis_title_face.clone());
     let val_axis_title_font_size_hpt = inline_val_title_size.or(style_axis_title_size);
-    let val_axis_title_font_bold = inline_val_title_bold.or(style_axis_title_bold);
+    let val_axis_title_font_bold = val_axis_title.as_ref().map(|_| {
+        inline_val_title_bold
+            .or(style_axis_title_bold)
+            .unwrap_or(false)
+    });
+    let val_axis_title_font_italic = inline_val_title_italic.or(style_axis_title_italic);
     let val_axis_title_font_color =
         inline_val_title_color.or_else(|| style_axis_title_color.clone());
     let val_axis_title_font_face = inline_val_title_face.or_else(|| style_axis_title_face.clone());
@@ -4268,6 +4366,8 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         style_cat_size.or_else(|| cat_axis.and_then(extract_axis_tick_label_size));
     let cat_axis_font_bold =
         style_cat_bold.or_else(|| cat_axis.and_then(extract_axis_tick_label_bold));
+    let cat_axis_font_italic =
+        style_cat_italic.or_else(|| cat_axis.and_then(extract_axis_tick_label_italic));
     let cat_axis_font_color = style_cat_color
         .or_else(|| cat_axis.and_then(|axis| extract_axis_tick_label_color(axis, resolver)));
     let cat_axis_font_face =
@@ -4276,6 +4376,8 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         style_val_size.or_else(|| val_axis.and_then(extract_axis_tick_label_size));
     let val_axis_font_bold =
         style_val_bold.or_else(|| val_axis.and_then(extract_axis_tick_label_bold));
+    let val_axis_font_italic =
+        style_val_italic.or_else(|| val_axis.and_then(extract_axis_tick_label_italic));
     let val_axis_font_color = style_val_color
         .or_else(|| val_axis.and_then(|axis| extract_axis_tick_label_color(axis, resolver)));
     let val_axis_font_face =
@@ -4482,19 +4584,23 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         val_axis_title,
         cat_axis_title_font_size_hpt,
         cat_axis_title_font_bold,
+        cat_axis_title_font_italic,
         cat_axis_title_font_color,
         cat_axis_title_rotation,
         cat_axis_title_vertical_mode,
         cat_axis_title_manual_layout,
         val_axis_title_font_size_hpt,
         val_axis_title_font_bold,
+        val_axis_title_font_italic,
         val_axis_title_font_color,
         val_axis_title_rotation,
         val_axis_title_vertical_mode,
         val_axis_title_manual_layout,
         title_font_bold: chartex_title_font_bold,
         cat_axis_font_bold,
+        cat_axis_font_italic,
         val_axis_font_bold,
+        val_axis_font_italic,
         chart_border_color,
         chart_border_width_emu,
         secondary_val_axis: None,
@@ -4576,6 +4682,7 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         chartex_color_style_method,
         chartex_data_point_style,
         chartex_data_point_line_style,
+        chartex_series_line_style,
         chartex_data_point_marker_style,
         chartex_marker_size_pt,
         chartex_marker_symbol,
@@ -5006,18 +5113,26 @@ fn parse_chartex_treemap(
 // the rich per-series fields for both pptx and xlsx.
 // ============================================================================
 
-/// Parse `<c:marker>` into `(symbol, size, fill, line)` — colors are hex without
+/// Parse `<c:marker>` into `(symbol, size, fill, line, line_width_emu)` — colors are hex without
 /// `#`. ECMA-376 §21.2.2.32 / §21.2.2.34. Fill and line come from `<c:spPr>`
 /// nested inside the marker, resolved via the full DrawingML color grammar
 /// ([`ColorResolver::resolve_shape_fill`]). `size` is the point value parsed as
 /// an integer (matching Excel's `<c:size val>` unsignedByte) then widened to
 /// `f64` for the shared model.
+pub type ParsedMarkerBlock = (
+    Option<String>,
+    Option<f64>,
+    Option<String>,
+    Option<String>,
+    Option<u32>,
+);
+
 pub fn parse_marker_block(
     marker_node: Option<Node>,
     resolver: &dyn ColorResolver,
-) -> (Option<String>, Option<f64>, Option<String>, Option<String>) {
+) -> ParsedMarkerBlock {
     let Some(mk) = marker_node else {
-        return (None, None, None, None);
+        return (None, None, None, None, None);
     };
     let symbol = child(mk, "symbol")
         .and_then(|n| n.attribute("val"))
@@ -5040,7 +5155,11 @@ pub fn parse_marker_block(
     let line = sp_pr
         .and_then(|p| child(p, "ln"))
         .and_then(|ln| resolver.resolve_shape_fill(ln));
-    (symbol, size, fill, line)
+    let line_width_emu = sp_pr
+        .and_then(|p| child(p, "ln"))
+        .and_then(|ln| ln.attribute("w"))
+        .and_then(|value| value.parse::<u32>().ok());
+    (symbol, size, fill, line, line_width_emu)
 }
 
 fn parse_series_pattern_fill(
@@ -5078,7 +5197,7 @@ pub fn parse_data_point_overrides(
         let (color, fill_hidden, line_color, line_width_emu, line_dash, line_hidden) =
             parse_data_point_shape(dpt, resolver);
         let mk = child(dpt, "marker");
-        let (marker_symbol, marker_size, marker_fill, marker_line) =
+        let (marker_symbol, marker_size, marker_fill, marker_line, marker_line_width_emu) =
             parse_marker_block(mk, resolver);
         let explosion = extract_dpt_explosion(dpt);
         result.push(ChartDataPointOverride {
@@ -5093,6 +5212,7 @@ pub fn parse_data_point_overrides(
             marker_size,
             marker_fill,
             marker_line,
+            marker_line_width_emu,
             explosion,
         });
     }
@@ -5179,6 +5299,76 @@ pub fn flatten_rich_text(rich_root: Node, cellrange_cache: Option<&str>) -> Stri
         }
     }
     out
+}
+
+const MAX_DATA_LABEL_RICH_SCALARS: usize = 4096;
+const MAX_DATA_LABEL_RICH_LINES: usize = 4;
+
+/// Preserve the effective DrawingML character properties of a custom chart
+/// data label without allowing an untrusted rich-text body to grow the public
+/// model without bound. Runs in the same paragraph stay inline; paragraph
+/// boundaries become a newline run so the canvas renderer can keep authored
+/// line breaks while measuring the complete label as one object.
+fn parse_data_label_rich_runs(
+    label: Node,
+    resolver: &dyn ColorResolver,
+    cellrange_cache: Option<&str>,
+) -> Option<Vec<ChartTextRun>> {
+    let rich = child(label, "tx").and_then(|tx| child(tx, "rich"))?;
+    let txpr_default = child(label, "txPr").and_then(|tx| {
+        tx.descendants()
+            .find(|node| node.is_element() && matches!(node.tag_name().name(), "rPr" | "defRPr"))
+    });
+    let mut runs = Vec::new();
+    let mut scalar_count = 0usize;
+
+    for (paragraph_index, paragraph) in rich
+        .children()
+        .filter(|node| node.is_element() && node.tag_name().name() == "p")
+        .take(MAX_DATA_LABEL_RICH_LINES)
+        .enumerate()
+    {
+        if paragraph_index > 0 {
+            if scalar_count >= MAX_DATA_LABEL_RICH_SCALARS {
+                break;
+            }
+            runs.push(ChartTextRun {
+                text: "\n".to_string(),
+                font_size_hpt: None,
+                bold: None,
+                color: None,
+                font_face: None,
+            });
+            scalar_count += 1;
+        }
+        let paragraph_default = child(paragraph, "pPr").and_then(|props| child(props, "defRPr"));
+        for run_node in paragraph
+            .children()
+            .filter(|node| node.is_element() && matches!(node.tag_name().name(), "r" | "fld"))
+        {
+            if scalar_count >= MAX_DATA_LABEL_RICH_SCALARS {
+                break;
+            }
+            let Some(mut run) =
+                chart_text_run_from_node(run_node, paragraph_default, txpr_default, resolver)
+            else {
+                continue;
+            };
+            if run_node.tag_name().name() == "fld"
+                && run_node.attribute("type") == Some("CELLRANGE")
+            {
+                run.text = cellrange_cache.unwrap_or_default().to_string();
+            }
+            let remaining = MAX_DATA_LABEL_RICH_SCALARS - scalar_count;
+            let bounded = run.text.chars().take(remaining).collect::<String>();
+            scalar_count += bounded.chars().count();
+            if !bounded.is_empty() {
+                run.text = bounded;
+                runs.push(run);
+            }
+        }
+    }
+    (!runs.is_empty()).then_some(runs)
 }
 
 /// Parse a data-label `<c:spPr>` (§21.2.2.197) into a callout [`ChartLabelBox`]
@@ -5329,8 +5519,15 @@ pub fn parse_series_data_labels(
             .and_then(|n| n.attribute("val"))
             .map(|s| s.to_string());
         let cache_for_idx = cellrange_cache.get(&idx).map(|s| s.as_str());
+        let rich_runs = if deleted {
+            None
+        } else {
+            parse_data_label_rich_runs(dl, resolver, cache_for_idx)
+        };
         let text = if deleted {
             String::new()
+        } else if let Some(runs) = rich_runs.as_ref() {
+            runs.iter().map(|run| run.text.as_str()).collect()
         } else {
             match child(dl, "tx") {
                 Some(tx_node) => flatten_rich_text(tx_node, cache_for_idx),
@@ -5348,20 +5545,31 @@ pub fn parse_series_data_labels(
                 .find(|n| n.is_element() && n.tag_name().name() == "rPr")
         });
         let default_run_props = child(dl, "txPr").and_then(|tx| {
-            tx.descendants()
-                .find(|n| n.is_element() && n.tag_name().name() == "defRPr")
+            tx.descendants().find(|node| {
+                node.is_element() && matches!(node.tag_name().name(), "rPr" | "defRPr")
+            })
         });
-        let font_color = rich_run_props
-            .and_then(|run| resolver.resolve_shape_fill(run))
+        let first_rich_run = rich_runs
+            .as_ref()
+            .and_then(|runs| runs.iter().find(|run| run.text != "\n"));
+        let font_color = first_rich_run
+            .and_then(|run| run.color.clone())
+            .or_else(|| rich_run_props.and_then(|run| resolver.resolve_shape_fill(run)))
             .or_else(|| default_run_props.and_then(|run| resolver.resolve_shape_fill(run)));
-        let font_size_hpt = rich_run_props
-            .and_then(|run| run.attribute("sz"))
-            .or_else(|| default_run_props.and_then(|run| run.attribute("sz")))
-            .and_then(|v| v.parse::<i32>().ok());
-        let font_bold = rich_run_props
-            .and_then(|run| run.attribute("b"))
-            .or_else(|| default_run_props.and_then(|run| run.attribute("b")))
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"));
+        let font_size_hpt = first_rich_run
+            .and_then(|run| run.font_size_hpt)
+            .or_else(|| {
+                rich_run_props
+                    .and_then(|run| run.attribute("sz"))
+                    .or_else(|| default_run_props.and_then(|run| run.attribute("sz")))
+                    .and_then(|v| v.parse::<i32>().ok())
+            });
+        let font_bold = first_rich_run.and_then(|run| run.bold).or_else(|| {
+            rich_run_props
+                .and_then(|run| run.attribute("b"))
+                .or_else(|| default_run_props.and_then(|run| run.attribute("b")))
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        });
         // Per-point callout box (`<c:dLbl>` §21.2.2.47 `<c:spPr>` §21.2.2.197):
         // direct child spPr overrides the series-default box for this one point.
         let label_box = parse_label_box(
@@ -5377,6 +5585,7 @@ pub fn parse_series_data_labels(
         overrides.push(ChartDataLabelOverride {
             idx,
             text,
+            rich_runs,
             position: pos,
             font_color,
             font_size_hpt,
@@ -6368,27 +6577,30 @@ pub fn parse_chart_part_with_references(
                                 .find(|n| n.is_element() && n.tag_name().name() == "spPr")
                         })
                         .and_then(|sp| {
-                            sp.children()
-                                .find(|n| n.is_element() && n.tag_name().name() == "solidFill")
+                            if child(sp, "noFill").is_some() {
+                                // A direct point noFill is more specific than
+                                // both series formatting and varyColors.
+                                Some("00000000".to_string())
+                            } else {
+                                sp.children()
+                                    .find(|n| n.is_element() && n.tag_name().name() == "solidFill")
+                                    .and_then(|fill| color_resolver.resolve_solid_fill(fill))
+                            }
                         })
-                        .and_then(|fill| color_resolver.resolve_solid_fill(fill))
                 })
                 .collect();
 
-            // §21.2.2.227 `<c:varyColors>`: a pie/doughnut varies each DATA POINT
-            // by the theme accent palette (`accent[(i % 6) + 1]`), rather than
-            // giving the whole series one fill. It defaults to ON for the pie
-            // family, so an absent element still cycles the accents. When on, fill
-            // every slice that lacks an explicit `<c:dPt>` fill from the resolver's
-            // accent for that point index — this is the same palette Office draws,
-            // so a docx/xlsx pie matches Word/Excel instead of falling back to the
-            // renderer's built-in default colors. Resolvers that own their own
-            // palette (pptx `resolve_series_accent` → None) contribute nothing here
-            // and stay byte-stable. Non-pie families are unaffected: only the pie
-            // renderer consumes `data_point_colors`, and a multi-series pie (rare)
-            // still varies by point within series[0].
+            // §21.2.2.227 `<c:varyColors>`: Office varies each DATA POINT in the
+            // pie family and in a lone bar/column or bubble series by the theme
+            // accent palette (`accent[(i % 6) + 1]`). The omitted element is
+            // observed as ON for these families; explicit false remains
+            // authoritative. Fill every point that lacks an explicit `<c:dPt>`
+            // fill from the resolver's accent for that point index. Resolvers
+            // that own their own palette (pptx `resolve_series_accent` → None)
+            // contribute nothing here and stay byte-stable.
             let is_pie_family = chart_type == "pie" || chart_type == "doughnut";
             let is_bar_family = chart_type.contains("Bar");
+            let is_bubble_family = chart_type == "bubble";
             // §21.2.2.227 `<c:varyColors>` — CT_Boolean (bare element ⇒ true).
             // "Vary colors by point" is the effective default for the pie family
             // AND for a SINGLE-series bar/column chart (Word/Excel/PowerPoint
@@ -6401,13 +6613,19 @@ pub fn parse_chart_part_with_references(
             // accent for its POINT index (i); `dPt` fills already sit in
             // `data_point_colors` and are never overwritten (explicit per-point
             // color keeps priority, §21.2.2.52).
-            let qualifies_for_vary = is_pie_family || (is_bar_family && series_count == 1);
+            let qualifies_for_vary =
+                is_pie_family || ((is_bar_family || is_bubble_family) && series_count == 1);
             let vary = group
                 .and_then(|g| bool_child(g, "varyColors"))
                 .unwrap_or(true);
             let vary_by_point = qualifies_for_vary && vary;
             let mut data_point_colors = data_point_colors;
-            if vary_by_point {
+            // Direct series noFill is authored DrawingML shape formatting and
+            // remains authoritative over the automatic varyColors palette.
+            // A direct dPt fill/noFill already occupies its slot and therefore
+            // still wins as the more specific point-level formatting.
+            let series_fill_hidden = color.as_deref() == Some("00000000");
+            if vary_by_point && !series_fill_hidden {
                 for (i, slot) in data_point_colors.iter_mut().enumerate() {
                     if slot.is_none() {
                         *slot = color_resolver.resolve_series_accent(i);
@@ -6417,7 +6635,7 @@ pub fn parse_chart_part_with_references(
             let has_dpt_colors = data_point_colors.iter().any(|c| c.is_some());
 
             // Per-point `<c:dPt>` overrides (§21.2.2.39): marker (symbol/size/
-            // fill/line) and `<c:explosion>` (pie/doughnut pull-out). Plain
+            // fill/line/line width) and `<c:explosion>` (pie/doughnut pull-out). Plain
             // per-point FILL flows through `data_point_colors` above (the pie
             // model the pptx path established), so we only emit an override when
             // it carries a marker or explosion — a color-only dPt yields no
@@ -6432,6 +6650,7 @@ pub fn parse_chart_part_with_references(
                             || o.marker_size.is_some()
                             || o.marker_fill.is_some()
                             || o.marker_line.is_some()
+                            || o.marker_line_width_emu.is_some()
                             || o.explosion.is_some()
                     })
                     .collect();
@@ -6527,7 +6746,7 @@ pub fn parse_chart_part_with_references(
             // ⇒ false (line series draw no markers unless opted in).
             let chart_marker_default = group.and_then(|g| bool_child(g, "marker")).unwrap_or(false);
             let marker_node = child(*ser, "marker");
-            let (marker_symbol, marker_size, marker_fill, marker_line) =
+            let (marker_symbol, marker_size, marker_fill, marker_line, marker_line_width_emu) =
                 parse_marker_block(marker_node, color_resolver);
             let show_marker = match (&marker_symbol, series_is_scatter_like) {
                 (Some(sym), _) => sym != "none",
@@ -6580,6 +6799,7 @@ pub fn parse_chart_part_with_references(
                 marker_size,
                 marker_fill,
                 marker_line,
+                marker_line_width_emu,
                 data_point_overrides: if data_point_overrides.is_empty() {
                     None
                 } else {
@@ -6717,6 +6937,7 @@ pub fn parse_chart_part_with_references(
     let chart_text_font_size_hpt = extract_axis_tick_label_size(root);
     let chart_text_font_color = extract_axis_tick_label_color(root, color_resolver);
     let chart_text_font_bold = extract_axis_tick_label_bold(root);
+    let chart_text_font_italic = extract_axis_tick_label_italic(root);
     let chart_text_font_face = extract_axis_tick_label_face(root);
     let cat_axis_font_size_hpt = cat_ax
         .and_then(extract_axis_tick_label_size)
@@ -6791,6 +7012,7 @@ pub fn parse_chart_part_with_references(
         let (min, max) = extract_axis_min_max(ax);
         let (t, title_size, title_bold, title_color) =
             extract_axis_title_with_props_resolved(ax, color_resolver);
+        let resolved_title_bold = t.as_ref().map(|_| title_bold.unwrap_or(false));
         let (line_color, line_width_emu, line_hidden) = extract_axis_line_style(ax, color_resolver);
         let (minor_gridline_color, minor_gridline_width_emu, minor_gridline_dash) =
             extract_minor_gridline_style(ax, color_resolver);
@@ -6803,6 +7025,7 @@ pub fn parse_chart_part_with_references(
             font_color: extract_axis_tick_label_color(ax, color_resolver)
                 .or_else(|| chart_text_font_color.clone()),
             font_size_hpt: extract_axis_tick_label_size(ax).or(chart_text_font_size_hpt),
+            font_italic: extract_axis_tick_label_italic(ax).or(chart_text_font_italic),
             font_face: extract_axis_tick_label_face(ax),
             line_color,
             line_width_emu,
@@ -6816,7 +7039,8 @@ pub fn parse_chart_part_with_references(
             major_unit: extract_axis_major_unit(ax),
             minor_unit: extract_axis_minor_unit(ax),
             title_font_size_hpt: title_size,
-            title_font_bold: title_bold,
+            title_font_bold: resolved_title_bold,
+            title_font_italic: extract_axis_title_italic(ax),
             title_font_color: title_color,
             title_font_face: extract_axis_title_face(ax),
             title_rotation: extract_axis_title_rotation(ax),
@@ -6882,6 +7106,7 @@ pub fn parse_chart_part_with_references(
     let mut cat_axis_title: Option<String> = None;
     let mut cat_axis_title_size: Option<i32> = None;
     let mut cat_axis_title_bold: Option<bool> = None;
+    let mut cat_axis_title_italic: Option<bool> = None;
     let mut cat_axis_title_color: Option<String> = None;
     let mut cat_axis_title_face: Option<String> = None;
     let mut cat_axis_title_rotation: Option<i32> = None;
@@ -6890,6 +7115,7 @@ pub fn parse_chart_part_with_references(
     let mut val_axis_title: Option<String> = None;
     let mut val_axis_title_size: Option<i32> = None;
     let mut val_axis_title_bold: Option<bool> = None;
+    let mut val_axis_title_italic: Option<bool> = None;
     let mut val_axis_title_color: Option<String> = None;
     let mut val_axis_title_face: Option<String> = None;
     let mut val_axis_title_rotation: Option<i32> = None;
@@ -6916,7 +7142,8 @@ pub fn parse_chart_part_with_references(
                 if t.is_some() {
                     cat_axis_title = t;
                     cat_axis_title_size = sz;
-                    cat_axis_title_bold = b;
+                    cat_axis_title_bold = Some(b.unwrap_or(false));
+                    cat_axis_title_italic = extract_axis_title_italic(ax);
                     cat_axis_title_color = col;
                     cat_axis_title_face = extract_axis_title_face(ax);
                     cat_axis_title_rotation = extract_axis_title_rotation(ax);
@@ -6929,7 +7156,8 @@ pub fn parse_chart_part_with_references(
             if t.is_some() {
                 val_axis_title = t;
                 val_axis_title_size = sz;
-                val_axis_title_bold = b;
+                val_axis_title_bold = Some(b.unwrap_or(false));
+                val_axis_title_italic = extract_axis_title_italic(ax);
                 val_axis_title_color = col;
                 val_axis_title_face = extract_axis_title_face(ax);
                 val_axis_title_rotation = extract_axis_title_rotation(ax);
@@ -6949,9 +7177,15 @@ pub fn parse_chart_part_with_references(
     let cat_axis_font_bold = cat_ax
         .and_then(extract_axis_tick_label_bold)
         .or(chart_text_font_bold);
+    let cat_axis_font_italic = cat_ax
+        .and_then(extract_axis_tick_label_italic)
+        .or(chart_text_font_italic);
     let val_axis_font_bold = val_ax
         .and_then(extract_axis_tick_label_bold)
         .or(chart_text_font_bold);
+    let val_axis_font_italic = val_ax
+        .and_then(extract_axis_tick_label_italic)
+        .or(chart_text_font_italic);
     let title_font_bold = title_node_opt
         .and_then(|t| t.parent())
         .and_then(extract_chart_title_bold);
@@ -7185,19 +7419,23 @@ pub fn parse_chart_part_with_references(
         // parser locals keep the shorter legacy names.
         cat_axis_title_font_size_hpt: cat_axis_title_size,
         cat_axis_title_font_bold: cat_axis_title_bold,
+        cat_axis_title_font_italic: cat_axis_title_italic,
         cat_axis_title_font_color: cat_axis_title_color,
         cat_axis_title_rotation,
         cat_axis_title_vertical_mode,
         cat_axis_title_manual_layout,
         val_axis_title_font_size_hpt: val_axis_title_size,
         val_axis_title_font_bold: val_axis_title_bold,
+        val_axis_title_font_italic: val_axis_title_italic,
         val_axis_title_font_color: val_axis_title_color,
         val_axis_title_rotation,
         val_axis_title_vertical_mode,
         val_axis_title_manual_layout,
         title_font_bold,
         cat_axis_font_bold,
+        cat_axis_font_italic,
         val_axis_font_bold,
+        val_axis_font_italic,
         chart_border_color,
         chart_border_width_emu,
         secondary_val_axis,
@@ -7275,6 +7513,7 @@ pub fn parse_chart_part_with_references(
         chartex_color_style_method: None,
         chartex_data_point_style: None,
         chartex_data_point_line_style: None,
+        chartex_series_line_style: None,
         chartex_data_point_marker_style: None,
         chartex_marker_size_pt: None,
         chartex_marker_symbol: None,
@@ -7381,6 +7620,7 @@ mod tests {
                 marker_size: None,
                 marker_fill: None,
                 marker_line: None,
+                marker_line_width_emu: None,
                 data_point_overrides: None,
                 data_label_overrides: None,
                 series_data_labels: None,
@@ -7429,15 +7669,19 @@ mod tests {
             data_label_font_bold: None,
             title_font_bold: None,
             cat_axis_font_bold: None,
+            cat_axis_font_italic: None,
             val_axis_font_bold: None,
+            val_axis_font_italic: None,
             cat_axis_title_font_size_hpt: None,
             cat_axis_title_font_bold: None,
+            cat_axis_title_font_italic: None,
             cat_axis_title_font_color: None,
             cat_axis_title_rotation: None,
             cat_axis_title_vertical_mode: None,
             cat_axis_title_manual_layout: None,
             val_axis_title_font_size_hpt: None,
             val_axis_title_font_bold: None,
+            val_axis_title_font_italic: None,
             val_axis_title_font_color: None,
             val_axis_title_rotation: None,
             val_axis_title_vertical_mode: None,
@@ -7519,6 +7763,7 @@ mod tests {
             chartex_color_style_method: None,
             chartex_data_point_style: None,
             chartex_data_point_line_style: None,
+            chartex_series_line_style: None,
             chartex_data_point_marker_style: None,
             chartex_marker_size_pt: None,
             chartex_marker_symbol: None,
@@ -9013,6 +9258,37 @@ mod tests {
         assert_eq!(val_title_layout.y, 0.1);
     }
 
+    #[test]
+    fn parse_chart_part_preserves_custom_data_label_run_styles() {
+        let xml = format!(
+            r#"<c:chartSpace xmlns:c="{C_NS}" xmlns:a="{A_NS}"><c:chart><c:plotArea>
+              <c:lineChart><c:grouping val="standard"/><c:ser>
+                <c:idx val="0"/><c:tx><c:v>Employer</c:v></c:tx>
+                <c:dLbls><c:dLbl><c:idx val="0"/><c:tx><c:rich><a:p>
+                  <a:pPr><a:defRPr sz="800" b="1"/></a:pPr>
+                  <a:r><a:rPr sz="1200" b="1"/><a:t>Employer</a:t></a:r>
+                  <a:r><a:rPr sz="1100" b="0"/><a:t> 36.0%</a:t></a:r>
+                </a:p></c:rich></c:tx><c:dLblPos val="l"/>
+                <c:showVal val="1"/><c:showSerName val="1"/>
+                </c:dLbl></c:dLbls>
+                <c:cat><c:strCache><c:pt idx="0"><c:v>Start</c:v></c:pt></c:strCache></c:cat>
+                <c:val><c:numCache><c:pt idx="0"><c:v>36</c:v></c:pt></c:numCache></c:val>
+              </c:ser></c:lineChart>
+            </c:plotArea></c:chart></c:chartSpace>"#
+        );
+        let document = chart_space_of(&xml);
+        let model =
+            parse_chart_part(document.root_element(), &FixtureResolver).expect("line chart parses");
+        let label = &model.series[0].data_label_overrides.as_ref().unwrap()[0];
+        assert_eq!(label.text, "Employer 36.0%");
+        assert_eq!(label.position.as_deref(), Some("l"));
+        let runs = label.rich_runs.as_ref().expect("rich runs on public model");
+        assert_eq!(runs[0].font_size_hpt, Some(1200));
+        assert_eq!(runs[0].bold, Some(true));
+        assert_eq!(runs[1].font_size_hpt, Some(1100));
+        assert_eq!(runs[1].bold, Some(false));
+    }
+
     /// A chart title may be a string reference cache rather than DrawingML
     /// rich text (§21.2.2.6 CT_Title → §21.2.2.198 CT_Tx). The cached `<c:v>`
     /// is the authored title and must win over the single-series auto title.
@@ -9551,24 +9827,25 @@ mod tests {
               <c:size val="6"/>
               <c:spPr>
                 <a:solidFill><a:srgbClr val="ff0000"/></a:solidFill>
-                <a:ln><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></a:ln>
+                <a:ln w="25400"><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></a:ln>
               </c:spPr>
             </c:marker>"#
         );
         let d = root_of(&xml);
-        let (symbol, size, fill, line) =
+        let (symbol, size, fill, line, line_width_emu) =
             parse_marker_block(Some(d.root_element()), &FixtureResolver);
         assert_eq!(symbol.as_deref(), Some("circle"));
         assert_eq!(size, Some(6.0));
         assert_eq!(fill.as_deref(), Some("FF0000"));
         assert_eq!(line.as_deref(), Some("4472C4"));
+        assert_eq!(line_width_emu, Some(25400));
     }
 
     #[test]
     fn parse_marker_block_none_node_returns_all_none() {
         assert_eq!(
             parse_marker_block(None, &FixtureResolver),
-            (None, None, None, None)
+            (None, None, None, None, None)
         );
     }
 
@@ -9576,12 +9853,13 @@ mod tests {
     fn parse_marker_block_symbol_none_no_sppr() {
         let xml = format!(r#"<c:marker xmlns:c="{C_NS}"><c:symbol val="none"/></c:marker>"#);
         let d = root_of(&xml);
-        let (symbol, size, fill, line) =
+        let (symbol, size, fill, line, line_width_emu) =
             parse_marker_block(Some(d.root_element()), &FixtureResolver);
         assert_eq!(symbol.as_deref(), Some("none"));
         assert_eq!(size, None);
         assert_eq!(fill, None);
         assert_eq!(line, None);
+        assert_eq!(line_width_emu, None);
     }
 
     #[test]
@@ -9593,9 +9871,11 @@ mod tests {
             </c:marker>"#
         );
         let d = root_of(&xml);
-        let (_, _, fill, line) = parse_marker_block(Some(d.root_element()), &FixtureResolver);
+        let (_, _, fill, line, line_width_emu) =
+            parse_marker_block(Some(d.root_element()), &FixtureResolver);
         assert_eq!(fill.as_deref(), Some("00000000"));
         assert_eq!(line.as_deref(), Some("777777"));
+        assert_eq!(line_width_emu, None);
     }
 
     #[test]
@@ -9744,11 +10024,11 @@ mod tests {
               <c:dLbls>
                 <c:dLbl>
                   <c:idx val="13"/>
-                  <c:tx><c:rich><a:p><a:r>
-                    <a:rPr sz="1100" b="1"><a:solidFill><a:srgbClr val="EC008B"/></a:solidFill></a:rPr>
-                    <a:t>Idaho</a:t>
-                  </a:r></a:p></c:rich></c:tx>
-                  <c:txPr><a:p><a:pPr><a:defRPr sz="900"><a:solidFill><a:srgbClr val="333333"/></a:solidFill></a:defRPr></a:pPr></a:p></c:txPr>
+                  <c:tx><c:rich><a:p><a:pPr><a:defRPr sz="800" b="1"><a:solidFill><a:srgbClr val="445566"/></a:solidFill></a:defRPr></a:pPr>
+                    <a:r><a:rPr sz="1200"><a:solidFill><a:srgbClr val="EC008B"/></a:solidFill></a:rPr><a:t>Employer</a:t></a:r>
+                    <a:r><a:rPr sz="1100" b="0"/><a:t> 36.0%</a:t></a:r>
+                  </a:p></c:rich></c:tx>
+                  <c:txPr><a:p><a:pPr><a:defRPr sz="900" b="0"><a:solidFill><a:srgbClr val="333333"/></a:solidFill><a:latin typeface="Tx Face"/></a:defRPr></a:pPr></a:p></c:txPr>
                 </c:dLbl>
               </c:dLbls>
             </c:ser>"#
@@ -9756,10 +10036,72 @@ mod tests {
         let d = root_of(&xml);
         let (_, overrides) = parse_series_data_labels(d.root_element(), &FixtureResolver, &cache);
         let label = &overrides[0];
-        assert_eq!(label.text, "Idaho");
+        assert_eq!(label.text, "Employer 36.0%");
         assert_eq!(label.font_color.as_deref(), Some("EC008B"));
-        assert_eq!(label.font_size_hpt, Some(1100));
+        assert_eq!(label.font_size_hpt, Some(1200));
         assert_eq!(label.font_bold, Some(true));
+        let runs = label.rich_runs.as_ref().expect("rich runs");
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[0].text, "Employer");
+        assert_eq!(runs[0].font_size_hpt, Some(1200));
+        assert_eq!(runs[0].bold, Some(true));
+        assert_eq!(runs[0].color.as_deref(), Some("EC008B"));
+        assert_eq!(runs[0].font_face.as_deref(), Some("Tx Face"));
+        assert_eq!(runs[1].text, " 36.0%");
+        assert_eq!(runs[1].font_size_hpt, Some(1100));
+        assert_eq!(runs[1].bold, Some(false));
+        assert_eq!(runs[1].color.as_deref(), Some("445566"));
+        assert_eq!(runs[1].font_face.as_deref(), Some("Tx Face"));
+    }
+
+    #[test]
+    fn parse_series_data_labels_bounds_rich_runs_by_scalars_and_paragraphs() {
+        let cache = std::collections::HashMap::new();
+        let paragraph_text = "x".repeat(1100);
+        let paragraphs = (0..5)
+            .map(|_| format!("<a:p><a:r><a:t>{paragraph_text}</a:t></a:r></a:p>"))
+            .collect::<String>();
+        let xml = format!(
+            r#"<c:ser xmlns:c="{C_NS}" xmlns:a="{A_NS}"><c:dLbls><c:dLbl>
+              <c:idx val="0"/><c:tx><c:rich>{paragraphs}</c:rich></c:tx>
+            </c:dLbl></c:dLbls></c:ser>"#
+        );
+        let document = root_of(&xml);
+        let (_, overrides) =
+            parse_series_data_labels(document.root_element(), &FixtureResolver, &cache);
+        let label = &overrides[0];
+        let runs = label.rich_runs.as_ref().expect("bounded rich runs");
+        let text = runs.iter().map(|run| run.text.as_str()).collect::<String>();
+        assert_eq!(text, label.text);
+        assert!(text.chars().count() <= MAX_DATA_LABEL_RICH_SCALARS);
+        assert!(text.split('\n').count() <= MAX_DATA_LABEL_RICH_LINES);
+    }
+
+    #[test]
+    fn parse_data_label_rich_run_size_obeys_st_text_font_size_and_cascades() {
+        let cache = std::collections::HashMap::new();
+        for (direct, fallback, expected) in [
+            ("99", "1200", 1200),
+            ("100", "1200", 100),
+            ("400000", "1200", 400_000),
+            ("400001", "1200", 1200),
+        ] {
+            let xml = format!(
+                r#"<c:ser xmlns:c="{C_NS}" xmlns:a="{A_NS}"><c:dLbls><c:dLbl>
+                  <c:idx val="0"/><c:tx><c:rich><a:p><a:pPr><a:defRPr sz="{fallback}"/></a:pPr>
+                    <a:r><a:rPr sz="{direct}"/><a:t>Label</a:t></a:r>
+                  </a:p></c:rich></c:tx>
+                </c:dLbl></c:dLbls></c:ser>"#
+            );
+            let document = root_of(&xml);
+            let (_, overrides) =
+                parse_series_data_labels(document.root_element(), &FixtureResolver, &cache);
+            assert_eq!(
+                overrides[0].rich_runs.as_ref().unwrap()[0].font_size_hpt,
+                Some(expected),
+                "direct size {direct}",
+            );
+        }
     }
 
     // ── CT_Boolean bare-element defaults (issue #806) ───────────────────────
@@ -10298,19 +10640,19 @@ mod tests {
               <cx:chart><cx:plotArea>
                 <cx:plotAreaRegion><cx:series layoutId="waterfall"/></cx:plotAreaRegion>
                 <cx:axis id="0"><cx:catScaling/><cx:title><cx:tx><cx:rich>
-                  <a:bodyPr/><a:p><a:r><a:t>Category</a:t></a:r></a:p>
+                  <a:bodyPr/><a:p><a:r><a:rPr i="1"/><a:t>Category</a:t></a:r></a:p>
                 </cx:rich></cx:tx></cx:title></cx:axis>
                 <cx:axis id="1"><cx:valScaling/><cx:title><cx:tx><cx:rich>
-                  <a:bodyPr/><a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="778899"/></a:solidFill></a:defRPr></a:pPr><a:r><a:rPr sz="1200" b="0"><a:latin typeface="Inline Val"/></a:rPr><a:t>Value</a:t></a:r></a:p>
-                </cx:rich></cx:tx></cx:title></cx:axis>
+                  <a:bodyPr/><a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="778899"/></a:solidFill></a:defRPr></a:pPr><a:r><a:rPr sz="1200" b="0" i="1"><a:latin typeface="Inline Val"/></a:rPr><a:t>Value</a:t></a:r></a:p>
+                </cx:rich></cx:tx></cx:title><cx:txPr><a:p><a:pPr><a:defRPr sz="900" i="1"><a:latin typeface="Inline Tick Val"/></a:defRPr></a:pPr></a:p></cx:txPr></cx:axis>
               </cx:plotArea></cx:chart>
             </cx:chartSpace>"#
         );
         let style = format!(
             r#"<cs:chartStyle xmlns:cs="{CS_NS}" xmlns:a="{A_NS}">
-              <cs:axisTitle><cs:defRPr sz="1000" b="1"><a:solidFill><a:srgbClr val="445566"/></a:solidFill><a:latin typeface="Style Axis"/></cs:defRPr></cs:axisTitle>
-              <cs:categoryAxis><cs:defRPr sz="700" b="0"><a:latin typeface="Tick Cat"/></cs:defRPr></cs:categoryAxis>
-              <cs:valueAxis><cs:defRPr sz="800" b="0"><a:latin typeface="Tick Val"/></cs:defRPr></cs:valueAxis>
+              <cs:axisTitle><cs:defRPr sz="1000" b="1" i="0"><a:solidFill><a:srgbClr val="445566"/></a:solidFill><a:latin typeface="Style Axis"/></cs:defRPr></cs:axisTitle>
+              <cs:categoryAxis><cs:defRPr sz="700" b="0" i="0"><a:latin typeface="Tick Cat"/></cs:defRPr></cs:categoryAxis>
+              <cs:valueAxis><cs:defRPr sz="800" b="0" i="0"><a:latin typeface="Tick Val"/></cs:defRPr></cs:valueAxis>
             </cs:chartStyle>"#
         );
         let document = chart_space_of(&xml);
@@ -10319,6 +10661,7 @@ mod tests {
 
         assert_eq!(model.cat_axis_title_font_size_hpt, Some(1000));
         assert_eq!(model.cat_axis_title_font_bold, Some(true));
+        assert_eq!(model.cat_axis_title_font_italic, Some(true));
         assert_eq!(model.cat_axis_title_font_color.as_deref(), Some("445566"));
         assert_eq!(
             model.cat_axis_title_font_face.as_deref(),
@@ -10327,14 +10670,21 @@ mod tests {
         // Inline run and default-run properties win independently over style.
         assert_eq!(model.val_axis_title_font_size_hpt, Some(1200));
         assert_eq!(model.val_axis_title_font_bold, Some(false));
+        assert_eq!(model.val_axis_title_font_italic, Some(true));
         assert_eq!(model.val_axis_title_font_color.as_deref(), Some("778899"));
         assert_eq!(
             model.val_axis_title_font_face.as_deref(),
             Some("Inline Val")
         );
         // Axis tick labels retain their separate category/value style roles.
+        // Unlike axis titles, Excel treats those role properties as the
+        // effective tick-label recipe; axis-local txPr only fills properties
+        // the linked role leaves unspecified.
         assert_eq!(model.cat_axis_font_size_hpt, Some(700));
+        assert_eq!(model.cat_axis_font_italic, Some(false));
         assert_eq!(model.val_axis_font_size_hpt, Some(800));
+        assert_eq!(model.val_axis_font_italic, Some(false));
+        assert_eq!(model.val_axis_font_face.as_deref(), Some("Tick Val"));
     }
 
     #[test]
@@ -10446,6 +10796,7 @@ mod tests {
             r#"<cs:chartStyle xmlns:cs="{CS_NS}" xmlns:a="{A_NS}">
               <cs:dataPoint><cs:spPr><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></cs:spPr></cs:dataPoint>
               <cs:dataPointLine><cs:spPr><a:ln w="28575" cap="rnd"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="dash"/><a:round/></a:ln></cs:spPr></cs:dataPointLine>
+              <cs:seriesLine><cs:spPr><a:ln w="38100"><a:solidFill><a:schemeClr val="accent2"/></a:solidFill></a:ln></cs:spPr></cs:seriesLine>
               <cs:dataPointMarker><cs:spPr><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:ln w="9525"><a:solidFill><a:schemeClr val="lt1"/></a:solidFill></a:ln></cs:spPr></cs:dataPointMarker>
             </cs:chartStyle>"#
         );
@@ -10484,6 +10835,12 @@ mod tests {
         assert_eq!(line.line_cap.as_deref(), Some("rnd"));
         assert_eq!(line.line_dash.as_deref(), Some("dash"));
         assert_eq!(line.line_join.as_deref(), Some("round"));
+        let series_line = model.chartex_series_line_style.expect("seriesLine role");
+        assert_eq!(series_line.line_width_emu, Some(38100));
+        assert_eq!(
+            series_line.line_colors,
+            Some(vec![Some("ED7D31".to_string()); 4])
+        );
         let marker = model.chartex_data_point_marker_style.expect("marker role");
         assert_eq!(marker.line_width_emu, Some(9525));
         assert_eq!(
@@ -11477,9 +11834,9 @@ mod tests {
         assert_eq!(m.val_axis_title_font_face.as_deref(), Some("Calibri"));
         assert_eq!(m.val_axis_format_code.as_deref(), Some("0.0"));
         assert_eq!(m.val_axis_major_gridlines, Some(true));
-        // The associated chartStyle's valueAxis entry supplies the effective
-        // ChartEx tick-label defaults. Its 9pt/gray properties therefore win
-        // over the otherwise-fallback axis txPr (12pt/112233).
+        // ChartEx tick-label appearance is supplied by the associated Chart
+        // Style valueAxis role. The axis-local txPr remains the fallback for a
+        // property the role does not provide.
         assert_eq!(m.val_axis_font_size_hpt, Some(900));
         assert_eq!(m.val_axis_font_bold, Some(false));
         assert_eq!(m.val_axis_font_color.as_deref(), Some("595959"));
@@ -12254,6 +12611,84 @@ mod tests {
         )
         .expect("explicit false showNegBubbles parses");
         assert_eq!(disabled_chart.show_negative_bubbles, Some(false));
+    }
+
+    /// Office varies a lone bubble series by point when `<c:varyColors>` is
+    /// omitted, just as it does for a lone bar series.  An authored false value
+    /// remains authoritative and keeps the series fill for every bubble.
+    #[test]
+    fn parse_chart_part_bubble_vary_colors_defaults_on_and_honors_false() {
+        let ser = r#"<c:ser><c:idx val="0"/><c:order val="0"/>
+            <c:xVal><c:numLit><c:ptCount val="3"/>
+              <c:pt idx="0"><c:v>1</c:v></c:pt><c:pt idx="1"><c:v>2</c:v></c:pt><c:pt idx="2"><c:v>3</c:v></c:pt>
+            </c:numLit></c:xVal>
+            <c:yVal><c:numLit><c:ptCount val="3"/>
+              <c:pt idx="0"><c:v>1</c:v></c:pt><c:pt idx="1"><c:v>2</c:v></c:pt><c:pt idx="2"><c:v>3</c:v></c:pt>
+            </c:numLit></c:yVal>
+            <c:bubbleSize><c:numLit><c:ptCount val="3"/>
+              <c:pt idx="0"><c:v>100</c:v></c:pt><c:pt idx="1"><c:v>400</c:v></c:pt><c:pt idx="2"><c:v>900</c:v></c:pt>
+            </c:numLit></c:bubbleSize>
+          </c:ser>"#;
+        let default_xml = chart_space_with_group(&format!("<c:bubbleChart>{ser}</c:bubbleChart>"));
+        let default_doc = chart_space_of(&default_xml);
+        let default_chart = parse_chart_part(default_doc.root_element(), &AccentResolver)
+            .expect("bubble chart parses");
+        let colors = default_chart.series[0]
+            .data_point_colors
+            .as_ref()
+            .expect("default point palette");
+        assert_eq!(colors[0].as_deref(), Some("4472C4"));
+        assert_eq!(colors[1].as_deref(), Some("ED7D31"));
+        assert_eq!(colors[2].as_deref(), Some("A5A5A5"));
+
+        let off_xml = chart_space_with_group(&format!(
+            "<c:bubbleChart><c:varyColors val=\"0\"/>{ser}</c:bubbleChart>"
+        ));
+        let off_doc = chart_space_of(&off_xml);
+        let off_chart =
+            parse_chart_part(off_doc.root_element(), &AccentResolver).expect("bubble chart parses");
+        assert!(off_chart.series[0].data_point_colors.is_none());
+
+        let point_formats = r#"<c:dPt><c:idx val="1"/><c:spPr><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></c:spPr></c:dPt>
+            <c:dPt><c:idx val="2"/><c:spPr><a:noFill/></c:spPr></c:dPt>"#;
+        let no_fill_ser = ser.replace(
+            "<c:xVal>",
+            &format!(r#"<c:spPr><a:noFill/></c:spPr>{point_formats}<c:xVal>"#),
+        );
+        let no_fill_xml = chart_space_with_group(&format!(
+            "<c:bubbleChart><c:varyColors/>{no_fill_ser}</c:bubbleChart>"
+        ));
+        let no_fill_doc = chart_space_of(&no_fill_xml);
+        let no_fill_chart = parse_chart_part(no_fill_doc.root_element(), &AccentResolver)
+            .expect("noFill bubble parses");
+        assert_eq!(no_fill_chart.series[0].color.as_deref(), Some("00000000"));
+        assert_eq!(
+            no_fill_chart.series[0].data_point_colors,
+            Some(vec![
+                None,
+                Some("FF0000".to_string()),
+                Some("00000000".to_string())
+            ]),
+        );
+
+        let solid_ser = ser.replace(
+            "<c:xVal>",
+            &format!(r#"<c:spPr><a:solidFill><a:srgbClr val="00FF00"/></a:solidFill></c:spPr>{point_formats}<c:xVal>"#),
+        );
+        let solid_xml = chart_space_with_group(&format!(
+            "<c:bubbleChart><c:varyColors/>{solid_ser}</c:bubbleChart>"
+        ));
+        let solid_doc = chart_space_of(&solid_xml);
+        let solid_chart = parse_chart_part(solid_doc.root_element(), &AccentResolver)
+            .expect("solid bubble parses");
+        assert_eq!(
+            solid_chart.series[0].data_point_colors,
+            Some(vec![
+                Some("4472C4".to_string()),
+                Some("FF0000".to_string()),
+                Some("00000000".to_string()),
+            ]),
+        );
     }
 
     #[test]

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -56,6 +56,7 @@ export interface Camera3d {
 export interface ChartDataLabelOverride {
     idx: number;
     text: string;
+    richRuns?: ChartTextRun[];
     position?: string;
     fontColor?: string;
     fontSizeHpt?: number;
@@ -82,6 +83,7 @@ export interface ChartDataPointOverride {
     markerSize?: number;
     markerFill?: string;
     markerLine?: string;
+    markerLineWidthEmu?: number;
     explosion?: number;
 }
 export interface ChartElement {
@@ -217,15 +219,19 @@ export interface ChartModel {
     dataLabelFormatCode?: string | null;
     titleFontBold?: boolean | null;
     catAxisFontBold?: boolean | null;
+    catAxisFontItalic?: boolean | null;
     valAxisFontBold?: boolean | null;
+    valAxisFontItalic?: boolean | null;
     catAxisTitleFontSizeHpt?: number | null;
     catAxisTitleFontBold?: boolean | null;
+    catAxisTitleFontItalic?: boolean | null;
     catAxisTitleFontColor?: string | null;
     catAxisTitleRotation?: number | null;
     catAxisTitleVerticalMode?: 'horz' | 'vert' | 'vert270' | 'wordArtVert' | 'eaVert' | 'mongolianVert' | 'wordArtVertRtl' | null;
     catAxisTitleManualLayout?: ChartManualLayout | null;
     valAxisTitleFontSizeHpt?: number | null;
     valAxisTitleFontBold?: boolean | null;
+    valAxisTitleFontItalic?: boolean | null;
     valAxisTitleFontColor?: string | null;
     valAxisTitleRotation?: number | null;
     valAxisTitleVerticalMode?: 'horz' | 'vert' | 'vert270' | 'wordArtVert' | 'eaVert' | 'mongolianVert' | 'wordArtVertRtl' | null;
@@ -307,6 +313,7 @@ export interface ChartModel {
     chartexColorStyleMethod?: string | null;
     chartexDataPointStyle?: ChartExElementStyle | null;
     chartexDataPointLineStyle?: ChartExElementStyle | null;
+    chartexSeriesLineStyle?: ChartExElementStyle | null;
     chartexDataPointMarkerStyle?: ChartExElementStyle | null;
     chartexMarkerSizePt?: number | null;
     chartexMarkerSymbol?: string | null;
@@ -341,6 +348,7 @@ export interface ChartSeries {
     markerSize?: number | null;
     markerFill?: string | null;
     markerLine?: string | null;
+    markerLineWidthEmu?: number | null;
     dataPointOverrides?: ChartDataPointOverride[] | null;
     dataLabelOverrides?: ChartDataLabelOverride[] | null;
     seriesDataLabels?: ChartSeriesDataLabels | null;
@@ -1118,6 +1126,7 @@ export interface SecondaryValueAxis {
     formatCode?: string | null;
     fontColor?: string | null;
     fontSizeHpt?: number | null;
+    fontItalic?: boolean | null;
     fontFace?: string | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
@@ -1132,6 +1141,7 @@ export interface SecondaryValueAxis {
     minorUnit?: number | null;
     titleFontSizeHpt?: number | null;
     titleFontBold?: boolean | null;
+    titleFontItalic?: boolean | null;
     titleFontColor?: string | null;
     titleFontFace?: string | null;
     titleRotation?: number | null;

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -167,6 +167,7 @@ export interface ChartAnchor {
 export interface ChartDataLabelOverride {
     idx: number;
     text: string;
+    richRuns?: ChartTextRun[];
     position?: string;
     fontColor?: string;
     fontSizeHpt?: number;
@@ -193,6 +194,7 @@ export interface ChartDataPointOverride {
     markerSize?: number;
     markerFill?: string;
     markerLine?: string;
+    markerLineWidthEmu?: number;
     explosion?: number;
 }
 export interface ChartErrBars {
@@ -317,15 +319,19 @@ export interface ChartModel {
     dataLabelFormatCode?: string | null;
     titleFontBold?: boolean | null;
     catAxisFontBold?: boolean | null;
+    catAxisFontItalic?: boolean | null;
     valAxisFontBold?: boolean | null;
+    valAxisFontItalic?: boolean | null;
     catAxisTitleFontSizeHpt?: number | null;
     catAxisTitleFontBold?: boolean | null;
+    catAxisTitleFontItalic?: boolean | null;
     catAxisTitleFontColor?: string | null;
     catAxisTitleRotation?: number | null;
     catAxisTitleVerticalMode?: 'horz' | 'vert' | 'vert270' | 'wordArtVert' | 'eaVert' | 'mongolianVert' | 'wordArtVertRtl' | null;
     catAxisTitleManualLayout?: ChartManualLayout | null;
     valAxisTitleFontSizeHpt?: number | null;
     valAxisTitleFontBold?: boolean | null;
+    valAxisTitleFontItalic?: boolean | null;
     valAxisTitleFontColor?: string | null;
     valAxisTitleRotation?: number | null;
     valAxisTitleVerticalMode?: 'horz' | 'vert' | 'vert270' | 'wordArtVert' | 'eaVert' | 'mongolianVert' | 'wordArtVertRtl' | null;
@@ -407,6 +413,7 @@ export interface ChartModel {
     chartexColorStyleMethod?: string | null;
     chartexDataPointStyle?: ChartExElementStyle | null;
     chartexDataPointLineStyle?: ChartExElementStyle | null;
+    chartexSeriesLineStyle?: ChartExElementStyle | null;
     chartexDataPointMarkerStyle?: ChartExElementStyle | null;
     chartexMarkerSizePt?: number | null;
     chartexMarkerSymbol?: string | null;
@@ -441,6 +448,7 @@ export interface ChartSeries {
     markerSize?: number | null;
     markerFill?: string | null;
     markerLine?: string | null;
+    markerLineWidthEmu?: number | null;
     dataPointOverrides?: ChartDataPointOverride[] | null;
     dataLabelOverrides?: ChartDataLabelOverride[] | null;
     seriesDataLabels?: ChartSeriesDataLabels | null;
@@ -1081,6 +1089,7 @@ export interface SecondaryValueAxis {
     formatCode?: string | null;
     fontColor?: string | null;
     fontSizeHpt?: number | null;
+    fontItalic?: boolean | null;
     fontFace?: string | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
@@ -1095,6 +1104,7 @@ export interface SecondaryValueAxis {
     minorUnit?: number | null;
     titleFontSizeHpt?: number | null;
     titleFontBold?: boolean | null;
+    titleFontItalic?: boolean | null;
     titleFontColor?: string | null;
     titleFontFace?: string | null;
     titleRotation?: number | null;


### PR DESCRIPTION
## Summary
- preserve authored line, marker, label, axis-title, and ChartEx style data through parser/model boundaries
- share bounded label, legend, hierarchy, and value-axis planning across chart families
- align automatic 1/2/5 axis intervals, minor ticks, semantic connectors, and legend keys with observed Office behavior
- harden extreme numeric ranges and hierarchy inputs before allocation

## Specification and compatibility
OOXML defines authored axis bounds and units but leaves omitted automatic values to the consumer. The compatibility defaults here use a bounded 1/2/5 ladder derived from broad Office observations while preserving explicit OOXML values. DrawingML run and line properties remain authoritative and are resolved before renderer fallbacks.

## Verification
- 674 core chart tests
- 374 ooxml-common tests plus doctest
- `pnpm typecheck`
- production build and public API baseline checks
- local-only previous-renderer VRT plus separate vector-reference fidelity review

Private inputs and local reference artifacts are not included.