### PR TITLE
fix(chart): prevent tick and label collisions

### DIFF
--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -231,7 +231,7 @@ stroke ss=#e0e0e0 lw=0.5 dash=
 set fillStyle=#555
 set textAlign=right
 set textBaseline=middle
-fillText "0" 84.8,335.45 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "0" 78.5,335.45 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -244,7 +244,7 @@ beginPath
 moveTo 88.8,301.5222
 lineTo 620,301.5222
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "0.5" 84.8,301.5222 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "0.5" 78.5,301.5222 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -257,7 +257,7 @@ beginPath
 moveTo 88.8,267.5944
 lineTo 620,267.5944
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "1" 84.8,267.5944 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "1" 78.5,267.5944 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -270,7 +270,7 @@ beginPath
 moveTo 88.8,233.6667
 lineTo 620,233.6667
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "1.5" 84.8,233.6667 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "1.5" 78.5,233.6667 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -283,7 +283,7 @@ beginPath
 moveTo 88.8,199.7389
 lineTo 620,199.7389
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "2" 84.8,199.7389 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "2" 78.5,199.7389 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -296,7 +296,7 @@ beginPath
 moveTo 88.8,165.8111
 lineTo 620,165.8111
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "2.5" 84.8,165.8111 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "2.5" 78.5,165.8111 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -309,7 +309,7 @@ beginPath
 moveTo 88.8,131.8833
 lineTo 620,131.8833
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "3" 84.8,131.8833 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "3" 78.5,131.8833 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -322,7 +322,7 @@ beginPath
 moveTo 88.8,97.9556
 lineTo 620,97.9556
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "3.5" 84.8,97.9556 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "3.5" 78.5,97.9556 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -335,7 +335,7 @@ beginPath
 moveTo 88.8,64.0278
 lineTo 620,64.0278
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "4" 84.8,64.0278 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "4" 78.5,64.0278 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -348,7 +348,7 @@ beginPath
 moveTo 88.8,30.1
 lineTo 620,30.1
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "4.5" 84.8,30.1 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "4.5" 78.5,30.1 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -373,42 +373,42 @@ stroke ss=#888 lw=1 dash=
 restore
 set textAlign=center
 set textBaseline=top
-fillText "0" 88.8,339.45 fs=#555 font=11px sans-serif al=center bl=top
+fillText "0" 88.8,345.75 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 88.8,341.75
 lineTo 88.8,335.45
 stroke ss=#888 lw=1 dash=
-fillText "0.5" 164.6857,339.45 fs=#555 font=11px sans-serif al=center bl=top
+fillText "0.5" 164.6857,345.75 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 164.6857,341.75
 lineTo 164.6857,335.45
 stroke ss=#888 lw=1 dash=
-fillText "1" 240.5714,339.45 fs=#555 font=11px sans-serif al=center bl=top
+fillText "1" 240.5714,345.75 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 240.5714,341.75
 lineTo 240.5714,335.45
 stroke ss=#888 lw=1 dash=
-fillText "1.5" 316.4571,339.45 fs=#555 font=11px sans-serif al=center bl=top
+fillText "1.5" 316.4571,345.75 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 316.4571,341.75
 lineTo 316.4571,335.45
 stroke ss=#888 lw=1 dash=
-fillText "2" 392.3429,339.45 fs=#555 font=11px sans-serif al=center bl=top
+fillText "2" 392.3429,345.75 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 392.3429,341.75
 lineTo 392.3429,335.45
 stroke ss=#888 lw=1 dash=
-fillText "2.5" 468.2286,339.45 fs=#555 font=11px sans-serif al=center bl=top
+fillText "2.5" 468.2286,345.75 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 468.2286,341.75
 lineTo 468.2286,335.45
 stroke ss=#888 lw=1 dash=
-fillText "3" 544.1143,339.45 fs=#555 font=11px sans-serif al=center bl=top
+fillText "3" 544.1143,345.75 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 544.1143,341.75
 lineTo 544.1143,335.45
 stroke ss=#888 lw=1 dash=
-fillText "3.5" 620,339.45 fs=#555 font=11px sans-serif al=center bl=top
+fillText "3.5" 620,345.75 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 620,341.75
 lineTo 620,335.45
@@ -2084,7 +2084,7 @@ stroke ss=#e0e0e0 lw=0.5 dash=
 set fillStyle=#555
 set textAlign=right
 set textBaseline=middle
-fillText "0" 112.1,312.95 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "0" 105.8,312.95 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -2097,7 +2097,7 @@ beginPath
 moveTo 116.1,277.2679
 lineTo 540,277.2679
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "1" 112.1,277.2679 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "1" 105.8,277.2679 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -2110,7 +2110,7 @@ beginPath
 moveTo 116.1,241.5857
 lineTo 540,241.5857
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "2" 112.1,241.5857 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "2" 105.8,241.5857 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -2123,7 +2123,7 @@ beginPath
 moveTo 116.1,205.9036
 lineTo 540,205.9036
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "3" 112.1,205.9036 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "3" 105.8,205.9036 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -2136,7 +2136,7 @@ beginPath
 moveTo 116.1,170.2214
 lineTo 540,170.2214
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "4" 112.1,170.2214 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "4" 105.8,170.2214 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -2149,7 +2149,7 @@ beginPath
 moveTo 116.1,134.5393
 lineTo 540,134.5393
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "5" 112.1,134.5393 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "5" 105.8,134.5393 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -2162,7 +2162,7 @@ beginPath
 moveTo 116.1,98.8571
 lineTo 540,98.8571
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "6" 112.1,98.8571 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "6" 105.8,98.8571 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -2175,7 +2175,7 @@ beginPath
 moveTo 116.1,63.175
 lineTo 540,63.175
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "7" 112.1,63.175 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "7" 105.8,63.175 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -2200,37 +2200,37 @@ stroke ss=#888 lw=1 dash=
 restore
 set textAlign=center
 set textBaseline=top
-fillText "0" 116.1,316.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "0" 116.1,323.25 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 116.1,319.25
 lineTo 116.1,312.95
 stroke ss=#888 lw=1 dash=
-fillText "1" 186.75,316.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "1" 186.75,323.25 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 186.75,319.25
 lineTo 186.75,312.95
 stroke ss=#888 lw=1 dash=
-fillText "2" 257.4,316.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "2" 257.4,323.25 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 257.4,319.25
 lineTo 257.4,312.95
 stroke ss=#888 lw=1 dash=
-fillText "3" 328.05,316.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "3" 328.05,323.25 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 328.05,319.25
 lineTo 328.05,312.95
 stroke ss=#888 lw=1 dash=
-fillText "4" 398.7,316.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "4" 398.7,323.25 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 398.7,319.25
 lineTo 398.7,312.95
 stroke ss=#888 lw=1 dash=
-fillText "5" 469.35,316.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "5" 469.35,323.25 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 469.35,319.25
 lineTo 469.35,312.95
 stroke ss=#888 lw=1 dash=
-fillText "6" 540,316.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "6" 540,323.25 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 540,319.25
 lineTo 540,312.95

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -411,6 +411,56 @@ describe('classic 3-D compatibility projection', () => {
     }
   });
 
+  it('places 3-D value and category labels beyond their outward major ticks', () => {
+    const rec = strokedPolylineCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: ['A', 'B'],
+      valMin: 0,
+      valMax: 10,
+      valAxisMajorUnit: 10,
+      valAxisMajorTickMark: 'out',
+      catAxisMajorTickMark: 'out',
+      valAxisLineColor: 'FF00FF',
+      catAxisLineColor: '00AA00',
+      valAxisMajorGridlines: false,
+      catAxisLabelRotation: 0,
+      threeD: { rotationX: 15, rotationY: 20, depthPercent: 100, perspective: 30 },
+      series: [series({ values: [5, 8] })],
+    }), RECT, 1);
+
+    const valueZero = rec.texts.find(text => text.text === '0');
+    const categoryA = rec.texts.find(text => text.text === 'A');
+    expect(valueZero).toBeDefined();
+    expect(categoryA).toBeDefined();
+
+    const valueTick = rec.strokes.find(stroke =>
+      stroke.ss === '#FF00FF'
+      && stroke.points.length === 2
+      && Math.abs(Math.abs(stroke.points[1].x - stroke.points[0].x) - 6) < 0.001
+      && Math.abs(stroke.points[1].y - stroke.points[0].y) < 0.001
+      && Math.abs(stroke.points[0].y - valueZero!.y) < 0.001);
+    const categoryTick = rec.strokes.find(stroke =>
+      stroke.ss === '#00AA00'
+      && stroke.points.length === 2
+      && Math.abs(Math.abs(stroke.points[1].y - stroke.points[0].y) - 6) < 0.001
+      && Math.abs(stroke.points[1].x - stroke.points[0].x) < 0.001
+      && Math.abs(stroke.points[0].x - categoryA!.x) < 0.001);
+    expect(valueTick).toBeDefined();
+    expect(categoryTick).toBeDefined();
+
+    if (valueZero!.align === 'right') {
+      expect(valueZero!.x).toBeLessThan(Math.min(valueTick!.points[0].x, valueTick!.points[1].x));
+    } else {
+      expect(valueZero!.x).toBeGreaterThan(Math.max(valueTick!.points[0].x, valueTick!.points[1].x));
+    }
+    if (categoryA!.baseline === 'top') {
+      expect(categoryA!.y).toBeGreaterThan(Math.max(categoryTick!.points[0].y, categoryTick!.points[1].y));
+    } else {
+      expect(categoryA!.y).toBeLessThan(Math.min(categoryTick!.points[0].y, categoryTick!.points[1].y));
+    }
+  });
+
   it('applies the Office 3-D value-axis default of cross minor ticks at major/5', () => {
     const rec = strokedPolylineCtx();
     renderChart(rec.ctx, baseModel({
@@ -5349,6 +5399,53 @@ describe('CH9 — scatter error-bar cap geometry (§21.2.2.20)', () => {
 });
 
 describe('CH9 — scatter axis crossing and tick-label position (§21.2.2.207)', () => {
+  it('places nextTo labels beyond authored outward tick marks on both numeric axes', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'scatter',
+      categories: ['0', '1'],
+      series: [series({ values: [0, 1], showMarker: false })],
+      catAxisMin: 0,
+      catAxisMax: 1,
+      valMin: 0,
+      valMax: 1,
+      catAxisMajorUnit: 1,
+      valAxisMajorUnit: 1,
+      catAxisMajorTickMark: 'out',
+      valAxisMajorTickMark: 'out',
+      catAxisTickLabelPos: 'nextTo',
+      valAxisTickLabelPos: 'nextTo',
+      catAxisMajorGridlines: false,
+      valAxisMajorGridlines: false,
+    }), RECT, 1);
+
+    const xZero = rec.texts.find(text =>
+      text.text === '0' && text.align === 'center' && text.baseline === 'top');
+    const yZero = rec.texts.find(text =>
+      text.text === '0' && text.align === 'right' && text.baseline === 'middle');
+    expect(xZero).toBeDefined();
+    expect(yZero).toBeDefined();
+
+    const xTick = rec.segments.find(segment =>
+      segment.length === 2
+      && Math.abs(segment[0].x - (xZero as TextCall).x) < 0.001
+      && Math.abs(segment[0].x - segment[1].x) < 0.001
+      && Math.abs(Math.abs(segment[1].y - segment[0].y) - 6) < 0.001);
+    const yTick = rec.segments.find(segment =>
+      segment.length === 2
+      && Math.abs(segment[0].y - (yZero as TextCall).y) < 0.001
+      && Math.abs(segment[0].y - segment[1].y) < 0.001
+      && Math.abs(Math.abs(segment[1].x - segment[0].x) - 6) < 0.001);
+    expect(xTick).toBeDefined();
+    expect(yTick).toBeDefined();
+
+    // Label anchors are measured from the outside endpoint of the tick, not
+    // from the axis rule. This keeps the 6pt Office major tick out of the
+    // adjacent glyphs at the lower-left crossing.
+    expect((xZero as TextCall).y).toBeGreaterThan(Math.max(xTick![0].y, xTick![1].y));
+    expect((yZero as TextCall).x).toBeLessThan(Math.min(yTick![0].x, yTick![1].x));
+  });
+
   it('crosses both numeric axes at zero while low tick labels stay on the plot edges', () => {
     const rec = markerRecordingCtx();
     renderChart(rec.ctx, baseModel({
@@ -6834,11 +6931,13 @@ function strokedPolylineCtx(): {
     points: Array<{ x: number; y: number }>; ss: string; lw: number; dash: number[];
     cap: string; join: string;
   }>;
+  texts: TextCall[];
 } {
   const strokes: Array<{
     points: Array<{ x: number; y: number }>; ss: string; lw: number; dash: number[];
     cap: string; join: string;
   }> = [];
+  const texts: TextCall[] = [];
   let path: Array<{ x: number; y: number }> = [];
   let dash: number[] = [];
   const state: Record<string, unknown> = {
@@ -6868,6 +6967,12 @@ function strokedPolylineCtx(): {
         };
         case 'setLineDash': return (value: number[]) => { dash = [...value]; };
         case 'getLineDash': return () => [...dash];
+        case 'fillText': return (text: string, x: number, y: number) => {
+          texts.push({
+            text: String(text), x, y,
+            align: String(state.textAlign), baseline: String(state.textBaseline),
+          });
+        };
         case 'createLinearGradient': case 'createRadialGradient':
           return () => ({ addColorStop() {} });
         default: return () => undefined;
@@ -6878,6 +6983,7 @@ function strokedPolylineCtx(): {
   return {
     ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D,
     strokes,
+    texts,
   };
 }
 

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -4175,6 +4175,32 @@ describe('ChartEx flat layouts dispatch to semantic renderers', () => {
     expect(rec.rects).toHaveLength(2);
   });
 
+  it('keeps ChartEx histogram value labels at the observed axis-relative offset', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'histogram',
+      categories: [],
+      series: [series({ values: [0, 1, 2, 3, 4] })],
+      chartexHistogramBinning: { binCount: 2, intervalClosed: 'l' },
+      valMin: 0,
+      valMax: 4,
+      valAxisMajorUnit: 2,
+      valAxisFontSizeHpt: 1000,
+      valAxisLineColor: '123456',
+      valAxisLineHidden: false,
+    }), RECT, 1);
+
+    const axis = rec.segs.find(segment =>
+      segment.ss === '#123456'
+      && Math.abs(segment.x0 - segment.x1) < 0.001
+      && Math.abs(segment.y1 - segment.y0) > 100
+    );
+    const zero = rec.texts.find(text => text.text === '0' && text.align === 'right');
+    expect(axis).toBeDefined();
+    expect(zero).toBeDefined();
+    expect(axis!.x0 - zero!.x).toBeCloseTo(7, 5);
+  });
+
   it('keeps dense one- and two-digit category labels on one line across fallback font metrics', () => {
     const categories = Array.from({ length: 29 }, (_, index) => String(index + 1));
     const rec = recordingCtx();
@@ -9126,6 +9152,28 @@ describe('CH15 — chartEx box-and-whisker', () => {
     });
   }
 
+  it('keeps ChartEx value-label offset stable across a larger authored font', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, boxModel({
+      valMin: 0,
+      valMax: 10,
+      valAxisMajorUnit: 10,
+      valAxisFontSizeHpt: 1200,
+      valAxisLineColor: '123456',
+      valAxisLineHidden: false,
+    }), RECT, 1);
+
+    const axis = rec.segs.find(segment =>
+      segment.ss === '#123456'
+      && Math.abs(segment.x0 - segment.x1) < 0.001
+      && Math.abs(segment.y1 - segment.y0) > 100
+    );
+    const zero = rec.texts.find(text => text.text === '0' && text.align === 'right');
+    expect(axis).toBeDefined();
+    expect(zero).toBeDefined();
+    expect(axis!.x0 - zero!.x).toBeCloseTo(7, 5);
+  });
+
   it('preserves the authored box-series outline on the filled legend key', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, boxModel({
@@ -9381,7 +9429,7 @@ describe('CH15 — chartEx box-and-whisker', () => {
 
     const zeroLabel = rec.texts.find(text => text.text === '0.0');
     expect(zeroLabel).toBeDefined();
-    expect((verticalAxis?.x0 ?? 0) - (zeroLabel?.x ?? 0)).toBeCloseTo(12);
+    expect((verticalAxis?.x0 ?? 0) - (zeroLabel?.x ?? 0)).toBeCloseTo(7);
   });
 
   it('places the value axis from measured tick-label width instead of a fixed chart-width gutter', () => {

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -989,8 +989,7 @@ function drawAxisTick(
   if (lineHidden || mode === 'none' || !mode) return;
   // Office's vector output uses 6pt major ticks and 4pt minor ticks. Tick
   // length still scales mildly with an unusually thick authored axis rule.
-  const baseLen = (level === 'minor' ? 4 : 6) * ptToPx;
-  const len = lineWidth ? Math.max(baseLen, lineWidth + 2 * ptToPx) : baseLen;
+  const len = axisTickLengthPx(level, lineWidth, ptToPx);
   // Office's 6pt/4pt observation is the complete cross-tick length, not the
   // length on each side of the axis. out/in use the full length on one side;
   // cross splits it evenly around the rule.
@@ -1024,6 +1023,27 @@ function drawAxisTick(
   ctx.stroke();
   ctx.strokeStyle = prevS;
   ctx.lineWidth = prevW;
+}
+
+function axisTickLengthPx(
+  level: 'major' | 'minor',
+  lineWidth: number | undefined,
+  ptToPx: number,
+): number {
+  const baseLen = (level === 'minor' ? 4 : 6) * ptToPx;
+  return lineWidth ? Math.max(baseLen, lineWidth + 2 * ptToPx) : baseLen;
+}
+
+/** Distance an axis tick occupies outside the plot-side axis rule. */
+function axisTickOutwardExtentPx(
+  mode: string | null | undefined,
+  level: 'major' | 'minor',
+  lineWidth: number | undefined,
+  ptToPx: number,
+): number {
+  if (mode !== 'out' && mode !== 'cross') return 0;
+  const length = axisTickLengthPx(level, lineWidth, ptToPx);
+  return mode === 'cross' ? length / 2 : length;
 }
 
 /** Stroke one horizontal value-axis gridline spanning the plot width at `gy`.
@@ -6635,6 +6655,11 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       chart.valAxisFontBold ?? false,
       chart.valAxisFontItalic ?? false,
     );
+    const yAxisLineColor = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : undefined;
+    const yAxisLineWidth = axisLineWidthPx(chart.valAxisLineWidthEmu, ptToPx);
+    const yMajorTickOutset = chart.valAxisLineHidden
+      ? 0
+      : axisTickOutwardExtentPx(chart.valAxisMajorTickMark, 'major', yAxisLineWidth, ptToPx);
     if (chart.valAxisMinorGridlines) {
       const minorGrid = valMinorGridStroke(chart, ptToPx);
       for (const value of yMinorTicks) {
@@ -6659,7 +6684,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
         } else if (labelPos === 'low') {
           ctx.textAlign = 'right'; labelX = px0 - yTickGap;
         } else {
-          ctx.textAlign = 'right'; labelX = yAxisX - yTickGap;
+          ctx.textAlign = 'right'; labelX = yAxisX - yMajorTickOutset - yTickGap;
         }
         ctx.textBaseline = 'middle';
         ctx.fillText(formatPrimaryValueAxisTick(chart, v, false), labelX, gy);
@@ -6667,13 +6692,11 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       // Scatter keeps its own undefined colour default (→ drawAxisTick's '#888'),
       // so only the width formula is shared. `axisLineWidthPx`'s 1 px fallback is
       // equivalent to undefined here (drawAxisTick treats both as a hairline).
-      const yAxisLineColor = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : undefined;
-      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', yAxisX, gy, yAxisLineColor, axisLineWidthPx(chart.valAxisLineWidthEmu, ptToPx), false, chart.valAxisLineHidden, 'major', ptToPx);
+      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', yAxisX, gy, yAxisLineColor, yAxisLineWidth, false, chart.valAxisLineHidden, 'major', ptToPx);
     }
     if (chart.valAxisMinorTickMark && chart.valAxisMinorTickMark !== 'none') {
-      const yAxisLineColor = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : undefined;
       for (const value of yMinorTicks) {
-        drawAxisTick(ctx, chart.valAxisMinorTickMark, 'val', yAxisX, toY(value), yAxisLineColor, axisLineWidthPx(chart.valAxisLineWidthEmu, ptToPx), false, chart.valAxisLineHidden, 'minor', ptToPx);
+        drawAxisTick(ctx, chart.valAxisMinorTickMark, 'val', yAxisX, toY(value), yAxisLineColor, yAxisLineWidth, false, chart.valAxisLineHidden, 'minor', ptToPx);
       }
     }
   }
@@ -6750,22 +6773,25 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#555';
     ctx.textAlign = 'center';
     const labelPos = chart.catAxisTickLabelPos ?? 'nextTo';
+    const lineWidth = axisLineWidthPx(chart.catAxisLineWidthEmu, ptToPx);
+    const xAxisLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : undefined;
+    const tickOutset = chart.catAxisLineHidden
+      ? 0
+      : axisTickOutwardExtentPx(chart.catAxisMajorTickMark, 'major', lineWidth, ptToPx);
     const labelY = labelPos === 'low'
       ? py0 + ph + tickGap
-      : labelPos === 'high' ? py0 - tickGap : xAxisY + tickGap;
+      : labelPos === 'high' ? py0 - tickGap : xAxisY + tickOutset + tickGap;
     ctx.textBaseline = labelPos === 'high' ? 'bottom' : 'top';
     for (const v of xMajorTicks) {
       const gx = toX(v);
       if (labelPos !== 'none') {
         ctx.fillText(formatAxisTickWithUnits(v, chart.catAxisFormatCode, chart.date1904, chart.catAxisDisplayUnits), gx, labelY);
       }
-      const xAxisLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : undefined;
-      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', xAxisY, gx, xAxisLineColor, axisLineWidthPx(chart.catAxisLineWidthEmu, ptToPx), false, chart.catAxisLineHidden, 'major', ptToPx);
+      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', xAxisY, gx, xAxisLineColor, lineWidth, false, chart.catAxisLineHidden, 'major', ptToPx);
     }
     if (chart.catAxisMinorTickMark && chart.catAxisMinorTickMark !== 'none') {
-      const xAxisLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : undefined;
       for (const value of xMinorTicks) {
-        drawAxisTick(ctx, chart.catAxisMinorTickMark, 'cat', xAxisY, toX(value), xAxisLineColor, axisLineWidthPx(chart.catAxisLineWidthEmu, ptToPx), false, chart.catAxisLineHidden, 'minor', ptToPx);
+        drawAxisTick(ctx, chart.catAxisMinorTickMark, 'cat', xAxisY, toX(value), xAxisLineColor, lineWidth, false, chart.catAxisLineHidden, 'minor', ptToPx);
       }
     }
   }
@@ -6811,13 +6837,16 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     ctx.fillStyle = secondaryX.fontColor ? `#${secondaryX.fontColor}` : '#555';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'bottom';
+    const tickOutset = secondaryX.lineHidden
+      ? 0
+      : axisTickOutwardExtentPx(secondaryX.majorTickMark, 'major', line.width, ptToPx);
     for (const value of secondaryXPlan.majorTicks) {
       const sx = toSecondaryX(value);
       if (secondaryX.tickLabelPos !== 'none') {
         ctx.fillText(
           formatAxisTickWithUnits(value, secondaryX.formatCode, chart.date1904, secondaryX.displayUnits),
           sx,
-          py0 - categoryTickLabelGapPx(fontPx),
+          py0 - tickOutset - categoryTickLabelGapPx(fontPx),
         );
       }
       drawAxisTick(

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -2161,6 +2161,17 @@ function drawBarDataLabel(
 // percentStacked. Also handles mixed bar+line series (seriesType per series).
 // ═══════════════════════════════════════════════════════════════════════════
 
+/**
+ * MS ChartEx does not expose a value-axis label-offset property. Office vector
+ * output from histogram, box-and-whisker, and Pareto charts (10 pt and 12 pt
+ * labels, with and without cross ticks) places the visible label edge about
+ * 6.2–7.5 pt from the axis centreline. Keep this compatibility fallback
+ * ChartEx-only; classic axes retain their existing font-relative contract.
+ */
+function chartExValueTickLabelOffsetPx(ptToPx: number): number {
+  return 7 * ptToPx;
+}
+
 function renderBarChart(
   ctx: CanvasRenderingContext2D,
   chart: ChartModel,
@@ -2638,9 +2649,11 @@ function renderBarChart(
         if (drawMajorGrid) strokeValueGridlineH(ctx, px0, pw, gy, isZero, grid);
         if (drawLabels) {
           ctx.textAlign = 'right';
-          const gap = chart.valAxisFontSizeHpt != null
-            ? valueTickLabelGapPx(drawnValTickFontPx)
-            : 12;
+          const gap = options.gapPolicy === 'chartex'
+            ? chartExValueTickLabelOffsetPx(ptToPx)
+            : chart.valAxisFontSizeHpt != null
+              ? valueTickLabelGapPx(drawnValTickFontPx)
+              : 12;
           ctx.fillText(label, px0 - gap, gy);
         }
       } else {
@@ -8828,7 +8841,11 @@ function renderBoxWhiskerChart(
 
   const font = chartFontFamily(chart, chart.valAxisFontFace, 'minor');
   const valFontPx = axisLabelPx(chart.valAxisFontSizeHpt, h, ptToPx);
-  const valTickLabelGap = valueTickLabelGapPx(valFontPx);
+  // Keep the existing font-relative layout reserve so the plot geometry stays
+  // stable; only the painted ChartEx label uses the observed axis-relative
+  // offset below.
+  const valTickLabelLayoutGap = valueTickLabelGapPx(valFontPx);
+  const valTickLabelPaintGap = chartExValueTickLabelOffsetPx(ptToPx);
   const provisionalScale = planLinearValueAxis({
     dataMin,
     dataMax,
@@ -8860,7 +8877,7 @@ function renderBoxWhiskerChart(
       maxLabelW = Math.max(maxLabelW, ctx.measureText(label).width);
     }
     ctx.font = previousFont;
-    valLabelBandW = maxLabelW + valTickLabelGap + AXIS_OUTER_TEXT_MARGIN_PT * ptToPx;
+    valLabelBandW = maxLabelW + valTickLabelLayoutGap + AXIS_OUTER_TEXT_MARGIN_PT * ptToPx;
   }
 
   // Shared title band + cartesian plot rect. Reserve category/value-axis bands
@@ -8956,7 +8973,7 @@ function renderBoxWhiskerChart(
       ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#595959';
       ctx.fillText(
         formatPrimaryValueAxisTick(chart, v, false),
-        px0 - valTickLabelGap,
+        px0 - valTickLabelPaintGap,
         gy,
       );
       drawAxisTick(

--- a/packages/core/src/chart/three-d-renderer.ts
+++ b/packages/core/src/chart/three-d-renderer.ts
@@ -754,19 +754,20 @@ function drawAngledCategoryLabel(
   rotation: number,
   horizontal: boolean,
   outwardY = 1,
+  offset = 6,
 ): void {
   if (horizontal || rotation === 0) {
     ctx.textAlign = horizontal ? 'right' : 'center';
     ctx.textBaseline = horizontal ? 'middle' : outwardY < 0 ? 'bottom' : 'top';
     ctx.fillText(
       label,
-      point.x + (horizontal ? -6 : 0),
-      point.y + (horizontal ? 0 : outwardY * 6),
+      point.x + (horizontal ? -offset : 0),
+      point.y + (horizontal ? 0 : outwardY * offset),
     );
     return;
   }
   ctx.save();
-  ctx.translate(point.x, point.y + outwardY * 6);
+  ctx.translate(point.x, point.y + outwardY * offset);
   ctx.rotate(rotation);
   ctx.textAlign = outwardY < 0 ? 'left' : 'right';
   ctx.textBaseline = 'middle';
@@ -1825,7 +1826,7 @@ function projectedAxisTick(
   const normal = screenAnnotationOutward(
     axisStart, axisEnd, projectedSceneCenter, screenDirection,
   );
-  const length = (level === 'minor' ? 4 : 6) * ptToPx;
+  const length = projectedAxisTickLengthPx(level, ptToPx);
   const sideLength = mode === 'cross' ? length / 2 : length;
   const outer = mode === 'out' || mode === 'cross' ? sideLength : 0;
   const inner = mode === 'in' || mode === 'cross' ? sideLength : 0;
@@ -1833,6 +1834,31 @@ function projectedAxisTick(
   ctx.moveTo(anchor.x + normal.x * outer, anchor.y + normal.y * outer);
   ctx.lineTo(anchor.x - normal.x * inner, anchor.y - normal.y * inner);
   ctx.stroke();
+}
+
+function projectedAxisTickLengthPx(level: 'major' | 'minor', ptToPx: number): number {
+  return (level === 'minor' ? 4 : 6) * ptToPx;
+}
+
+function projectedAxisTickOutwardExtentPx(
+  mode: string | null | undefined,
+  level: 'major' | 'minor',
+  ptToPx: number,
+): number {
+  if (mode !== 'out' && mode !== 'cross') return 0;
+  const length = projectedAxisTickLengthPx(level, ptToPx);
+  return mode === 'cross' ? length / 2 : length;
+}
+
+function projectedAxisTickLabelOffsetPx(
+  mode: string | null | undefined,
+  lineHidden: boolean | null | undefined,
+  ptToPx: number,
+  previousMinimum: number,
+): number {
+  if (lineHidden) return previousMinimum;
+  const tickOutset = projectedAxisTickOutwardExtentPx(mode, 'major', ptToPx);
+  return Math.max(previousMinimum, tickOutset + 3 * ptToPx);
 }
 
 interface ThreeDAxisGeometry {
@@ -3019,6 +3045,9 @@ function renderCartesian(
     );
     ctx.textAlign = Math.abs(labelNormal.x) < 0.2 ? 'center' : labelNormal.x < 0 ? 'right' : 'left';
     ctx.textBaseline = Math.abs(labelNormal.y) < 0.2 ? 'middle' : labelNormal.y < 0 ? 'bottom' : 'top';
+    const labelOffset = projectedAxisTickLabelOffsetPx(
+      chart.valAxisMajorTickMark, chart.valAxisLineHidden, ptToPx, 5,
+    );
     const displayUnitDivisor = chart.valAxisDisplayUnits?.divisor;
     for (const value of axis.majorTicks) {
       const point = horizontal
@@ -3034,13 +3063,16 @@ function renderCartesian(
             : value,
         percent ? chart.valAxisFormatCode ?? '0%' : chart.valAxisFormatCode,
         chart.date1904,
-      ), point.x + labelNormal.x * 5, point.y + labelNormal.y * 5);
+      ), point.x + labelNormal.x * labelOffset, point.y + labelNormal.y * labelOffset);
     }
   }
   const categoryFontPx = chartTextFontSizePx(chart.catAxisFontSizeHpt, ptToPx) ?? 9 * ptToPx;
   ctx.font = `${chart.catAxisFontItalic ? 'italic ' : ''}${chart.catAxisFontBold ? 'bold ' : ''}${categoryFontPx}px ${fontFamily(chart.catAxisFontFace)}`;
   ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#595959';
   if (!chart.catAxisHidden && chart.catAxisTickLabelPos !== 'none') {
+    const labelOffset = projectedAxisTickLabelOffsetPx(
+      chart.catAxisMajorTickMark, chart.catAxisLineHidden, ptToPx, 6,
+    );
     const formattedCategories = Array.from({ length: categoryCount }, (_, index) =>
       formatCategoryLabel(
         String(categories[index] ?? index + 1),
@@ -3097,7 +3129,11 @@ function renderCartesian(
         const onScreenLeft = axisMidpoint.x <= sceneMidpoint.x;
         ctx.textAlign = onScreenLeft ? 'right' : 'left';
         ctx.textBaseline = 'middle';
-        ctx.fillText(formattedCategories[categoryIndex], point.x + (onScreenLeft ? -6 : 6), point.y);
+        ctx.fillText(
+          formattedCategories[categoryIndex],
+          point.x + (onScreenLeft ? -labelOffset : labelOffset),
+          point.y,
+        );
       } else {
         const sceneMidpoint = projection.project(
           front.x + front.w / 2,
@@ -3117,6 +3153,7 @@ function renderCartesian(
           rotation,
           horizontal,
           outward.y < 0 ? -1 : 1,
+          labelOffset,
         );
       }
     }


### PR DESCRIPTION
## Summary
- place classic scatter and 3-D axis labels beyond authored outward tick marks
- preserve the established 3-D compatibility spacing while keeping classic scatter independent
- use a ChartEx-only value-label offset derived from multiple Office vector outputs

## Verification
- 902 core chart tests
- workspace typecheck
- optional 3-D bundle boundary
- private XLSX self-regression VRT with each changed rendering adjudicated against Office output
- git diff --check

No private samples or generated visual artifacts are included.