### PR TITLE
refactor(chart): retire archived compatibility probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,9 @@ The Region Map addon is deterministic and network-free. It uses a pinned
 Natural Earth country dataset, supports authored world projections and
 two/three-stop value ramps, and fails closed for cached identities or
 sub-country/view-specific layouts that the bounded offline model cannot yet
-represent safely.
+represent safely. The specification/Office evidence boundary for automatic
+chart behavior is documented in
+[Chart compatibility evidence and scope](docs/chart-compatibility-evidence.md).
 
 ### Off-main-thread rendering
 

--- a/docs/chart-compatibility-evidence.md
+++ b/docs/chart-compatibility-evidence.md
@@ -1,0 +1,97 @@
+# Chart compatibility evidence and scope
+
+This document records the compatibility rules that remain after the local
+Office-observation workbooks and render exports have been discarded. It is an
+index, not an alternative implementation: the executable rules, safety bounds,
+and causal tests live beside the shared parser and renderer code.
+
+## Authority order
+
+1. Authored OOXML properties and schema defaults are authoritative. Classic
+   charts follow ECMA-376 / ISO 29500 Part 1, especially DrawingML chart markup
+   in §21.2. Microsoft ChartEx behavior follows MS-ODRAWXML.
+2. Host-independent parsing belongs to `packages/ooxml-common`; DOCX, XLSX, and
+   PPTX provide only relationship, formula/cache, and theme resolution required
+   by their packages. The resulting `ChartModel` is painted by
+   `packages/core` in all three hosts.
+3. Office compatibility rules are used only where the standards deliberately
+   leave application layout or automatic choices unspecified. They must name
+   their observed input class in code and retain a focused boundary test.
+4. Unobserved semantics are not guessed. Unsupported geography/cache scopes and
+   unsafe or oversized chart models fail closed with a bounded placeholder.
+
+## Retained Office compatibility observations
+
+The following completed local corpora were used to derive the current rules.
+Their raw workbooks, scripts, PDFs, and screenshots are intentionally not part
+of the repository.
+
+| Surface | Valid Office observations | Implemented scope |
+| --- | ---: | --- |
+| Fully automatic linear value axes | 6,354 | Finite classic linear axes; strict 1.2 zero-pin boundary; 1/2/5 ceiling ladder; automatic minor unit is major/5. Twenty-four unstable tiny-offset outputs were not emulated. |
+| Explicit min/max with omitted major unit | 297 | Classic linear, non-percent axes. Vertical and horizontal axes use separately observed density classes. Authored units always win. |
+| Percent-stacked automatic units | 48 | Horizontal/vertical and positive/signed percentage axes, with the observed 120 pt vertical density boundary. |
+| Radar automatic units | 36 | Small, ordinary, and large spoke lengths. |
+| Pie Style 2 repeated colors | point counts 1–48 | ECMA-376 Style 2 accent order plus Office-observed repeated-set luminance transforms. Point formatting and `noFill` remain authoritative. Counts above 48 use the same documented repeat-set rule but are not claimed as byte-exact Office observations. |
+| Cartesian 3-D camera | multiple families and view/depth boundaries | One homogeneous camera per chart. Bar/column and line/area use separately observed model-depth occupancy; every wall, axis, mesh, line, and area vertex still passes through the same camera. |
+| Region Map omitted world view | Office-produced global maps | Offline country-level rendering only. Omitted projection uses the observed Robinson world view; non-world view contracts and geo-cache identity data fail closed. |
+
+Automatic choices are compatibility policy, not OOXML semantics. The comments
+on `planLinearValueAxis`, `automaticPercentMajorUnit`,
+`automaticRadarMajorUnit`, `planChartThreeDProjection`, and
+`projectRegionMapPoint` define the exact supported domain. Family-local legacy
+axis helpers that were no longer reachable were removed so there is one active
+linear planner.
+
+## Availability boundaries
+
+- Each numeric tick layer is capped at 512 positions. Automatic plans coarsen
+  before allocation; unsafe authored minor plans are skipped rather than
+  truncated to one side of the axis.
+- Classic Canvas chart input is capped at 10,000 expanded point slots. The
+  optional 3-D addon also applies a cumulative projected-face/stroke budget.
+- Chart hierarchy input is capped by both row/segment count and depth before
+  tree construction.
+- Indexed point and label overrides are resolved into maps before paint loops;
+  stacked 3-D primitives are bucketed by category once rather than rescanned
+  per category.
+- Region Map work is limited to 10,000 source rows and a fixed, checked-in
+  Natural Earth 1:110m country asset. Rendering performs no network requests.
+
+These are availability limits. They must not silently select a partial data
+prefix or alter authored chart geometry.
+
+## Optional modules and host wiring
+
+Math, 3-D charts, and Region Maps use the same dependency-injection model.
+`CoreLoadOptions` defines the optional engines, and DOCX, XLSX, and PPTX pass
+them unchanged from viewer/document/workbook/presentation construction to the
+shared chart painter. Their implementations live in separate package entries:
+
+- `@silurus/ooxml/math`
+- `@silurus/ooxml/three-d`
+- `@silurus/ooxml/region-map`
+
+Omitting an addon removes its implementation and large assets from the base
+dependency closure. Function-valued addons are intentionally main-thread only;
+worker mode reports that restriction and uses the documented fallback. Clean
+build checks verify both the optional entry and the absence of its marker from
+the base DOCX/XLSX/PPTX entries.
+
+## Known, deliberately limited compatibility surfaces
+
+- OOXML does not define automatic chart layout geometry. Classic title, legend,
+  pie-label, and plot-band defaults are bounded Office compatibility policies;
+  authored manual layout and explicit text/axis properties take precedence.
+- Box-and-whisker's omitted major unit is a narrow ChartEx family policy derived
+  from Office vector observations. It does not override an authored unit and is
+  not reused by other ChartEx families.
+- The 3-D mesh addon implements the six ST_Shape values as model-space box,
+  revolved, or tapered meshes. Office lighting is approximated from face normals;
+  no sample-specific screen-space paint patches are permitted.
+- Region Map supports deterministic offline country geometry. It does not
+  geocode arbitrary localized text or reinterpret an authored non-world view.
+
+When new Office evidence changes one of these policies, update the adjacent
+implementation comment and causal boundary test in the same change. Do not
+reintroduce archived observation workbooks as permanent repository fixtures.

--- a/packages/core/src/chart/axis-scale.test.ts
+++ b/packages/core/src/chart/axis-scale.test.ts
@@ -3,8 +3,6 @@ import {
   automaticPercentMajorUnit,
   automaticRadarMajorUnit,
   niceStep,
-  niceAxisMax,
-  niceAxisMin,
   valueAxisScale,
   axisFraction,
   logAxisScale,
@@ -137,38 +135,6 @@ describe('niceStep', () => {
   });
   it('zero range falls back to 1', () => {
     expect(niceStep(0)).toBe(1);
-  });
-});
-
-describe('niceAxisMax (Excel headroom: first major unit above Ymax + range/20)', () => {
-  it('rounds up past the ~5% headroom to the next major unit', () => {
-    expect(niceAxisMax(41, 10)).toBe(50);        // 41 + 2.05 = 43.05 → 50
-    expect(niceAxisMax(9715, 2000)).toBe(12000); // 9715 + 485.75 = 10200.75 → 12000
-  });
-  it('adds headroom even when data sits on a gridline (not flush against the top)', () => {
-    expect(niceAxisMax(40, 10)).toBe(50);   // 40 + 2 = 42 → 50
-    expect(niceAxisMax(100, 20)).toBe(120); // 100 + 5 = 105 → 120
-  });
-  it('uses dataMin for the range', () => {
-    // range 100-(-100)=200, headroom 10 → 110 → step 50 → 150
-    expect(niceAxisMax(100, 50, -100)).toBe(150);
-  });
-  it('non-positive max returns one step', () => {
-    expect(niceAxisMax(0, 10)).toBe(10);
-    expect(niceAxisMax(-5, 10)).toBe(10);
-  });
-});
-
-describe('niceAxisMin', () => {
-  it('non-negative data anchors at 0', () => {
-    expect(niceAxisMin(15, 10)).toBe(0);
-    expect(niceAxisMin(0, 10)).toBe(0);
-  });
-  it('negative data floors to a major-unit multiple', () => {
-    expect(niceAxisMin(-15, 10)).toBe(-20);
-  });
-  it('data exactly on a gridline drops one extra step', () => {
-    expect(niceAxisMin(-20, 10)).toBe(-30);
   });
 });
 

--- a/packages/core/src/chart/axis-scale.ts
+++ b/packages/core/src/chart/axis-scale.ts
@@ -36,53 +36,6 @@ export function niceStep(range: number, targetSteps = 5): number {
   return nice * mag;
 }
 
-/** Excel / PowerPoint automatic value-axis maximum. Microsoft's documented
- *  algorithm (per Peltier Tech) is "the first major unit above
- *  `Ymax + (Ymax − Ymin)/20`": ~5% of the data range is added as headroom so the
- *  tallest series sits just below the top gridline rather than flush against it,
- *  then the result is rounded up to the next major unit. `dataMin` is the axis
- *  minimum (0 for bar/column charts; the data minimum otherwise).
- *
- *  The major unit itself is Excel-proprietary (it varies with plot size, tick
- *  font, etc. and is not documented), so we approximate it with `niceStep`; the
- *  computed max can therefore differ from PowerPoint by one major unit on some
- *  charts. */
-export function niceAxisMax(dataMax: number, step: number, dataMin = 0): number {
-  if (dataMax <= 0) return step;
-  const withHeadroom = dataMax + (dataMax - dataMin) / 20;
-  return Math.ceil(withHeadroom / step) * step;
-}
-
-/** Axis minimum for data that dips below zero: the largest major-unit multiple
- *  <= dataMin, dropping one extra step when the data sits exactly on a
- *  gridline so the lowest point isn't flush against the axis. Non-negative data
- *  anchors the axis at 0. */
-export function niceAxisMin(dataMin: number, step: number): number {
-  if (dataMin >= 0) return 0;
-  const ax = Math.floor(dataMin / step) * step;
-  return Math.abs(ax - dataMin) < step * 1e-9 ? ax - step : ax;
-}
-
-/** Target gridline spacing in POINTS. Excel's auto major unit is not a fixed
- *  gridline count — it targets a roughly constant on-screen spacing, so a long
- *  axis (e.g. a horizontal bar chart's wide value axis) gets MORE, finer
- *  gridlines than a short one of the same data range. This density is a
- *  compatibility approximation, because OOXML does not define it. */
-const GRIDLINE_SPACING_PT = 42;
-
-/** Pick the target-gridline count for an axis of `axisLenPt` points. Unknown
- *  lengths use five intervals; the four-interval floor keeps short axes
- *  readable and the ceiling bounds paint work on unusually long axes. */
-function targetStepsForAxis(axisLenPt?: number): number {
-  if (axisLenPt == null || !isFinite(axisLenPt) || axisLenPt <= 0) return 5;
-  return Math.min(15, Math.max(4, Math.round(axisLenPt / GRIDLINE_SPACING_PT)));
-}
-
-/** Existing nearest-ladder density used by specialized percent axes. */
-export function axisLengthNiceStep(range: number, axisLenPt?: number): number {
-  return niceStep(range, targetStepsForAxis(axisLenPt));
-}
-
 /**
  * Automatic percent-stacked major unit in percentage-point data space.
  * OOXML does not define the omitted unit.  The 48-case boundary corpus found

--- a/packages/core/src/chart/layout.ts
+++ b/packages/core/src/chart/layout.ts
@@ -169,7 +169,7 @@ export function chartTitleFontPx(chart: ChartModel, _h: number, ptToPx: number):
  *  `textBaseline='top'` the glyph cap-top sits ~0.19×font below the draw origin
  *  (the box-top → cap-top gap intrinsic to the face), so a top pad of ~0.62×font
  *  places the cap-top at ~0.81×font from the band top, matching PowerPoint's
- *  rendered chart titles (measured against the demo sample-1 line chart PDF).
+ *  rendered chart titles in the bounded Office vector corpus.
  *
  *  For an already-resolved `fontPx`, the band's TOTAL height (`bandH`) is
  *  unchanged by this top/bottom-pad redistribution — see
@@ -370,8 +370,8 @@ export function chartAxisTitleBands(
 // with no `<c:manualLayout>`). ECMA-376 does not specify the auto-layout geometry
 // — it only says the plot area is positioned automatically — so these constants
 // model the RUNTIME behavior PowerPoint applies, pinned to the rendered ground
-// truth. The load-bearing pin is the PLOT/frame ratio: the demo sample-1 slide-5
-// line chart PDF places the plot rect at 0.611 of the frame height. The remaining
+// truth. The load-bearing pin is the observed PLOT/frame ratio: a classic line
+// chart places the plot rect at 0.611 of the frame height. The remaining
 // 0.389 splits into the top reserve above the plot (title band + the gap down to
 // the first gridline ≈ 0.236) and the bottom reserve (category-label band ≈
 // 0.154). The title BAND itself is ≈ 0.200 of the frame — 0.236 is the top pad,
@@ -387,7 +387,7 @@ export function chartAxisTitleBands(
 /** Total vertical band a chart TITLE reserves, as a multiple of the title font
  *  size. PowerPoint centers the title text in a slot with air above and below;
  *  `2.25 × fontPx` reserves that slot. The reserve is pinned via the plot/frame
- *  ratio (0.611 on the demo slide-5 line chart PDF, see the block comment above);
+ *  ratio (0.611 in the measured classic-line case, see the block comment above);
  *  at that frame size the title BAND works out to ≈ 0.200 of the frame. (The
  *  0.236 figure sometimes quoted is the TOP PAD — band plus the gap down to the
  *  first gridline — not the band itself.) Replaces the old `fontPx + h·(top+bottom)`

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -10467,8 +10467,8 @@ describe('CH — combo bar+line primary value axis spans BOTH the bars and the p
     // Excel draws $0..$200 for this data. The axis top must at minimum cover the
     // line's 180 (the bug capped it at 160, hiding the tallest line point).
     expect(axisMax).toBeGreaterThanOrEqual(180);
-    // And it must be the next nice unit above 180 — 200 — not an over-scaled
-    // value. (niceAxisMax(180, step=50) with headroom = 200.)
+    // And it must be the observed automatic bound above 180 — 200 — not an
+    // over-scaled value.
     expect(axisMax).toBe(200);
   });
 

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -1588,11 +1588,10 @@ const FIXED_ANGLE_LIMIT_60K = 5_400_000;
  *  {@link FIXED_ANGLE_LIMIT_60K}). Office writes `rot="-60000000"` (-1000°,
  *  ≈2.8 full turns) as a sentinel for "auto / horizontal" axis text and renders
  *  those labels horizontal; the identical value even appears on the numeric
- *  value axis in sample-1/sample-24, whose labels are indisputably horizontal
- *  in the Word/Excel PDF ground truth. So a rot whose magnitude exceeds ±90°
+ *  value axes whose Office-rendered labels are horizontal. So a rot whose magnitude exceeds ±90°
  *  is outside the valid text-rotation domain and is treated as no rotation
  *  (0°) rather than reduced mod 360 (which would map -1000° → +80°,
- *  near-vertical — wrong per sample-24.pdf). Genuine rotations within the
+ *  near-vertical). Genuine rotations within the
  *  closed range (-45° = -2700000, -90° = -5400000) are honored unchanged. */
 function catLabelRotationRad(chart: ChartModel): number {
   const rot = chart.catAxisLabelRotation;
@@ -2026,8 +2025,8 @@ function renderBarChart(
   const valAxLabelFontPx = axisLabelPx(chart.valAxisFontSizeHpt, h, ptToPx);
   const leg = measuredLegendReserve(ctx, legendChart, w, h, 0.22, ptToPx);
   const { legRightW, legLeftW, legTopH, legBottomH } = chartLegendBands(leg);
-  // Axis-title bands sized from the *actual* title font (honoring XML @sz, e.g.
-  // sample-30's 18pt) plus a small gap, so big titles get a wide enough gutter
+  // Axis-title bands sized from the *actual* title font (honoring XML @sz)
+  // plus a small gap, so big titles get a wide enough gutter
   // and never collide with the tick labels.
   const axBands = chartAxisTitleBands(chart, w, h, ptToPx);
   const catTitlePx = axBands.catFontPx;
@@ -2131,10 +2130,8 @@ function renderBarChart(
   // line rides the same `<c:valAx>` as the bars — no secondary axis, or one the
   // line doesn't opt into) must expand the primary axis extent just like the
   // bars do. Excel scales a shared value axis to encompass EVERY series on it,
-  // regardless of chart type; a tall line point can exceed the bar stack (xlsx
-  // sample-9 "MONTHLY OVERVIEW": bars sum to 150 but the line reaches 180, so
-  // Excel draws $0..$200 — sizing to the bars alone would clip the line into the
-  // title). The line is an unstacked overlay, so each raw datum widens the range
+  // regardless of chart type; a tall line point can exceed the bar stack, so
+  // sizing to the bars alone would clip the line. The line is an unstacked overlay, so each raw datum widens the range
   // directly. Secondary-axis line series are excluded (they own an independent
   // scale, mirrored by the `yOf` split below). Skipped for percentStacked, whose
   // axis is definitionally ±100% (§21.2.2.76). `sec` matches the draw-time gate.
@@ -2267,9 +2264,8 @@ function renderBarChart(
 
   // Plot-area placement: honor `<c:plotArea><c:layout><c:manualLayout>` when
   // present (ECMA-376 §21.2.2.32). Templates use this to keep bars from
-  // overflowing into side annotations — sample-2 slide-16's horizontal bar
-  // chart has the chart frame extending into the right-hand text column,
-  // and the explicit `x=0.184, w=0.797` keeps the actual bars on the left.
+  // overflowing into side annotations; an explicit inner rectangle keeps the
+  // data region separate from adjacent authored content.
   // `layoutTarget="inner"` (default) means the rectangle covers the inner
   // data region; "outer" includes axes/labels. We treat both identically
   // because the inner padding stays the same either way. computeChartFrame
@@ -2460,7 +2456,7 @@ function renderBarChart(
   // (horizontal) for a column chart, left (vertical) for a horizontal bar
   // chart — and the VALUE axis is perpendicular to it. The previous code
   // assumed the left rule was always the value axis, so a horizontal bar
-  // chart whose value axis is `<c:delete val="1">` (sample-2 slide-16) drew
+  // chart whose value axis is `<c:delete val="1">` drew
   // no axis line at all even though its category axis carries an explicit
   // `<c:spPr><a:ln>`. `<a:noFill>` on a line suppresses just the rule (labels
   // stay) → `*AxisLineHidden`; an `<a:solidFill>` gives `*AxisLineColor`/Width
@@ -2792,8 +2788,7 @@ function renderBarChart(
   }
 
   if (!chart.catAxisHidden && catLabelsVisible(chart)) {
-    // `<c:catAx><c:txPr>…<a:solidFill>` colors the category tick labels (e.g.
-    // sample-2 slide-16's "2025年3月期" labels are `bg1 lumMod 75%` gray).
+    // `<c:catAx><c:txPr>…<a:solidFill>` colors the category tick labels.
     ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#555';
     const drawnCatTickFontPx = chart.catAxisFontSizeHpt != null
       ? catAxFontPx
@@ -4046,9 +4041,8 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
 
   // Value-axis MAJOR gridlines are drawn UNDER the series (before the fills), so
   // an opaque/translucent area occludes the gridlines inside its region —
-  // matching PowerPoint (verified against private/sample-14.pdf slide-6, where
-  // every gridline inside the teal ARR fill reads solid teal and only the
-  // gridlines above the fill top stay visible). This mirrors the bar/line/stock/
+  // matching Office vector observations in which opaque area fill occludes
+  // gridlines below its top edge. This mirrors the bar/line/stock/
   // scatter/waterfall/box renderers, which already stroke gridlines first. The
   // axis rules, tick marks and value/category labels stay AFTER the series (drawn
   // further below) so they sit atop the plot. `<c:valAx><c:majorGridlines>` is on
@@ -4403,8 +4397,8 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
 
 /** Inside-radius fraction (of the outer radius) for a SOLID pie's `ctr` / `inEnd`
  *  / `bestFit` data labels (§21.2.2.48). PowerPoint places these near the rim,
- *  not at the disc mid-radius: measured from sample-14.pdf, the 54/27/14/5%
- *  slice labels sit at 0.878 / 0.888 / 0.887 / 0.912·outerR — a flat near-rim
+ *  not at the disc mid-radius: four observed slice sizes place labels at
+ *  0.878 / 0.888 / 0.887 / 0.912·outerR — a flat near-rim
  *  constant independent of slice angle (see the `labelR` comment in
  *  {@link drawPieRichLabels}). 0.88 is the empirical fit; it is an approximation
  *  of an undocumented PowerPoint layout, not a spec-defined geometry. Doughnut
@@ -4824,14 +4818,14 @@ function drawPieRichLabels(
     // A per-point `<c:dLbl idx>` (§21.2.2.47) overrides the series-level
     // `<c:dLbls>` (§21.2.2.49) for this one slice. Its show-flags, font color /
     // size / bold, and position each fall back to the series default when the
-    // point declares none. sample-14 slide-7's pie sets `showCatName=0
-    // showPercent=1` + white text per slice while the series default is
+    // point declares none. A point may set `showCatName=0 showPercent=1` plus
+    // white text while the series default is
     // `showCatName=1` black — so honoring the per-point flags is what makes the
     // labels render as white percent-only (matching PowerPoint / the PDF).
     const ov = overridesByIndex.get(i);
     // A genuinely deleted label (`<c:delete val="1">`, §21.2.2.43) is skipped.
-    // A style/flag-only `<c:dLbl>` (no `<c:tx>`) is NOT a delete — sample-14's
-    // pie slices carry `text: ""` with white/percent-only flag overrides, so we
+    // A style/flag-only `<c:dLbl>` (no `<c:tx>`) is NOT a delete. Such slices
+    // can carry `text: ""` with white/percent-only flag overrides, so we
     // key off the explicit `deleted` flag, never the empty text.
     if (ov?.deleted) continue;
     const showCatName = ov?.showCatName ?? def.showCatName;
@@ -4917,8 +4911,8 @@ function drawPieRichLabels(
     }
     // §21.2.2.48 ST_DLblPos radial placement. The spec enumerates the positions
     // (bestFit / ctr / inEnd / outEnd …) but gives no geometry, so the inside
-    // radii below reproduce PowerPoint's own layout, measured from sample-14.pdf
-    // (PowerPoint's render of slide-7's pie + doughnut):
+    // radii below reproduce the bounded Office vector observations for solid
+    // pie and doughnut labels:
     //
     //   • DOUGHNUT (innerR > 0), ctr / inEnd / bestFit → the RING midpoint
     //     (innerR + outerR)/2. Verified on the 55%-hole doughnut: labels sit at
@@ -5236,13 +5230,13 @@ function drawPieCalloutLabels(
 
     const ov = findOverride(i);
     // A genuine `<c:delete val="1"/>` (§21.2.2.43) skips the label; a per-point
-    // *styling / flag* override (sample-25's idx 0) is NOT a delete even though
+    // *styling / flag* override is NOT a delete even though
     // it also has `text === ""` — key off the explicit `deleted` flag.
     if (ov?.deleted) continue;
 
     // §21.2.2.35 composition, with per-point `<c:dLbl>` show-flags (§21.2.2.47)
     // overriding the series defaults for this slice. Word stacks category name
-    // and percent on SEPARATE lines (see sample-25.pdf), so each `show*` part is
+    // and percent on separate lines, so each `show*` part is
     // its own line rather than space-joined.
     const showCatName = ov?.showCatName ?? def.showCatName;
     const showSerName = ov?.showSerName ?? def.showSerName;
@@ -5761,8 +5755,8 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
   // translucent area fill; "standard" / "marker" (and default) draw the
   // line only. Markers come from per-series `<c:marker>` (which can
   // override the chart-type style by setting `<c:symbol val="none"/>`);
-  // sample-1 "Biodiversity Index" sets radarStyle="marker" but every
-  // series carries `<c:marker><c:symbol val="none"/>`, so Excel draws
+  // A chart may set radarStyle="marker" while every series carries
+  // `<c:marker><c:symbol val="none"/>`, in which case Office draws
   // lines only — no dots.
   const filled = chart.radarStyle === 'filled';
   const markerRadius = Math.max(2, rd * 0.025);
@@ -5770,8 +5764,7 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
     const s = chart.series[si];
     const color = chartColor(si, s);
     // Build the per-spoke point list, leaving holes where the series has
-    // no value (`<c:val>` ptCount > pts implies missing indices — sample-1
-    // "Biodiversity Index" omits idx 0, so Excel draws an open polyline
+    // no value (`<c:val>` ptCount > pts implies missing indices), so Office draws an open polyline
     // from idx 1 to idx 10 without bridging back through the top spoke).
     const pts: Array<[number, number] | null> = [];
     for (let i = 0; i < n; i++) {

--- a/packages/core/src/chart/three-d-renderer.ts
+++ b/packages/core/src/chart/three-d-renderer.ts
@@ -72,6 +72,28 @@ const SUPPORTED_CARTESIAN_THREE_D_TYPES = new Set([
  * the renderer preflight so higher fidelity never expands unbounded work. */
 export const THREE_D_ROUND_MESH_FACE_WEIGHT = DEFAULT_THREE_D_ROUND_SEGMENTS + 4;
 
+/** Group stack geometry in one pass before resolving shared internal caps.
+ * The parser/render preflight bounds the item count, but rescanning the whole
+ * primitive array once per category still turns a valid wide chart into
+ * quadratic CPU work. Invalid public-model category indexes are ignored. */
+export function bucketThreeDStackItems<T extends { readonly categoryIndex: number }>(
+  items: readonly T[],
+  categoryCount: number,
+): T[][] {
+  const boundedCount = Number.isSafeInteger(categoryCount) && categoryCount > 0
+    ? categoryCount : 0;
+  const buckets = Array.from({ length: boundedCount }, () => [] as T[]);
+  for (const item of items) {
+    const categoryIndex = item.categoryIndex;
+    if (Number.isSafeInteger(categoryIndex)
+      && categoryIndex >= 0
+      && categoryIndex < boundedCount) {
+      buckets[categoryIndex].push(item);
+    }
+  }
+  return buckets;
+}
+
 interface Point { x: number; y: number }
 
 interface SceneFace {
@@ -607,8 +629,10 @@ function drawThreeDDataLabel(
   defaultPosition = 't',
   leaderAnchor: Point = anchor,
 ): void {
-  const override = resolvedOverride
-    ?? series.dataLabelOverrides?.find(item => item.idx === categoryIndex);
+  // Callers resolve indexed overrides through their per-series Map before the
+  // paint loop. Falling back to Array.find here would quietly reintroduce
+  // quadratic work for a fully-authored maximum-size public model.
+  const override = resolvedOverride;
   if (override?.deleted) return;
   const defaults = series.seriesDataLabels;
   const showVal = override?.showVal ?? defaults?.showVal ?? chart.showDataLabels;
@@ -1790,11 +1814,12 @@ function renderCartesian(
       // Remove only genuinely shared internal cross-sections. This converts a
       // compatible stack into one continuous mesh while preserving caps when
       // shapes/scales differ or an authored axis clips away the neighbour.
+      const primitivesByCategory = bucketThreeDStackItems(primitives, categoryCount);
       for (let categoryIndex = 0; categoryIndex < categoryCount; categoryIndex++) {
+        const categoryPrimitives = primitivesByCategory[categoryIndex];
         for (const sign of [-1, 1] as const) {
-          const segments = primitives
-            .filter(item => item.categoryIndex === categoryIndex
-              && Math.sign(item.labelValue) === sign
+          const segments = categoryPrimitives
+            .filter(item => Math.sign(item.labelValue) === sign
               && !isTransparentPaint(item.color)
               && Math.abs(item.endCoord - item.baseCoord) > 1e-9)
             .sort((a, b) => a.seriesIndex - b.seriesIndex);
@@ -1818,10 +1843,10 @@ function renderCartesian(
         // one continuous signed stack, so neither solid may paint a cap there.
         // A noFill neighbour is deliberately excluded: it cannot occlude the
         // opaque slab's exposed cap.
-        const positive = primitives.find(item => item.categoryIndex === categoryIndex
-          && item.labelValue > 0 && !isTransparentPaint(item.color));
-        const negative = primitives.find(item => item.categoryIndex === categoryIndex
-          && item.labelValue < 0 && !isTransparentPaint(item.color));
+        const positive = categoryPrimitives.find(item =>
+          item.labelValue > 0 && !isTransparentPaint(item.color));
+        const negative = categoryPrimitives.find(item =>
+          item.labelValue < 0 && !isTransparentPaint(item.color));
         if (positive && negative) {
           const tolerance = 1e-8 * Math.max(
             1, Math.abs(positive.baseCoord), Math.abs(negative.baseCoord),

--- a/packages/core/src/chart/three-d.test.ts
+++ b/packages/core/src/chart/three-d.test.ts
@@ -10,8 +10,36 @@ import {
   buildThreeDPieSectorMesh,
   buildThreeDShapeMesh,
 } from './three-d-mesh.js';
+import { bucketThreeDStackItems } from './three-d-renderer.js';
 
 const PLOT = { x: 20, y: 10, w: 360, h: 180 };
+
+describe('bucketThreeDStackItems', () => {
+  it('groups a maximum-size public model with one category read per item', () => {
+    let categoryReads = 0;
+    const items = Array.from({ length: 10_000 }, (_, index) => ({
+      get categoryIndex() {
+        categoryReads++;
+        return index % 257;
+      },
+      index,
+    }));
+    const buckets = bucketThreeDStackItems(items, 257);
+    expect(buckets.reduce((sum, bucket) => sum + bucket.length, 0)).toBe(10_000);
+    expect(categoryReads).toBe(10_000);
+    expect(buckets[0][0].index).toBe(0);
+    expect(buckets[256][0].index).toBe(256);
+  });
+
+  it('ignores invalid caller-constructed category indexes', () => {
+    expect(bucketThreeDStackItems([
+      { categoryIndex: -1 },
+      { categoryIndex: 0 },
+      { categoryIndex: 2 },
+      { categoryIndex: Number.NaN },
+    ], 2).map(bucket => bucket.length)).toEqual([1, 0]);
+  });
+});
 
 describe('buildThreeDShapeMesh', () => {
   const mesh = (shape: string, toMaxBaseScale = 1, toMaxEndScale = 0) =>

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -6,9 +6,8 @@
 //! historically did so with two near-identical bodies sitting in
 //! `packages/xlsx/parser/src/lib.rs` and `packages/pptx/parser/src/lib.rs`.
 //! The result was that fields added on one side stayed missing on the other
-//! until somebody noticed (e.g. PowerPoint sample-2 slide-7 displaying its
-//! legend on the right because the pptx adapter had a hard-coded
-//! `legendPos: null` while xlsx already passed it through).
+//! until a host-specific regression exposed the drift (for example, one
+//! adapter once discarded `legendPos` while another preserved it).
 //!
 //! This module hosts the helpers that don't need any crate-private state:
 //! they're pure XML probes that take a roxmltree node and return the parsed
@@ -896,10 +895,10 @@ pub struct ChartDataLabelOverride {
     /// `CT_DLbl` show-flag group: §21.2.2.189 `<c:showVal>`, §21.2.2.177
     /// `<c:showCatName>`, §21.2.2.180 `<c:showSerName>`, §21.2.2.187
     /// `<c:showPercent>`). When a `<c:dLbl>` sets these they OVERRIDE the
-    /// series-level `<c:dLbls>` defaults (§21.2.2.49) for that one point — e.g.
-    /// sample-14 slide-7's pie sets `showCatName=0 showPercent=1` per slice even
-    /// though the series default is `showCatName=1`, so each label is percent
-    /// only. `None` = the point declared no such flag, so the series default
+    /// series-level `<c:dLbls>` defaults (§21.2.2.49) for that one point. A
+    /// point can therefore disable `showCatName` and enable `showPercent` even
+    /// when the series does the reverse. `None` means the point declared no
+    /// such flag, so the series default
     /// governs (byte-stable for points that carry none).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub show_val: Option<bool>,
@@ -7089,8 +7088,8 @@ pub fn parse_chart_part_with_references(
             // AND for a SINGLE-series bar/column chart (Word/Excel/PowerPoint
             // draw a lone series' bars in the rotating theme palette and keep an
             // explicit `<c:varyColors val="0"/>` when the user forces one color
-            // — verified against the sample-17/18 decks, whose single-series
-            // columns render four accent-colored bars with the element ABSENT).
+            // — verified against Office-produced single-series columns whose
+            // points use successive accents while the element is absent).
             // A multi-series plot keeps per-series colors, so it never varies by
             // point even with `val="1"`. When ON, each data point takes the
             // accent for its POINT index (i); `dPt` fills already sit in
@@ -7128,7 +7127,7 @@ pub fn parse_chart_part_with_references(
             // model the pptx path established), so we only emit an override when
             // it carries a marker or explosion — a color-only dPt yields no
             // override and stays clean on the wire. This makes the shared parser
-            // populate xlsx's marker overrides (e.g. sample-26 scatter) without
+            // populate indexed scatter-marker overrides without
             // double-representing pie slice fills.
             let data_point_overrides: Vec<ChartDataPointOverride> =
                 parse_data_point_overrides(*ser, color_resolver)
@@ -7285,7 +7284,7 @@ pub fn parse_chart_part_with_references(
                 },
                 // Legacy `<c:chart>` per-point label colors are extracted via
                 // `<c:dLbls><c:dLbl idx>` — not yet wired here; chartEx is the only
-                // path that needs it for sample-2's waterfall.
+                // path that currently consumes this separate color array.
                 data_label_colors: None,
                 categories: series_categories,
                 bubble_sizes,
@@ -7345,10 +7344,8 @@ pub fn parse_chart_part_with_references(
     // governs WHETHER an auto title may be shown ("val=0/false ⇒ the chart title
     // SHALL be shown" when otherwise absent; "val=1/true ⇒ it SHALL NOT be
     // shown"); the spec leaves the auto title's TEXT implementation-defined.
-    // Word's observed rule — the ground truth here is sample-25.docx / .pdf,
-    // whose `<c:title>` carries a `<c:txPr>` (fonts, `cap="all"`) but NO `<c:tx>`
-    // text, `<c:autoTitleDeleted val="0"/>`, and exactly one series named
-    // "Production in 2017" — is:
+    // Word's observed rule for a title frame that carries `<c:txPr>` but no
+    // `<c:tx>` text, with `<c:autoTitleDeleted val="0"/>`, is:
     //   * exactly ONE series  → the auto title is that single series' name
     //   * two or more series   → NO auto title (a lone series name would be
     //                            misleading, so Word shows none)
@@ -7375,8 +7372,7 @@ pub fn parse_chart_part_with_references(
 
     // Data labels are on when `<c:dLbls>` enables `<c:showVal>` OR
     // `<c:showPercent>` (ECMA-376 §21.2.2.189 / §21.2.2.187) — at chart level
-    // or in any series. Pie/doughnut decks commonly use showPercent only (e.g.
-    // sample-14 slide-7's "54%/27%/…" slice labels); the renderer draws the
+    // or in any series. Pie/doughnut charts commonly use showPercent only; the renderer draws the
     // slice percentage for pie/doughnut and the raw value for bar/line.
     let show_data_labels = root
         .descendants()
@@ -7460,7 +7456,7 @@ pub fn parse_chart_part_with_references(
 
     // Bar gap / overlap, dLblPos and numFmt — all shared helpers so any new
     // chart property added to the xlsx side stays applied to pptx without
-    // a manual port (the slide-7 / sample-2 issue this PR avoids).
+    // a manual host-specific port.
     let (bar_gap_width, bar_overlap) = extract_bar_gap_overlap(root);
     let data_label_position = extract_data_label_position(root);
     let data_label_format_code = extract_data_label_format_code(root);
@@ -7473,8 +7469,8 @@ pub fn parse_chart_part_with_references(
     // Axis tick-label text color + axis-line style (color / width / noFill).
     // ECMA-376 §21.2.2.* — `<c:catAx|valAx><c:txPr>…<a:solidFill>` colors the
     // tick labels and `<c:spPr><a:ln>` styles the axis rule. Shared helpers so
-    // the gray "2025年3月期" category labels and the light-gray category-axis
-    // line in sample-2 slide-16's horizontal bar chart resolve the same way.
+    // category-label paint and the category-axis line resolve the same way in
+    // all three hosts.
     // `CT_ChartSpace.style` is optional. PowerPoint treats its omission as the
     // legacy default chart style: black 0.75 pt axes/gridlines and black chart
     // text. This form is common in charts produced by non-Office generators.
@@ -7769,7 +7765,7 @@ pub fn parse_chart_part_with_references(
     let val_axis_major_gridlines = val_ax.map(axis_major_gridlines_visible);
     let cat_axis_major_gridlines = cat_ax.map(axis_major_gridlines_visible);
     // `<c:majorGridlines><c:spPr><a:ln>` colour/width — the explicit gridline
-    // style (e.g. sample-1 slide 5's `accent3` 0.25 pt value-axis gridlines).
+    // style (for example `accent3` with a 0.25 pt value-axis line).
     // `(None, None)` when absent, so the renderer keeps its faint default.
     let (mut val_axis_gridline_color, mut val_axis_gridline_width_emu, val_axis_gridline_dash) =
         val_ax
@@ -8709,7 +8705,7 @@ mod tests {
 
     #[test]
     fn gridline_style_solid_scheme_with_width() {
-        // sample-1 slide 5: `<c:majorGridlines><c:spPr><a:ln w="3175">
+        // `<c:majorGridlines><c:spPr><a:ln w="3175">
         // <a:solidFill><a:schemeClr val="accent3"/>` → the explicit gridline
         // colour + 0.25 pt width (3175 EMU) the renderer must honor.
         let xml = r#"<c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
@@ -10296,8 +10292,7 @@ mod tests {
     /// §21.2.2.198: a scatter series whose `<c:spPr><a:ln>` is `<a:noFill/>`
     /// has its connecting line turned OFF, overriding the group-level
     /// `<c:scatterStyle val="lineMarker">` (§21.2.2.42). The parser must set
-    /// `line_hidden = Some(true)` so the renderer draws markers only — the
-    /// sample-30 sheet-1 scatter shape. A series with a paintable line leaves
+    /// `line_hidden = Some(true)` so the renderer draws markers only. A series with a paintable line leaves
     /// `line_hidden = None`.
     #[test]
     fn parse_chart_part_scatter_series_line_nofill_sets_line_hidden() {
@@ -10350,8 +10345,8 @@ mod tests {
 
     /// §21.2.2.47: a per-point `<c:dLbl>` carries its own show-flag group and
     /// text style, overriding the series-level `<c:dLbls>` (§21.2.2.49) for that
-    /// point. sample-14 slide-7's pie sets `showCatName=0 showPercent=1` + white
-    /// per slice while the series default is `showCatName=1` black. The parser
+    /// point. Office can set `showCatName=0 showPercent=1` plus white text per
+    /// slice while the series default is `showCatName=1` black. The parser
     /// must surface both the series default AND the per-point flag / color
     /// overrides, and mark a genuine `<c:delete>` distinctly from a style-only
     /// `<c:dLbl>` (which has an empty `text`).
@@ -10846,8 +10841,8 @@ mod tests {
 
     #[test]
     fn parse_series_data_labels_callout_box_and_leader_lines() {
-        // Mirror of sample-25 (Word pie callout labels): the series `<c:dLbls>`
-        // carries a `<c:spPr>` box (white fill + coloured border), a per-point
+        // A Word-style pie-callout series `<c:dLbls>` carries a `<c:spPr>` box
+        // (white fill + coloured border), a per-point
         // `<c:dLbl>` with its own box, and `<c:showLeaderLines>` +
         // `<c:leaderLines>` style. All must round-trip into the model.
         let cache = std::collections::HashMap::new();
@@ -11110,8 +11105,7 @@ mod tests {
     /// dimension with negatives, `<cx:subtotals>` (idx 0 is implicit, idx 5 is
     /// explicit), a series `<cx:spPr>` fill, per-idx `<cx:dataLabel>` colours
     /// (positives → tx1, negatives → accent1), a hidden value axis, and a
-    /// `<cx:catScaling gapWidth="0.8">` fraction (→ legacy 80%). Mirrors the
-    /// sample-2 waterfall the golden JSON was captured from.
+    /// `<cx:catScaling gapWidth="0.8">` fraction (→ legacy 80%).
     #[test]
     fn parse_chartex_part_waterfall_full_contract() {
         let xml = format!(
@@ -12264,7 +12258,7 @@ mod tests {
 
     /// (d) Newlines inside a category `<cx:pt>` are flattened to spaces (Office
     /// writes multi-line axis labels this way; the renderer wants a single
-    /// line). Mirrors the sample-2 "FY2024\n1Q営業利益" categories.
+    /// line).
     #[test]
     fn parse_chartex_part_category_newline_flattened() {
         let xml = format!(
@@ -13131,9 +13125,8 @@ mod tests {
 
     /// A SINGLE-series bar chart with `<c:varyColors>` ABSENT varies by point by
     /// default (issue #931): each data point takes the accent for its index and
-    /// the chart-level flag is set. This is the sample-17/18 shape — a lone
-    /// column series whose four bars render in the rotating theme palette even
-    /// though the file carries no `<c:varyColors>` element.
+    /// the chart-level flag is set. Office-produced lone column series rotate
+    /// through the theme palette even without a `<c:varyColors>` element.
     #[test]
     fn parse_chart_part_bar_single_series_varies_by_default() {
         let group = format!(
@@ -13153,7 +13146,7 @@ mod tests {
 
     /// A SINGLE-series bar chart with an explicit `<c:varyColors val="0"/>`
     /// keeps its one per-series color (Office records the forced-single-color
-    /// choice this way — sample-1.xlsx / sample-14 chart8/9). No per-point fill,
+    /// choice this way). No per-point fill,
     /// no chart-level flag.
     #[test]
     fn parse_chart_part_bar_single_series_vary_off_keeps_series_color() {
@@ -13238,8 +13231,8 @@ mod tests {
 
     /// A `<c:chart>` with an optional `<c:autoTitleDeleted val=…>`, NO explicit
     /// `<c:title>` text, and the given series in a bar plot area. Models the
-    /// sample-25 shape (auto-title chart: title frame present but empty, so the
-    /// synthesized title comes from the series name).
+    /// observed auto-title shape: title frame present but empty, so the
+    /// synthesized title comes from the sole series name.
     fn chart_space_auto_title(auto_title_deleted: Option<&str>, sers: &str) -> String {
         let atd = auto_title_deleted
             .map(|v| format!(r#"<c:autoTitleDeleted val="{v}"/>"#))
@@ -13260,9 +13253,9 @@ mod tests {
 
     /// ECMA-376 §21.2.2.7 auto-title: a chart with NO explicit title text,
     /// `autoTitleDeleted` absent (⇒ auto title may show), and EXACTLY ONE named
-    /// series adopts that series' name as the chart title. Ground truth:
-    /// sample-25.docx — pie3D with a lone "Production in 2017" series and an
-    /// empty title frame — where Word shows "Production in 2017" as the title.
+    /// series adopts that series' name as the chart title. Word-produced output
+    /// with a lone named series and an empty title frame provides the
+    /// compatibility evidence.
     #[test]
     fn parse_chart_part_auto_title_single_series() {
         let xml = chart_space_auto_title(None, &named_ser(0, "Production in 2017"));


### PR DESCRIPTION
## Summary
- remove unreachable legacy automatic-axis helpers so the shared planner is the only live linear policy
- bucket stacked 3-D primitives by category to avoid quadratic work on bounded maximum-size models
- document the normative and Office-observed compatibility boundary, availability limits, and optional-module architecture
- remove local corpus identifiers from public implementation comments

## Specification and compatibility
Authored ECMA-376 / ISO 29500 and MS-ODRAWXML properties remain authoritative. The new evidence index records where automatic behavior is an Office compatibility policy, its measured scope, and the fail-closed boundary for unobserved semantics.

## Verification
- chart Vitest: 24 files / 865 tests
- ooxml-common: 379 tests + doctest
- workspace typecheck
- production build and Storybook build
- optional 3-D and Region Map bundle-boundary checks
- DOCX/XLSX/PPTX API baselines, viewer symmetry, and public type exports
- full Vitest: 7,482 passed; six loopback-only cases were rerun outside the sandbox and passed 12/12
- private corpus harness: 2/2