### PR TITLE
fix(chart): stabilize 3-D outline topology

### DIFF
--- a/packages/core/src/chart/region-map-renderer.test.ts
+++ b/packages/core/src/chart/region-map-renderer.test.ts
@@ -89,6 +89,7 @@ describe('offline ChartEx Region Map renderer', () => {
     }
     expect(new Set(coordinates.map(({ x, y }) => `${x.toFixed(6)},${y.toFixed(6)}`)).size).toBe(4);
     expect(projectRegionMapPoint(point, 'unknown')).toEqual(projectRegionMapPoint(point, 'robinson'));
+    expect(projectRegionMapPoint(point, undefined)).toEqual(projectRegionMapPoint(point, 'robinson'));
   });
 
   it('keeps two- and three-stop scales finite at equal and opposite finite extremes', () => {
@@ -139,6 +140,25 @@ describe('offline ChartEx Region Map renderer', () => {
     expect(rec.texts).toContain('United States');
     expect(rec.texts).not.toContain('Atlantis');
     expect(rec.nonFiniteArguments).toEqual([]);
+  });
+
+  it('derives the rendered automatic ramp from the workbook accent instead of fixed blue', () => {
+    const rec = recordingContext();
+    const model = chart({
+      rows: [
+        { label: 'Canada', value: 0 },
+        { label: 'United States', value: 1 },
+      ],
+      geography: { projectionType: 'robinson', cachePresent: false },
+    });
+    model.chartexAccents = ['C00000'];
+
+    renderRegionMapChart(rec.ctx, model, { x: 0, y: 0, w: 640, h: 360 }, 1);
+
+    expect(rec.fills).toContain('#FFBFBF');
+    expect(rec.fills).toContain('#900000');
+    expect(rec.fills).not.toContain('#C1E5F5');
+    expect(rec.fills).not.toContain('#104862');
   });
 
   it('rejects oversized public-model rows before allocating paths or resolving geometry', () => {

--- a/packages/core/src/chart/three-d-outline.test.ts
+++ b/packages/core/src/chart/three-d-outline.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildThreeDOutlinePaths } from './three-d-outline.js';
+import type { ThreeDScenePoint } from './three-d.js';
+
+const point = (x: number, y: number, depth = 0): ThreeDScenePoint => ({ x, y, depth });
+const signature = (paths: readonly (readonly ThreeDScenePoint[])[]): string[] => paths
+  .map(path => path.map(value => `${value.x},${value.y},${value.depth}`).join('>'))
+  .sort();
+
+describe('buildThreeDOutlinePaths', () => {
+  it('keeps every branch at a degree-three mesh junction as an independent path', () => {
+    const center = point(0, 0);
+    const left = point(-1, 0);
+    const right = point(1, 0);
+    const top = point(0, -1);
+    const first = buildThreeDOutlinePaths([
+      [center, right],
+      [left, center],
+      [top, center],
+    ]);
+    const reordered = buildThreeDOutlinePaths([
+      [center, top],
+      [right, center],
+      [center, left],
+    ]);
+
+    expect(first).toHaveLength(3);
+    expect(first.every(path => path.length === 2)).toBe(true);
+    expect(signature(first)).toEqual(signature(reordered));
+  });
+
+  it('joins only degree-two vertices into one maximal open path', () => {
+    const paths = buildThreeDOutlinePaths([
+      [point(1, 0), point(2, 0)],
+      [point(0, 0), point(1, 0)],
+      [point(2, 0), point(3, 0)],
+    ]);
+
+    expect(paths).toHaveLength(1);
+    expect(paths[0]).toEqual([
+      point(0, 0), point(1, 0), point(2, 0), point(3, 0),
+    ]);
+  });
+
+  it('returns an all-degree-two component as one closed path', () => {
+    const paths = buildThreeDOutlinePaths([
+      [point(1, 0), point(1, 1)],
+      [point(0, 1), point(0, 0)],
+      [point(1, 1), point(0, 1)],
+      [point(0, 0), point(1, 0)],
+    ]);
+    const reordered = buildThreeDOutlinePaths([
+      [point(1, 0), point(0, 0)],
+      [point(0, 0), point(0, 1)],
+      [point(0, 1), point(1, 1)],
+      [point(1, 1), point(1, 0)],
+    ]);
+
+    expect(paths).toHaveLength(1);
+    expect(paths[0]).toHaveLength(5);
+    expect(paths[0][0]).toEqual(paths[0].at(-1));
+    expect(signature(paths)).toEqual(signature(reordered));
+  });
+});

--- a/packages/core/src/chart/three-d-outline.ts
+++ b/packages/core/src/chart/three-d-outline.ts
@@ -1,0 +1,142 @@
+import type { ThreeDScenePoint } from './three-d.js';
+
+const POINT_EPSILON = 1e-9;
+
+export type ThreeDOutlineEdge = readonly [ThreeDScenePoint, ThreeDScenePoint];
+
+interface OutlineNode {
+  point: ThreeDScenePoint;
+  edges: number[];
+  order: number;
+}
+
+interface OutlineEdge {
+  first: OutlineNode;
+  second: OutlineNode;
+  key: string;
+}
+
+const samePoint = (left: ThreeDScenePoint, right: ThreeDScenePoint): boolean =>
+  Math.hypot(left.x - right.x, left.y - right.y, left.depth - right.depth)
+    <= POINT_EPSILON;
+
+const comparePoints = (left: ThreeDScenePoint, right: ThreeDScenePoint): number =>
+  left.x - right.x || left.y - right.y || left.depth - right.depth;
+
+const comparePaths = (
+  left: readonly ThreeDScenePoint[],
+  right: readonly ThreeDScenePoint[],
+): number => {
+  const sharedLength = Math.min(left.length, right.length);
+  for (let index = 0; index < sharedLength; index++) {
+    const comparison = comparePoints(left[index], right[index]);
+    if (comparison !== 0) return comparison;
+  }
+  return left.length - right.length;
+};
+
+function canonicalOpenPath(path: ThreeDScenePoint[]): ThreeDScenePoint[] {
+  const reversed = [...path].reverse();
+  return comparePaths(path, reversed) <= 0 ? path : reversed;
+}
+
+function canonicalClosedPath(path: ThreeDScenePoint[]): ThreeDScenePoint[] {
+  const ring = samePoint(path[0], path.at(-1)!) ? path.slice(0, -1) : [...path];
+  if (ring.length === 0) return [];
+  let start = 0;
+  for (let index = 1; index < ring.length; index++) {
+    if (comparePoints(ring[index], ring[start]) < 0) start = index;
+  }
+  const forward = ring.map((_, offset) => ring[(start + offset) % ring.length]);
+  const reverse = ring.map((_, offset) =>
+    ring[(start - offset + ring.length) % ring.length]);
+  const canonical = comparePaths(forward, reverse) <= 0 ? forward : reverse;
+  return [...canonical, canonical[0]];
+}
+
+/**
+ * Turn the visible boundary edges of a projected 3-D solid into deterministic
+ * maximal paths. A degree-two vertex is a real stroke join. Endpoints and
+ * degree-three-or-higher mesh junctions terminate a path, because pairing two
+ * arbitrary branches would make dash phase and join geometry depend on face
+ * enumeration order. All-degree-two components remain closed paths.
+ */
+export function buildThreeDOutlinePaths(
+  sourceEdges: readonly ThreeDOutlineEdge[],
+): ThreeDScenePoint[][] {
+  // A renderer mesh is schema-bounded to at most 64 radial segments. Keeping
+  // epsilon clustering local to one mesh avoids a global spatial index while
+  // preserving coincident vertices emitted with different mesh indices.
+  const nodes: OutlineNode[] = [];
+  const nodeFor = (point: ThreeDScenePoint): OutlineNode => {
+    const existing = nodes.find(node => samePoint(node.point, point));
+    if (existing) {
+      if (comparePoints(point, existing.point) < 0) existing.point = point;
+      return existing;
+    }
+    const node: OutlineNode = { point, edges: [], order: -1 };
+    nodes.push(node);
+    return node;
+  };
+
+  const rawEdges: Array<readonly [OutlineNode, OutlineNode]> = [];
+  for (const [start, end] of sourceEdges) {
+    if (samePoint(start, end)) continue;
+    const first = nodeFor(start);
+    const second = nodeFor(end);
+    if (first !== second) rawEdges.push([first, second]);
+  }
+  nodes.sort((left, right) => comparePoints(left.point, right.point));
+  nodes.forEach((node, index) => { node.order = index; });
+
+  const edges: OutlineEdge[] = [];
+  const seen = new Set<string>();
+  for (const [left, right] of rawEdges) {
+    const first = left.order < right.order ? left : right;
+    const second = left.order < right.order ? right : left;
+    const key = `${first.order}:${second.order}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    edges.push({ first, second, key });
+  }
+  edges.sort((left, right) => left.key.localeCompare(right.key));
+  edges.forEach((edge, index) => {
+    edge.first.edges.push(index);
+    edge.second.edges.push(index);
+  });
+  for (const node of nodes) node.edges.sort((left, right) => left - right);
+
+  const used = new Set<number>();
+  const walk = (start: OutlineNode, firstEdge: number): ThreeDScenePoint[] => {
+    const path = [start.point];
+    let current = start;
+    let edgeIndex = firstEdge;
+    while (!used.has(edgeIndex)) {
+      used.add(edgeIndex);
+      const edge = edges[edgeIndex];
+      const next = edge.first === current ? edge.second : edge.first;
+      path.push(next.point);
+      if (next.edges.length !== 2) break;
+      const continuation = next.edges.find(index => !used.has(index));
+      if (continuation === undefined) break;
+      current = next;
+      edgeIndex = continuation;
+    }
+    return path;
+  };
+
+  const paths: ThreeDScenePoint[][] = [];
+  for (const node of nodes) {
+    if (node.edges.length === 2) continue;
+    for (const edgeIndex of node.edges) {
+      if (!used.has(edgeIndex)) paths.push(canonicalOpenPath(walk(node, edgeIndex)));
+    }
+  }
+  for (let edgeIndex = 0; edgeIndex < edges.length; edgeIndex++) {
+    if (used.has(edgeIndex)) continue;
+    const edge = edges[edgeIndex];
+    const start = edge.first.order <= edge.second.order ? edge.first : edge.second;
+    paths.push(canonicalClosedPath(walk(start, edgeIndex)));
+  }
+  return paths.sort(comparePaths);
+}

--- a/packages/core/src/chart/three-d-renderer.ts
+++ b/packages/core/src/chart/three-d-renderer.ts
@@ -59,6 +59,7 @@ import {
   type ProjectedStrokePoint,
   type ProjectedStrokePrimitive,
 } from './three-d-stroke.js';
+import { buildThreeDOutlinePaths } from './three-d-outline.js';
 
 const PALETTE = ['4472C4', 'ED7D31', '70AD47', 'A5A5A5', 'FFC000', '5B9BD5'] as const;
 const SUPPORTED_CARTESIAN_THREE_D_TYPES = new Set([
@@ -386,30 +387,9 @@ function projectThreeDMesh(
       addOutlineEdge(startIndex, endIndex);
     }
   }
-  const sameScenePoint = (left: ThreeDScenePoint, right: ThreeDScenePoint): boolean =>
-    Math.hypot(left.x - right.x, left.y - right.y, left.depth - right.depth) <= 1e-9;
-  const remaining = [...outlineEdges.values()].map(([startIndex, endIndex]) => [
+  const paths = buildThreeDOutlinePaths([...outlineEdges.values()].map(([startIndex, endIndex]) => [
     mesh.vertices[startIndex], mesh.vertices[endIndex],
-  ] as ThreeDScenePoint[]);
-  const paths: ThreeDScenePoint[][] = [];
-  while (remaining.length > 0) {
-    const path = remaining.pop()!;
-    let extended = true;
-    while (extended) {
-      extended = false;
-      for (let index = remaining.length - 1; index >= 0; index--) {
-        const segment = remaining[index];
-        if (sameScenePoint(path.at(-1)!, segment[0])) path.push(segment[1]);
-        else if (sameScenePoint(path.at(-1)!, segment[1])) path.push(segment[0]);
-        else if (sameScenePoint(path[0], segment[1])) path.unshift(segment[0]);
-        else if (sameScenePoint(path[0], segment[0])) path.unshift(segment[1]);
-        else continue;
-        remaining.splice(index, 1);
-        extended = true;
-      }
-    }
-    paths.push(path);
-  }
+  ]));
   if (!outlineStyle) return visibleFaces;
   for (const scenePath of paths) {
     const projectedPath = scenePath.map(point => projection.project(point.x, point.y, point.depth));


### PR DESCRIPTION
## Summary
- build 3-D mesh outline paths from deterministic graph topology
- stop authored dash and join continuity at branch vertices instead of pairing arbitrary edges
- lock Region Map omitted-projection and theme-derived ramp behavior with render-level tests

## Root cause
The prior greedy outline path builder joined whichever coincident edge appeared first. At degree-three-or-higher mesh vertices, dash phase and join geometry therefore depended on face enumeration order.

## Verification
- core chart: 870 tests
- full workspace tests: 7,499 tests (loopback tests rerun with local socket permission)
- workspace typecheck and production build
- optional 3-D and Region Map bundle-boundary checks
- public API, public type export, viewer API symmetry, lint, and diff checks