### PR TITLE
chore(release): 0.79.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ semantic versioning. While the major version is zero, minor releases may contain
 explicitly documented breaking changes; patch releases remain compatible with
 the corresponding minor release.
 
+## 0.79.1 — 2026-08-15
+
+Patch. Corrects authored chart labels, legend frames, and automatic worksheet
+row heights without changing the 0.79 public integration contract.
+
+- **data labels:** keep series-local label settings on their authored series,
+  and apply value-axis display units consistently to generated value labels in
+  classic, ChartEx, and optional 3-D chart paths.
+- **trendline labels:** align automatic equation and R² blocks with Excel's
+  plot-relative placement while preserving authored manual layouts.
+- **legend frames:** retain explicit solid legend fills and outlines, including
+  DrawingML theme color transforms, across DOCX, XLSX, and PPTX chart hosts.
+- **worksheet row heights:** auto-fit rows that omit an authored `ht` to wrapped,
+  rich, rotated, or larger text while preserving explicit heights and excluding
+  merged cells, matching Excel's display behavior. (#1260)
+- **compatibility:** no application or API migration is required from 0.79.0.
+
 ## 0.79.0 — 2026-08-14
 
 Compatible minor release. Adds opt-in advanced chart renderers and completes a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.79.0",
+  "version": "0.79.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.79.0",
+  "version": "0.79.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/src/chart/data-label-content.ts
+++ b/packages/core/src/chart/data-label-content.ts
@@ -9,6 +9,10 @@ export interface EffectiveDataLabelTextOptions {
   category?: string;
   seriesName?: string;
   sourceValue?: number;
+  /** Effective divisor of the value axis associated with this label. Office
+   * applies `<c:dispUnits>` to generated `showVal` text while leaving the
+   * source value and value-to-pixel geometry unchanged. */
+  valueDivisor?: number | null;
   percentRatio?: number;
   formatCode?: string | null;
   percentFormatCode?: string | null;
@@ -24,8 +28,13 @@ export function effectiveDataLabelText(options: EffectiveDataLabelTextOptions): 
   if (options.showCategory && options.category) parts.push(options.category);
   if (options.showSeries && options.seriesName) parts.push(options.seriesName);
   if (options.showValue && options.sourceValue != null) {
+    const divisor = options.valueDivisor != null
+      && Number.isFinite(options.valueDivisor)
+      && options.valueDivisor > 0
+      ? options.valueDivisor
+      : 1;
     parts.push(formatChartValWithCode(
-      options.sourceValue, options.formatCode ?? null, options.date1904,
+      options.sourceValue / divisor, options.formatCode ?? null, options.date1904,
     ));
   }
   if (options.showPercent && options.percentRatio != null) {

--- a/packages/core/src/chart/legend-frame.ts
+++ b/packages/core/src/chart/legend-frame.ts
@@ -1,0 +1,35 @@
+import type { ChartModel, ChartRect } from '../types/chart.js';
+import { axisLineWidthPx } from './axis-style.js';
+
+/** Paint the authored solid `<c:legend><c:spPr>` frame before legend content.
+ * Omitted/noFill properties stay transparent; there is no invented default.
+ * The shared model currently carries solid fill and basic solid-line color/
+ * width only; DrawingML dash/cap/join remain outside this helper's contract. */
+export function paintLegendFrame(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  bounds: ChartRect,
+  ptToPx: number,
+): void {
+  if (!chart.legendFillColor && !chart.legendLineColor) return;
+  ctx.save();
+  if (chart.legendFillColor) {
+    ctx.fillStyle = `#${chart.legendFillColor}`;
+    ctx.fillRect(bounds.x, bounds.y, bounds.w, bounds.h);
+  }
+  if (chart.legendLineColor && bounds.w > 0 && bounds.h > 0) {
+    const width = axisLineWidthPx(chart.legendLineWidthEmu, ptToPx);
+    ctx.strokeStyle = `#${chart.legendLineColor}`;
+    ctx.lineWidth = width;
+    ctx.lineCap = 'butt';
+    ctx.lineJoin = 'miter';
+    ctx.setLineDash([]);
+    ctx.strokeRect(
+      bounds.x + width / 2,
+      bounds.y + width / 2,
+      Math.max(0, bounds.w - width),
+      Math.max(0, bounds.h - width),
+    );
+  }
+  ctx.restore();
+}

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -2249,6 +2249,34 @@ describe('bar chart authored layout and fills', () => {
     )).toBe(true);
   });
 
+  it('paints an authored legend-frame fill and outline behind its manual content box', () => {
+    const rec = recordingCtx();
+    const chart = baseModel({
+      chartType: 'clusteredBar',
+      categories: ['A'],
+      series: [series({ name: 'Framed', values: [1] })],
+      showLegend: true,
+      legendPos: 'r',
+      legendManualLayout: {
+        xMode: 'edge', yMode: 'edge', wMode: 'factor', hMode: 'factor',
+        x: 0.1, y: 0.2, w: 0.5, h: 0.3,
+      },
+    });
+    Object.assign(chart, {
+      legendFillColor: 'FFFFFF',
+      legendLineColor: '808080',
+      legendLineWidthEmu: 3175,
+    });
+
+    renderChart(rec.ctx, chart, RECT, 1);
+
+    expect(rec.rects).toContainEqual({ x: 64, y: 72, w: 320, h: 108, fs: '#FFFFFF' });
+    expect(rec.strokeRects).toContainEqual({
+      x: 64.25, y: 72.25, w: 319.5, h: 107.5,
+      ss: '#808080', lw: 0.5, dash: [], cap: 'butt', join: 'miter',
+    });
+  });
+
   it('renders scatter-series markers and labels over a reversed horizontal category axis', () => {
     const rec = recordingCtx();
     const hiddenAxis = {
@@ -2807,6 +2835,7 @@ describe('bar point styles, clustered order, and stacked labels', () => {
             showSerName: false,
             showPercent: false,
             fontColor: 'FFFFFF',
+            fontFace: 'Meiryo UI',
           },
         }),
         series({ color: '000000', values: [0.6] }),
@@ -2824,6 +2853,7 @@ describe('bar point styles, clustered order, and stacked labels', () => {
     expect(label?.y).toBeCloseTo(firstSegment.y + firstSegment.h / 2);
     expect(label?.align).toBe('center');
     expect(label?.baseline).toBe('middle');
+    expect(label?.font).toContain('"Meiryo UI"');
   });
 
   it('clips stacked geometry to an explicit value-axis maximum', () => {
@@ -3321,6 +3351,137 @@ describe('axis display units', () => {
     expect(text).toEqual(expect.arrayContaining(['0', '2', '4', '6', '8']));
     expect(text).not.toContain('200');
     expect(text).not.toContain('800');
+  });
+
+  it.each(['scatter', 'line', 'clusteredBar'] as const)(
+    '%s applies the associated value-axis display unit to showVal data labels',
+    chartType => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType,
+        categories: chartType === 'scatter' ? [] : ['A'],
+        series: [series({
+          values: [8],
+          categories: chartType === 'scatter' ? ['1000'] : undefined,
+          showMarker: true,
+          seriesDataLabels: {
+            showVal: true,
+            showCatName: false,
+            showSerName: false,
+            showPercent: false,
+            fontColor: 'FF0000',
+            formatCode: '0.00',
+          },
+        })],
+        catAxisMin: chartType === 'scatter' ? 0 : undefined,
+        catAxisMax: chartType === 'scatter' ? 2_000 : undefined,
+        valMin: 0,
+        valMax: 100,
+        valAxisDisplayUnits: {
+          divisor: 100,
+          builtInUnit: 'hundreds',
+          label: null,
+        },
+      }), RECT, 1);
+
+      expect(rec.texts.find(text => text.fillStyle === '#FF0000')?.text).toBe('0.08');
+    },
+  );
+
+  it('applies value-axis display units to chart-group showVal labels', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: ['A'],
+      series: [series({ values: [8], showMarker: true })],
+      showDataLabels: true,
+      dataLabelFormatCode: '0.00',
+      dataLabelFontColor: 'FF0000',
+      valMin: 0,
+      valMax: 100,
+      valAxisDisplayUnits: {
+        divisor: 100,
+        builtInUnit: 'hundreds',
+        label: null,
+      },
+    }), RECT, 1);
+
+    expect(rec.texts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ text: '0.08', fillStyle: '#FF0000' }),
+    ]));
+  });
+
+  it('uses the secondary scatter Y-axis display unit for that group only', () => {
+    const rec = recordingCtx();
+    const hiddenAxis = {
+      min: 0,
+      max: 20,
+      title: null,
+      hidden: true,
+      lineHidden: true,
+      majorTickMark: 'none',
+    };
+    renderChart(rec.ctx, baseModel({
+      chartType: 'scatter',
+      categories: [],
+      series: [
+        series({ categories: ['1'], values: [8] }),
+        series({
+          categories: ['1000'],
+          values: [8],
+          useSecondaryAxis: true,
+          seriesDataLabels: {
+            showVal: true,
+            showCatName: false,
+            showSerName: false,
+            showPercent: false,
+            fontColor: 'FF0000',
+            formatCode: '0.0',
+          },
+        }),
+      ],
+      catAxisMin: 0,
+      catAxisMax: 2,
+      valMin: 0,
+      valMax: 10,
+      valAxisDisplayUnits: { divisor: 100, builtInUnit: 'hundreds', label: null },
+      secondaryCatAxis: { ...hiddenAxis, max: 2_000 },
+      secondaryValAxis: {
+        ...hiddenAxis,
+        displayUnits: { divisor: 10, builtInUnit: null, label: null },
+      },
+    }), RECT, 1);
+
+    expect(rec.texts.find(text => text.fillStyle === '#FF0000')?.text).toBe('0.8');
+  });
+
+  it('applies value-axis display units to cartesian 3-D showVal labels', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredBar',
+      categories: ['A'],
+      series: [series({
+        values: [8],
+        seriesDataLabels: {
+          showVal: true,
+          showCatName: false,
+          showSerName: false,
+          showPercent: false,
+          fontColor: 'FF0000',
+          formatCode: '0.00',
+        },
+      })],
+      valMin: 0,
+      valMax: 100,
+      valAxisDisplayUnits: {
+        divisor: 100,
+        builtInUnit: 'hundreds',
+        label: null,
+      },
+      threeD: { rotationX: 15, rotationY: 20 },
+    }), RECT, 1);
+
+    expect(rec.texts.find(text => text.fillStyle === '#FF0000')?.text).toBe('0.08');
   });
 });
 
@@ -4064,6 +4225,29 @@ describe('ChartEx flat layouts dispatch to semantic renderers', () => {
 
     expect(rec.texts.find(text => text.text === 'not bold')?.font).not.toMatch(/^bold /);
   });
+
+  it.each(['waterfall', 'funnel'] as const)(
+    '%s honors a series-local data-label font face',
+    chartType => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType,
+        categories: ['A'],
+        catAxisHidden: true,
+        valAxisHidden: true,
+        series: [series({
+          values: [10],
+          seriesDataLabels: {
+            showVal: true, showCatName: false, showSerName: false, showPercent: false,
+            position: 'ctr', fontFace: 'ChartEx Label Face',
+          },
+        })],
+      }), RECT, 1);
+
+      expect(rec.texts.find(text => text.text === '10')?.font)
+        .toContain('"ChartEx Label Face"');
+    },
+  );
 
   it.each(['waterfall', 'funnel'])(
     '%s preserves category-only point slots when the string dimension is longer',
@@ -6473,7 +6657,7 @@ describe('CH8 — pie / doughnut geometry', () => {
         name: 'S', categories: ['A', 'B'], values: [1, 2],
         seriesDataLabels: {
           showVal: false, showCatName: false, showSerName: false, showPercent: true,
-          formatCode: '0.0%', fontSizeHpt: 1200, position: 'ctr',
+          formatCode: '0.0%', fontSizeHpt: 1200, position: 'ctr', fontFace: 'Pie Face',
         },
       })],
     });
@@ -6483,6 +6667,8 @@ describe('CH8 — pie / doughnut geometry', () => {
     renderChart(scaled.ctx, model, RECT, 2);
     expect(normal.fontTexts.some(text => text.text === '33.3%' && text.font.includes('12px')))
       .toBe(true);
+    expect(normal.fontTexts.find(text => text.text === '33.3%')?.font)
+      .toContain('"Pie Face"');
     expect(scaled.fontTexts.some(text => text.text === '33.3%' && text.font.includes('24px')))
       .toBe(true);
   });
@@ -7964,7 +8150,7 @@ describe('CH6-follow — series trendlines (commit 3)', () => {
     expect(hidden.segs).toEqual(without.segs);
   });
 
-  it('places equation and R² beside each trendline endpoint and keeps both blocks bounded', () => {
+  it('aligns automatic equation blocks to one plot-relative column while following endpoint height', () => {
     const renderLabels = (values: number[]) => {
       const rec = recordingCtx();
       renderChart(rec.ctx, lineWithTrend({
@@ -8047,7 +8233,7 @@ describe('CH6-follow — series trendlines (commit 3)', () => {
       .toEqual(expected);
   });
 
-  it('places automatic labels near each fitted trendline endpoint', () => {
+  it('uses the rightmost fitted value only for automatic label height', () => {
     const labelY = (values: number[]): number => {
       const rec = recordingCtx();
       renderChart(rec.ctx, lineWithTrend({
@@ -9917,11 +10103,13 @@ describe('CH15 — chartEx sunburst', () => {
     renderChart(rec.ctx, sunburstModel({
       series: [series({
         values: [],
+        dataLabelOverrides: [{ idx: 0, text: 'Branch A', fontFace: 'Point Sunburst Face' }],
         seriesDataLabels: {
           showVal: false,
           showCatName: true,
           showSerName: false,
           showPercent: false,
+          fontFace: 'Sunburst Face',
         },
       })],
     }), RECT, 1);
@@ -9931,6 +10119,8 @@ describe('CH15 — chartEx sunburst', () => {
     expect(joined).toContain('Branch');
     expect(joined).toContain('Stem');
     expect(joined).toContain('Leaf');
+    expect(rec.fontTexts.some(text => text.font.includes('"Sunburst Face"'))).toBe(true);
+    expect(rec.fontTexts.some(text => text.font.includes('"Point Sunburst Face"'))).toBe(true);
   });
 
   it('does not invent ring labels when the ChartEx series omits dataLabels', () => {
@@ -10483,7 +10673,7 @@ describe('CH15 — chartEx treemap', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, baseModel({
       chartType: 'treemap',
-      dataLabelFontFace: 'Aptos Narrow',
+      dataLabelFontFace: 'Wrong Chart Face',
       series: [series({
         seriesDataLabels: {
           showVal: true,
@@ -10493,6 +10683,7 @@ describe('CH15 — chartEx treemap', () => {
           position: 'outEnd',
           fontSizeHpt: 1000,
           fontBold: true,
+          fontFace: 'Aptos Narrow',
         },
       })],
       chartexTreemap: {

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -62,6 +62,7 @@ import {
 } from './rich-data-label.js';
 import { effectiveDataLabelText } from './data-label-content.js';
 import { placeTrendlineLabel } from './trendline-label.js';
+import { paintLegendFrame } from './legend-frame.js';
 import {
   boundDataLabelText,
   fitDataLabelLines,
@@ -956,9 +957,11 @@ function drawLegendForLayout(
     : null;
   if (manualBox) {
     const orient = manualBox.w >= manualBox.h ? 'horizontal' : 'vertical';
+    paintLegendFrame(ctx, chart, manualBox, ptToPx);
     drawLegend(ctx, chart.series, manualBox.x, manualBox.y, manualBox.w, manualBox.h, orient, chart.chartType, legStyle, chart.scatterStyle, varyByPoint, chart.categories, ptToPx, fillPaints, shapeRotationDeg, chart.varyColors !== false);
     return;
   }
+  paintLegendFrame(ctx, chart, defaultBox, ptToPx);
   drawLegend(ctx, chart.series, defaultBox.x, defaultBox.y, defaultBox.w, defaultBox.h,
     defaultOrientation, chart.chartType, legStyle, chart.scatterStyle, varyByPoint,
     chart.categories, ptToPx, fillPaints, shapeRotationDeg, chart.varyColors !== false);
@@ -2912,6 +2915,7 @@ function renderBarChart(
           },
           labelOverrides[si],
           pct ? sv / 100 : undefined,
+          s.useSecondaryAxis && sec ? sec.displayUnits : chart.valAxisDisplayUnits,
         );
         if (label) {
           // ECMA-376 §21.2.2.30 / §21.1.2.3.2 — data label font size comes from
@@ -2924,7 +2928,10 @@ function renderBarChart(
           const authoredLabel = labelOverrides[si].get(ci);
           const bold = label.fontBold
             || (seriesLabels?.fontBold == null && authoredLabel?.fontBold == null);
-          ctx.font = `${bold ? 'bold ' : ''}${lsz}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
+          const labelFont = chartFontFamily(
+            chart, label.fontFace ?? chart.dataLabelFontFace, 'minor',
+          );
+          ctx.font = `${bold ? 'bold ' : ''}${lsz}px ${labelFont}`;
           // drawBarDataLabel takes (bx, by, barL=length, barW=thickness). For
           // a vertical column bar, "length" is the bar's height and
           // "thickness" is its horizontal width — pass them in that order.
@@ -2947,7 +2954,7 @@ function renderBarChart(
               chart,
               authoredLabel,
               ptToPx,
-              chartFontFamily(chart, chart.dataLabelFontFace, 'minor'),
+              labelFont,
               bold,
             ),
           );
@@ -2993,6 +3000,7 @@ function renderBarChart(
           },
           labelOverrides[si],
           pct ? sv / 100 : undefined,
+          s.useSecondaryAxis && sec ? sec.displayUnits : chart.valAxisDisplayUnits,
         );
         if (label) {
           const sizeHpt = label.fontSizeHpt ?? chart.dataLabelFontSizeHpt;
@@ -3001,7 +3009,10 @@ function renderBarChart(
           const authoredLabel = labelOverrides[si].get(ci);
           const bold = label.fontBold
             || (seriesLabels?.fontBold == null && authoredLabel?.fontBold == null);
-          ctx.font = `${bold ? 'bold ' : ''}${lsz}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
+          const labelFont = chartFontFamily(
+            chart, label.fontFace ?? chart.dataLabelFontFace, 'minor',
+          );
+          ctx.font = `${bold ? 'bold ' : ''}${lsz}px ${labelFont}`;
           drawBarDataLabel(
             ctx, label.text,
             bx, by, barL, barW,
@@ -3017,7 +3028,7 @@ function renderBarChart(
               chart,
               authoredLabel,
               ptToPx,
-              chartFontFamily(chart, chart.dataLabelFontFace, 'minor'),
+              labelFont,
               bold,
             ),
           );
@@ -3662,6 +3673,7 @@ function renderLineChart(
             return ((dpt?.markerSize ?? s.markerSize ?? 5) / 2) * ptToPx;
           },
           face => chartFontFamily(chart, face, 'minor'),
+          isSecondarySeries(s) ? sec?.displayUnits : chart.valAxisDisplayUnits,
         );
       });
     }
@@ -3698,9 +3710,19 @@ function renderLineChart(
           // §21.2.2.48 `<c:dLblPos>`: the family-level value dump honors the
           // chart-level position (else the line default `'r'`). The marker gap
           // stays directional while the whole label layer is painted last.
+          const labelText = effectiveDataLabelText({
+            showValue: true,
+            sourceValue: s.values[ci] ?? 0,
+            valueDivisor: displayUnitDivisor(
+              isSecondarySeries(s) ? sec?.displayUnits : chart.valAxisDisplayUnits,
+            ),
+            formatCode: chart.dataLabelFormatCode ?? s.valFormatCode ?? null,
+            date1904: chart.date1904,
+          });
           drawDataLabelText(
-            ctx, toX(ci), yOf(pv), formatChartVal(s.values[ci] ?? 0),
-            chart.dataLabelPosition ?? 'r', dataLabelPx, undefined, false,
+            ctx, toX(ci), yOf(pv), labelText,
+            chart.dataLabelPosition ?? 'r', dataLabelPx,
+            chart.dataLabelFontColor ?? undefined, chart.dataLabelFontBold ?? false,
             chartFontFamily(chart, chart.dataLabelFontFace, 'minor'),
             drawMarkers ? markerR + 1 : 2,
             { x: px0, y: py0, w: pw, h: ph },
@@ -4472,6 +4494,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
           : undefined,
         undefined,
         face => chartFontFamily(chart, face, 'minor'),
+        isSecondarySeries(s) ? sec?.displayUnits : chart.valAxisDisplayUnits,
       );
     }
   }
@@ -4537,6 +4560,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
       undefined,
       undefined,
       face => chartFontFamily(chart, face, 'minor'),
+      isSecondarySeries(s) ? sec?.displayUnits : chart.valAxisDisplayUnits,
     );
     drawSeriesTrendlines(
       ctx, s, stroke, toX, yOf, ptToPx, undefined,
@@ -4911,7 +4935,9 @@ function renderPieChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   // rich dispatch so the legacy chart-wide percent path cannot resurrect it.
   const hasRichLabels = s.seriesDataLabels != null || (s.dataLabelOverrides?.length ?? 0) > 0;
   const legacyLabels = chart.showDataLabels && !hasRichLabels;
-  const dLblFont = chartFontFamily(chart, chart.dataLabelFontFace, 'minor');
+  const dLblFont = chartFontFamily(
+    chart, richDef.fontFace ?? chart.dataLabelFontFace, 'minor',
+  );
 
   for (let ring = 0; ring < rings.length; ring++) {
     const rs = rings[ring];
@@ -5106,12 +5132,15 @@ function drawPieRichLabels(
     const sizePx = chartTextFontSizePx(sizeHpt, ptToPx) ?? Math.max(8, outerR * 0.1);
     const bold = ov?.fontBold ?? def.fontBold;
     const fontColor = ov?.fontColor ?? def.fontColor;
-    const rich = customRichDataLabelOptions(chart, ov, ptToPx, font, bold ?? false);
+    const labelFont = (ov?.fontFace ?? def.fontFace)
+      ? chartFontFamily(chart, ov?.fontFace ?? def.fontFace, 'minor')
+      : font;
+    const rich = customRichDataLabelOptions(chart, ov, ptToPx, labelFont, bold ?? false);
     const automaticLabelR = innerR > 0.01
       ? (innerR + outerR) / 2
       : outerR * PIE_CTR_LABEL_RADIUS_FRAC;
     if (ov?.manualLayout) {
-      ctx.font = `${bold ? 'bold ' : ''}${sizePx}px ${font}`;
+      ctx.font = `${bold ? 'bold ' : ''}${sizePx}px ${labelFont}`;
       drawBoundedDataLabelText(
         ctx,
         text,
@@ -5131,7 +5160,7 @@ function drawPieRichLabels(
       continue;
     }
     if (outside) {
-      ctx.font = `${bold ? 'bold ' : ''}${sizePx}px ${font}`;
+      ctx.font = `${bold ? 'bold ' : ''}${sizePx}px ${labelFont}`;
       const richBlock = rich
         ? resolveRichDataLabelBlock(ctx, rich, sizePx, fontColor ? `#${fontColor}` : '#333')
         : null;
@@ -5153,6 +5182,7 @@ function drawPieRichLabels(
         Math.min(textH, Math.max(0, chartH - sizePx)),
         lineHeight, sizePx, bold ?? false,
         fontColor ? `#${fontColor}` : '#333',
+        labelFont,
         richBlock ?? undefined,
       ));
       continue;
@@ -5176,7 +5206,7 @@ function drawPieRichLabels(
     const labelR = automaticLabelR;
     const lx2 = cx2 + Math.cos(midAngle) * labelR;
     const ly2 = cy2 + Math.sin(midAngle) * labelR;
-    ctx.font = `${bold ? 'bold ' : ''}${sizePx}px ${font}`;
+    ctx.font = `${bold ? 'bold ' : ''}${sizePx}px ${labelFont}`;
     const tangentialCapacity = 2 * labelR * Math.sin(Math.min(Math.PI, Math.abs(slice)) / 2)
       - sizePx;
     const radialCapacity = innerR > 0.01
@@ -5207,7 +5237,7 @@ function drawPieRichLabels(
   }
 
   drawPieOutsideLabels(
-    ctx, def, outsideLabels, cx2, cy2, outerR, font, ptToPx,
+    ctx, def, outsideLabels, cx2, cy2, outerR, ptToPx,
     chartX, chartY, chartW, chartH,
   );
 }
@@ -5227,6 +5257,7 @@ interface PieOutsideLabel {
   fontPx: number;
   bold: boolean;
   fontColor: string;
+  font: string;
   cxBox: number;
   cyBox: number;
   initialCx: number;
@@ -5280,6 +5311,7 @@ function createPieOutsideLabel(
   fontPx: number,
   bold: boolean,
   fontColor: string,
+  font: string,
   rich?: RichDataLabelBlock,
 ): PieOutsideLabel {
   const clearance = fontPx * 0.5;
@@ -5292,7 +5324,7 @@ function createPieOutsideLabel(
     lines, rich,
     rimX: pieCx + Math.cos(midAngle) * outerR,
     rimY: pieCy + Math.sin(midAngle) * outerR,
-    boxW, boxH, lineHeight, fontPx, bold, fontColor,
+    boxW, boxH, lineHeight, fontPx, bold, fontColor, font,
     cxBox, cyBox, initialCx: cxBox, initialCy: cyBox,
     leftSide: Math.cos(midAngle) < 0,
   };
@@ -5309,7 +5341,6 @@ function drawPieOutsideLabels(
   pieCx: number,
   pieCy: number,
   outerR: number,
-  font: string,
   ptToPx: number,
   boundsX: number,
   boundsY: number,
@@ -5388,7 +5419,7 @@ function drawPieOutsideLabels(
       paintRichDataLabelBlock(ctx, label.rich, label.cxBox, label.cyBox);
       continue;
     }
-    ctx.font = `${label.bold ? 'bold ' : ''}${label.fontPx}px ${font}`;
+    ctx.font = `${label.bold ? 'bold ' : ''}${label.fontPx}px ${label.font}`;
     ctx.fillStyle = label.fontColor;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
@@ -5425,6 +5456,7 @@ interface PieCalloutLabel {
   boxBorderPx: number;
   fontPx: number;
   bold: boolean;
+  font: string;
   /** An authored inside position keeps the box at its slice anchor. */
   inside: boolean;
   /** Explicit per-point manual layout is never moved by the auto collision pass. */
@@ -5493,6 +5525,9 @@ function drawPieCalloutLabels(
     // Per-point overrides (font colour/size/bold + box), else series defaults.
     const fontPx = chartTextFontSizePx(ov?.fontSizeHpt, ptToPx) ?? baseFontPx;
     const bold = ov?.fontBold ?? def.fontBold ?? false;
+    const labelFont = (ov?.fontFace ?? def.fontFace)
+      ? chartFontFamily(chart, ov?.fontFace ?? def.fontFace, 'minor')
+      : font;
     const fontColor = ov?.fontColor ? `#${ov.fontColor}` : (def.fontColor ? `#${def.fontColor}` : '#000');
     const box = ov?.labelBox ?? seriesBox;
     const boxFill = box?.fill ? `#${box.fill}` : null;
@@ -5519,13 +5554,13 @@ function drawPieCalloutLabels(
       defaultSeparator: '\n',
     });
     if (!text) continue;
-    const richOptions = customRichDataLabelOptions(chart, ov, ptToPx, font, bold);
+    const richOptions = customRichDataLabelOptions(chart, ov, ptToPx, labelFont, bold);
 
     const padX = Math.max(4, fontPx * 0.45);
     const padY = Math.max(2, fontPx * 0.28);
     const lineGap = fontPx * 0.22;
     const lineH = fontPx + lineGap;
-    ctx.font = `${bold ? 'bold ' : ''}${fontPx}px ${font}`;
+    ctx.font = `${bold ? 'bold ' : ''}${fontPx}px ${labelFont}`;
     const rich = richOptions
       ? resolveRichDataLabelBlock(ctx, richOptions, fontPx, fontColor)
       : null;
@@ -5645,7 +5680,7 @@ function drawPieCalloutLabels(
 
     labels.push({
       lines, rich: rich ?? undefined, lineHeight: lineH, midAngle, rimX, rimY, boxW, boxH, cxBox, cyBox,
-      leftSide, fontColor, boxFill, boxBorder, boxBorderPx, fontPx, bold, inside, manualClip,
+      leftSide, fontColor, boxFill, boxBorder, boxBorderPx, fontPx, bold, font: labelFont, inside, manualClip,
     });
   }
 
@@ -5802,7 +5837,7 @@ function drawPieCalloutLabels(
       if (l.manualClip) ctx.restore();
       continue;
     }
-    ctx.font = `${l.bold ? 'bold ' : ''}${l.fontPx}px ${font}`;
+    ctx.font = `${l.bold ? 'bold ' : ''}${l.fontPx}px ${l.font}`;
     ctx.fillStyle = l.fontColor;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
@@ -6212,6 +6247,7 @@ function drawScatterSeriesLayer(
   isBubble: boolean,
   style: string,
   layoutReferenceRect: DataLabelRect,
+  valueDisplayUnits?: ChartDisplayUnits | null,
 ): void {
   const drawLines = style === 'line' || style === 'lineMarker' || style === 'lineNoMarker';
   const drawSmooth = style === 'smooth' || style === 'smoothMarker' || style === 'smoothNoMarker';
@@ -6324,6 +6360,7 @@ function drawScatterSeriesLayer(
       { x: px0, y: py0, w: pw, h: ph },
       layoutReferenceRect,
       face => chartFontFamily(chart, face, 'minor'),
+      valueDisplayUnits,
     );
   }
 
@@ -6741,11 +6778,13 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
   drawScatterSeriesLayer(
     ctx, chart, primaryEntries, useIndexX, toX, toY, r,
     px0, py0, pw, ph, ptToPx, isBubble, style, { x, y, w, h },
+    chart.valAxisDisplayUnits,
   );
   if (secondaryEntries.length > 0 && secondaryXPlan && secondaryYPlan) {
     drawScatterSeriesLayer(
       ctx, chart, secondaryEntries, useIndexX, toSecondaryX, toSecondaryY, r,
       px0, py0, pw, ph, ptToPx, isBubble, style, { x, y, w, h },
+      secondaryY?.displayUnits,
     );
   }
 
@@ -7021,6 +7060,7 @@ function drawSeriesDataLabels(
   bounds: DataLabelRect = { x: -1e6, y: -1e6, w: 2e6, h: 2e6 },
   layoutReferenceRect: DataLabelRect = bounds,
   richFontFamilyForFace?: (face: string) => string,
+  valueDisplayUnits?: ChartDisplayUnits | null,
 ): void {
   const overrides = s.dataLabelOverrides ?? [];
   const overridesByIndex = indexPointOverrides(overrides);
@@ -7049,6 +7089,7 @@ function drawSeriesDataLabels(
       ),
       seriesName: s.name,
       sourceValue: yv,
+      valueDivisor: displayUnitDivisor(valueDisplayUnits),
       formatCode: ovr?.formatCode ?? seriesDef?.formatCode ?? null,
       date1904,
       separator: ovr?.separator ?? seriesDef?.separator,
@@ -7060,8 +7101,12 @@ function drawSeriesDataLabels(
       ?? Math.max(9, Math.min(11, ph / 25));
     const color = ovr?.fontColor ?? seriesDef?.fontColor;
     const bold = ovr?.fontBold ?? seriesDef?.fontBold ?? false;
+    const labelFace = ovr?.fontFace ?? seriesDef?.fontFace;
+    const labelFont = labelFace && richFontFamilyForFace
+      ? richFontFamilyForFace(labelFace)
+      : fontFamily;
     drawDataLabelText(
-      ctx, toX(xv), toY(yv), text, pos, fontSizePx, color, bold, fontFamily, 0,
+      ctx, toX(xv), toY(yv), text, pos, fontSizePx, color, bold, labelFont, 0,
       bounds, ovr?.manualLayout,
       layoutReferenceRect,
       ovr?.richRuns,
@@ -7360,6 +7405,7 @@ function drawCategoryDataLabels(
   percentRatioAt?: (index: number) => number,
   markerGapAt?: (index: number) => number,
   richFontFamilyForFace?: (face: string) => string,
+  valueDisplayUnits?: ChartDisplayUnits | null,
 ): boolean {
   const overrides = s.dataLabelOverrides ?? [];
   const overridesByIndex = indexPointOverrides(overrides);
@@ -7387,6 +7433,7 @@ function drawCategoryDataLabels(
       category: cats[ci] ?? '',
       seriesName: s.name,
       sourceValue,
+      valueDivisor: displayUnitDivisor(valueDisplayUnits),
       percentRatio: percentRatioAt?.(ci),
       formatCode: ovr?.formatCode ?? seriesDef?.formatCode ?? null,
       date1904,
@@ -7399,8 +7446,12 @@ function drawCategoryDataLabels(
       ?? Math.max(9, Math.min(11, ph / 25));
     const color = ovr?.fontColor ?? seriesDef?.fontColor;
     const bold = ovr?.fontBold ?? seriesDef?.fontBold ?? false;
+    const labelFace = ovr?.fontFace ?? seriesDef?.fontFace;
+    const labelFont = labelFace && richFontFamilyForFace
+      ? richFontFamilyForFace(labelFace)
+      : fontFamily;
     drawDataLabelText(
-      ctx, xAt(ci), yAt(anchorValue), text, pos, fontSizePx, color, bold, fontFamily,
+      ctx, xAt(ci), yAt(anchorValue), text, pos, fontSizePx, color, bold, labelFont,
       markerGapAt?.(ci) ?? 0,
       bounds, ovr?.manualLayout,
       layoutReferenceRect,
@@ -7424,6 +7475,7 @@ interface ResolvedChartExLabel {
   fontColor?: string;
   fontSizeHpt?: number;
   fontBold?: boolean;
+  fontFace?: string;
   manualLayout?: ChartDataLabelOverride['manualLayout'];
 }
 
@@ -7455,6 +7507,7 @@ function resolveChartExLabel(
   },
   overrideLookup: ReadonlyMap<number, NonNullable<ChartSeries['dataLabelOverrides']>[number]>,
   valueOption?: boolean | number,
+  valueDisplayUnits?: ChartDisplayUnits | null,
 ): ResolvedChartExLabel | null {
   if (!series) return null;
   const definition = series.seriesDataLabels;
@@ -7487,6 +7540,7 @@ function resolveChartExLabel(
     category,
     seriesName: series.name,
     sourceValue: value,
+    valueDivisor: displayUnitDivisor(valueDisplayUnits),
     percentRatio,
     formatCode: authoredFormatCode ?? series.valFormatCode ?? null,
     percentFormatCode: authoredFormatCode ?? '0%',
@@ -7500,6 +7554,7 @@ function resolveChartExLabel(
     fontColor: override?.fontColor ?? definition?.fontColor,
     fontSizeHpt: override?.fontSizeHpt ?? definition?.fontSizeHpt,
     fontBold: override?.fontBold ?? definition?.fontBold,
+    fontFace: override?.fontFace ?? definition?.fontFace,
     manualLayout: override?.manualLayout,
   };
 }
@@ -8277,7 +8332,10 @@ function renderWaterfallChart(
       const dataLabelFontPx = chartTextFontSizePx(label.fontSizeHpt, ptToPx)
         ?? axisLabelPx(chart.dataLabelFontSizeHpt, h, ptToPx);
       const dataLabelBold = label.fontBold ?? chart.dataLabelFontBold ?? false;
-      ctx.font = `${dataLabelBold ? 'bold ' : ''}${dataLabelFontPx}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
+      const dataLabelFont = chartFontFamily(
+        chart, label.fontFace ?? chart.dataLabelFontFace, 'minor',
+      );
+      ctx.font = `${dataLabelBold ? 'bold ' : ''}${dataLabelFontPx}px ${dataLabelFont}`;
       drawBoundedDataLabelText(
         ctx,
         label.text,
@@ -8441,7 +8499,10 @@ function renderFunnelChart(
     if (label) {
       const fontPx = chartTextFontSizePx(label.fontSizeHpt, ptToPx)
         ?? axisLabelPx(chart.dataLabelFontSizeHpt, h, ptToPx);
-      ctx.font = `${label.fontBold ? 'bold ' : ''}${fontPx}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
+      const labelFont = chartFontFamily(
+        chart, label.fontFace ?? chart.dataLabelFontFace, 'minor',
+      );
+      ctx.font = `${label.fontBold ? 'bold ' : ''}${fontPx}px ${labelFont}`;
       drawBoundedDataLabelText(
         ctx,
         label.text,
@@ -9489,7 +9550,9 @@ function renderSunburstChart(
   );
 
   const labelDef = series?.seriesDataLabels;
-  const labelFont = chartFontFamily(chart, chart.dataLabelFontFace, 'minor');
+  const labelFont = chartFontFamily(
+    chart, labelDef?.fontFace ?? chart.dataLabelFontFace, 'minor',
+  );
   const labelPx = chartTextFontSizePx(labelDef?.fontSizeHpt, ptToPx)
     ?? Math.max(7, Math.min(13, outerR * 0.075));
   const labelColor = labelDef?.fontColor ? `#${labelDef.fontColor}` : '#ffffff';
@@ -9553,6 +9616,9 @@ function renderSunburstChart(
       const labelText = label.text;
       const nodeLabelPx = chartTextFontSizePx(label.fontSizeHpt, ptToPx) ?? labelPx;
       const nodeLabelColor = label.fontColor ? `#${label.fontColor}` : labelColor;
+      const nodeLabelFont = label.fontFace
+        ? chartFontFamily(chart, label.fontFace, 'minor')
+        : labelFont;
 
       // Excel's sunburst category labels run along the radius (not around the
       // circumference). Center the text at the wedge mid-radius and wrap it to
@@ -9569,7 +9635,7 @@ function renderSunburstChart(
 
       const labelX = cx + Math.cos(midA) * midR;
       const labelY = cy + Math.sin(midA) * midR;
-      ctx.font = `${label.fontBold ? 'bold ' : ''}${nodeLabelPx}px ${labelFont}`;
+      ctx.font = `${label.fontBold ? 'bold ' : ''}${nodeLabelPx}px ${nodeLabelFont}`;
       if (label.manualLayout) {
         drawBoundedDataLabelText(
           ctx,
@@ -9592,7 +9658,7 @@ function renderSunburstChart(
       const deg = ((rot * 180) / Math.PI) % 360;
       if (deg > 90 || deg < -90) rot += Math.PI;
       ctx.rotate(rot);
-      ctx.font = `${label.fontBold ? 'bold ' : ''}${nodeLabelPx}px ${labelFont}`;
+      ctx.font = `${label.fontBold ? 'bold ' : ''}${nodeLabelPx}px ${nodeLabelFont}`;
       drawBoundedDataLabelText(
         ctx,
         labelText,
@@ -9769,9 +9835,11 @@ function renderTreemapChart(
   const { px0, py0, pw, ph } = frame.plotRect;
   const plotBounds = { x: px0, y: py0, w: pw, h: ph };
 
-  const fontFamily = chartFontFamily(chart, chart.dataLabelFontFace, 'minor');
   const parentMode = treemap.parentLabelLayout ?? 'overlapping';
   const labelDef = chart.series[0]?.seriesDataLabels;
+  const fontFamily = chartFontFamily(
+    chart, labelDef?.fontFace ?? chart.dataLabelFontFace, 'minor',
+  );
   const labelFontPx = chartTextFontSizePx(labelDef?.fontSizeHpt, ptToPx)
     ?? Math.max(8, Math.min(13, frame.plotRect.ph * 0.025));
   const labelColor = labelDef?.fontColor ? `#${labelDef.fontColor}` : '#ffffff';
@@ -9814,6 +9882,9 @@ function renderTreemapChart(
       const showParent = parentLabel != null
         && (parentMode !== 'overlapping' || node.depth === 0);
       const fontPx = nodeLabelFontPx;
+      const parentFontFamily = parentLabel?.fontFace
+        ? chartFontFamily(chart, parentLabel.fontFace, 'minor')
+        : fontFamily;
       const bannerH = parentMode === 'banner' && showParent
         ? Math.min(tile.h * 0.28, fontPx + 7)
         : 0;
@@ -9844,7 +9915,7 @@ function renderTreemapChart(
       for (const child of layoutTreemapTiles(node.children, content)) paint(child.node, child.rect);
 
       if (showParent && (parentLabel.manualLayout || (tile.w > fontPx * 2 && tile.h > fontPx + 4))) {
-        ctx.font = `${nodeLabelBold ? 'bold ' : ''}${fontPx}px ${fontFamily}`;
+        ctx.font = `${nodeLabelBold ? 'bold ' : ''}${fontPx}px ${parentFontFamily}`;
         const labelRect = bannerH > 0
           ? { x: tile.x, y: tile.y, w: tile.w, h: bannerH }
           : tile;
@@ -9908,7 +9979,10 @@ function renderTreemapChart(
     const fontPx = chartTextFontSizePx(leafLabel.fontSizeHpt, ptToPx)
       ?? nodeLabelFontPx;
     if (!leafLabel.manualLayout && (tile.w <= fontPx * 1.2 || tile.h <= fontPx * 1.2)) return;
-    ctx.font = `${leafLabel.fontBold ? 'bold ' : ''}${fontPx}px ${fontFamily}`;
+    const leafFontFamily = leafLabel.fontFace
+      ? chartFontFamily(chart, leafLabel.fontFace, 'minor')
+      : fontFamily;
+    ctx.font = `${leafLabel.fontBold ? 'bold ' : ''}${fontPx}px ${leafFontFamily}`;
     const automaticBounds = tile;
     // ChartEx uses `outEnd` for treemap value labels but Excel paints that
     // token inside the tile at its lower-left corner. Keep the family-specific

--- a/packages/core/src/chart/three-d-renderer.ts
+++ b/packages/core/src/chart/three-d-renderer.ts
@@ -1,6 +1,7 @@
 import type {
   ChartDataLabelOverride,
   ChartDataPointOverride,
+  ChartDisplayUnits,
   ChartModel,
   ChartRect,
   ChartSeries,
@@ -61,6 +62,7 @@ import {
   type ProjectedStrokePrimitive,
 } from './three-d-stroke.js';
 import { buildThreeDOutlineTopology } from './three-d-outline.js';
+import { paintLegendFrame } from './legend-frame.js';
 
 const PALETTE = ['4472C4', 'ED7D31', '70AD47', 'A5A5A5', 'FFC000', '5B9BD5'] as const;
 const SUPPORTED_CARTESIAN_THREE_D_TYPES = new Set([
@@ -869,6 +871,7 @@ function drawThreeDDataLabel(
   defaultPosition = 't',
   leaderAnchor: Point = anchor,
   leaderLineEligible = true,
+  valueDisplayUnits?: ChartDisplayUnits | null,
 ): void {
   // Callers resolve indexed overrides through their per-series Map before the
   // paint loop. Falling back to Array.find here would quietly reintroduce
@@ -891,6 +894,7 @@ function drawThreeDDataLabel(
       ?? chart.categories[categoryIndex] ?? `${categoryIndex + 1}`,
     seriesName: series.name || `Series ${seriesIndex + 1}`,
     sourceValue: value,
+    valueDivisor: valueDisplayUnits?.divisor,
     percentRatio: percentValue != null && Number.isFinite(percentValue) ? percentValue : undefined,
     formatCode: override?.formatCode
       ?? defaults?.formatCode ?? chart.dataLabelFormatCode ?? series.valFormatCode,
@@ -905,7 +909,9 @@ function drawThreeDDataLabel(
     ptToPx,
   ) ?? 9 * ptToPx;
   const bold = override?.fontBold ?? defaults?.fontBold ?? chart.dataLabelFontBold ?? false;
-  const fallbackFamily = chartFontFamily(chart, chart.dataLabelFontFace);
+  const fallbackFamily = chartFontFamily(
+    chart, override?.fontFace ?? defaults?.fontFace ?? chart.dataLabelFontFace,
+  );
   ctx.font = `${bold ? 'bold ' : ''}${fontPx}px ${fallbackFamily}`;
   const fallbackColor = `#${override?.fontColor ?? defaults?.fontColor
     ?? series.labelColor ?? chart.dataLabelFontColor ?? '111111'}`;
@@ -1312,6 +1318,7 @@ function simpleLegend(
   categoryDriven = false,
 ): void {
   if (!bounds) return;
+  paintLegendFrame(ctx, chart, bounds, ptToPx);
   const indexedPoints = new Map<number, ChartDataPointOverride>(
     chart.series[0]?.dataPointOverrides?.map(override => [override.idx, override]) ?? [],
   );
@@ -2407,6 +2414,7 @@ function renderCartesian(
         deferredDataLabels.push(() => drawThreeDDataLabel(
           ctx, chart, series, item.seriesIndex, item.categoryIndex,
           item.labelValue, anchor, rect, ptToPx, 0, undefined, labelOverride,
+          't', anchor, true, chart.valAxisDisplayUnits,
         ));
       }
     }
@@ -2905,6 +2913,7 @@ function renderCartesian(
               : 0,
             undefined,
             labelOverride,
+            't', point, true, chart.valAxisDisplayUnits,
           ));
         }
       }
@@ -3348,7 +3357,7 @@ function renderPie(
       ) ?? 9 * ptToPx;
       ctx.font = `${labelOverride?.fontBold ?? defaults?.fontBold
         ?? chart.dataLabelFontBold ? 'bold ' : ''}${fontPx}px ${chartFontFamily(
-        chart, chart.dataLabelFontFace,
+        chart, labelOverride?.fontFace ?? defaults?.fontFace ?? chart.dataLabelFontFace,
       )}`;
       const labelText = effectiveDataLabelText({
         customText: labelOverride?.text,
@@ -3366,7 +3375,9 @@ function renderPie(
         separator: labelOverride?.separator ?? defaults?.separator,
         date1904: chart.date1904,
       });
-      const fallbackFamily = chartFontFamily(chart, chart.dataLabelFontFace);
+      const fallbackFamily = chartFontFamily(
+        chart, labelOverride?.fontFace ?? defaults?.fontFace ?? chart.dataLabelFontFace,
+      );
       const richMeasure = labelOverride?.text && labelOverride.richRuns?.length
         ? resolveRichDataLabelBlock(ctx, {
           runs: labelOverride.richRuns,

--- a/packages/core/src/chart/trendline-label.test.ts
+++ b/packages/core/src/chart/trendline-label.test.ts
@@ -29,12 +29,21 @@ describe('automatic trendline label placement', () => {
     })).toEqual({ x: 40, y: 60, w: 100, h: 30, automatic: false });
   });
 
-  it('follows a fitted-curve endpoint while remaining inside the plot', () => {
+  it('uses the Office automatic column and follows only the fitted endpoint height', () => {
     expect(placeTrendlineLabel(CHART, PLOT, 90, 30, 10, null, { x: 220, y: 180 }))
-      .toEqual({ x: 130, y: 145, w: 90, h: 30, automatic: true });
+      .toEqual({ x: 185, y: 152.5, w: 90, h: 30, automatic: true });
     expect(placeTrendlineLabel(CHART, PLOT, 90, 30, 10, null, { x: 999, y: -10 }))
-      .toEqual({ x: 260, y: 40, w: 90, h: 30, automatic: true });
+      .toEqual({ x: 185, y: 40, w: 90, h: 30, automatic: true });
   });
+
+  it.each([{ width: 55 }, { width: 90 }, { width: 140 }])(
+    'keeps the measured block right edge at 75% of plot width ($width px)',
+    ({ width }) => {
+      const placed = placeTrendlineLabel(CHART, PLOT, width, 24, 8, null, { x: 999, y: 120 });
+      expect((placed?.x ?? 0) + (placed?.w ?? 0)).toBe(PLOT.x + PLOT.w * 0.75);
+      expect((placed?.y ?? 0) + (placed?.h ?? 0)).toBe(122);
+    },
+  );
 
   it.each([
     { x: 10, y: 20, w: 600, h: 120 },

--- a/packages/core/src/chart/trendline-label.ts
+++ b/packages/core/src/chart/trendline-label.ts
@@ -12,9 +12,9 @@ export interface TrendlineLabelPlacement {
 /**
  * Resolve one measured trendline-label block.
  *
- * Automatic labels use the visible fitted-curve endpoint when supplied. A
- * valid authored manual layout is resolved against chart space and bypasses
- * that anchor.
+ * Automatic labels use the visible fitted-curve endpoint for vertical
+ * placement when supplied. A valid authored manual layout is resolved against
+ * chart space and bypasses that anchor.
  */
 export function placeTrendlineLabel(
   chartRect: ManualLayoutRect,
@@ -30,16 +30,22 @@ export function placeTrendlineLabel(
   const inset = Math.max(4, fontPx * 0.5);
   const w = Math.min(measuredWidth, Math.max(0, plotRect.w - inset * 2));
   const h = Math.min(measuredHeight, plotRect.h);
-  // Office's automatic trendline labels follow their fitted curve rather than
-  // sharing one chart-corner anchor. Use the visible run endpoint supplied by
-  // the renderer and clamp the measured block to the plot; callers without a
-  // curve anchor retain the established top-right compatibility placement.
+  // Office's automatic classic trendline label rule is under-specified. A
+  // boundary set measured from Excel (positive/negative, shallow/steep, and
+  // unequal endpoint values) keeps the measured block's RIGHT edge at 75% of
+  // the plot width while its BOTTOM follows the fitted curve's right endpoint
+  // with a quarter-em text-baseline allowance. Keep this compatibility rule
+  // local to automatic trendline labels; authored manual layout remains exact.
+  const automaticRight = plotRect.x + plotRect.w * 0.75;
   const automatic = {
     x: automaticAnchor
-      ? Math.max(plotRect.x, Math.min(plotRect.x + plotRect.w - w, automaticAnchor.x - w))
+      ? Math.max(plotRect.x, Math.min(plotRect.x + plotRect.w - w, automaticRight - w))
       : Math.max(plotRect.x, plotRect.x + plotRect.w - inset - w),
     y: automaticAnchor
-      ? Math.max(plotRect.y, Math.min(plotRect.y + plotRect.h - h, automaticAnchor.y - h - inset))
+      ? Math.max(
+        plotRect.y,
+        Math.min(plotRect.y + plotRect.h - h, automaticAnchor.y - h + fontPx * 0.25),
+      )
       : Math.min(plotRect.y + plotRect.h - h, plotRect.y + inset),
     w,
     h,

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -272,6 +272,8 @@ export interface ChartDataLabelOverride {
   position?: string;
   fontColor?: string;
   fontSizeHpt?: number;
+  /** Effective per-point `<a:latin typeface>`; undefined inherits the series. */
+  fontFace?: string;
   /** `<a:defRPr b="1">` inside the per-idx rich text. */
   fontBold?: boolean;
   /** Per-point number format; undefined inherits the series default. */
@@ -335,6 +337,8 @@ export interface ChartSeriesDataLabels {
   fontBold?: boolean;
   /** Series-level font size for data labels (OOXML hundredths of a point). */
   fontSizeHpt?: number;
+  /** Series-level `<c:dLbls><c:txPr>…<a:latin typeface>` font face. */
+  fontFace?: string;
   /** Series-default callout box (`<c:dLbls><c:spPr>`, ECMA-376 §21.2.2.49/
    *  §21.2.2.197). When present the pie/doughnut renderer draws Word's boxed
    *  callout layout (box + optional leader line) instead of plain text. */
@@ -611,6 +615,12 @@ export interface ChartModel {
   legendFontSizeHpt?: number | null;
   /** `<c:legend><c:txPr>…defRPr@b` legend bold flag. */
   legendFontBold?: boolean | null;
+  /** `<c:legend><c:spPr>` explicit frame fill (hex without '#'). */
+  legendFillColor?: string | null;
+  /** `<c:legend><c:spPr><a:ln>` explicit frame stroke (hex without '#'). */
+  legendLineColor?: string | null;
+  /** `<c:legend><c:spPr><a:ln@w>` frame stroke width in EMU. */
+  legendLineWidthEmu?: number | null;
   /**
    * Theme font-scheme faces (`<a:fontScheme>`, ECMA-376 §20.1.4.2). Latin
    * heading (majorFont) and body (minorFont) typefaces, used as the fallback
@@ -1288,8 +1298,9 @@ export interface SecondaryValueAxis {
   titleManualLayout?: ChartManualLayout | null;
 }
 
-/** ECMA-376 §21.2.2.45 display-unit scaling. The divisor changes tick text,
- * never the value-to-pixel mapping. */
+/** ECMA-376 §21.2.2.45 display-unit scaling. The divisor changes displayed
+ * axis-associated values (ticks and generated `showVal` data-label text),
+ * never the source value or value-to-pixel mapping. */
 export interface ChartDisplayUnits {
   divisor: number;
   /** Authored `ST_BuiltInUnit` token; absent for `<c:custUnit>`. */

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -62,6 +62,7 @@ export interface ChartDataLabelOverride {
     position?: string;
     fontColor?: string;
     fontSizeHpt?: number;
+    fontFace?: string;
     fontBold?: boolean;
     formatCode?: string;
     separator?: string;
@@ -288,6 +289,9 @@ export interface ChartModel {
     legendFontColor?: string | null;
     legendFontSizeHpt?: number | null;
     legendFontBold?: boolean | null;
+    legendFillColor?: string | null;
+    legendLineColor?: string | null;
+    legendLineWidthEmu?: number | null;
     themeMajorFontLatin?: string | null;
     themeMinorFontLatin?: string | null;
     chartBorderColor?: string | null;
@@ -451,6 +455,7 @@ export interface ChartSeriesDataLabels {
     separator?: string;
     fontBold?: boolean;
     fontSizeHpt?: number;
+    fontFace?: string;
     labelBox?: ChartLabelBox;
     showLeaderLines?: boolean;
     leaderLineColor?: string;

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.79.0",
+  "version": "0.79.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.79.0",
+  "version": "0.79.1",
   "description": "Internal workspace adapter for DOCX / XLSX / PPTX Markdown projection",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.79.0"
+version = "0.79.1"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.79.0",
+  "version": "0.79.1",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -208,8 +208,9 @@ pub struct ChartModel {
     pub legend_manual_layout: Option<LegendManualLayout>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub val_axis_format_code: Option<String>,
-    /// `<c:valAx><c:dispUnits>` (§21.2.2.45) scales only the displayed tick
-    /// values; geometry and the underlying series values remain unscaled.
+    /// `<c:valAx><c:dispUnits>` (§21.2.2.45) scales displayed axis-associated
+    /// values (ticks and Office-generated `showVal` data-label text); geometry
+    /// and the underlying series values remain unscaled.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub val_axis_display_units: Option<ChartDisplayUnits>,
     /// The same display-unit contract for a numeric horizontal axis (scatter /
@@ -364,6 +365,15 @@ pub struct ChartModel {
     /// `<c:legend><c:txPr>…defRPr@b` legend bold flag.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub legend_font_bold: Option<bool>,
+    /// `<c:legend><c:spPr>` explicit frame fill (hex, no `#`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legend_fill_color: Option<String>,
+    /// `<c:legend><c:spPr><a:ln>` explicit frame stroke (hex, no `#`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legend_line_color: Option<String>,
+    /// `<c:legend><c:spPr><a:ln@w>` frame stroke width in EMU.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legend_line_width_emu: Option<u32>,
     /// Theme heading (majorFont) Latin face — fallback for chart title / axis
     /// titles when their `<c:txPr>` supplies no `<a:latin>`. `None` when the
     /// theme is not threaded (renderer keeps sans-serif; byte-stable).
@@ -632,7 +642,6 @@ pub struct ChartThreeDSeriesAxis {
     pub font_color: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_size_hpt: Option<i32>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_bold: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_italic: Option<bool>,
@@ -968,6 +977,8 @@ pub struct ChartDataLabelOverride {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_size_hpt: Option<i32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub font_face: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_bold: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub format_code: Option<String>,
@@ -1058,6 +1069,9 @@ pub struct ChartSeriesDataLabels {
     pub font_bold: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_size_hpt: Option<i32>,
+    /// `<c:dLbls><c:txPr>…<a:latin typeface>` series-default label face.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub font_face: Option<String>,
     /// Series-default callout-box style (`<c:dLbls>` §21.2.2.49 `<c:spPr>`
     /// §21.2.2.197) — the box drawn around each pie/doughnut label. When present
     /// the pie renderer switches from plain outer-ring text to Word's boxed
@@ -1961,17 +1975,21 @@ pub fn extract_bar_gap_overlap(root: Node) -> (Option<i32>, Option<i32>) {
     (gap, ov)
 }
 
+fn is_chart_group_data_labels(node: Node) -> bool {
+    node.is_element()
+        && matches!(node.tag_name().name(), "dLbls" | "dataLabels")
+        && node
+            .parent()
+            .map(|parent| !matches!(parent.tag_name().name(), "ser" | "series"))
+            .unwrap_or(true)
+}
+
 /// First chart-group-level `<c:dLbls><c:dLblPos val>` in the chart.
 /// Series-level positions are retained on `ChartSeriesDataLabels` and must not
 /// leak into sibling series as a chart-wide fallback. ECMA-376 §21.2.2.49.
 pub fn extract_data_label_position(root: Node) -> Option<String> {
     root.descendants()
-        .filter(|n| n.is_element() && n.tag_name().name() == "dLbls")
-        .filter(|n| {
-            n.parent()
-                .map(|parent| parent.tag_name().name() != "ser")
-                .unwrap_or(true)
-        })
+        .filter(|n| is_chart_group_data_labels(*n))
         .find_map(|dlbls| {
             child(dlbls, "dLblPos")
                 .and_then(|n| n.attribute("val"))
@@ -1979,11 +1997,13 @@ pub fn extract_data_label_position(root: Node) -> Option<String> {
         })
 }
 
-/// First non-`General` `<c:dLbls><c:numFmt formatCode>` in the chart.
+/// First non-`General` chart-group `<c:dLbls><c:numFmt formatCode>`. Series
+/// format codes stay on `ChartSeriesDataLabels` and do not become a sibling
+/// series fallback.
 /// ECMA-376 §21.2.2.37.
 pub fn extract_data_label_format_code(root: Node) -> Option<String> {
     root.descendants()
-        .filter(|n| n.is_element() && n.tag_name().name() == "dLbls")
+        .filter(|n| is_chart_group_data_labels(*n))
         .find_map(|dlbls| {
             child(dlbls, "numFmt")
                 .and_then(|n| n.attribute("formatCode"))
@@ -2626,12 +2646,11 @@ pub fn extract_axis_title_face(axis_node: Node) -> Option<String> {
     title_latin_typeface(child(axis_node, "title")?)
 }
 
-/// First `<c:dLbls><c:txPr>…<a:latin typeface>` in the chart — the data-label
-/// font face. Scoped to a `<c:txPr>` inside a `<c:dLbls>` so a series-value
-/// run's face isn't picked up. `None` when absent.
+/// First chart-group `<c:dLbls><c:txPr>…<a:latin typeface>` — the chart-wide
+/// data-label font face. Series-local faces remain on their series.
 pub fn extract_data_label_face(root: Node) -> Option<String> {
     root.descendants()
-        .filter(|n| n.is_element() && n.tag_name().name() == "dLbls")
+        .filter(|n| is_chart_group_data_labels(*n))
         .find_map(|dlbls| first_latin_typeface(child(dlbls, "txPr")?))
 }
 
@@ -2686,6 +2705,34 @@ pub fn extract_legend_font_color(root: Node, resolver: &dyn ColorResolver) -> Op
             None
         }
     })
+}
+
+/// `<c:legend><c:spPr>` frame paint. The frame fill and line are independent
+/// DrawingML choices; absent or explicit `noFill` remains `None`, while an
+/// authored solid fill/stroke is resolved through the package theme.
+pub fn extract_legend_frame_style(
+    root: Node,
+    resolver: &dyn ColorResolver,
+) -> (Option<String>, Option<String>, Option<u32>) {
+    let Some(legend) = root
+        .descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "legend")
+    else {
+        return (None, None, None);
+    };
+    let fill = child(legend, "spPr").and_then(|shape| {
+        if child(shape, "noFill").is_some() {
+            None
+        } else {
+            resolver.resolve_shape_fill(shape)
+        }
+    });
+    let (line_color, line_width, line_hidden) = extract_sp_pr_ln_style(legend, resolver);
+    (
+        fill,
+        if line_hidden { None } else { line_color },
+        line_width,
+    )
 }
 
 // ============================================================================
@@ -2974,12 +3021,11 @@ pub fn extract_chart_space_border(chart_space_root: Node) -> (Option<String>, Op
     (color, width)
 }
 
-/// First `<c:dLbls><c:txPr>` font size (hpt). Mirrors the per-series + chart
-/// fallback chain: walk every `<c:dLbls>` in document order, returning the
-/// first inner `<a:defRPr@sz>` / `<a:rPr@sz>` we find.
+/// First chart-group `<c:dLbls><c:txPr>` font size (hpt). Series-local sizes
+/// stay on `ChartSeriesDataLabels` and must not become a sibling fallback.
 pub fn extract_data_label_font_size(root: Node) -> Option<i32> {
     root.descendants()
-        .filter(|n| n.is_element() && n.tag_name().name() == "dLbls")
+        .filter(|n| is_chart_group_data_labels(*n))
         .find_map(|dl| {
             child(dl, "txPr").and_then(|tx| {
                 tx.descendants().find_map(|n| {
@@ -2996,10 +3042,10 @@ pub fn extract_data_label_font_size(root: Node) -> Option<i32> {
         })
 }
 
-/// First explicit data-label bold flag from `<c:dLbls><c:txPr>`.
+/// First explicit chart-group data-label bold flag from `<c:dLbls><c:txPr>`.
 pub fn extract_data_label_font_bold(root: Node) -> Option<bool> {
     root.descendants()
-        .filter(|n| n.is_element() && matches!(n.tag_name().name(), "dLbls" | "dataLabels"))
+        .filter(|n| is_chart_group_data_labels(*n))
         .find_map(|labels| {
             child(labels, "txPr").and_then(|tx| {
                 tx.descendants().find_map(|node| {
@@ -3012,15 +3058,8 @@ pub fn extract_data_label_font_bold(root: Node) -> Option<bool> {
         })
 }
 
-/// First `<c:dLbls><c:txPr>...<a:solidFill>` resolved to a hex color.
-///
-/// Walks each `<c:dLbls>` (chart-level + per-series) in document order,
-/// drills into its `<c:txPr>` and looks for the first descendant
-/// `<a:solidFill>` whose color the resolver can map. Stops on the first
-/// successful resolution — this matches the chart-then-series fallback
-/// pattern Office writers actually emit (e.g. a top-level `<c:dLbls>`
-/// declaring the label color globally and the `<c:ser><c:dLbls>` blocks
-/// inheriting it).
+/// First chart-group `<c:dLbls><c:txPr>...<a:solidFill>` resolved to a hex
+/// color. Series-local text paint remains on its series.
 ///
 /// Note we deliberately scope the search to inside `<c:txPr>` so a
 /// sibling `<c:dLbls><c:spPr><a:solidFill>` (the label *background*
@@ -3028,7 +3067,7 @@ pub fn extract_data_label_font_bold(root: Node) -> Option<bool> {
 pub fn extract_data_label_font_color(root: Node, resolver: &dyn ColorResolver) -> Option<String> {
     for dlbls in root
         .descendants()
-        .filter(|n| n.is_element() && n.tag_name().name() == "dLbls")
+        .filter(|n| is_chart_group_data_labels(*n))
     {
         let Some(txpr) = child(dlbls, "txPr") else {
             continue;
@@ -4069,6 +4108,7 @@ fn parse_chartex_series_labels(
             .map(ToOwned::to_owned),
         font_bold: extract_axis_tick_label_bold(labels),
         font_size_hpt: extract_axis_tick_label_size(labels),
+        font_face: extract_axis_tick_label_face(labels),
         label_box: None,
         show_leader_lines: false,
         leader_line_color: None,
@@ -4103,6 +4143,7 @@ fn parse_chartex_series_labels(
             position: attr(&label, "pos"),
             font_color,
             font_size_hpt: extract_axis_tick_label_size(label),
+            font_face: extract_axis_tick_label_face(label),
             font_bold: extract_axis_tick_label_bold(label),
             format_code: child(label, "numFmt").and_then(|node| attr(&node, "formatCode")),
             separator: child(label, "separator")
@@ -4141,6 +4182,7 @@ fn parse_chartex_series_labels(
                 position: None,
                 font_color: None,
                 font_size_hpt: None,
+                font_face: None,
                 font_bold: None,
                 format_code: None,
                 separator: None,
@@ -4810,6 +4852,7 @@ pub fn parse_chartex_part_with_references_and_style_parts(
                 .map(|value| value.to_string()),
             font_bold: data_label_font_bold,
             font_size_hpt: data_label_font_size_hpt,
+            font_face: data_label_font_face.clone(),
             label_box: None,
             show_leader_lines: false,
             leader_line_color: None,
@@ -4873,6 +4916,8 @@ pub fn parse_chartex_part_with_references_and_style_parts(
     let (legend_font_face, legend_font_size_hpt, legend_font_bold) =
         extract_legend_text_props(root);
     let legend_font_color = extract_legend_font_color(root, resolver);
+    let (legend_fill_color, legend_line_color, legend_line_width_emu) =
+        extract_legend_frame_style(root, resolver);
     let (chart_border_color, chart_border_width_emu) = child(root, "spPr")
         .and_then(|shape| child(shape, "ln"))
         .map(|line| {
@@ -5009,6 +5054,9 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         legend_font_color,
         legend_font_size_hpt,
         legend_font_bold,
+        legend_fill_color,
+        legend_line_color,
+        legend_line_width_emu,
         theme_major_font_latin: resolver.theme_major_font_latin(),
         theme_minor_font_latin: resolver.theme_minor_font_latin(),
         val_axis_minor_tick_mark: Some(val_axis_minor_tick_mark),
@@ -6071,6 +6119,7 @@ pub fn parse_series_data_labels(
             .and_then(|n| n.attribute("sz"))
             .and_then(parse_text_font_size_hpt)
     });
+    let font_face_default = txpr.and_then(first_latin_typeface);
 
     // §21.2.2.197 series-level callout-box shape (`<c:dLbls><c:spPr>`) and
     // §21.2.2.183/§21.2.2.92 leader-line style. `<c:spPr>` may appear both as a
@@ -6096,6 +6145,7 @@ pub fn parse_series_data_labels(
         separator,
         font_bold: font_bold_default,
         font_size_hpt: font_size_default,
+        font_face: font_face_default,
         label_box,
         show_leader_lines,
         leader_line_color,
@@ -6163,6 +6213,10 @@ pub fn parse_series_data_labels(
                     .or_else(|| default_run_props.and_then(|run| run.attribute("sz")))
                     .and_then(parse_text_font_size_hpt)
             });
+        let font_face = first_rich_run
+            .and_then(|run| run.font_face.clone())
+            .or_else(|| rich_run_props.and_then(first_latin_typeface))
+            .or_else(|| default_run_props.and_then(first_latin_typeface));
         let font_bold = first_rich_run.and_then(|run| run.bold).or_else(|| {
             rich_run_props
                 .and_then(|run| run.attribute("b"))
@@ -6188,6 +6242,7 @@ pub fn parse_series_data_labels(
             position: pos,
             font_color,
             font_size_hpt,
+            font_face,
             font_bold,
             format_code: child(dl, "numFmt").and_then(|node| attr(&node, "formatCode")),
             separator: child(dl, "separator")
@@ -6215,6 +6270,7 @@ pub fn parse_series_data_labels(
         || series_defaults.format_code.is_some()
         || series_defaults.font_bold.is_some()
         || series_defaults.font_size_hpt.is_some()
+        || series_defaults.font_face.is_some()
         || series_defaults.label_box.is_some()
         || series_defaults.show_leader_lines
         || series_defaults.leader_line_color.is_some()
@@ -7725,13 +7781,18 @@ pub fn parse_chart_part_with_references(
         }
     }
 
-    // Data labels are on when `<c:dLbls>` enables `<c:showVal>` OR
-    // `<c:showPercent>` (ECMA-376 §21.2.2.189 / §21.2.2.187) — at chart level
-    // or in any series. Pie/doughnut charts commonly use showPercent only; the renderer draws the
-    // slice percentage for pie/doughnut and the raw value for bar/line.
+    // Chart-group data labels are on when a chart-level `<c:dLbls>` enables
+    // `<c:showVal>` or `<c:showPercent>` (§21.2.2.189 / §21.2.2.187).
+    // Series-local `<c:ser><c:dLbls>` is retained on that ChartSeries and must
+    // not turn labels on for unlabelled sibling series.
     let show_data_labels = root
         .descendants()
         .filter(|n| n.is_element() && n.tag_name().name() == "dLbls")
+        .filter(|n| {
+            n.parent()
+                .map(|parent| parent.tag_name().name() != "ser")
+                .unwrap_or(true)
+        })
         .any(|d_lbls| {
             // `<c:showVal>` / `<c:showPercent>` are CT_Boolean: a present element
             // is ON unless `val` explicitly disables it (bare element ⇒ true), so
@@ -8112,6 +8173,8 @@ pub fn parse_chart_part_with_references(
     let (legend_font_face, legend_font_size_hpt, legend_font_bold) =
         extract_legend_text_props(root);
     let legend_font_color = { extract_legend_font_color(root, color_resolver) };
+    let (legend_fill_color, legend_line_color, legend_line_width_emu) =
+        extract_legend_frame_style(root, color_resolver);
     // Theme fallback fonts: the resolver supplies the theme's major/minor Latin
     // faces (pptx keys them `+mj-lt` / `+mn-lt` in its color+font map). None
     // when the theme lacks a fontScheme. The renderer uses these when a chart
@@ -8343,6 +8406,9 @@ pub fn parse_chart_part_with_references(
         legend_font_color,
         legend_font_size_hpt,
         legend_font_bold,
+        legend_fill_color,
+        legend_line_color,
+        legend_line_width_emu,
         theme_major_font_latin,
         theme_minor_font_latin,
         // ChartModel fields the legacy pptx `<c:chart>` path leaves unset
@@ -8618,6 +8684,9 @@ mod tests {
             legend_font_color: None,
             legend_font_size_hpt: None,
             legend_font_bold: None,
+            legend_fill_color: None,
+            legend_line_color: None,
+            legend_line_width_emu: None,
             theme_major_font_latin: None,
             theme_minor_font_latin: None,
             date1904: false,
@@ -9625,6 +9694,115 @@ mod tests {
         assert_eq!(face.as_deref(), Some("Calibri"));
         assert_eq!(size, Some(1100));
         assert_eq!(bold, Some(true));
+    }
+
+    #[test]
+    fn classic_series_data_labels_do_not_enable_unlabelled_sibling_series() {
+        let xml = format!(
+            r#"<c:chartSpace xmlns:c="{C_NS}" xmlns:a="{A_NS}"><c:chart><c:plotArea>
+              <c:barChart><c:barDir val="col"/><c:grouping val="clustered"/>
+                <c:ser><c:idx val="0"/><c:val><c:numLit><c:pt idx="0"><c:v>8</c:v></c:pt></c:numLit></c:val>
+                  <c:dLbls><c:txPr><a:p><a:pPr><a:defRPr b="0"/></a:pPr></a:p></c:txPr><c:showVal val="1"/></c:dLbls>
+                </c:ser>
+                <c:ser><c:idx val="1"/><c:val><c:numLit><c:pt idx="0"><c:v>7</c:v></c:pt></c:numLit></c:val></c:ser>
+              </c:barChart></c:plotArea></c:chart></c:chartSpace>"#,
+        );
+        let model = parse_chart_part(chart_space_of(&xml).root_element(), &FixtureResolver)
+            .expect("bar chart parses");
+
+        assert!(
+            !model.show_data_labels,
+            "series-local dLbls is not chart-wide"
+        );
+        assert_eq!(
+            model.series[0]
+                .series_data_labels
+                .as_ref()
+                .map(|d| d.show_val),
+            Some(true)
+        );
+        assert_eq!(
+            model.series[0]
+                .series_data_labels
+                .as_ref()
+                .and_then(|d| d.font_bold),
+            Some(false)
+        );
+        assert!(model.series[1].series_data_labels.is_none());
+    }
+
+    #[test]
+    fn classic_chart_group_label_style_does_not_inherit_the_first_series_style() {
+        let xml = format!(
+            r#"<c:chartSpace xmlns:c="{C_NS}" xmlns:a="{A_NS}"><c:chart><c:plotArea>
+              <c:lineChart><c:grouping val="standard"/>
+                <c:ser><c:idx val="0"/><c:val><c:numLit><c:pt idx="0"><c:v>8</c:v></c:pt></c:numLit></c:val>
+                  <c:dLbls><c:numFmt formatCode="0.0"/><c:txPr><a:p><a:pPr><a:defRPr sz="800" b="0">
+                    <a:solidFill><a:schemeClr val="accent1"/></a:solidFill><a:latin typeface="Series Face"/>
+                  </a:defRPr></a:pPr></a:p></c:txPr><c:showVal val="1"/></c:dLbls>
+                </c:ser>
+                <c:dLbls><c:numFmt formatCode="0.00"/><c:txPr><a:p><a:pPr><a:defRPr sz="1200" b="1">
+                  <a:solidFill><a:schemeClr val="accent2"/></a:solidFill><a:latin typeface="Group Face"/>
+                </a:defRPr></a:pPr></a:p></c:txPr><c:showVal val="1"/></c:dLbls>
+              </c:lineChart></c:plotArea></c:chart></c:chartSpace>"#,
+        );
+        let model = parse_chart_part(chart_space_of(&xml).root_element(), &FixtureResolver)
+            .expect("line chart parses");
+
+        assert!(model.show_data_labels);
+        assert_eq!(model.data_label_format_code.as_deref(), Some("0.00"));
+        assert_eq!(model.data_label_font_size_hpt, Some(1200));
+        assert_eq!(model.data_label_font_bold, Some(true));
+        assert_eq!(model.data_label_font_color.as_deref(), Some("ED7D31"));
+        assert_eq!(model.data_label_font_face.as_deref(), Some("Group Face"));
+        let local = model.series[0]
+            .series_data_labels
+            .as_ref()
+            .expect("series-local label style is preserved");
+        assert_eq!(local.format_code.as_deref(), Some("0.0"));
+        assert_eq!(local.font_size_hpt, Some(800));
+        assert_eq!(local.font_bold, Some(false));
+        assert_eq!(local.font_color.as_deref(), Some("4472C4"));
+        assert_eq!(local.font_face.as_deref(), Some("Series Face"));
+    }
+
+    #[test]
+    fn classic_legend_frame_fill_and_outline_are_preserved() {
+        struct TransformAwareLegendResolver;
+        impl ColorResolver for TransformAwareLegendResolver {
+            fn resolve_solid_fill(&self, node: Node) -> Option<String> {
+                FixtureResolver.resolve_solid_fill(node)
+            }
+
+            fn resolve_shape_fill(&self, parent: Node) -> Option<String> {
+                match parent.tag_name().name() {
+                    "spPr" => Some("DDEEFF".to_string()),
+                    "ln" => Some("808080".to_string()),
+                    _ => None,
+                }
+            }
+        }
+        let xml = format!(
+            r#"<c:chartSpace xmlns:c="{C_NS}" xmlns:a="{A_NS}"><c:chart>
+              <c:plotArea><c:barChart><c:barDir val="col"/><c:ser><c:idx val="0"/>
+                <c:val><c:numLit><c:pt idx="0"><c:v>1</c:v></c:pt></c:numLit></c:val>
+              </c:ser></c:barChart></c:plotArea>
+              <c:legend><c:legendPos val="r"/><c:spPr>
+                <a:solidFill><a:schemeClr val="accent1"><a:lumMod val="20000"/><a:lumOff val="80000"/></a:schemeClr></a:solidFill>
+                <a:ln w="3175"><a:solidFill><a:srgbClr val="808080"/></a:solidFill></a:ln>
+              </c:spPr></c:legend>
+            </c:chart></c:chartSpace>"#,
+        );
+        let model = parse_chart_part(
+            chart_space_of(&xml).root_element(),
+            &TransformAwareLegendResolver,
+        )
+        .expect("legend chart parses");
+        let serialized = serde_json::to_value(model).expect("chart serializes");
+
+        assert_eq!(serialized["legendFillColor"], "DDEEFF");
+        assert_eq!(serialized["legendLineColor"], "808080");
+        assert_eq!(serialized["legendLineWidthEmu"], 3175);
     }
 
     #[test]
@@ -10671,7 +10849,14 @@ mod tests {
         assert_eq!(m.chart_type, "doughnut");
         assert_eq!(m.hole_size, Some(45));
         assert_eq!(m.first_slice_angle, Some(90));
-        assert!(m.show_data_labels);
+        assert!(!m.show_data_labels);
+        assert_eq!(
+            m.series[0]
+                .series_data_labels
+                .as_ref()
+                .map(|labels| labels.show_percent),
+            Some(true)
+        );
 
         let colors = m.series[0]
             .data_point_colors

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -60,6 +60,7 @@ export interface ChartDataLabelOverride {
     position?: string;
     fontColor?: string;
     fontSizeHpt?: number;
+    fontFace?: string;
     fontBold?: boolean;
     formatCode?: string;
     separator?: string;
@@ -297,6 +298,9 @@ export interface ChartModel {
     legendFontColor?: string | null;
     legendFontSizeHpt?: number | null;
     legendFontBold?: boolean | null;
+    legendFillColor?: string | null;
+    legendLineColor?: string | null;
+    legendLineWidthEmu?: number | null;
     themeMajorFontLatin?: string | null;
     themeMinorFontLatin?: string | null;
     chartBorderColor?: string | null;
@@ -439,6 +443,7 @@ export interface ChartSeriesDataLabels {
     separator?: string;
     fontBold?: boolean;
     fontSizeHpt?: number;
+    fontFace?: string;
     labelBox?: ChartLabelBox;
     showLeaderLines?: boolean;
     leaderLineColor?: string;

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.79.0",
+  "version": "0.79.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity local viewer for Office files (.docx / .xlsx / .pptx), powered by Rust/WASM and Canvas. Optional MCP integration can share requested context with an AI agent.",
-  "version": "0.79.0",
+  "version": "0.79.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -171,6 +171,7 @@ export interface ChartDataLabelOverride {
     position?: string;
     fontColor?: string;
     fontSizeHpt?: number;
+    fontFace?: string;
     fontBold?: boolean;
     formatCode?: string;
     separator?: string;
@@ -397,6 +398,9 @@ export interface ChartModel {
     legendFontColor?: string | null;
     legendFontSizeHpt?: number | null;
     legendFontBold?: boolean | null;
+    legendFillColor?: string | null;
+    legendLineColor?: string | null;
+    legendLineWidthEmu?: number | null;
     themeMajorFontLatin?: string | null;
     themeMinorFontLatin?: string | null;
     chartBorderColor?: string | null;
@@ -539,6 +543,7 @@ export interface ChartSeriesDataLabels {
     separator?: string;
     fontBold?: boolean;
     fontSizeHpt?: number;
+    fontFace?: string;
     labelBox?: ChartLabelBox;
     showLeaderLines?: boolean;
     leaderLineColor?: string;
@@ -1203,6 +1208,7 @@ export function resolveSharedStrings(ws: Worksheet, sharedStrings: SharedString[
 export interface Row {
     index: number;
     height: number | null;
+    customHeight?: boolean;
     cells: Cell[];
     outlineLevel?: number;
     collapsed?: boolean;
@@ -1537,6 +1543,7 @@ export interface Worksheet {
     colHidden?: Record<number, boolean>;
     defaultColWidth: number;
     defaultRowHeight: number;
+    defaultRowHeightCustom?: boolean;
     mergeCells: MergeCell[];
     freezeRows: number;
     freezeCols: number;

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.79.0",
+  "version": "0.79.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -705,6 +705,7 @@ mod retained_model_limit_tests {
         Row {
             index,
             height: None,
+            custom_height: false,
             cells,
             outline_level: 0,
             collapsed: false,
@@ -1501,6 +1502,7 @@ fn parse_projected_worksheet(
     // both this default and per-row `<row ht="…">` values share the
     // same units across the parser/renderer boundary.
     let mut default_row_height = 15.0;
+    let mut default_row_height_custom = false;
     let mut rows_hidden_by_default = false;
     let mut conditional_formats: Vec<ConditionalFormat> = Vec::new();
     let mut show_zeros = true;
@@ -1655,6 +1657,7 @@ fn parse_projected_worksheet(
                 {
                     default_row_height = v;
                 }
+                default_row_height_custom = attr_bool(&node, "customHeight").unwrap_or(false);
                 // ECMA-376 §18.3.1.81: zeroHeight makes unspecified rows hidden
                 // by default. Keep this fact separate from defaultRowHeight:
                 // explicit, non-hidden rows still use the authored default
@@ -2180,6 +2183,7 @@ fn parse_projected_worksheet(
         col_hidden,
         default_col_width,
         default_row_height,
+        default_row_height_custom,
         merge_cells,
         freeze_rows,
         freeze_cols,
@@ -4112,6 +4116,38 @@ mod sheet_view_tests {
         );
         let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
         assert_eq!(ws.default_row_height, 0.0);
+    }
+
+    #[test]
+    fn sheet_format_preserves_manual_default_row_height_fact() {
+        let automatic_xml = format!(
+            r#"<worksheet xmlns="{NS}"><sheetFormatPr defaultRowHeight="15"/><sheetData/></worksheet>"#
+        );
+        let manual_xml = format!(
+            r#"<worksheet xmlns="{NS}"><sheetFormatPr defaultRowHeight="30" customHeight="1"/><sheetData/></worksheet>"#
+        );
+        let (automatic, _) =
+            parse_worksheet(&automatic_xml, &[], &[], "Automatic").expect("worksheet parses");
+        let (manual, _) =
+            parse_worksheet(&manual_xml, &[], &[], "Manual").expect("worksheet parses");
+
+        assert!(!automatic.default_row_height_custom);
+        assert!(manual.default_row_height_custom);
+        assert_eq!(manual.default_row_height, 30.0);
+        assert!(
+            serde_json::to_value(automatic)
+                .expect("serializes")
+                .get("defaultRowHeightCustom")
+                .is_none(),
+            "the false schema default stays wire-compatible"
+        );
+        assert_eq!(
+            serde_json::to_value(manual)
+                .expect("serializes")
+                .get("defaultRowHeightCustom")
+                .and_then(|value| value.as_bool()),
+            Some(true)
+        );
     }
 
     #[test]

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -118,6 +118,10 @@ pub struct Worksheet {
     pub col_hidden: BTreeMap<u32, bool>,
     pub default_col_width: f64,
     pub default_row_height: f64,
+    /// `<sheetFormatPr customHeight>` (§18.3.1.81): the sheet-wide default row
+    /// height was manually set. Omitted when false, the schema default.
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub default_row_height_custom: bool,
     pub merge_cells: Vec<MergeCell>,
     pub freeze_rows: u32,
     pub freeze_cols: u32,
@@ -236,6 +240,7 @@ impl Worksheet {
             col_hidden: BTreeMap::new(),
             default_col_width: 0.0,
             default_row_height: 0.0,
+            default_row_height_custom: false,
             merge_cells: Vec::new(),
             freeze_rows: 0,
             freeze_cols: 0,
@@ -1341,6 +1346,11 @@ impl Default for OutlinePr {
 pub struct Row {
     pub index: u32,
     pub height: Option<f64>,
+    /// `<row customHeight>` (§18.3.1.73): the row height was manually set.
+    /// Retained even when producers omit `ht`, because Office then
+    /// keeps the sheet default rather than applying display-time auto-fit.
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub custom_height: bool,
     pub cells: Vec<Cell>,
     /// Outline (grouping) depth of this row, 0-7 (ECMA-376 §18.3.1.73
     /// `<row outlineLevel>`). `0` (the ungrouped default) is omitted from JSON

--- a/packages/xlsx/parser/src/worksheet_projector.rs
+++ b/packages/xlsx/parser/src/worksheet_projector.rs
@@ -482,6 +482,7 @@ fn parse_row_node(
             .and_then(|s| s.parse::<f64>().ok())
             .filter(|value| value.is_finite() && *value >= 0.0)
     };
+    let custom_height = attr_bool(node, "customHeight").unwrap_or(false);
     let outline_level = node
         .attribute("outlineLevel")
         .and_then(|s| s.parse::<u8>().ok())
@@ -493,6 +494,7 @@ fn parse_row_node(
     Ok(Row {
         index: row_idx,
         height,
+        custom_height,
         cells,
         outline_level,
         collapsed,
@@ -1751,6 +1753,29 @@ mod worksheet_streaming_tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn row_height_presence_distinguishes_authored_height_from_auto_fit() {
+        let xml = r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+          <sheetData>
+            <row r="1"><c r="A1" t="inlineStr"><is><t>automatic</t></is></c></row>
+            <row r="2" ht="30" customHeight="1"><c r="A2" t="inlineStr"><is><t>manual</t></is></c></row>
+            <row r="3" ht="24" customHeight="0"><c r="A3" t="inlineStr"><is><t>authored ht still wins</t></is></c></row>
+            <row r="4" customHeight="1"><c r="A4" t="inlineStr"><is><t>manual default</t></is></c></row>
+          </sheetData>
+        </worksheet>"#;
+        let streamed = stream_sheet_data(xml, &[], &[]).expect("rows project");
+        assert_eq!(streamed.rows[0].height, None);
+        assert_eq!(streamed.rows[1].height, Some(30.0));
+        // §18.3.1.73: customHeight describes how the height was set; it does
+        // not erase an authored ht value when false.
+        assert_eq!(streamed.rows[2].height, Some(24.0));
+        assert!(!streamed.rows[0].custom_height);
+        assert!(streamed.rows[1].custom_height);
+        assert!(!streamed.rows[2].custom_height);
+        assert_eq!(streamed.rows[3].height, None);
+        assert!(streamed.rows[3].custom_height);
     }
 
     struct CountingRead<'a> {

--- a/packages/xlsx/parser/src/worksheet_reference.rs
+++ b/packages/xlsx/parser/src/worksheet_reference.rs
@@ -874,6 +874,7 @@ mod tests {
         let rows = vec![Row {
             index: 1,
             height: None,
+            custom_height: false,
             cells: vec![
                 crate::Cell {
                     col: 1,

--- a/packages/xlsx/src/auto-row-height.test.ts
+++ b/packages/xlsx/src/auto-row-height.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyAutoRowHeights,
+  getGridGeometryForWorksheet,
+  invalidateAutoRowHeights,
+  markAutoRowHeightsPrepared,
+  rowHeightToPx,
+} from './renderer.js';
+import { worksheetWithAutoRowHeights } from './render-orchestrator.js';
+import { GridGeometry } from './internal/grid-geometry.js';
+import type { CellFont, CellXf, Styles, Worksheet } from './types.js';
+
+function measurementContext(): CanvasRenderingContext2D {
+  let font = '15px sans-serif';
+  return {
+    canvas: { width: 1, height: 1 },
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    measureText: (text: string) => ({ width: [...text].length * 7 }) as TextMetrics,
+    save() {},
+    restore() {},
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function countingMeasurementContext(): {
+  ctx: CanvasRenderingContext2D;
+  count: () => number;
+} {
+  let calls = 0;
+  const ctx = measurementContext();
+  ctx.measureText = (text: string) => {
+    calls++;
+    return { width: [...text].length * 7 } as TextMetrics;
+  };
+  return { ctx, count: () => calls };
+}
+
+const fonts: CellFont[] = [
+  { bold: false, italic: false, underline: false, strike: false, size: 11, color: null, name: 'Calibri' },
+  { bold: false, italic: false, underline: false, strike: false, size: 20, color: null, name: 'Calibri' },
+  { bold: false, italic: false, underline: false, strike: false, size: 11, color: null, name: 'Meiryo' },
+];
+
+const xf = (fontId: number, over: Partial<CellXf> = {}): CellXf => ({
+  fontId,
+  fillId: 0,
+  borderId: 0,
+  numFmtId: 0,
+  alignH: 'left',
+  alignV: 'top',
+  wrapText: false,
+  ...over,
+});
+
+const styles: Styles = {
+  fonts,
+  fills: [],
+  borders: [],
+  cellXfs: [
+    xf(0),
+    xf(0, { wrapText: true }),
+    xf(1),
+    xf(0, { textRotation: 90 }),
+    xf(2, { textRotation: 255 }),
+    { ...xf(0, { wrapText: true }), numFmtId: 164 },
+    { ...xf(0, { wrapText: true }), numFmtId: 165 },
+    xf(0, { textRotation: 1 }),
+  ],
+  numFmts: [
+    { numFmtId: 164, formatCode: '"one two three"' },
+    { numFmtId: 165, formatCode: '"漢字"' },
+  ],
+  dxfs: [],
+};
+
+function worksheet(): Worksheet {
+  return {
+    name: 'auto height',
+    rows: [
+      {
+        index: 1,
+        height: null,
+        cells: [{ row: 1, col: 1, styleIndex: 1, value: { type: 'text', text: 'abcdefghi klmnopqrst' } }],
+      },
+      {
+        index: 2,
+        height: 15,
+        cells: [{ row: 2, col: 1, styleIndex: 1, value: { type: 'text', text: 'abcdefghi klmnopqrst' } }],
+      },
+      {
+        index: 3,
+        height: null,
+        cells: [{ row: 3, col: 1, styleIndex: 1, value: { type: 'text', text: 'abcdefghi klmnopqrst' } }],
+      },
+      {
+        index: 4,
+        height: null,
+        cells: [{ row: 4, col: 1, styleIndex: 2, value: { type: 'text', text: 'large' } }],
+      },
+      {
+        index: 5,
+        height: null,
+        cells: [{ row: 5, col: 1, styleIndex: 3, value: { type: 'text', text: 'rotated text' } }],
+      },
+      {
+        index: 6,
+        height: null,
+        cells: [{
+          row: 6,
+          col: 1,
+          styleIndex: 1,
+          value: {
+            type: 'text',
+            text: 'large rich tail',
+            runs: [
+              { text: 'large ', font: { ...fonts[1] } },
+              { text: 'rich tail' },
+            ],
+          },
+        }],
+      },
+    ],
+    colWidths: { 1: 10 },
+    rowHeights: { 2: 15 },
+    defaultColWidth: 8.43,
+    defaultRowHeight: 15,
+    mergeCells: [{ top: 3, left: 1, bottom: 3, right: 2 }],
+    freezeRows: 0,
+    freezeCols: 0,
+    conditionalFormats: [],
+    images: [],
+    charts: [],
+  };
+}
+
+describe('XLSX automatic row height (ECMA-376 §18.3.1.73 / Office auto-fit)', () => {
+  it('fits wrapped, rich, large, and rotated text while preserving explicit and merged rows', () => {
+    const ws = worksheet();
+    expect(applyAutoRowHeights(measurementContext(), ws, styles)).toBe(true);
+
+    // 19 glyphs × 7px wrap into two lines in the 74px content band:
+    // 2 × 18px Calibri line boxes + 4px top/bottom inset = 40px = 30pt.
+    expect(ws.rowHeights[1]).toBe(30);
+    expect(ws.rowHeights[2]).toBe(15); // authored row@ht always wins
+    expect(ws.rowHeights[3]).toBeUndefined(); // merged cells do not drive auto-fit
+    expect(ws.rowHeights[4]).toBeGreaterThan(15); // single large-font line
+    expect(ws.rowHeights[5]).toBeGreaterThan(15); // rotated width becomes vertical extent
+    expect(ws.rowHeights[6]).toBeGreaterThan(ws.rowHeights[1]); // rich max run metrics
+
+    const rowAxis = getGridGeometryForWorksheet(ws).row;
+    expect(rowAxis.sizeOf(1)).toBe(rowHeightToPx(30));
+    expect(rowAxis.sizeOf(3)).toBe(rowHeightToPx(15));
+    expect(applyAutoRowHeights(measurementContext(), ws, styles)).toBe(false);
+  });
+
+  it('keeps a wrap-enabled value that still fits one line at the default height', () => {
+    const ws = worksheet();
+    ws.rows = [{
+      index: 1,
+      height: null,
+      cells: [{ row: 1, col: 1, styleIndex: 1, value: { type: 'text', text: 'short' } }],
+    }];
+    ws.rowHeights = {};
+
+    expect(applyAutoRowHeights(measurementContext(), ws, styles)).toBe(false);
+    expect(ws.rowHeights).toEqual({});
+  });
+
+  it('refits after a column-width change without replacing manual row overrides', () => {
+    const ws = worksheet();
+    expect(applyAutoRowHeights(measurementContext(), ws, styles)).toBe(true);
+    expect(ws.rowHeights[1]).toBe(30);
+
+    ws.colWidths[1] = 30;
+    invalidateAutoRowHeights(ws, [2]);
+    expect(applyAutoRowHeights(measurementContext(), ws, styles)).toBe(true);
+    expect(ws.rowHeights[1]).toBeUndefined();
+    expect(ws.rowHeights[2]).toBe(15);
+
+    const manual = worksheet();
+    applyAutoRowHeights(measurementContext(), manual, styles);
+    const sameNumericHeight = manual.rowHeights[1];
+    invalidateAutoRowHeights(manual, [1]);
+    applyAutoRowHeights(measurementContext(), manual, styles);
+    expect(manual.rowHeights[1]).toBe(sameNumericHeight);
+  });
+
+  it('does not measure ordinary default-height cells in a dense sheet', () => {
+    const ws = worksheet();
+    ws.rows = Array.from({ length: 1_000 }, (_, index) => ({
+      index: index + 1,
+      height: null,
+      cells: [{
+        row: index + 1,
+        col: 1,
+        styleIndex: 0,
+        value: { type: 'number' as const, number: index },
+      }],
+    }));
+    ws.rowHeights = {};
+    ws.mergeCells = [];
+    const measured = countingMeasurementContext();
+
+    expect(applyAutoRowHeights(measured.ctx, ws, styles)).toBe(false);
+    expect(measured.count()).toBe(0);
+  });
+
+  it('does not grow a Normal-font single line because the default row rounds down to 19px', () => {
+    const ws = worksheet();
+    ws.defaultRowHeight = 14.25;
+    ws.defaultFontFamily = 'Calibri';
+    ws.defaultFontSize = 11;
+    ws.rows = [{
+      index: 1,
+      height: null,
+      cells: [{ row: 1, col: 1, styleIndex: 0, value: { type: 'text', text: 'ordinary' } }],
+    }];
+    ws.rowHeights = {};
+    ws.mergeCells = [];
+    const measured = countingMeasurementContext();
+
+    expect(rowHeightToPx(ws.defaultRowHeight)).toBe(19);
+    expect(applyAutoRowHeights(measured.ctx, ws, styles)).toBe(false);
+    expect(ws.rowHeights).toEqual({});
+    expect(measured.count()).toBe(0);
+  });
+
+  it('uses the tallest rich run for an unwrapped automatic row', () => {
+    const ws = worksheet();
+    ws.rows = [{
+      index: 1,
+      height: null,
+      cells: [{
+        row: 1,
+        col: 1,
+        styleIndex: 0,
+        value: {
+          type: 'text',
+          text: 'ordinary large',
+          runs: [
+            { text: 'ordinary ' },
+            { text: 'large', font: { ...fonts[1] } },
+          ],
+        },
+      }],
+    }];
+    ws.rowHeights = {};
+    ws.mergeCells = [];
+
+    expect(applyAutoRowHeights(measurementContext(), ws, styles)).toBe(true);
+    expect(ws.rowHeights[1]).toBeGreaterThan(15);
+  });
+
+  it('preserves a manually authored sheet-wide default row height', () => {
+    const ws = worksheet();
+    ws.defaultRowHeight = 30;
+    ws.defaultRowHeightCustom = true;
+    ws.rowHeights = {};
+    ws.mergeCells = [];
+
+    expect(applyAutoRowHeights(measurementContext(), ws, styles)).toBe(false);
+    expect(ws.rowHeights).toEqual({});
+    expect(getGridGeometryForWorksheet(ws).row.sizeOf(1)).toBe(rowHeightToPx(30));
+  });
+
+  it('preserves a row marked customHeight even when ht is absent', () => {
+    const ws = worksheet();
+    ws.rows = [{ ...ws.rows[0], customHeight: true }];
+    ws.rowHeights = {};
+    ws.mergeCells = [];
+
+    expect(applyAutoRowHeights(measurementContext(), ws, styles)).toBe(false);
+    expect(ws.rowHeights).toEqual({});
+  });
+
+  it('uses the same compact glyph slots as paint for stacked text', () => {
+    const ws = worksheet();
+    ws.rows = [{
+      index: 1,
+      height: null,
+      cells: [{ row: 1, col: 1, styleIndex: 4, value: { type: 'text', text: '縦書' } }],
+    }];
+    ws.rowHeights = {};
+    ws.mergeCells = [];
+
+    expect(applyAutoRowHeights(measurementContext(), ws, styles)).toBe(true);
+    expect(ws.rowHeights[1]).toBe(27);
+  });
+
+  it('reserves conditional-format icon width when wrapping', () => {
+    const base = worksheet();
+    base.colWidths = { 1: 13 };
+    base.rows = [{
+      index: 1,
+      height: null,
+      cells: [{ row: 1, col: 1, styleIndex: 5, value: { type: 'number', number: 123456 } }],
+    }];
+    base.rowHeights = {};
+    base.mergeCells = [];
+    const withIcon: Worksheet = {
+      ...base,
+      rows: base.rows.map((row) => ({ ...row, cells: row.cells.map((cell) => ({ ...cell })) })),
+      rowHeights: {},
+      conditionalFormats: [{
+        sqref: [{ top: 1, left: 1, bottom: 1, right: 1 }],
+        rules: [{
+          type: 'iconSet',
+          iconSet: '3TrafficLights1',
+          cfvos: [
+            { kind: 'percent', value: '0' },
+            { kind: 'percent', value: '33' },
+            { kind: 'percent', value: '67' },
+          ],
+          reverse: false,
+          priority: 1,
+        }],
+      }],
+    };
+
+    applyAutoRowHeights(measurementContext(), base, styles);
+    applyAutoRowHeights(measurementContext(), withIcon, styles);
+    expect(withIcon.rowHeights[1]).toBeGreaterThan(base.rowHeights[1] ?? base.defaultRowHeight);
+  });
+
+  it('preserves the caller-authoritative MDW on a render-local auto-height projection', () => {
+    const source = worksheet();
+    source.rowHeights = {};
+    source.mergeCells = [];
+    GridGeometry.forWorksheet(source, 13);
+
+    const projection = worksheetWithAutoRowHeights(measurementContext(), source, styles);
+
+    expect(projection).not.toBe(source);
+    expect(source.rowHeights).toEqual({});
+    expect(projection.rowHeights[1]).toBeDefined();
+    expect(getGridGeometryForWorksheet(projection).maximumDigitWidth).toBe(13);
+  });
+
+  it('solves icon wrapping against the rounded row height used by paint', () => {
+    const ws = worksheet();
+    ws.rows = [{
+      index: 1,
+      height: null,
+      cells: [
+        { row: 1, col: 1, styleIndex: 6, value: { type: 'number', number: 1 } },
+        { row: 1, col: 2, styleIndex: 7, value: { type: 'text', text: 'driver' } },
+      ],
+    }];
+    ws.colWidths = { 1: 4.375, 2: 20 };
+    ws.rowHeights = {};
+    ws.mergeCells = [];
+    ws.conditionalFormats = [{
+      sqref: [{ top: 1, left: 1, bottom: 1, right: 1 }],
+      rules: [{
+        type: 'iconSet',
+        iconSet: '3TrafficLights1',
+        cfvos: [
+          { kind: 'percent', value: '0' },
+          { kind: 'percent', value: '33' },
+          { kind: 'percent', value: '67' },
+        ],
+        reverse: false,
+        priority: 1,
+      }],
+    }];
+    GridGeometry.forWorksheet(ws, 8); // 4.375 × 8 MDW = 35px
+
+    expect(applyAutoRowHeights(measurementContext(), ws, styles)).toBe(true);
+    expect(rowHeightToPx(ws.rowHeights[1])).toBeGreaterThanOrEqual(40);
+  });
+
+  it('does not rescan a worker projection whose viewer supplied derived row heights', () => {
+    const workerProjection = worksheet();
+    workerProjection.rowHeights = { 1: 30 };
+    const measured = countingMeasurementContext();
+    markAutoRowHeightsPrepared(workerProjection);
+
+    const rendered = worksheetWithAutoRowHeights(measured.ctx, workerProjection, styles);
+
+    expect(rendered).toBe(workerProjection);
+    expect(rendered.rowHeights[1]).toBe(30);
+    expect(measured.count()).toBe(0);
+  });
+});

--- a/packages/xlsx/src/render-orchestrator.ts
+++ b/packages/xlsx/src/render-orchestrator.ts
@@ -24,6 +24,9 @@ import {
   worksheetHasUncachedMath,
   imageCacheKey,
   getGridGeometryForWorksheet,
+  applyAutoRowHeights,
+  hasPreparedAutoRowHeights,
+  inheritSheetRenderCache,
   HEADER_W,
   HEADER_H,
 } from './renderer.js';
@@ -378,6 +381,35 @@ export interface RenderDeps {
   regionMap?: ChartRegionMapRenderer;
 }
 
+const autoHeightProjectionCache = new WeakMap<Worksheet, Worksheet>();
+
+export function worksheetWithAutoRowHeights(
+  ctx: CanvasRenderingContext2D,
+  source: Worksheet,
+  styles: ParsedWorkbook['styles'],
+): Worksheet {
+  if (hasPreparedAutoRowHeights(source)) return source;
+  const cached = autoHeightProjectionCache.get(source);
+  if (cached) return cached;
+  const projection: Worksheet = {
+    ...source,
+    rowHeights: { ...source.rowHeights },
+  };
+  inheritSheetRenderCache(source, projection);
+  // The viewer/main realm supplies the authoritative Normal-font MDW used by
+  // hit-testing and spacer geometry. Preserve it across the render-local clone
+  // so worker/direct auto-fit wraps at the exact same column pixels.
+  const mdw = getGridGeometryForWorksheet(source).maximumDigitWidth;
+  GridGeometry.forWorksheet(projection, mdw);
+  applyAutoRowHeights(ctx, projection, styles);
+  // applyAutoRowHeights invalidates geometry after deriving row sizes; seed the
+  // rebuilt row axis with the same authoritative MDW rather than remeasuring in
+  // another Canvas realm.
+  GridGeometry.forWorksheet(projection, mdw);
+  autoHeightProjectionCache.set(source, projection);
+  return projection;
+}
+
 /** The full per-frame orchestration: preload uncached images, pre-rasterize
  *  equations, size the target, draw. Shared verbatim by the main-thread
  *  XlsxWorkbook and the render worker.
@@ -412,7 +444,10 @@ async function renderWorksheetViewportLeased(
   viewport: ViewportRange,
   opts: RenderViewportOptions = {},
 ): Promise<void> {
-  const { ws, styles } = deps;
+  const styles = deps.styles;
+  const measurementCtx = target.getContext('2d') as CanvasRenderingContext2D | null;
+  if (!measurementCtx) throw new Error('XLSX render target does not provide a 2-D canvas context');
+  const ws = worksheetWithAutoRowHeights(measurementCtx, deps.ws, styles);
   const rawW = isHTMLCanvas(target) ? (target.clientWidth || 800) : target.width;
   const rawH = isHTMLCanvas(target) ? (target.clientHeight || 600) : target.height;
   const width = opts.width ?? rawW;

--- a/packages/xlsx/src/render-worker.ts
+++ b/packages/xlsx/src/render-worker.ts
@@ -28,7 +28,7 @@ import {
   type PullSessionResponse,
 } from '@silurus/ooxml-core/worker';
 import { renderWorksheetViewport } from './render-orchestrator.js';
-import { inheritSheetRenderCache } from './renderer.js';
+import { inheritSheetRenderCache, markAutoRowHeightsPrepared } from './renderer.js';
 import { XLSX_GOOGLE_FONTS, xlsxFontPreloadNames } from './google-fonts.js';
 import { resolveSharedStringRows } from './shared-strings.js';
 import {
@@ -231,6 +231,9 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest | PullSessionCommand
       );
       const renderWorksheet = projected.worksheet;
       if (projected.created) inheritSheetRenderCache(ws, renderWorksheet);
+      if (req.viewProjection?.autoRowHeightsPrepared) {
+        markAutoRowHeightsPrepared(renderWorksheet);
+      }
       const maximumDigitWidth = req.layoutMetrics?.maximumDigitWidth;
       if (maximumDigitWidth !== undefined) {
         if (!Number.isFinite(maximumDigitWidth) || maximumDigitWidth <= 0) {

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -11,7 +11,7 @@ import { placePhoneticRuns } from './phonetic.js';
 import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, isUax14NoBreakPair, containsSeaScript, isGraphemeFillText, seaMixedBreakOffsets, fitSeaWordPrefix, graphemeClusterOffsets, xlsxBorderDashArray, drawImageCropped, hexToRgba, intendedSingleLinePx, verticalTrLongMark, verticalVertGlyphReachable, applyStroke, resolveFill, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValueWithColor } from './number-format.js';
-import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
+import { type CfContext, type CfResult, compileCf, evaluateCf } from './conditional-format.js';
 import { computeLineVisualOrder, cellBaseRtl, resolveCellBidi } from './bidi-line.js';
 import { formatA1, parseA1 } from './a1.js';
 import { drawStackedVerticalChar } from './vertical-text.js';
@@ -1403,49 +1403,18 @@ function drawMultiLineRichText(
 ): void {
   const { alignV, cy, cellH, paddingY } = geom;
 
-  // Split runs into lines at LF. A run "A\nB" yields "A" on the current line and
-  // "B" on a new one; an empty piece (consecutive / leading / trailing LF) adds
-  // no segment but the line still exists, so a blank line is preserved.
-  const lineRuns: Run[][] = [[]];
-  for (const run of runs) {
-    const parts = run.text.split('\n');
-    for (let p = 0; p < parts.length; p++) {
-      if (p > 0) lineRuns.push([]);
-      if (parts[p] !== '') lineRuns[lineRuns.length - 1].push({ ...run, text: parts[p] });
-    }
-  }
-
-  // Per-line height source (pt) + the family of that height run. A text line uses
-  // the max run size on it; a blank line inherits the nearest preceding text
-  // run's size AND family — the same seed `layoutRichTextLines` / `drawShapeText`
-  // use for blank lines (PR #585). The family drives the single-line-height floor.
-  let lastTextPt = baseFont.size;
-  let lastTextFamily: string | null = baseFont.name;
-  const lineSizes = lineRuns.map((lr) => {
-    if (lr.length === 0) return { pt: lastTextPt || DEFAULT_FONT_SIZE, family: lastTextFamily };
-    let m = 0;
-    let family: string | null = null;
-    for (const r of lr) {
-      const rf = applyRunFont(baseFont, r);
-      if (rf.size > m) { m = rf.size; family = rf.name; }
-      lastTextPt = rf.size; // nearest preceding text size, for a following blank line
-      lastTextFamily = rf.name;
-    }
-    return { pt: m, family };
-  });
-  const lineHeights = lineSizes.map((s) => vMetricPx(s.pt, cs, 1.2, s.family ?? undefined));
-  const totalH = lineHeights.reduce((a, b) => a + b, 0);
+  const lines = richHardBreakLineMetrics(runs, baseFont, cs);
+  const totalH = lines.reduce((sum, line) => sum + line.heightPx, 0);
 
   let yy: number;
   if (alignV === 'top') yy = cy + paddingY;
   else if (alignV === 'center') yy = cy + (cellH - totalH) / 2;
   else yy = cy + cellH - totalH - paddingY;
 
-  for (let li = 0; li < lineRuns.length; li++) {
-    const lr = lineRuns[li];
+  for (const line of lines) {
     // A blank line draws nothing but still reserves its height.
-    if (lr.length > 0) drawRichLine(ctx, lr, baseFont, geom, cs, dpr, opts, yy, 'top');
-    yy += lineHeights[li];
+    if (line.runs.length > 0) drawRichLine(ctx, line.runs, baseFont, geom, cs, dpr, opts, yy, 'top');
+    yy += line.heightPx;
   }
 }
 
@@ -2960,6 +2929,7 @@ interface SheetRenderCache {
   cellMap: Map<string, Cell>;
   nonEmptyColsByRow: Map<number, readonly number[]>;
   cfContext: CfContext;
+  mergeAnchorSet: Set<string>;
   mergeSkipSet: Set<string>;
   autoFilterCells: Set<string>;
   hyperlinkMap: Map<string, string>;
@@ -2994,11 +2964,17 @@ export function getSheetRenderCache(worksheet: Worksheet): SheetRenderCache {
   // Merge skip-set is pure topology (no scaled sizes) so it is cacheable; the
   // anchor map's pixel sizes depend on cellScale and stay per-frame.
   const mergeSkipSet = new Set<string>();
+  const mergeAnchorSet = new Set<string>();
+  const mergeAnchorIdentity = coordinateIndexIdentity(
+    'worksheet-merge-anchor-index',
+    'index-merge-anchor-coordinates',
+  );
   const mergeIdentity = coordinateIndexIdentity(
     'worksheet-merge-skip-index',
     'expand-merged-cell-coordinates',
   );
   for (const mc of worksheet.mergeCells ?? []) {
+    addCoordinateIndexEntry(mergeAnchorSet, `${mc.top}:${mc.left}`, mergeAnchorIdentity);
     assertCoordinateRangeArea(mc, mergeIdentity, 1);
     for (let r = mc.top; r <= mc.bottom; r++) {
       for (let c = mc.left; c <= mc.right; c++) {
@@ -3047,6 +3023,7 @@ export function getSheetRenderCache(worksheet: Worksheet): SheetRenderCache {
     cellMap,
     nonEmptyColsByRow,
     cfContext: compileCf(worksheet, cellMap),
+    mergeAnchorSet,
     mergeSkipSet,
     autoFilterCells,
     hyperlinkMap,
@@ -3056,6 +3033,374 @@ export function getSheetRenderCache(worksheet: Worksheet): SheetRenderCache {
   };
   sheetRenderCache.set(worksheet, entry);
   return entry;
+}
+
+/** Worksheets whose absent row heights have already been resolved against the
+ * loaded document fonts and effective column widths. Kept outside the public
+ * model: parsed `row.height` / `rowHeights` continue to mean authored OOXML,
+ * while viewer-owned projections may carry the derived display heights. */
+interface AutoRowHeightState {
+  /** Derived point heights keyed by 1-based row. Used to distinguish an
+   * automatic value from a later user resize when column widths change. */
+  derived: Map<number, number>;
+}
+
+const autoRowHeightState = new WeakMap<Worksheet, AutoRowHeightState>();
+
+function effectiveMeasurementFont(
+  base: CellFont,
+  cf: CfResult,
+  tableStyle: TableCellStyle | undefined,
+  styles: Styles,
+): CellFont {
+  const dxfList = styles.dxfs ?? [];
+  const tableFontDxf = tableStyle
+    ? tableStyle.isHeader
+      ? dxfList[tableStyle.headerRowDxf ?? -1]
+      : tableStyle.isTotals
+        ? dxfList[tableStyle.totalRowDxf ?? -1]
+        : tableStyle.isLastCol && tableStyle.lastColumnDxf != null
+          ? dxfList[tableStyle.lastColumnDxf]
+          : tableStyle.isFirstCol && tableStyle.firstColumnDxf != null
+            ? dxfList[tableStyle.firstColumnDxf]
+            : tableStyle.stripeDxf != null
+              ? dxfList[tableStyle.stripeDxf]
+              : dxfList[tableStyle.wholeTableDxf ?? -1]
+    : undefined;
+  const tableBold = tableStyle
+    ? tableStyle.isCustom
+      ? !!tableFontDxf?.font?.bold
+      : tableStyle.isHeader || tableStyle.isTotals
+    : false;
+  const bold = base.bold || !!cf.fontBold || tableBold;
+  const italic = base.italic || !!cf.fontItalic;
+  return bold === base.bold && italic === base.italic
+    ? base
+    : { ...base, bold, italic };
+}
+
+function richHardBreakLineMetrics(
+  runs: Run[],
+  baseFont: CellFont,
+  cs: number,
+): Array<{ runs: Run[]; heightPx: number }> {
+  const lineRuns: Run[][] = [[]];
+  for (const run of runs) {
+    const parts = run.text.split('\n');
+    for (let index = 0; index < parts.length; index++) {
+      if (index > 0) lineRuns.push([]);
+      if (parts[index] !== '') lineRuns[lineRuns.length - 1].push({ ...run, text: parts[index] });
+    }
+  }
+
+  let lastTextPt = baseFont.size;
+  let lastTextFamily: string | null = baseFont.name;
+  return lineRuns.map((line) => {
+    if (line.length === 0) {
+      return {
+        runs: line,
+        heightPx: vMetricPx(lastTextPt || DEFAULT_FONT_SIZE, cs, 1.2, lastTextFamily ?? undefined),
+      };
+    }
+    let maxPt = 0;
+    let maxFamily: string | null = null;
+    for (const run of line) {
+      const font = applyRunFont(baseFont, run);
+      if (font.size > maxPt) {
+        maxPt = font.size;
+        maxFamily = font.name;
+      }
+      lastTextPt = font.size;
+      lastTextFamily = font.name;
+    }
+    return {
+      runs: line,
+      heightPx: vMetricPx(maxPt, cs, 1.2, maxFamily ?? undefined),
+    };
+  });
+}
+
+function requiredAutoCellHeightPx(
+  ctx: CanvasRenderingContext2D,
+  cell: Cell,
+  text: string,
+  font: CellFont,
+  xf: CellXf,
+  cellWidthPx: number,
+  mdw: number,
+  iconSet: CfResult['iconSet'],
+  currentRowHeightPx: number,
+): number {
+  const paddingX = 3;
+  const paddingY = 2;
+  const alignH = xf.alignH ?? (cell.value.type === 'number' ? 'right' : 'left');
+  const indentPx = xf.indent ? Math.round(xf.indent * 3 * mdw) : 0;
+  // Keep the wrapping width identical to paint: icon-set cells reserve their
+  // current icon square plus 4px. The icon itself scales with the row height,
+  // so the row solver below iterates this monotonic dependency to a fixed point.
+  const iconSize = iconSet
+    ? Math.max(8, Math.round(Math.min(cellWidthPx, currentRowHeightPx) * 0.55))
+    : 0;
+  const iconPad = iconSize > 0 ? iconSize + 4 : 0;
+  const leftPad = paddingX + (alignH === 'left' || !xf.alignH ? indentPx : 0) + iconPad;
+  const availableWidth = Math.max(1, cellWidthPx - leftPad - paddingX);
+  const runs = cell.value.type === 'text' ? cell.value.runs : undefined;
+  const hasRichText = !!runs?.length;
+  const rotation = xf.textRotation ?? 0;
+
+  ctx.font = buildFont(font, 1);
+  if (rotation === 255) {
+    // Paint deliberately uses the compact 1.1 slot without a document-family
+    // design-line floor for stacked glyphs; auto-fit must use the same metric.
+    return [...text].length * vMetricPx(font.size, 1, 1.1) + paddingY * 2;
+  }
+  if (rotation > 0) {
+    const angle = rotation <= 90
+      ? rotation * Math.PI / 180
+      : (rotation - 90) * Math.PI / 180;
+    const lineHeight = vMetricPx(font.size, 1, 1.2, font.name ?? undefined);
+    const textWidth = ctx.measureText(text.replace(/\n/g, ' ')).width;
+    return Math.abs(Math.sin(angle)) * textWidth
+      + Math.abs(Math.cos(angle)) * lineHeight
+      + paddingY * 2;
+  }
+
+  let lineHeights: number[];
+  if (xf.wrapText && hasRichText) {
+    lineHeights = layoutRichTextLines(ctx, runs, font, 1, availableWidth)
+      .map((line) => vMetricPx(line.maxFontSize, 1, 1.2, line.maxFontFamily ?? undefined));
+  } else if (xf.wrapText) {
+    ctx.font = buildFont(font, 1);
+    const lineHeight = vMetricPx(font.size, 1, 1.2, font.name ?? undefined);
+    lineHeights = wrapTextLines(ctx, text, availableWidth).map(() => lineHeight);
+  } else if (hasRichText) {
+    lineHeights = richHardBreakLineMetrics(runs, font, 1).map((line) => line.heightPx);
+  } else {
+    const lineCount = Math.max(1, text.split('\n').length);
+    const lineHeight = vMetricPx(font.size, 1, 1.2, font.name ?? undefined);
+    lineHeights = Array.from({ length: lineCount }, () => lineHeight);
+  }
+
+  const textHeight = lineHeights.reduce((sum, height) => sum + height, 0);
+  // One ordinary 11pt line fits Excel's 15pt default row: its design line box
+  // plus the bottom inset is exactly 20 CSS px. Multi-line blocks need both
+  // top and bottom insets because they use the wrapped top-baseline painter.
+  return textHeight + (lineHeights.length > 1 ? paddingY * 2 : paddingY);
+}
+
+function cellCanGrowAutomaticRow(
+  cell: Cell,
+  font: CellFont,
+  xf: CellXf,
+  defaultFontLineHeightPx: number,
+): boolean {
+  if (xf.wrapText || (xf.textRotation ?? 0) > 0) return true;
+  if (cell.value.type === 'text') {
+    if (cell.value.text.includes('\n')) return true;
+    for (const run of cell.value.runs ?? []) {
+      const runFont = applyRunFont(font, run);
+      if (vMetricPx(runFont.size, 1, 1.2, runFont.name ?? undefined) > defaultFontLineHeightPx) {
+        return true;
+      }
+    }
+  }
+  // Excel's authored/default row height already accommodates a Normal-style
+  // single line. Comparing that design line box with the rounded CSS-pixel row
+  // height can spuriously grow every ordinary row by one pixel (for example a
+  // 14.25pt default row rounds to 19px while Calibri 11pt plus cell inset is
+  // 20px). Only a font whose design line box exceeds the workbook Normal font
+  // can make an otherwise unwrapped, single-line cell eligible for auto-fit.
+  return vMetricPx(font.size, 1, 1.2, font.name ?? undefined) > defaultFontLineHeightPx;
+}
+
+/**
+ * Resolve Excel's display-time row auto-fit for rows that omit `row@ht`.
+ *
+ * ECMA-376 Part 1 §18.3.1.73 defines `customHeight` only as the fact that a row
+ * was manually sized and defines `ht` as the point height; it does not specify
+ * an auto-fit formula. Office behavior therefore supplies the limited
+ * compatibility contract here: explicit/hidden heights and a manually set
+ * sheet default win, merged cells do not drive auto-fit, and unmerged cells use
+ * the exact same Canvas wrapping, rich-run line metrics, font fallback, and
+ * rotation geometry as cell paint. The sheet-default distinction was verified
+ * with an Office boundary workbook that varied only sheetFormatPr@customHeight.
+ * The function mutates only a viewer/render-owned worksheet projection.
+ */
+export function applyAutoRowHeights(
+  ctx: CanvasRenderingContext2D,
+  worksheet: Worksheet,
+  styles: Styles,
+): boolean {
+  if (autoRowHeightState.has(worksheet) || worksheet.isChartSheet) return false;
+  if (worksheet.defaultRowHeightCustom === true) {
+    autoRowHeightState.set(worksheet, { derived: new Map() });
+    return false;
+  }
+
+  const geometry = getGridGeometryForWorksheet(worksheet);
+  const defaultHeightPx = rowHeightToPx(worksheet.defaultRowHeight);
+  const defaultFontLineHeightPx = vMetricPx(
+    worksheet.defaultFontSize ?? DEFAULT_FONT_SIZE,
+    1,
+    1.2,
+    worksheet.defaultFontFamily,
+  );
+  const { cfContext, mergeAnchorSet, mergeSkipSet, tableStyleMap } = getSheetRenderCache(worksheet);
+  const derived = new Map<number, number>();
+  let changed = false;
+  ctx.save();
+  try {
+    for (const row of worksheet.rows) {
+      // `height !== null` is the parser-preserved `row@ht` fact. A pre-existing
+      // view override on an otherwise automatic row (resize/worker projection)
+      // is also authoritative for this projection.
+      if (
+        row.hidden ||
+        row.customHeight === true ||
+        row.height !== null ||
+        Object.hasOwn(worksheet.rowHeights, row.index)
+      ) continue;
+      let requiredPx = defaultHeightPx;
+      const iconMeasurements: Array<{
+        cell: Cell;
+        text: string;
+        font: CellFont;
+        xf: CellXf;
+        cellWidthPx: number;
+        iconSet: CfResult['iconSet'];
+      }> = [];
+      for (const cell of row.cells) {
+        const key = `${row.index}:${cell.col}`;
+        if (
+          cell.value.type === 'empty' ||
+          mergeAnchorSet.has(key) ||
+          mergeSkipSet.has(key)
+        ) continue;
+        const { font, xf } = resolveXf(styles, cell.styleIndex ?? 0);
+        // The common spreadsheet case (ordinary unwrapped default-font cells)
+        // cannot exceed the default row. Avoid number formatting, CF lookup,
+        // and Canvas measurement for those cells so one-time auto-fit remains
+        // O(cells) with a small constant even on a dense virtualized sheet.
+        if (!cellCanGrowAutomaticRow(cell, font, xf, defaultFontLineHeightPx)) continue;
+        const cf = evaluateCf(cell, row.index, cell.col, cfContext, styles.dxfs ?? []);
+        const measuredFont = effectiveMeasurementFont(font, cf, tableStyleMap.get(key), styles);
+        const formatted = formatCellValueWithColor(cell, styles, cf.numFmt, worksheet.date1904);
+        const text = formatted.text;
+        if (!text || (text === '0' && worksheet.showZeros === false)) continue;
+        const cellWidthPx = geometry.col.sizeOf(cell.col);
+        requiredPx = Math.max(requiredPx, requiredAutoCellHeightPx(
+          ctx,
+          cell,
+          text,
+          measuredFont,
+          xf,
+          cellWidthPx,
+          geometry.maximumDigitWidth,
+          cf.iconSet,
+          Math.ceil(requiredPx),
+        ));
+        if (cf.iconSet) {
+          iconMeasurements.push({ cell, text, font: measuredFont, xf, cellWidthPx, iconSet: cf.iconSet });
+        }
+      }
+      // Icon size depends on the final row height used by paint. Re-evaluate
+      // icon-bearing cells until their reserved width and row height agree.
+      // The relation is monotonic and saturates once the icon reaches the cell
+      // width. The hard bound prevents malformed input from creating an
+      // unbounded loop; the final conservative pass uses that saturated width.
+      let converged = iconMeasurements.length === 0;
+      for (let iteration = 0; !converged && iteration < 32; iteration++) {
+        // Paint receives the integer CSS-pixel row size reconstructed from the
+        // derived point height. Resolve every icon against that same candidate,
+        // not the pre-rounded floating measurement, or a 0.1px difference can
+        // cross the icon's round() boundary and add an unmeasured wrap line.
+        const candidateHeightPx = Math.ceil(requiredPx);
+        let nextRequiredPx = requiredPx;
+        for (const measurement of iconMeasurements) {
+          nextRequiredPx = Math.max(nextRequiredPx, requiredAutoCellHeightPx(
+            ctx,
+            measurement.cell,
+            measurement.text,
+            measurement.font,
+            measurement.xf,
+            measurement.cellWidthPx,
+            geometry.maximumDigitWidth,
+            measurement.iconSet,
+            candidateHeightPx,
+          ));
+        }
+        requiredPx = nextRequiredPx;
+        converged = Math.ceil(requiredPx) === candidateHeightPx;
+      }
+      if (!converged) {
+        for (const measurement of iconMeasurements) {
+          requiredPx = Math.max(requiredPx, requiredAutoCellHeightPx(
+            ctx,
+            measurement.cell,
+            measurement.text,
+            measurement.font,
+            measurement.xf,
+            measurement.cellWidthPx,
+            geometry.maximumDigitWidth,
+            measurement.iconSet,
+            measurement.cellWidthPx,
+          ));
+        }
+      }
+      const roundedPx = Math.ceil(requiredPx);
+      if (roundedPx > defaultHeightPx) {
+        const pointHeight = pxToRowHeight(roundedPx);
+        worksheet.rowHeights[row.index] = pointHeight;
+        derived.set(row.index, pointHeight);
+        changed = true;
+      }
+    }
+  } finally {
+    ctx.restore();
+  }
+  autoRowHeightState.set(worksheet, { derived });
+  if (changed) GridGeometry.invalidate(worksheet);
+  return changed;
+}
+
+export function hasPreparedAutoRowHeights(worksheet: Worksheet): boolean {
+  return autoRowHeightState.has(worksheet);
+}
+
+/** @internal Viewer/worker transport of display-derived heights. The returned
+ * map is immutable by convention; authored/manual row sizes are deliberately
+ * absent so they remain a separate override class. */
+export function derivedAutoRowHeights(worksheet: Worksheet): ReadonlyMap<number, number> {
+  return autoRowHeightState.get(worksheet)?.derived ?? new Map();
+}
+
+/** @internal Mark a render-local worker projection whose derived row heights
+ * were already supplied by its owning viewer. */
+export function markAutoRowHeightsPrepared(worksheet: Worksheet): void {
+  if (!autoRowHeightState.has(worksheet)) {
+    autoRowHeightState.set(worksheet, { derived: new Map() });
+  }
+}
+
+/** Drop display-derived row heights before refitting after a view-only column
+ * resize. A row manually resized after auto-fit is intentionally preserved:
+ * its current value no longer equals the derived value recorded here. */
+export function invalidateAutoRowHeights(
+  worksheet: Worksheet,
+  preserveRows: Iterable<number> = [],
+): void {
+  const state = autoRowHeightState.get(worksheet);
+  if (!state) return;
+  const preserved = new Set(preserveRows);
+  let changed = false;
+  for (const [row, derived] of state.derived) {
+    if (preserved.has(row)) continue;
+    if (worksheet.rowHeights[row] !== derived) continue;
+    delete worksheet.rowHeights[row];
+    changed = true;
+  }
+  autoRowHeightState.delete(worksheet);
+  if (changed) GridGeometry.invalidate(worksheet);
 }
 
 interface OverflowColumnOverscan {

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -85,6 +85,10 @@ export interface Worksheet {
   colHidden?: Record<number, boolean>;
   defaultColWidth: number;
   defaultRowHeight: number;
+  /** `<sheetFormatPr customHeight>` (ECMA-376 §18.3.1.81). When true, rows
+   *  without their own `ht` use the manually authored sheet default instead of
+   *  display-time auto-fit. Omitted when false. */
+  defaultRowHeightCustom?: boolean;
   mergeCells: MergeCell[];
   freezeRows: number;
   freezeCols: number;
@@ -782,6 +786,9 @@ export interface CfValue {
 export interface Row {
   index: number;
   height: number | null;
+  /** `<row customHeight>` (ECMA-376 §18.3.1.73). A true value suppresses
+   *  display-time auto-fit even when `ht` is omitted. */
+  customHeight?: boolean;
   cells: Cell[];
   /** Outline (grouping) depth 0-7 (ECMA-376 §18.3.1.73 `<row outlineLevel>`).
    *  Omitted on the wire when `0` (ungrouped); read as `outlineLevel ?? 0`. */

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -1,5 +1,6 @@
 import {
   XlsxWorkbook,
+  prepareXlsxViewerRowHeights,
   releaseXlsxViewerProjection,
   retainXlsxViewerFonts,
 } from './workbook.js';
@@ -17,6 +18,8 @@ import {
   HEADER_H,
   pxToColWidth,
   pxToRowHeight,
+  invalidateAutoRowHeights,
+  derivedAutoRowHeights,
   getGridGeometryForWorksheet,
   rtlMirrorX,
 } from './renderer.js';
@@ -623,6 +626,7 @@ class XlsxViewerEngine implements ZoomableViewer {
     number,
     {
       rows: Map<number, number | null>;
+      automaticRows: Map<number, number>;
       cols: Map<number, number | null>;
       revision: number;
       wire?: WireSizeOverrides;
@@ -1181,6 +1185,13 @@ class XlsxViewerEngine implements ZoomableViewer {
       if (!await this.ensureHostFonts(workbook)) return;
       const source = await workbook.getWorksheet(index);
       worksheet = this.sheetViews.get(index) ?? createSheetViewModel(source);
+      const prepareRowHeights = workbook[prepareXlsxViewerRowHeights];
+      if (typeof prepareRowHeights === 'function') {
+        const measureCanvas = this.hostDocument.createElement('canvas');
+        const measureCtx = measureCanvas.getContext('2d');
+        if (measureCtx) prepareRowHeights.call(workbook, worksheet, measureCtx);
+      }
+      this.syncAutomaticRowOverrides(index, worksheet);
       this.sheetViews.set(index, worksheet);
     } catch (error) {
       if (!this.isCurrentSheetRequest(generation, workbook)) return;
@@ -1725,10 +1736,11 @@ class XlsxViewerEngine implements ZoomableViewer {
     if (!ws) return;
     let entry = this.sizeOverrideStore.get(this.currentSheet);
     if (!entry) {
-      entry = { rows: new Map(), cols: new Map(), revision: 0 };
+      entry = { rows: new Map(), automaticRows: new Map(), cols: new Map(), revision: 0 };
       this.sizeOverrideStore.set(this.currentSheet, entry);
     }
     const target = axis === 'row' ? entry.rows : entry.cols;
+    if (axis === 'row') entry.automaticRows.delete(index);
     const value = axis === 'row' ? ws.rowHeights[index] ?? null : ws.colWidths[index] ?? null;
     if (target.get(index) === value && target.has(index)) return;
     target.set(index, value);
@@ -1743,14 +1755,34 @@ class XlsxViewerEngine implements ZoomableViewer {
     revision: number;
   }> | undefined {
     const entry = this.sizeOverrideStore.get(this.currentSheet);
-    if (!entry || (entry.rows.size === 0 && entry.cols.size === 0)) return undefined;
+    if (!entry || (entry.rows.size === 0 && entry.automaticRows.size === 0 && entry.cols.size === 0)) {
+      return undefined;
+    }
     if (!entry.wire) {
       const wire: WireSizeOverrides = {};
-      if (entry.rows.size > 0) wire.rows = Object.fromEntries(entry.rows);
+      if (entry.rows.size > 0 || entry.automaticRows.size > 0) {
+        wire.rows = Object.fromEntries([...entry.automaticRows, ...entry.rows]);
+      }
       if (entry.cols.size > 0) wire.cols = Object.fromEntries(entry.cols);
       entry.wire = wire;
     }
     return { overrides: entry.wire, revision: entry.revision };
+  }
+
+  /** Mirror only display-derived heights into the worker projection channel.
+   * Manual/authored sizes remain in `rows`, so a later column refit can replace
+   * automatic values without reclassifying a user's row resize. */
+  private syncAutomaticRowOverrides(sheetIndex: number, worksheet: Worksheet): void {
+    const next = new Map(derivedAutoRowHeights(worksheet));
+    let entry = this.sizeOverrideStore.get(sheetIndex);
+    if (!entry && next.size === 0) return;
+    if (!entry) {
+      entry = { rows: new Map(), automaticRows: new Map(), cols: new Map(), revision: 0 };
+      this.sizeOverrideStore.set(sheetIndex, entry);
+    }
+    entry.automaticRows = next;
+    entry.revision++;
+    entry.wire = undefined;
   }
 
   /** Update the `collapsed` flag on a band's model entry so the outline rebuild
@@ -2517,6 +2549,27 @@ class XlsxViewerEngine implements ZoomableViewer {
     // Live resize drag fires per pointermove; coalesce the canvas repaint into
     // one frame. The spacer (scrollbar extent) and overlay updates are cheap DOM
     // writes that must track the drag immediately, so they stay synchronous.
+    this.scheduleRender();
+  }
+
+  /** Refit automatic rows once after a column-resize gesture. Doing this on
+   * every pointermove would turn a drag into O(sheet cells × pointer events),
+   * while Excel's observable result only needs to be committed at release. */
+  private refitAutoRowsAfterColumnResize(): void {
+    const ws = this.currentWorksheet;
+    const workbook = this.preparedWorkbook;
+    if (!ws || !workbook) return;
+    const manualRows = this.sizeOverrideStore.get(this.currentSheet)?.rows.keys() ?? [];
+    invalidateAutoRowHeights(ws, manualRows);
+    const prepareRowHeights = workbook[prepareXlsxViewerRowHeights];
+    if (typeof prepareRowHeights !== 'function') return;
+    const measureCanvas = this.hostDocument.createElement('canvas');
+    const measureCtx = measureCanvas.getContext('2d');
+    if (!measureCtx) return;
+    prepareRowHeights.call(workbook, ws, measureCtx);
+    this.syncAutomaticRowOverrides(this.currentSheet, ws);
+    this.updateSpacerSize(ws);
+    this.updateSelectionOverlay();
     this.scheduleRender();
   }
 
@@ -3872,6 +3925,7 @@ class XlsxViewerEngine implements ZoomableViewer {
 
     this.surface.on('pointerup', (e: PointerEvent) => {
       if (this.resizeDrag && this.resizeDrag.pointerId === e.pointerId) {
+        if (this.resizeDrag.kind === 'col') this.refitAutoRowsAfterColumnResize();
         this.scrollHost.releasePointerCapture(e.pointerId);
         this.resizeDrag = null;
         return;
@@ -3945,6 +3999,7 @@ class XlsxViewerEngine implements ZoomableViewer {
 
     this.surface.on('pointercancel', (e: PointerEvent) => {
       if (this.resizeDrag && this.resizeDrag.pointerId === e.pointerId) {
+        if (this.resizeDrag.kind === 'col') this.refitAutoRowsAfterColumnResize();
         this.resizeDrag = null;
       }
       if (this.pendingTap && this.pendingTap.pointerId === e.pointerId) {
@@ -4534,7 +4589,7 @@ class XlsxViewerEngine implements ZoomableViewer {
       {
         worksheet: ws,
         projection: sizeProjection
-          ? { id: this.projectionId, revision: sizeProjection.revision }
+          ? { id: this.projectionId, revision: sizeProjection.revision, autoRowHeightsPrepared: true }
           : undefined,
       },
     );

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -65,7 +65,7 @@ import {
   XlsxWorksheetPullClient,
 } from './worksheet-pull-client.js';
 import { GridGeometry } from './internal/grid-geometry.js';
-import { inheritSheetRenderCache } from './renderer.js';
+import { applyAutoRowHeights, inheritSheetRenderCache } from './renderer.js';
 
 /** Public options for {@link XlsxWorkbook.renderViewportToBitmap}. Viewer-only
  * worksheet projection state is intentionally not part of this contract. */
@@ -76,6 +76,8 @@ export type RenderViewportToBitmapOptions = Omit<
 
 /** @internal Viewer-only hook for retaining web fonts in the canvas document. */
 export const retainXlsxViewerFonts = Symbol('retain-xlsx-viewer-fonts');
+/** @internal Resolve display-time row auto-fit on a viewer-owned projection. */
+export const prepareXlsxViewerRowHeights = Symbol('prepare-xlsx-viewer-row-heights');
 /** @internal Release worker-side viewer projection cache entries. */
 export const releaseXlsxViewerProjection = Symbol('release-xlsx-viewer-projection');
 
@@ -386,6 +388,13 @@ export class XlsxWorkbook {
   /** @internal Retain required faces in the document that owns a viewer canvas. */
   async [retainXlsxViewerFonts](targetDocument: Document): Promise<() => void> {
     return await this.retainFontsInSet(targetDocument.fonts);
+  }
+
+  /** @internal Fonts are retained before this hook runs, so Canvas text
+   * measurement observes the same faces that the subsequent paint uses. */
+  [prepareXlsxViewerRowHeights](worksheet: Worksheet, ctx: CanvasRenderingContext2D): void {
+    if (!this.parsedWorkbook) return;
+    applyAutoRowHeights(ctx, worksheet, this.parsedWorkbook.styles);
   }
 
   get sheetNames(): string[] {

--- a/packages/xlsx/src/worker-protocol.ts
+++ b/packages/xlsx/src/worker-protocol.ts
@@ -87,6 +87,9 @@ export function createSizeOverriddenWorksheet(
 export interface WireViewProjection {
   readonly id: number;
   readonly revision: number;
+  /** The owning viewer supplied every display-derived automatic row height in
+   * `sizeOverrides.rows`; the worker must not rescan cells for this revision. */
+  readonly autoRowHeightsPrepared?: boolean;
 }
 
 /** Worker-local cache for one shallow worksheet projection per viewer/sheet.

--- a/packages/xlsx/tests/visual/visual.spec.ts
+++ b/packages/xlsx/tests/visual/visual.spec.ts
@@ -28,7 +28,9 @@ const XLSX_FILES: { name: string; sheetCount: number }[] = [
   { name: 'private/sample-12', sheetCount: 8 },
   { name: 'private/sample-13', sheetCount: 2 },
   { name: 'private/sample-14', sheetCount: 2 },
-  { name: 'private/sample-15', sheetCount: 2 },
+  // Keep Plot Area, Legend, Titles, and Labels in the private self-VRT. The
+  // fifth sheet is source data without chart-renderer coverage.
+  { name: 'private/sample-15', sheetCount: 4 },
   { name: 'private/sample-16', sheetCount: 2 },
   { name: 'private/sample-17', sheetCount: 2 },
   { name: 'private/sample-18', sheetCount: 2 },

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.79.0",
+  "version": "0.79.1",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",


### PR DESCRIPTION
## Summary

- preserve authored chart data-label scope, value-axis display-unit formatting, trendline placement, and solid legend frames
- auto-fit worksheet rows that omit authored heights while preserving row/sheet custom-height semantics and merged-cell exclusions
- keep direct and worker rendering on the same measured grid geometry and bounded Canvas text-layout rules
- bump all packages and the MCP server to 0.79.1

## Specification and compatibility

Fixed row heights follow ECMA-376 CT_Row and CT_SheetFormatPr. Automatic fitting uses the renderer's existing Canvas measurement contract plus bounded Office observations for wrapped, rich, rotated, and icon-bearing cells.

No API migration is required from 0.79.0.

## Verification

- full product suite: 7,534 tests passed; the 6 sandbox-only loopback failures passed in an unrestricted rerun
- XLSX parser: 301 tests passed
- XLSX renderer: 798 tests passed
- build, typecheck, public API/type exports, viewer API symmetry, optional 3-D boundary, and MCP cargo check passed
- private self-VRT against the fixed 0.79.0 merge-base found no new worksheet-row-height regressions

Fixes #1260