### PR TITLE
chore(release): 0.80.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ semantic versioning. While the major version is zero, minor releases may contain
 explicitly documented breaking changes; patch releases remain compatible with
 the corresponding minor release.
 
+## 0.80.0 — 2026-08-16
+
+Compatible minor release. Completes built-in renderer parity between the
+existing main-thread and worker rendering modes across DOCX, XLSX, and PPTX.
+
+- **worker renderer parity:** equations, authored 3-D charts, and country-level
+  Region Maps now use the same `math`, `threeD`, and `regionMap` injection
+  options in main and worker modes.
+- **production-safe workers:** publish self-contained render workers and carry
+  consumer-resolved assets such as MathJax across the worker boundary, including
+  applications that rebundle the packages with Vite.
+- **equation quality:** use one bounded Canvas raster path in Window and Worker
+  contexts, with staged high-resolution reduction for cleaner equation output.
+- **integration guidance:** add worker file-upload examples and document how to
+  choose between main and worker rendering, including responsiveness, download,
+  frame-transfer, browser-support, and custom-renderer trade-offs.
+- **compatibility:** main mode remains the default and existing applications do
+  not require migration. DOCX content requiring browser-only vertical-glyph
+  selection automatically falls back to effective main mode for correct shaping.
+
 ## 0.79.1 — 2026-08-15
 
 Patch. Corrects authored chart labels, legend frames, and automatic worksheet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.79.1"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ chart behavior is documented in
 ### Off-main-thread rendering
 
 By default the headless engines parse in a worker but render on the main thread.
-Pass `mode: 'worker'` to `.load()` to parse **and** render entirely inside a Web
-Worker — the main thread only paints the returned `ImageBitmap` via a
+Pass `mode: 'worker'` to `.load()` to normally parse **and** render inside a Web
+Worker — the main thread presents the returned `ImageBitmap` via a
 `bitmaprenderer` context, keeping it free for scrolling and input. It requires
 `Worker` + `OffscreenCanvas`.
 
@@ -276,6 +276,10 @@ Notes:
   through the same `math`, `threeD`, and `regionMap` options. Custom renderer
   objects are main-realm code and therefore use the feature's documented
   fallback in `mode: 'worker'`.
+- A DOCX document that requires browser-only OpenType vertical-glyph selection
+  automatically uses effective main mode for correct shaping. Read
+  `document.mode` after loading when your integration needs to observe this
+  fallback.
 - Trade-off: worker mode keeps the main thread responsive, but each frame is
   transferred back as an `ImageBitmap`, so a single render can be marginally
   slower than `mode: 'main'`. Choose it for non-blocking UI, not raw speed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.79.1",
+  "version": "0.80.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.79.1",
+  "version": "0.80.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.79.1",
+  "version": "0.80.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.79.1",
+  "version": "0.80.0",
   "description": "Internal workspace adapter for DOCX / XLSX / PPTX Markdown projection",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.79.1"
+version = "0.80.0"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.79.1",
+  "version": "0.80.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.79.1",
+  "version": "0.80.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity local viewer for Office files (.docx / .xlsx / .pptx), powered by Rust/WASM and Canvas. Optional MCP integration can share requested context with an AI agent.",
-  "version": "0.79.1",
+  "version": "0.80.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.79.1",
+  "version": "0.80.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.79.1",
+  "version": "0.80.0",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",

--- a/site/src/announcement-content.test.ts
+++ b/site/src/announcement-content.test.ts
@@ -7,9 +7,9 @@ const articlePage = readFileSync(new URL('./pages/announcements/[slug].astro', i
 describe('v0.80 worker rendering announcement', () => {
   const announcement = announcements.find((item) => item.slug === 'v080-worker-rendering');
 
-  it('presents worker rendering as an upcoming opt-in minor release', () => {
+  it('presents worker rendering as a released compatible minor version', () => {
     expect(announcement).toBeDefined();
-    expect(announcement).toMatchObject({ label: 'Upcoming release', version: 'v0.80.0' });
+    expect(announcement).toMatchObject({ label: 'Release note', version: 'v0.80.0' });
     expect(announcement?.summary).toContain('extends the existing');
     expect(announcement?.summary).not.toContain('adds one worker rendering mode');
     expect(announcement?.sections[0]).toMatchObject({ title: 'In short', kind: 'summary' });

--- a/site/src/lib/announcements.ts
+++ b/site/src/lib/announcements.ts
@@ -38,7 +38,7 @@ export const announcements: readonly Announcement[] = [
   {
     slug: 'v080-worker-rendering',
     date: '2026-08-16',
-    label: 'Upcoming release',
+    label: 'Release note',
     version: 'v0.80.0',
     title: 'Built-in renderer parity for worker mode in v0.80.0',
     summary: 'v0.80.0 extends the existing DOCX, XLSX and PPTX worker mode so the built-in math, 3-D chart and Region Map renderers use the same injection API and rendering path as main-thread mode.',


### PR DESCRIPTION
## Summary

- release built-in math, 3-D chart, and Region Map parity in the existing worker rendering mode across DOCX, XLSX, and PPTX
- publish self-contained render workers with consumer-safe MathJax asset resolution and improved equation raster quality
- document when to choose main or worker rendering, their trade-offs, and single-Viewer versus shared-document loading scenarios
- bump all packages, the site, VS Code extension, and MCP server to 0.80.0

## Compatibility

Main mode remains the default and existing applications do not require migration. DOCX documents that require browser-only vertical-glyph selection automatically use effective main mode for correct shaping.

## Release checklist

- README implementation, imports, feature table, bundle sizes, and worker guidance reviewed against the release build
- README screenshots reviewed: the public samples use default main rendering and are visually unchanged by this release, so the existing images remain current
- site API reference and v0.80 release note synchronized
- CHANGELOG and all package/site/extension/MCP versions updated to 0.80.0

## Verification

- independent release audit: no remaining P1/P2 findings after README follow-up
- feature PR CI: audit, rust, smoke, and typecheck all passed
- same-browser main/worker comparisons: 0.000% on exercised DOCX, XLSX, PPTX, equation, 3-D chart, and Region Map frames
- production raw-package and Vite-consumer worker smoke tests
- TypeScript checks, package/site builds, public API baselines, viewer API symmetry, Cargo check, and focused site tests