### PR TITLE
chore(release): 0.79.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ semantic versioning. While the major version is zero, minor releases may contain
 explicitly documented breaking changes; patch releases remain compatible with
 the corresponding minor release.
 
+## 0.79.0 — 2026-08-14
+
+Compatible minor release. Adds opt-in advanced chart renderers and completes a
+specification-first fidelity audit across charts hosted by Word, Excel, and
+PowerPoint.
+
+- **optional 3-D charts:** add the tree-shakeable `@silurus/ooxml/three-d`
+  entry, using one homogeneous model-space camera for chart walls, axes, grids,
+  labels, and bounded meshes. It supports cartesian and pie 3-D families plus
+  authored box, cylinder, cone, cone-to-max, pyramid, and pyramid-to-max bar
+  shapes. Applications opt in on the main thread; existing integrations retain
+  the 2-D fallback.
+- **offline Region Maps:** add the tree-shakeable
+  `@silurus/ooxml/region-map` entry for country-level ChartEx world maps using
+  pinned public-domain Natural Earth geometry. Authored projections, theme
+  colors, and two/three-stop value ramps are retained; unsupported cached or
+  sub-country views fail closed without network access.
+- **shared chart fidelity:** preserve more authored axis, title, rich-label,
+  legend, point, line, fill, and Chart Style properties through the shared
+  parser/model/renderer pipeline. Automatic linear axes, explicit bounds,
+  major/minor ticks, plot margins, secondary axes, and legend layout now use
+  common bounded policies across classic and ChartEx families.
+- **specialized chart families:** improve waterfall connectors and labels,
+  Pareto and histogram axes, box-and-whisker geometry, treemap and sunburst
+  hierarchy labels, funnel, bubble, line, area, combo, and chart-sheet layout.
+  XLSX chart sheets and absolute chart anchors are retained.
+- **bounded work and package boundaries:** cap expanded 3-D primitives,
+  hierarchy/data-label work, map rows, ticks, and parser caches. The 3-D camera,
+  mesh code, and geographic asset remain outside ordinary DOCX/XLSX/PPTX entry
+  graphs unless explicitly imported.
+- **site and compatibility:** the API reference and Try Yours demo expose the
+  optional renderers consistently across all three host formats. No existing
+  option is removed or renamed; add-ons are required only for their authored
+  chart families.
+
 ## 0.78.1 — 2026-08-12
 
 Patch. Fixes a DOCX pagination regression introduced in v0.78.0 without

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.78.1"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ pnpm add @silurus/ooxml
 > **Bundle size note**: the package is ESM-only (`.mjs`). npm's *Unpacked
 > Size* sums every entry bundle **and** the standalone MathJax + STIX Two Math
 > asset, so the reported figure is much larger than any single app build. For
-> v0.78.1, the complete npm package is approximately 12.0 MB unpacked (4.0 MB
+> v0.79.0, the complete npm package is approximately 13.0 MB unpacked (4.3 MB
 > as the downloaded tarball), while a format-specific application graph is
 > approximately:
 >
@@ -89,7 +89,7 @@ pnpm add @silurus/ooxml
 > | `@silurus/ooxml/xlsx` | 2.6 MB | 0.82 MB | XLSX renderer, parser WASM, and lazy worker |
 > | `@silurus/ooxml/pptx` | 2.5 MB | 0.78 MB | PPTX renderer, parser WASM, and lazy worker |
 > | `@silurus/ooxml/math` | 3.1 MB | 1.1 MB | Optional MathJax + STIX Two Math engine |
-> | `@silurus/ooxml/three-d` | 79 KB | 23 KB | Optional model-space 3-D chart mesh and camera |
+> | `@silurus/ooxml/three-d` | 81 KB | 23 KB | Optional model-space 3-D chart mesh and camera |
 > | `@silurus/ooxml/region-map` | 236 KB | 66 KB | Optional offline Region Map renderer and fixed country geometry |
 >
 > These are production-artifact estimates, not initial-load figures: each row

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.78.1",
+  "version": "0.79.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.78.1",
+  "version": "0.79.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.78.1",
+  "version": "0.79.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.78.1",
+  "version": "0.79.0",
   "description": "Internal workspace adapter for DOCX / XLSX / PPTX Markdown projection",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.78.1"
+version = "0.79.0"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.78.1",
+  "version": "0.79.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.78.1",
+  "version": "0.79.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity local viewer for Office files (.docx / .xlsx / .pptx), powered by Rust/WASM and Canvas. Optional MCP integration can share requested context with an AI agent.",
-  "version": "0.78.1",
+  "version": "0.79.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.78.1",
+  "version": "0.79.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.78.1",
+  "version": "0.79.0",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",


### PR DESCRIPTION
## Summary

- release optional 3-D chart rendering and offline Region Map rendering as tree-shakeable add-ons
- ship the chart layout, axis, labels, legend, style, and specialized-family fidelity improvements completed for 0.79.0
- enable the full renderer set in the public Try Yours demo
- synchronize package, site, VS Code extension, and MCP server versions

## Verification

- independent release-wide adversarial review: no remaining P1/P2 findings
- TypeScript typecheck, package build, site build, Rust MCP check
- public API, public type export, viewer symmetry, and optional add-on boundary checks
- focused site tests: 105 passed
- private previous-release visual regression: DOCX exact; XLSX and PPTX changes confined to chart regions

The README screenshots were reviewed and remain representative of their format demos. The new chart gallery is published with the release announcement rather than replacing the format-specific README images.
