### PR TITLE
fix(xlsx): expose anchored charts in gallery sheets

### DIFF
--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1408,6 +1408,38 @@ describe('classic 3-D compatibility projection', () => {
     expect(rec.texts.map(item => item.text)).not.toContain('Second');
   });
 
+  it('draws pie leader lines only for labels placed outside the slice', () => {
+    const inside = recordingCtx(() => 8);
+    renderChart(inside.ctx, baseModel({
+      chartType: 'pie', threeD: { rotationX: 15, rotationY: 20 },
+      series: [series({
+        values: [1, 1],
+        seriesDataLabels: {
+          showVal: true, showCatName: false, showSerName: false, showPercent: false,
+          showLeaderLines: true, leaderLineColor: '00FF00', position: 'ctr',
+        },
+      })],
+    }), RECT, 1);
+    expect(inside.paintEvents.some(event =>
+      event.kind === 'stroke' && event.strokeStyle === '#00FF00'
+    )).toBe(false);
+
+    const outside = recordingCtx(() => 200);
+    renderChart(outside.ctx, baseModel({
+      chartType: 'pie', threeD: { rotationX: 15, rotationY: 20 },
+      series: [series({
+        values: [99, 1],
+        seriesDataLabels: {
+          showVal: true, showCatName: false, showSerName: false, showPercent: false,
+          showLeaderLines: true, leaderLineColor: '00FF00',
+        },
+      })],
+    }), RECT, 1);
+    expect(outside.paintEvents.some(event =>
+      event.kind === 'stroke' && event.strokeStyle === '#00FF00'
+    )).toBe(true);
+  });
+
   it('keeps non-finite firstSliceAngle out of 3-D pie geometry', () => {
     for (const firstSliceAngle of [Number.NaN, Number.POSITIVE_INFINITY]) {
       const rec = recordingCtx();

--- a/packages/core/src/chart/three-d-renderer.ts
+++ b/packages/core/src/chart/three-d-renderer.ts
@@ -628,6 +628,7 @@ function drawThreeDDataLabel(
   resolvedOverride?: ChartDataLabelOverride,
   defaultPosition = 't',
   leaderAnchor: Point = anchor,
+  leaderLineEligible = true,
 ): void {
   // Callers resolve indexed overrides through their per-series Map before the
   // paint loop. Falling back to Array.find here would quietly reintroduce
@@ -701,7 +702,7 @@ function drawThreeDDataLabel(
   );
   if (!placement) return;
   const labelBox = override?.labelBox ?? defaults?.labelBox;
-  if (defaults?.showLeaderLines) {
+  if (defaults?.showLeaderLines && leaderLineEligible) {
     ctx.beginPath();
     ctx.moveTo(leaderAnchor.x, leaderAnchor.y);
     ctx.lineTo(
@@ -2839,10 +2840,11 @@ function renderPie(
         );
         previousArcPoint = current;
       }
-      const outside = authoredPosition == null
+      const outside = (authoredPosition == null || authoredPosition === 'bestFit')
         && (slice.percentValue === 0 || arcCapacity < (richMeasure?.width
           ?? ctx.measureText(labelText).width));
-      const labelRadius = radius * (outside ? 1.12 : 0.64);
+      const labelOutside = outside || authoredPosition === 'outEnd';
+      const labelRadius = radius * (labelOutside ? 1.12 : 0.64);
       const label = projection.project(
         slice.centerX + Math.cos(middle) * labelRadius,
         surfaceY,
@@ -2856,6 +2858,7 @@ function renderPie(
       deferredLabels.push(() => drawThreeDDataLabel(
         ctx, chart, series, 0, slice.index, slice.value, label, plot, ptToPx,
         0, slice.percentValue, labelOverride, 'ctr', leader,
+        labelOutside,
       ));
     }
   }

--- a/packages/xlsx/src/internal/worksheet-content-bounds.ts
+++ b/packages/xlsx/src/internal/worksheet-content-bounds.ts
@@ -1,0 +1,43 @@
+import type { Worksheet } from '../types.js';
+import { MAX_WORKSHEET_COL, MAX_WORKSHEET_ROW } from './grid-geometry.js';
+
+type CellAnchoredObject = {
+  readonly fromCol: number;
+  readonly fromRow: number;
+  readonly toCol: number;
+  readonly toRow: number;
+};
+
+/** Return the worksheet grid bounds needed to expose both cell content and
+ * DrawingML objects. Two-cell anchors use zero-based markers (§20.5.2.33), so
+ * an object ending at marker row 113 requires row 114 in the scroll extent.
+ * Excel permits drawings well beyond the `<dimension>` / populated cell range;
+ * ignoring them makes those authored objects unreachable in a viewer. */
+export function worksheetContentBounds(ws: Worksheet): { maxRow: number; maxCol: number } {
+  let maxRow = Math.max(50, ws.freezeRows ?? 0);
+  let maxCol = Math.max(26, ws.freezeCols ?? 0);
+  for (const row of ws.rows) {
+    if (row.index > maxRow) maxRow = row.index;
+    for (const cell of row.cells) {
+      if (cell.col > maxCol) maxCol = cell.col;
+    }
+  }
+  const anchored: readonly CellAnchoredObject[] = [
+    ...ws.charts,
+    ...ws.images,
+    ...(ws.shapeGroups ?? []),
+    ...(ws.slicers ?? []),
+  ];
+  for (const anchor of anchored) {
+    const fromRow = Number.isSafeInteger(anchor.fromRow) ? anchor.fromRow + 1 : 0;
+    const toRow = Number.isSafeInteger(anchor.toRow) ? anchor.toRow + 1 : 0;
+    const fromCol = Number.isSafeInteger(anchor.fromCol) ? anchor.fromCol + 1 : 0;
+    const toCol = Number.isSafeInteger(anchor.toCol) ? anchor.toCol + 1 : 0;
+    maxRow = Math.max(maxRow, fromRow, toRow);
+    maxCol = Math.max(maxCol, fromCol, toCol);
+  }
+  return {
+    maxRow: Math.min(MAX_WORKSHEET_ROW, maxRow),
+    maxCol: Math.min(MAX_WORKSHEET_COL, maxCol),
+  };
+}

--- a/packages/xlsx/src/viewer-zoom-contract.test.ts
+++ b/packages/xlsx/src/viewer-zoom-contract.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { XlsxViewer } from './viewer.js';
+import { worksheetContentBounds } from './internal/worksheet-content-bounds.js';
 import { installDom, makeContainer } from './viewer-destroy-test-dom.js';
 import { HEADER_W, HEADER_H, colWidthToPx, rowHeightToPx, getMdwForWorksheet } from './renderer.js';
 import type { Worksheet } from './types.js';
@@ -102,12 +103,7 @@ function mount(
  *  `_naturalContentExtent` (header + used cols/rows, no scroll headroom). */
 function naturalExtent(ws: Worksheet): { width: number; height: number } {
   const mdw = getMdwForWorksheet(ws);
-  let maxRow = Math.max(50, ws.freezeRows ?? 0);
-  let maxCol = Math.max(26, ws.freezeCols ?? 0);
-  for (const row of ws.rows) {
-    if (row.index > maxRow) maxRow = row.index;
-    for (const cell of row.cells) if (cell.col > maxCol) maxCol = cell.col;
-  }
+  const { maxRow, maxCol } = worksheetContentBounds(ws);
   let width = HEADER_W;
   for (let c = 1; c <= maxCol; c++) width += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, mdw);
   let height = HEADER_H;
@@ -116,6 +112,16 @@ function naturalExtent(ws: Worksheet): { width: number; height: number } {
 }
 
 describe('XlsxViewer IX9 zoom contract', () => {
+  it('extends the scrollable used range through cell-anchored drawings', () => {
+    const ws = makeSheet();
+    ws.charts = [{
+      fromCol: 9, fromColOff: 0, fromRow: 95, fromRowOff: 0,
+      toCol: 17, toColOff: 0, toRow: 113, toRowOff: 0,
+      chart: {} as never,
+    }];
+    expect(worksheetContentBounds(ws)).toEqual({ maxRow: 114, maxCol: 26 });
+  });
+
   it('getScale() is 1 (100%) by default and reflects the cellScale option', () => {
     installDom();
     expect(mount(makeSheet()).v.getScale()).toBe(1);

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -89,6 +89,7 @@ import {
 import { CanvasSurface, SheetOverlayHost } from './internal/sheet-surface.js';
 import { withXlsxRenderCommitGuard } from './render-orchestrator.js';
 import { selectionAutoScrollVelocity } from './selection-auto-scroll.js';
+import { worksheetContentBounds } from './internal/worksheet-content-bounds.js';
 
 const borrowedWorkbookOption = Symbol('XlsxViewer.borrowedWorkbook');
 
@@ -4404,14 +4405,7 @@ class XlsxViewerEngine implements ZoomableViewer {
    *  {@link updateSpacerSize} at cs=1 (same used-range detection) so the fit
    *  targets exactly the region the spacer/scroll extent covers. */
   private _naturalContentExtent(ws: Worksheet): { width: number; height: number } {
-    let maxRow = Math.max(50, ws.freezeRows ?? 0);
-    let maxCol = Math.max(26, ws.freezeCols ?? 0);
-    for (const row of ws.rows) {
-      if (row.index > maxRow) maxRow = row.index;
-      for (const cell of row.cells) {
-        if (cell.col > maxCol) maxCol = cell.col;
-      }
-    }
+    const { maxRow, maxCol } = worksheetContentBounds(ws);
     return getGridGeometryForWorksheet(ws).logicalContentExtent(
       maxRow,
       maxCol,
@@ -4426,14 +4420,7 @@ class XlsxViewerEngine implements ZoomableViewer {
     const freezeCols = ws.freezeCols ?? 0;
 
     // Find actual scrollable data extent
-    let maxRow = Math.max(50, freezeRows);
-    let maxCol = Math.max(26, freezeCols);
-    for (const row of ws.rows) {
-      if (row.index > maxRow) maxRow = row.index;
-      for (const cell of row.cells) {
-        if (cell.col > maxCol) maxCol = cell.col;
-      }
-    }
+    let { maxRow, maxCol } = worksheetContentBounds(ws);
     maxRow += 30;
     maxCol += 10;
 


### PR DESCRIPTION
## Summary
- include DrawingML cell anchors in worksheet scroll extents
- keep consolidated chart galleries reachable beyond populated cells
- draw 3-D pie leader lines only for labels placed outside a slice

## Basis
DrawingML two-cell anchors use zero-based cell markers (ECMA-376 §20.5.2.33) and may extend beyond the worksheet dimension or populated cell range.

## Verification
- focused XLSX viewer and chart renderer tests (579 tests)
- workspace typecheck
- local Storybook interaction and scroll inspection
- git diff --check