### PR TITLE
fix(vscode): exclude worker graph from webview bundle

### DIFF
--- a/packages/vscode-extension/.vscodeignore
+++ b/packages/vscode-extension/.vscodeignore
@@ -6,4 +6,5 @@ node_modules/**
 *.config.mjs
 tsconfig.json
 esbuild.config.mjs
+esbuild-worker-stub.*
 *.vsix

--- a/packages/vscode-extension/esbuild-worker-stub.d.mts
+++ b/packages/vscode-extension/esbuild-worker-stub.d.mts
@@ -1,0 +1,3 @@
+import type { Plugin } from 'esbuild';
+
+export const mainThreadOnlyWorkerStubs: Plugin;

--- a/packages/vscode-extension/esbuild-worker-stub.mjs
+++ b/packages/vscode-extension/esbuild-worker-stub.mjs
@@ -1,0 +1,53 @@
+/**
+ * The VS Code webview always renders on the main thread. Replace both worker
+ * entry mechanisms before esbuild traverses them: the lazy host used by the
+ * public viewers and the Vite `?worker&inline` parser worker imports retained
+ * by their main-thread modules.
+ *
+ * Besides keeping unused workers out of the VSIX, this prevents esbuild from
+ * entering worker-only modules that intentionally use Vite asset queries such
+ * as `mathjax-stix2.js?url`.
+ */
+export const mainThreadOnlyWorkerStubs = {
+  name: 'main-thread-only-worker-stubs',
+  setup(build) {
+    // The shared worker barrel is also imported by main-thread code for resource
+    // limits and error transport. Replace only its renderer loader re-export;
+    // otherwise esbuild follows the loader's dynamic imports even though the
+    // exported functions are unused by this webview.
+    build.onResolve({ filter: /^\.\/renderer-module\.js$/ }, (args) => {
+      const importer = args.importer.replaceAll('\\', '/');
+      if (!importer.endsWith('/packages/core/src/worker/index.ts')) return null;
+      return { path: args.path, namespace: 'stub-worker-renderer-module' };
+    });
+    build.onLoad({ filter: /.*/, namespace: 'stub-worker-renderer-module' }, () => ({
+      contents:
+        "export async function loadWorkerRenderer() { throw new Error('[ooxml] worker renderer loading is not available in the VS Code extension (main-thread only)'); }" +
+        " export async function loadWorkerRenderers() { return {}; }",
+      loader: 'js',
+    }));
+
+    build.onResolve({ filter: /render-worker-host$/ }, (args) => ({
+      path: args.path,
+      namespace: 'stub-render-worker-host',
+    }));
+    build.onLoad({ filter: /.*/, namespace: 'stub-render-worker-host' }, () => ({
+      contents:
+        "export function createRenderWorker() {" +
+        " throw new Error('[ooxml] worker rendering is not available in the VS Code extension (main-thread only)'); }",
+      loader: 'js',
+    }));
+
+    build.onResolve({ filter: /\?worker&inline$/ }, (args) => ({
+      path: args.path,
+      namespace: 'stub-inline-worker',
+    }));
+    build.onLoad({ filter: /.*/, namespace: 'stub-inline-worker' }, () => ({
+      contents:
+        "export default class MainThreadOnlyWorker {" +
+        " constructor() { throw new Error('[ooxml] parser worker is not available in the VS Code extension (main-thread only)'); }" +
+        " }",
+      loader: 'js',
+    }));
+  },
+};

--- a/packages/vscode-extension/esbuild.config.mjs
+++ b/packages/vscode-extension/esbuild.config.mjs
@@ -1,5 +1,5 @@
 import * as esbuild from 'esbuild';
-import { readFileSync } from 'fs';
+import { mainThreadOnlyWorkerStubs } from './esbuild-worker-stub.mjs';
 
 const production = process.argv.includes('--production');
 const watch = process.argv.includes('--watch');
@@ -17,29 +17,6 @@ const extensionConfig = {
   minify: production,
 };
 
-// The extension renders on the main thread only (it never passes `mode: 'worker'`
-// nor calls render*ToBitmap). Each viewer package still ships a render worker as
-// a dynamically-imported host plus a self-contained module asset. esbuild's iife
-// output can't code-split that dynamic import into a lazy chunk (only
-// esm/splitting can), so it would otherwise inline dead worker-loading code into
-// webview.js. Stub the import to a throwing no-op — it is never reached at
-// runtime in the extension.
-const stubRenderWorkerPlugin = {
-  name: 'stub-render-worker',
-  setup(build) {
-    build.onResolve({ filter: /render-worker-host/ }, (args) => ({
-      path: args.path,
-      namespace: 'stub-render-worker',
-    }));
-    build.onLoad({ filter: /.*/, namespace: 'stub-render-worker' }, () => ({
-      contents:
-        "export function createRenderWorker() {" +
-        " throw new Error('[ooxml] worker rendering is not available in the VS Code extension (main-thread only)'); }",
-      loader: 'js',
-    }));
-  },
-};
-
 /** @type {esbuild.BuildOptions} */
 const webviewConfig = {
   entryPoints: ['src/webview/bootstrap.ts'],
@@ -55,7 +32,7 @@ const webviewConfig = {
   loader: {
     '.wasm': 'file',
   },
-  plugins: [stubRenderWorkerPlugin],
+  plugins: [mainThreadOnlyWorkerStubs],
 };
 
 async function build() {

--- a/packages/vscode-extension/src/mathEngineBundle.test.ts
+++ b/packages/vscode-extension/src/mathEngineBundle.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { build } from 'esbuild';
-import { dirname } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { mainThreadOnlyWorkerStubs } from '../esbuild-worker-stub.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
+const EXTENSION_ROOT = resolve(HERE, '..');
 
 describe('VS Code webview math engine bundle', () => {
   it('retains the MathJax STIX2 side-effect entry used by DOCX, XLSX, and PPTX', async () => {
@@ -23,5 +25,34 @@ describe('VS Code webview math engine bundle', () => {
 
     expect(result.warnings).toEqual([]);
     expect(result.outputFiles[0]?.text).toContain('globalThis.__ooxmlStix2');
+  });
+
+  it('excludes worker-only Vite asset imports from the main-thread webview bundle', async () => {
+    const result = await build({
+      entryPoints: [resolve(EXTENSION_ROOT, 'src/webview/bootstrap.ts')],
+      bundle: true,
+      write: false,
+      outdir: 'dist-test',
+      format: 'iife',
+      platform: 'browser',
+      target: 'es2020',
+      logLevel: 'silent',
+      alias: {
+        '@silurus/ooxml-docx': resolve(EXTENSION_ROOT, '../docx/src/index.ts'),
+        '@silurus/ooxml-xlsx': resolve(EXTENSION_ROOT, '../xlsx/src/index.ts'),
+        '@silurus/ooxml-pptx': resolve(EXTENSION_ROOT, '../pptx/src/index.ts'),
+      },
+      external: ['*.wasm'],
+      loader: { '.wasm': 'file' },
+      plugins: [mainThreadOnlyWorkerStubs],
+    });
+
+    expect(result.warnings).toEqual([]);
+    const bundle = result.outputFiles.find((file) => file.path.endsWith('/bootstrap.js'))?.text
+      ?? result.outputFiles.find((file) => file.path.endsWith('.js'))?.text
+      ?? '';
+    expect(bundle).toContain('globalThis.__ooxmlStix2');
+    expect(bundle).not.toContain('Failed to load math engine from');
+    expect(bundle).not.toContain('ooxml-worker-renderer-module');
   });
 });

--- a/packages/vscode-extension/src/package-boundary.test.ts
+++ b/packages/vscode-extension/src/package-boundary.test.ts
@@ -34,6 +34,8 @@ describe('VS Code extension package boundary', () => {
     writeFileSync(resolve(fixture, 'dist/webview.js'), '(() => {})();');
     writeFileSync(resolve(fixture, 'dist/extension.js.map'), '{"version":3}');
     writeFileSync(resolve(fixture, 'dist/webview.js.map'), '{"version":3}');
+    writeFileSync(resolve(fixture, 'esbuild-worker-stub.mjs'), 'export const plugin = {};');
+    writeFileSync(resolve(fixture, 'esbuild-worker-stub.d.mts'), 'export const plugin: unknown;');
 
     const files = execFileSync(process.execPath, [vsce, 'ls', '--no-dependencies'], {
       cwd: fixture,
@@ -43,5 +45,6 @@ describe('VS Code extension package boundary', () => {
     expect(files).toContain('dist/extension.js');
     expect(files).toContain('dist/webview.js');
     expect(files.filter((file) => file.endsWith('.map'))).toEqual([]);
+    expect(files.filter((file) => file.startsWith('esbuild-worker-stub.'))).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- exclude Vite inline-worker entries from the main-thread-only VS Code webview bundle
- stop the shared worker barrel from pulling the worker renderer loader into plain esbuild
- add a production bundle regression and keep build-only stubs out of the VSIX

## Root cause
The v0.80.0 Marketplace workflow used plain esbuild for the VS Code webview. Although the extension renders on the main thread, esbuild still traversed the format packages' inline worker graph and reached a worker-only Vite asset query. Plain esbuild treated that JavaScript asset as a module rather than a URL and failed the build.

## Verification
- focused VS Code bundle and package-boundary tests
- VS Code extension TypeScript check
- production esbuild bundle
- VSIX packaging
- git diff check