### PR TITLE
fix(chart): preserve themed axis stroke geometry

### DIFF
--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -6867,6 +6867,165 @@ describe('classic multi-level category labels', () => {
     expect(separatorSegments).toHaveLength(5);
   });
 
+  it('paints each multi-level boundary once with one continuous axis stroke', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredBar',
+      categories: ['Male', 'Female', 'Male', 'Female'],
+      categoryLevels: [
+        ['Male', 'Female', 'Male', 'Female'],
+        ['Smoker', '', 'Non-Smoker', ''],
+      ],
+      catAxisFontSizeHpt: 1000,
+      catAxisLineColor: '000000',
+      catAxisLineWidthEmu: 12_700,
+      catAxisMajorTickMark: 'cross',
+      catAxisMinorTickMark: 'none',
+      valAxisLineHidden: true,
+      valAxisMajorGridlines: false,
+      series: [series({ name: 'Prevalence', values: [25, 22, 15, 18] })],
+    }), RECT, 1);
+
+    const categoryRule = rec.segs.find(segment =>
+      segment.ss === '#000000'
+      && Math.abs(segment.y1 - segment.y0) < 0.01
+      && Math.abs(segment.x1 - segment.x0) > 100);
+    expect(categoryRule).toBeDefined();
+    const axisY = categoryRule!.y0;
+    const boundaries = rec.segs.filter(segment =>
+      segment.ss === '#000000'
+      && Math.abs(segment.x1 - segment.x0) < 0.01
+      && Math.min(segment.y0, segment.y1) < axisY
+      && Math.max(segment.y0, segment.y1) > axisY + 10);
+    expect(boundaries).toHaveLength(5);
+    expect(boundaries.every(segment => segment.lw === 1)).toBe(true);
+    const allAxisCrossingVertical = rec.segs.filter(segment =>
+      segment.ss === '#000000'
+      && Math.abs(segment.x1 - segment.x0) < 0.01
+      && Math.min(segment.y0, segment.y1) < axisY
+      && Math.max(segment.y0, segment.y1) > axisY);
+    expect(allAxisCrossingVertical).toHaveLength(5);
+  });
+
+  it('keeps major ticks on the actual axis when labels and brackets are low', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredBar',
+      categories: ['A', 'B', 'C', 'D'],
+      categoryLevels: [
+        ['A', 'B', 'C', 'D'],
+        ['Left', '', 'Right', ''],
+      ],
+      catAxisTickLabelPos: 'low',
+      catAxisLineColor: '000000',
+      catAxisMajorTickMark: 'cross',
+      catAxisMinorTickMark: 'none',
+      valAxisLineHidden: true,
+      valAxisMajorGridlines: false,
+      series: [series({ name: 'Mixed', values: [-10, 15, -5, 20] })],
+    }), RECT, 1);
+
+    const categoryRule = rec.segs.find(segment =>
+      segment.ss === '#000000'
+      && Math.abs(segment.y1 - segment.y0) < 0.01
+      && Math.abs(segment.x1 - segment.x0) > 100);
+    expect(categoryRule).toBeDefined();
+    const axisY = categoryRule!.y0;
+    const actualAxisTicks = rec.segs.filter(segment =>
+      segment.ss === '#000000'
+      && Math.abs(segment.x1 - segment.x0) < 0.01
+      && Math.min(segment.y0, segment.y1) < axisY
+      && Math.max(segment.y0, segment.y1) > axisY
+      && Math.abs(segment.y1 - segment.y0) < 20);
+    expect(actualAxisTicks).toHaveLength(5);
+  });
+
+  it('extends only authored major boundaries into the plot when ticks are skipped', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredBar',
+      categories: ['A', 'B', 'C', 'D'],
+      categoryLevels: [
+        ['A', 'B', 'C', 'D'],
+        ['Left', '', 'Right', ''],
+      ],
+      catAxisLineColor: '000000',
+      catAxisMajorTickMark: 'cross',
+      catAxisMinorTickMark: 'none',
+      catAxisTickMarkSkip: 2,
+      valAxisLineHidden: true,
+      valAxisMajorGridlines: false,
+      series: [series({ name: 'Positive', values: [10, 15, 5, 20] })],
+    }), RECT, 1);
+
+    const categoryRule = rec.segs.find(segment =>
+      segment.ss === '#000000'
+      && Math.abs(segment.y1 - segment.y0) < 0.01
+      && Math.abs(segment.x1 - segment.x0) > 100);
+    expect(categoryRule).toBeDefined();
+    const axisY = categoryRule!.y0;
+    const plotwardBoundaries = rec.segs.filter(segment =>
+      segment.ss === '#000000'
+      && Math.abs(segment.x1 - segment.x0) < 0.01
+      && Math.min(segment.y0, segment.y1) < axisY
+      && Math.max(segment.y0, segment.y1) > axisY + 10);
+    expect(plotwardBoundaries).toHaveLength(3);
+  });
+
+  it('does not revive hidden category ticks above multi-level brackets', () => {
+    const bracketGeometry = (majorTickMark: 'cross' | 'none') => {
+      const rec = segRecordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType: 'clusteredBar',
+        categories: ['A', 'B', 'C', 'D'],
+        categoryLevels: [
+          ['A', 'B', 'C', 'D'],
+          ['Left', '', 'Right', ''],
+        ],
+        catAxisLineHidden: true,
+        catAxisMajorTickMark: majorTickMark,
+        catAxisMinorTickMark: 'none',
+        valAxisLineHidden: true,
+        valAxisMajorGridlines: false,
+        series: [series({ name: 'Positive', values: [10, 15, 5, 20] })],
+      }), RECT, 1);
+      return rec.segs
+        .filter(segment =>
+          Math.abs(segment.x1 - segment.x0) < 0.01
+          && Math.abs(segment.y1 - segment.y0) > 10)
+        .map(segment => [segment.x0, segment.y0, segment.x1, segment.y1]);
+    };
+
+    const withoutTicks = bracketGeometry('none');
+    expect(withoutTicks).toHaveLength(5);
+    expect(bracketGeometry('cross')).toEqual(withoutTicks);
+  });
+
+  it('keeps horizontal-bar major ticks when category levels are present', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredBarH',
+      categories: ['Male', 'Female', 'Male', 'Female'],
+      categoryLevels: [
+        ['Male', 'Female', 'Male', 'Female'],
+        ['Smoker', '', 'Non-Smoker', ''],
+      ],
+      catAxisLineColor: '000000',
+      catAxisMajorTickMark: 'cross',
+      catAxisMinorTickMark: 'none',
+      valAxisHidden: true,
+      valAxisMajorGridlines: false,
+      series: [series({ name: 'Prevalence', values: [25, 22, 15, 18] })],
+    }), RECT, 1);
+
+    const majorTicks = rec.segs.filter(segment =>
+      segment.ss === '#000000'
+      && Math.abs(segment.y1 - segment.y0) < 0.01
+      && Math.abs(segment.x1 - segment.x0) > 2
+      && Math.abs(segment.x1 - segment.x0) < 20);
+    expect(majorTicks).toHaveLength(5);
+  });
+
   it('honors noMultiLvlLbl by suppressing outer labels', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, baseModel({

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -3500,6 +3500,13 @@ function renderBarChart(
   const categoryLabelAxisY = !isH && (chart.catAxisTickLabelPos ?? 'nextTo') === 'nextTo'
     ? primaryCatAxisY
     : py0 + ph;
+  const catMajorTickSkip = Math.max(1, Math.floor(chart.catAxisTickMarkSkip ?? 1));
+  const multiLevelBoundariesOwnMajorTicks = !isH
+    && categoryLevels != null
+    && dateAxisPlan == null
+    && !chart.catAxisLineHidden
+    && isCrossBetween(chart)
+    && Math.abs(categoryLabelAxisY - primaryCatAxisY) < 0.01;
   // Axis rules + tick marks are drawn AFTER the bars/line (see `drawAxesOnTop`
   // below) so the bars don't paint over the category baseline — PowerPoint
   // keeps the axis line crisp on top of the columns.
@@ -3543,11 +3550,16 @@ function renderBarChart(
     // matters when both levels use `cross`: Office's 6pt major boundary marks
     // remain visibly longer than its 4pt centred minor marks.
     if (!chart.catAxisHidden && chart.catAxisMajorTickMark && chart.catAxisMajorTickMark !== 'none') {
-      const ordinalFractions = catGridlineFractions(chart, n);
-      const tickSkip = Math.max(1, Math.floor(chart.catAxisTickMarkSkip ?? 1));
+      // Multi-level category brackets already occupy every interval boundary.
+      // They absorb the coincident major tick into one continuous stroke below,
+      // avoiding darker/thicker Canvas seams from painting the same segment
+      // twice. Mid-category ticks remain independent of those boundaries.
+      const ordinalFractions = multiLevelBoundariesOwnMajorTicks
+        ? []
+        : catGridlineFractions(chart, n);
       const tickFractions = dateAxisPlan
         ? dateAxisPlan.majorTicks.map(tick => tick.fraction)
-        : ordinalFractions.filter((_, index) => index % tickSkip === 0);
+        : ordinalFractions.filter((_, index) => index % catMajorTickSkip === 0);
       for (const frac of tickFractions) {
         if (!isH) {
           drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', primaryCatAxisY, px0 + frac * pw, catLineColor, catLineW, false, chart.catAxisLineHidden, 'major', ptToPx);
@@ -4108,6 +4120,20 @@ function renderBarChart(
       ctx.strokeStyle = catLineColor;
       ctx.lineWidth = catLineW;
       ctx.setLineDash([]);
+      const boundaryStartY = (boundaryIndex: number): number => {
+        if (!multiLevelBoundariesOwnMajorTicks
+          || boundaryIndex % catMajorTickSkip !== 0) {
+          return categoryLabelAxisY;
+        }
+        const tickLength = axisTickLengthPx('major', catLineW, ptToPx);
+        if (chart.catAxisMajorTickMark === 'cross') {
+          return categoryLabelAxisY - tickLength / 2;
+        }
+        if (chart.catAxisMajorTickMark === 'in') {
+          return categoryLabelAxisY - tickLength;
+        }
+        return categoryLabelAxisY;
+      };
 
       // Each boundary in the innermost category level separates adjacent
       // labels. Boundaries shared by an outer level are extended below by the
@@ -4126,7 +4152,7 @@ function renderBarChart(
         if (outerBoundaryIndices.has(boundaryIndex)) continue;
         const boundary = px0 + boundaryIndex / n * pw;
         ctx.beginPath();
-        ctx.moveTo(boundary, categoryLabelAxisY);
+        ctx.moveTo(boundary, boundaryStartY(boundaryIndex));
         ctx.lineTo(boundary, firstBandBottom);
         ctx.stroke();
       }
@@ -4166,7 +4192,7 @@ function renderBarChart(
       for (const [boundaryIndex, bracketBottom] of outerBoundaryBottoms) {
         const boundary = px0 + boundaryIndex / n * pw;
         ctx.beginPath();
-        ctx.moveTo(boundary, categoryLabelAxisY);
+        ctx.moveTo(boundary, boundaryStartY(boundaryIndex));
         ctx.lineTo(boundary, bracketBottom);
         ctx.stroke();
       }

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -3666,6 +3666,31 @@ fn chart_style_line_ref_xml(
     Some(Ok(entry.to_xml()))
 }
 
+/// Width inherited by a classic Style 2 axis overlay from the first theme
+/// line-style entry. Classic chart axes do not carry an explicit `lnRef`, but
+/// Office's Style 2 recipe applies `lnStyleLst[0]` before overlaying the local
+/// `<c:*Ax><c:spPr><a:ln>` properties. Consequently a local line that authors
+/// only its color retains the theme width; an absent local line remains absent.
+/// The Office vector boundary set establishes this rule for primary category,
+/// date and value axes, while secondary axes and other numbered built-in styles
+/// remain unresolved.
+fn classic_style_two_axis_line_width_emu(resolver: &dyn ColorResolver) -> Option<u32> {
+    use crate::theme::StyleMatrixLookup;
+
+    let entry = match resolver.theme_format_scheme()?.lookup_line_ref(1) {
+        StyleMatrixLookup::Entry(entry) => entry,
+        StyleMatrixLookup::NoStyle | StyleMatrixLookup::Missing => return None,
+    };
+    let xml = entry.to_xml();
+    let document = crate::depth::parse_guarded(&xml).ok()?;
+    let line = document
+        .descendants()
+        .find(|node| node.is_element() && node.tag_name().name() == "ln")?;
+    parse_chart_style_line(line, resolver, None)
+        .width
+        .and_then(|width| u32::try_from(width).ok())
+}
+
 fn parse_chartex_element_style(
     style_node: Node,
     resolver: &dyn ColorResolver,
@@ -8459,6 +8484,31 @@ pub fn parse_chart_part_with_references(
     let (mut val_axis_line_color, mut val_axis_line_width_emu, val_axis_line_hidden) = val_ax
         .map(|n| extract_axis_line_style(n, color_resolver))
         .unwrap_or((None, None, false));
+    if legacy_chart_style == Some(2) {
+        let cat_needs_theme_width = cat_ax.is_some_and(|axis| {
+            !cat_axis_line_hidden
+                && cat_axis_line_width_emu.is_none()
+                && child(axis, "spPr")
+                    .and_then(|shape| child(shape, "ln"))
+                    .is_some()
+        });
+        let val_needs_theme_width = val_ax.is_some_and(|axis| {
+            !val_axis_line_hidden
+                && val_axis_line_width_emu.is_none()
+                && child(axis, "spPr")
+                    .and_then(|shape| child(shape, "ln"))
+                    .is_some()
+        });
+        if cat_needs_theme_width || val_needs_theme_width {
+            let inherited_width = classic_style_two_axis_line_width_emu(color_resolver);
+            if cat_needs_theme_width {
+                cat_axis_line_width_emu = inherited_width;
+            }
+            if val_needs_theme_width {
+                val_axis_line_width_emu = inherited_width;
+            }
+        }
+    }
     if uses_implicit_legacy_style && cat_ax.is_some() && !cat_axis_line_hidden {
         cat_axis_line_color.get_or_insert_with(|| "000000".to_string());
         cat_axis_line_width_emu.get_or_insert(9_525);
@@ -11260,7 +11310,7 @@ Subtitle</a:t></a:r></a:p>
     }
 
     #[test]
-    fn parse_chart_part_does_not_invent_axis_width_from_theme_line_index() {
+    fn style_two_axis_overlay_inherits_first_theme_line_width() {
         let xml = format!(
             r#"<c:chartSpace xmlns:c="{C_NS}" xmlns:a="{A_NS}"><c:style val="2"/>
               <c:chart><c:plotArea><c:barChart><c:barDir val="col"/><c:ser>
@@ -11282,8 +11332,41 @@ Subtitle</a:t></a:r></a:p>
         };
         let doc = chart_space_of(&xml);
         let model = parse_chart_part(doc.root_element(), &resolver).expect("chart parses");
-        assert_eq!(model.cat_axis_line_width_emu, None);
-        assert_eq!(model.val_axis_line_width_emu, None);
+        assert_eq!(model.cat_axis_line_width_emu, Some(12700));
+        assert_eq!(model.val_axis_line_width_emu, Some(12700));
+
+        let other_style = xml.replace("<c:style val=\"2\"/>", "<c:style val=\"10\"/>");
+        let other_doc = chart_space_of(&other_style);
+        let other = parse_chart_part(other_doc.root_element(), &resolver).expect("chart parses");
+        assert_eq!(other.cat_axis_line_width_emu, None);
+        assert_eq!(other.val_axis_line_width_emu, None);
+
+        let absent_overlay = xml.replace(
+            "<c:catAx><c:spPr><a:ln><a:solidFill><a:srgbClr val=\"000000\"/></a:solidFill></a:ln></c:spPr></c:catAx>",
+            "<c:catAx/>",
+        );
+        let absent_doc = chart_space_of(&absent_overlay);
+        let absent = parse_chart_part(absent_doc.root_element(), &resolver).expect("chart parses");
+        assert_eq!(absent.cat_axis_line_width_emu, None);
+
+        let explicit_width = xml.replacen("<a:ln>", "<a:ln w=\"9525\">", 1);
+        let explicit_doc = chart_space_of(&explicit_width);
+        let explicit =
+            parse_chart_part(explicit_doc.root_element(), &resolver).expect("chart parses");
+        assert_eq!(explicit.cat_axis_line_width_emu, Some(9525));
+        assert_eq!(explicit.val_axis_line_width_emu, Some(12700));
+
+        let no_fill = xml.replace(
+            "<a:ln><a:solidFill><a:srgbClr val=\"000000\"/></a:solidFill></a:ln>",
+            "<a:ln><a:noFill/></a:ln>",
+        );
+        let no_fill_doc = chart_space_of(&no_fill);
+        let no_fill_model =
+            parse_chart_part(no_fill_doc.root_element(), &resolver).expect("chart parses");
+        assert!(no_fill_model.cat_axis_line_hidden);
+        assert!(no_fill_model.val_axis_line_hidden);
+        assert_eq!(no_fill_model.cat_axis_line_width_emu, None);
+        assert_eq!(no_fill_model.val_axis_line_width_emu, None);
     }
 
     /// (b) Combo chart: a bar series on the primary value axis plus a line


### PR DESCRIPTION
## Summary
- inherit the Office Style 2 axis width from the theme line-style recipe when the local axis line supplies only an overlay
- combine coincident multi-level category boundaries and major ticks into one continuous stroke
- retain authored behavior for explicit/no-fill lines, tick skipping, alternate label positions, date axes, and horizontal bars

## Verification
- Office-produced vector reference comparison
- `cargo test -p ooxml-common --lib`
- `cargo test -p xlsx-parser --lib`
- focused core chart suite (650 tests)
- `pnpm typecheck`
- `cargo fmt --check`
- `git diff --check`
- independent adversarial review: no Blocker, High, or Medium findings
