### PR TITLE
fix(core): align surface axes and chart ticks

### DIFF
--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -679,20 +679,26 @@ stroke ss=#aaa lw=1 dash=
 setLineDash
 setLineDash
 beginPath
-moveTo 149.2167,319.25
-lineTo 149.2167,312.95
+moveTo 68.5,319.25
+lineTo 68.5,312.95
 stroke ss=#aaa lw=1 dash=
 setLineDash
 setLineDash
 beginPath
-moveTo 310.65,319.25
-lineTo 310.65,312.95
+moveTo 229.9333,319.25
+lineTo 229.9333,312.95
 stroke ss=#aaa lw=1 dash=
 setLineDash
 setLineDash
 beginPath
-moveTo 472.0833,319.25
-lineTo 472.0833,312.95
+moveTo 391.3667,319.25
+lineTo 391.3667,312.95
+stroke ss=#aaa lw=1 dash=
+setLineDash
+setLineDash
+beginPath
+moveTo 552.8,319.25
+lineTo 552.8,312.95
 stroke ss=#aaa lw=1 dash=
 setLineDash
 set font=10.5px sans-serif
@@ -889,20 +895,26 @@ stroke ss=#aaa lw=1 dash=
 setLineDash
 setLineDash
 beginPath
-moveTo 24.475,108.5542
-lineTo 30.775,108.5542
+moveTo 24.475,63.175
+lineTo 30.775,63.175
 stroke ss=#aaa lw=1 dash=
 setLineDash
 setLineDash
 beginPath
-moveTo 24.475,199.3125
-lineTo 30.775,199.3125
+moveTo 24.475,153.9333
+lineTo 30.775,153.9333
 stroke ss=#aaa lw=1 dash=
 setLineDash
 setLineDash
 beginPath
-moveTo 24.475,290.0708
-lineTo 30.775,290.0708
+moveTo 24.475,244.6917
+lineTo 30.775,244.6917
+stroke ss=#aaa lw=1 dash=
+setLineDash
+setLineDash
+beginPath
+moveTo 24.475,335.45
+lineTo 30.775,335.45
 stroke ss=#aaa lw=1 dash=
 setLineDash
 set font=10.5px sans-serif
@@ -1098,20 +1110,26 @@ stroke ss=#aaa lw=1 dash=
 setLineDash
 setLineDash
 beginPath
-moveTo 123.6833,341.75
-lineTo 123.6833,335.45
+moveTo 47.8,341.75
+lineTo 47.8,335.45
 stroke ss=#aaa lw=1 dash=
 setLineDash
 setLineDash
 beginPath
-moveTo 275.45,341.75
-lineTo 275.45,335.45
+moveTo 199.5667,341.75
+lineTo 199.5667,335.45
 stroke ss=#aaa lw=1 dash=
 setLineDash
 setLineDash
 beginPath
-moveTo 427.2167,341.75
-lineTo 427.2167,335.45
+moveTo 351.3333,341.75
+lineTo 351.3333,335.45
+stroke ss=#aaa lw=1 dash=
+setLineDash
+setLineDash
+beginPath
+moveTo 503.1,341.75
+lineTo 503.1,335.45
 stroke ss=#aaa lw=1 dash=
 setLineDash
 setLineDash
@@ -2974,20 +2992,26 @@ stroke ss=#aaa lw=1 dash=
 setLineDash
 setLineDash
 beginPath
-moveTo 139.8,323.25
-lineTo 139.8,316.95
+moveTo 41.2,323.25
+lineTo 41.2,316.95
 stroke ss=#aaa lw=1 dash=
 setLineDash
 setLineDash
 beginPath
-moveTo 337,323.25
-lineTo 337,316.95
+moveTo 238.4,323.25
+lineTo 238.4,316.95
 stroke ss=#aaa lw=1 dash=
 setLineDash
 setLineDash
 beginPath
-moveTo 534.2,323.25
-lineTo 534.2,316.95
+moveTo 435.6,323.25
+lineTo 435.6,316.95
+stroke ss=#aaa lw=1 dash=
+setLineDash
+setLineDash
+beginPath
+moveTo 632.8,323.25
+lineTo 632.8,316.95
 stroke ss=#aaa lw=1 dash=
 setLineDash
 set font=10.5px sans-serif
@@ -3169,20 +3193,26 @@ stroke ss=#aaa lw=1 dash=
 setLineDash
 setLineDash
 beginPath
-moveTo 217.4667,341.75
-lineTo 217.4667,335.45
+moveTo 134.4,341.75
+lineTo 134.4,335.45
 stroke ss=#aaa lw=1 dash=
 setLineDash
 setLineDash
 beginPath
-moveTo 383.6,341.75
-lineTo 383.6,335.45
+moveTo 300.5333,341.75
+lineTo 300.5333,335.45
 stroke ss=#aaa lw=1 dash=
 setLineDash
 setLineDash
 beginPath
-moveTo 549.7333,341.75
-lineTo 549.7333,335.45
+moveTo 466.6667,341.75
+lineTo 466.6667,335.45
+stroke ss=#aaa lw=1 dash=
+setLineDash
+setLineDash
+beginPath
+moveTo 632.8,341.75
+lineTo 632.8,335.45
 stroke ss=#aaa lw=1 dash=
 setLineDash
 set font=10.5px sans-serif

--- a/packages/core/src/chart/material-color.test.ts
+++ b/packages/core/src/chart/material-color.test.ts
@@ -33,10 +33,17 @@ describe('legacy Pattern 2 generated colours', () => {
 
 describe('surface automatic material', () => {
   it('is winding-invariant and bounded to the surface compatibility range', () => {
-    const lit = surfaceMaterialFactor({ x: -0.2, y: 0.4, z: 0.9 });
-    expect(surfaceMaterialFactor({ x: 0.2, y: -0.4, z: -0.9 })).toBeCloseTo(lit, 12);
+    const lit = surfaceMaterialFactor({ x: 0.2, y: 0.4, z: 0.9 });
+    expect(surfaceMaterialFactor({ x: -0.2, y: -0.4, z: -0.9 })).toBeCloseTo(lit, 12);
     expect(lit).toBeGreaterThan(1);
     expect(surfaceMaterialFactor({ x: 0.2, y: -0.4, z: 0.1 })).toBeGreaterThanOrEqual(0.48);
+  });
+
+  it('lights camera-space upper-right facets more strongly than their mirrors', () => {
+    expect(surfaceMaterialFactor({ x: 0.4, y: 0, z: 0.92 }))
+      .toBeGreaterThan(surfaceMaterialFactor({ x: -0.4, y: 0, z: 0.92 }));
+    expect(surfaceMaterialFactor({ x: 0, y: 0.4, z: 0.92 }))
+      .toBeGreaterThan(surfaceMaterialFactor({ x: 0, y: -0.4, z: 0.92 }));
   });
 });
 

--- a/packages/core/src/chart/material-color.ts
+++ b/packages/core/src/chart/material-color.ts
@@ -93,7 +93,9 @@ export function surfaceMaterialFactor(normal: { x: number; y: number; z: number 
   const facing = normal.z < 0
     ? { x: -normal.x, y: -normal.y, z: -normal.z }
     : normal;
-  const light = { x: -0.24, y: 0.42, z: 0.88 };
+  // The observed Office surface material is lit from screen upper-right.
+  // Shared camera projection maps +x rightward and +y upward on screen.
+  const light = { x: 0.24, y: 0.42, z: 0.88 };
   const length = Math.hypot(light.x, light.y, light.z);
   const lambert = Math.max(0,
     (facing.x * light.x + facing.y * light.y + facing.z * light.z) / length,

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -6604,7 +6604,7 @@ describe('CH9 — line/area smooth splines (§21.2.2.194)', () => {
     )).toBe(true);
   });
 
-  it('uses category centers for major ticks, boundaries for minor ticks, and italic labels', () => {
+  it('uses longer major ticks at category boundaries and shorter minor ticks at centers', () => {
     const ticks = segRecordingCtx();
     const model = baseModel({
       chartType: 'clusteredBar',
@@ -6622,6 +6622,20 @@ describe('CH9 — line/area smooth splines (§21.2.2.194)', () => {
       && Math.abs(segment.x1 - segment.x0) < 0.001
       && Math.abs(segment.y1 - segment.y0) <= 8);
     expect(categoryTicks).toHaveLength(11);
+    const byLength = (length: number) => categoryTicks.filter(segment =>
+      Math.abs(Math.abs(segment.y1 - segment.y0) - length) < 0.001);
+    const boundaryTicks = byLength(6).sort((left, right) => left.x0 - right.x0);
+    const centreTicks = byLength(4).sort((left, right) => left.x0 - right.x0);
+    expect(boundaryTicks).toHaveLength(6);
+    expect(centreTicks).toHaveLength(5);
+    expect(boundaryTicks[0].x0).toBeLessThan(centreTicks[0].x0);
+    expect(boundaryTicks.at(-1)!.x0).toBeGreaterThan(centreTicks.at(-1)!.x0);
+    for (let index = 0; index < centreTicks.length; index++) {
+      expect(centreTicks[index].x0).toBeCloseTo(
+        (boundaryTicks[index].x0 + boundaryTicks[index + 1].x0) / 2,
+        6,
+      );
+    }
 
     const labels = recordingCtx();
     renderChart(labels.ctx, model, RECT, 1);
@@ -9331,7 +9345,7 @@ describe('CH13 — stock chart (high/low/close)', () => {
 });
 
 describe('surface contour charts', () => {
-  it('separates Surface point centres from category-grid boundaries', () => {
+  it('centres category points but places Surface series on axis endpoints', () => {
     const rec = strokedPolylineCtx();
     renderChart(rec.ctx, baseModel({
       chartType: 'surface',
@@ -9378,7 +9392,7 @@ describe('surface contour charts', () => {
       });
     };
     expect(fractionsAlong('#FF00FF', ['Y1', 'Y2'], { x: 8, y: 0 }))
-      .toEqual([expect.closeTo(0.25, 6), expect.closeTo(0.75, 6)]);
+      .toEqual([expect.closeTo(0, 6), expect.closeTo(1, 6)]);
     expect(fractionsAlong('#00FFFF', ['X1', 'X2'], { x: 0, y: 8 }))
       .toEqual([expect.closeTo(0.25, 6), expect.closeTo(0.75, 6)]);
 
@@ -9436,8 +9450,8 @@ describe('surface contour charts', () => {
     // bounded Surface-family perspective gain without coupling other 3-D
     // families to the compatibility observation.
     const points = omitted.flat();
-    expect(Math.min(...points.map(point => point.x))).toBeCloseTo(198.2, 0);
-    expect(Math.max(...points.map(point => point.y))).toBeCloseTo(229.0, 0);
+    expect(Math.min(...points.map(point => point.x))).toBeCloseTo(149.2, 0);
+    expect(Math.max(...points.map(point => point.y))).toBeCloseTo(264.4, 0);
   });
 
   it('rejects an unbounded authored band count before allocating tick arrays', () => {

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -3537,15 +3537,13 @@ function renderBarChart(
         }
       }
     }
-    // Major category ticks identify labelled category centers. Minor ticks
-    // identify the intervening boundaries when crossBetween="between". Excel
-    // therefore emits N centered major ticks plus N+1 boundary minor ticks for
-    // an ordinary column axis that authors both tick levels.
+    // Category-axis major ticks share the major-grid positions: with
+    // crossBetween="between" they mark the N+1 interval boundaries, while
+    // labels and minor ticks sit at the N category centres. This distinction
+    // matters when both levels use `cross`: Office's 6pt major boundary marks
+    // remain visibly longer than its 4pt centred minor marks.
     if (!chart.catAxisHidden && chart.catAxisMajorTickMark && chart.catAxisMajorTickMark !== 'none') {
-      const ordinalFractions = Array.from(
-        { length: n },
-        (_, ci) => isCrossBetween(chart) ? (ci + 0.5) / n : (n === 1 ? 0.5 : ci / (n - 1)),
-      );
+      const ordinalFractions = catGridlineFractions(chart, n);
       const tickSkip = Math.max(1, Math.floor(chart.catAxisTickMarkSkip ?? 1));
       const tickFractions = dateAxisPlan
         ? dateAxisPlan.majorTicks.map(tick => tick.fraction)
@@ -3560,7 +3558,7 @@ function renderBarChart(
     }
     if (!chart.catAxisHidden && chart.catAxisMinorTickMark && chart.catAxisMinorTickMark !== 'none') {
       const ordinalFractions = isCrossBetween(chart)
-        ? Array.from({ length: n + 1 }, (_, ci) => ci / n)
+        ? Array.from({ length: n }, (_, ci) => (ci + 0.5) / n)
         : Array.from({ length: Math.max(0, n - 1) }, (_, ci) => (ci + 0.5) / (n - 1));
       const tickFractions = dateAxisPlan
         ? dateAxisPlan.minorTicks.map(tick => tick.fraction)
@@ -5565,10 +5563,14 @@ function renderSurfaceChart(
     column, columnCount, categoryBetween, categoryReversed,
   ) * front.w;
   const seriesReversed = seriesAxis?.orientation === 'maxMin';
-  const toDepth = (row: number): number => {
-    const authoredDepth = projection.seriesDepth(row, rowCount, false);
-    return seriesReversed ? 1 - authoredDepth : authoredDepth;
-  };
+  // Surface rows are values on `<c:serAx>`, whose schema has no
+  // `<c:crossBetween>`. Office places the first and last rows on the series
+  // axis endpoints, unlike category points centred by value-axis
+  // crossBetween="between". Reuse the shared endpoint placement so reversal
+  // and the single-row midpoint remain consistent with other ordinal axes.
+  const toDepth = (row: number): number => categoryPositionFraction(
+    row, rowCount, false, seriesReversed,
+  );
   const toValueY = (value: number): number =>
     front.y + front.h - surfaceFrac(value) * front.h;
   interface SurfacePaint {


### PR DESCRIPTION
## What changed

- place classic Surface series-axis rows on the axis endpoints while keeping category-axis data points centered within intervals
- orient the bounded automatic Surface material toward camera-space upper-right
- align ordinal bar-chart major category ticks with interval boundaries and minor ticks with category centers

## Why

The Surface renderer reused the centered 3-D series-slot placement even though `serAx` has no `crossBetween`, which inset the first and last rows. The automatic material also used the opposite horizontal light direction. For ordinal bar axes, category tick levels were assigned to the opposite positions, making category-boundary marks shorter than the centered marks in Office output.

## Impact

Surface meshes and labels now follow the observed endpoint/center asymmetry and lighting direction. Bar/column category separators retain the longer major tick treatment. Date axes and `midCat` paths are unchanged.

## Verification

- core chart tests: 961 passed
- TypeScript typecheck
- focused Office/PDF visual comparison
- independent adversarial review: 0 Blocker / 0 High / 0 Medium
- `git diff --check`