### PR TITLE
chore(release): 0.80.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ semantic versioning. While the major version is zero, minor releases may contain
 explicitly documented breaking changes; patch releases remain compatible with
 the corresponding minor release.
 
+## 0.80.1 — 2026-08-17
+
+Patch. Corrects numeric axis-label spacing across authored chart families
+without changing the 0.80 public integration contract.
+
+- **scatter charts:** place numeric labels beyond authored outward tick marks
+  instead of allowing major ticks to enter or touch adjacent glyphs.
+- **3-D charts:** keep value and category labels clear of projected tick marks
+  while preserving the established Office-compatible axis spacing.
+- **ChartEx axes:** use an axis-relative label offset for histogram,
+  box-and-whisker, and Pareto value axes instead of scaling the offset with the
+  label font size.
+- **compatibility:** no application or API migration is required from 0.80.0.
+
 ## 0.80.0 — 2026-08-16
 
 Compatible minor release. Completes built-in renderer parity between the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.80.0",
+  "version": "0.80.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.80.0",
+  "version": "0.80.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.80.0",
+  "version": "0.80.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.80.0",
+  "version": "0.80.1",
   "description": "Internal workspace adapter for DOCX / XLSX / PPTX Markdown projection",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.80.0"
+version = "0.80.1"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.80.0",
+  "version": "0.80.1",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.80.0",
+  "version": "0.80.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity local viewer for Office files (.docx / .xlsx / .pptx), powered by Rust/WASM and Canvas. Optional MCP integration can share requested context with an AI agent.",
-  "version": "0.80.0",
+  "version": "0.80.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.80.0",
+  "version": "0.80.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.80.0",
+  "version": "0.80.1",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",


### PR DESCRIPTION
## Release
- bump all published packages and the MCP server to 0.80.1
- document the compatible chart axis-label spacing corrections
- keep announcements and public API documentation unchanged; this patch adds no new integration surface

## Verification
- 902 core chart tests
- workspace typecheck
- cargo check for the MCP server
- version consistency and git diff --check
- feature PR #1267 passed audit, rust, smoke, and typecheck CI

## Release checklist
- README reviewed against the current implementation
- existing README screenshots retained because default public sample rendering is unchanged
- no private samples or generated local artifacts are included