### PR TITLE
chore(release): 0.80.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ semantic versioning. While the major version is zero, minor releases may contain
 explicitly documented breaking changes; patch releases remain compatible with
 the corresponding minor release.
 
+## 0.80.2 — 2026-08-18
+
+Compatible patch release improving Office document fidelity and navigation
+without changing the 0.80 public integration contract.
+
+- **Excel chart fidelity:** improve authored date axes, grouped and stacked
+  bar scales, 3-D Surface geometry and materials, classic tick placement,
+  theme-derived axis widths, and multi-level category separators.
+- **Excel navigation:** follow internal hyperlinks to direct cell references,
+  ranges, and in-scope defined names, switching sheets when necessary.
+- **Word pagination resilience:** preserve completed pages when an unsupported
+  later section flow cannot be placed, while retaining a source-bound
+  diagnostic for the unsupported content.
+- **compatibility:** no application or API migration is required from 0.80.1.
+
 ## 0.80.1 — 2026-08-17
 
 Patch. Corrects numeric axis-label spacing across authored chart families

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.80.1",
+  "version": "0.80.2",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.80.1",
+  "version": "0.80.2",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.80.1",
+  "version": "0.80.2",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.80.1",
+  "version": "0.80.2",
   "description": "Internal workspace adapter for DOCX / XLSX / PPTX Markdown projection",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.80.1"
+version = "0.80.2"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.80.1",
+  "version": "0.80.2",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.80.1",
+  "version": "0.80.2",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity local viewer for Office files (.docx / .xlsx / .pptx), powered by Rust/WASM and Canvas. Optional MCP integration can share requested context with an AI agent.",
-  "version": "0.80.1",
+  "version": "0.80.2",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.80.1",
+  "version": "0.80.2",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.80.1",
+  "version": "0.80.2",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",

--- a/site/src/components/Capabilities.astro
+++ b/site/src/components/Capabilities.astro
@@ -19,7 +19,7 @@ const cols = [
       'Classic / ChartEx charts, optional 3-D / Region Maps, sparklines and conditional formatting',
       'Images, drawing shapes and styled slicers',
       'Pivot metadata, comments and CJK cell text',
-      'Multiple-area selection, range / element context, TSV copy, find, zoom & drag-resize',
+      'Multiple-area selection, range / element context, TSV copy, find, internal links, zoom & drag-resize',
     ],
   },
   {


### PR DESCRIPTION
## Summary
- bump all published packages and the MCP server to 0.80.2
- document compatible Excel chart, internal-link navigation, and Word pagination fixes
- surface XLSX internal-link support in the public capability summary

## Release verification
- parser WASM rebuilt for DOCX, XLSX, and PPTX
- Rust parser suites and `cargo check -p ooxml-mcp-server`
- full TypeScript suite; loopback and load-sensitive tests rerun independently in their required environment
- public API declaration baselines and viewer symmetry
- workspace type checking
- official site production build
- formatting and diff checks
- independent adversarial review: no Blocker, High, or Medium findings; no unbounded heuristic scope

No migration is required from 0.80.1.
