### PR TITLE
fix(api): export reachable chart types

### DIFF
--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -629,12 +629,10 @@ fillText "Q2" 310.65,315.95 fs=#555 font=11px sans-serif al=center bl=top
 fillText "Q3" 472.0833,315.95 fs=#555 font=11px sans-serif al=center bl=top
 set strokeStyle=#aaa
 set lineWidth=1
-setLineDash
 beginPath
 moveTo 68.5,312.95
 lineTo 552.8,312.95
 stroke ss=#aaa lw=1 dash=
-setLineDash
 setLineDash
 beginPath
 moveTo 62.2,312.95
@@ -845,12 +843,10 @@ fillText "Q2" 26.775,199.3125 fs=#555 font=11px sans-serif al=right bl=middle
 fillText "Q3" 26.775,108.5542 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
-setLineDash
 beginPath
 moveTo 30.775,63.175
 lineTo 30.775,335.45
 stroke ss=#aaa lw=1 dash=
-setLineDash
 setLineDash
 beginPath
 moveTo 30.775,341.75
@@ -1048,12 +1044,10 @@ arc 427.2167,131.2438,3,0,6.2832
 fill fs=#ED7D31 ga=1
 set strokeStyle=#aaa
 set lineWidth=1
-setLineDash
 beginPath
 moveTo 47.8,335.45
 lineTo 503.1,335.45
 stroke ss=#aaa lw=1 dash=
-setLineDash
 setLineDash
 beginPath
 moveTo 41.5,335.45
@@ -1132,12 +1126,10 @@ moveTo 503.1,341.75
 lineTo 503.1,335.45
 stroke ss=#aaa lw=1 dash=
 setLineDash
-setLineDash
 beginPath
 moveTo 503.1,63.175
 lineTo 503.1,335.45
 stroke ss=#aaa lw=1 dash=
-setLineDash
 set fillStyle=#555
 set textAlign=left
 set textBaseline=middle
@@ -2924,12 +2916,10 @@ fillText "Q2" 337,319.95 fs=#555 font=11px sans-serif al=center bl=top
 fillText "Q3" 534.2,319.95 fs=#555 font=11px sans-serif al=center bl=top
 set strokeStyle=#aaa
 set lineWidth=1
-setLineDash
 beginPath
 moveTo 41.2,316.95
 lineTo 632.8,316.95
 stroke ss=#aaa lw=1 dash=
-setLineDash
 setLineDash
 beginPath
 moveTo 34.9,316.95
@@ -3119,12 +3109,10 @@ fillText "Q2" 383.6,338.45 fs=#555 font=11px sans-serif al=center bl=top
 fillText "Q3" 549.7333,338.45 fs=#555 font=11px sans-serif al=center bl=top
 set strokeStyle=#aaa
 set lineWidth=1
-setLineDash
 beginPath
 moveTo 134.4,335.45
 lineTo 632.8,335.45
 stroke ss=#aaa lw=1 dash=
-setLineDash
 setLineDash
 beginPath
 moveTo 128.1,335.45

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -1464,14 +1464,17 @@ function strokeAxisSegment(
   dash?: string | null,
 ): void {
   const previousDash = ctx.getLineDash?.() ?? [];
+  const resolvedDash = dashPatternForPreset(dash ?? undefined, lineWidth);
+  const dashChanged = resolvedDash.length !== previousDash.length
+    || resolvedDash.some((value, index) => value !== previousDash[index]);
   ctx.strokeStyle = color;
   ctx.lineWidth = lineWidth;
-  ctx.setLineDash(dashPatternForPreset(dash ?? undefined, lineWidth));
+  if (dashChanged) ctx.setLineDash(resolvedDash);
   ctx.beginPath();
   ctx.moveTo(x1, y1);
   ctx.lineTo(x2, y2);
   ctx.stroke();
-  ctx.setLineDash(previousDash);
+  if (dashChanged) ctx.setLineDash(previousDash);
 }
 
 function axisTickLengthPx(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,11 +28,16 @@ export type {
   TileInfo,
 } from './types/common';
 export type {
+  ChartAreaGroupDecorations,
+  ChartBarGroupDecorations,
   ChartDataLabelOverride,
   ChartDataTable,
   ChartDataPointOverride,
+  ChartDecorationLineStyle,
   ChartErrBars,
   ChartLabelBox,
+  ChartLegendEntryOverride,
+  ChartLineGroupDecorations,
   ChartManualLayout,
   ChartModel,
   ChartRect,

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -55,11 +55,11 @@ export type CellElement = ({
 } & DocParagraph) | ({
     type: 'table';
 } & DocTable);
-interface ChartAreaGroupDecorations {
+export interface ChartAreaGroupDecorations {
     groupIndex: number;
     dropLines?: ChartDecorationLineStyle | null;
 }
-interface ChartBarGroupDecorations {
+export interface ChartBarGroupDecorations {
     groupIndex: number;
     seriesLines?: ChartDecorationLineStyle[] | null;
 }
@@ -116,7 +116,7 @@ export interface ChartDataTable {
     lineDash?: string | null;
     lineHidden?: boolean | null;
 }
-interface ChartDecorationLineStyle {
+export interface ChartDecorationLineStyle {
     color?: string | null;
     widthEmu?: number | null;
     dash?: string | null;
@@ -247,7 +247,7 @@ export interface ChartLabelBox {
     borderColor?: string;
     borderWidthEmu?: number;
 }
-interface ChartLegendEntryOverride {
+export interface ChartLegendEntryOverride {
     idx: number;
     deleted?: boolean | null;
     fontFace?: string | null;
@@ -255,7 +255,7 @@ interface ChartLegendEntryOverride {
     fontSizeHpt?: number | null;
     fontBold?: boolean | null;
 }
-interface ChartLineGroupDecorations {
+export interface ChartLineGroupDecorations {
     groupIndex: number;
     dropLines?: ChartDecorationLineStyle | null;
     hiLowLines?: ChartDecorationLineStyle | null;
@@ -1230,7 +1230,7 @@ export type HyperlinkTarget = {
     ref: string;
     slideIndex?: number;
 };
-interface ImageFill {
+export interface ImageFill {
     fillType: 'image';
     imagePath: string;
     mimeType: string;
@@ -1437,7 +1437,7 @@ export interface MathSvg {
     ascentEm: number;
     descentEm: number;
 }
-interface NoFill {
+export interface NoFill {
     fillType: 'none';
 }
 export interface NoteRef {

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -19,11 +19,16 @@ export {
 } from './selection-context';
 export type { DocxElementContextOptions } from './element-context';
 export type {
+  ChartAreaGroupDecorations,
+  ChartBarGroupDecorations,
   ChartDataLabelOverride,
   ChartDataTable,
   ChartDataPointOverride,
+  ChartDecorationLineStyle,
   ChartErrBars,
   ChartLabelBox,
+  ChartLegendEntryOverride,
+  ChartLineGroupDecorations,
   ChartManualLayout,
   ChartModel,
   ChartRect,
@@ -58,6 +63,7 @@ export type {
   Duotone,
   FillRect,
   GradientFill,
+  ImageFill,
   LegendManualLayout,
   MathAccent,
   MathArray,
@@ -82,6 +88,7 @@ export type {
   MathSvg,
   MatchRunSlice,
   PatternFill,
+  NoFill,
   SolidFill,
   ChartDisplayUnits,
   ChartDisplayUnitsLabel,

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -53,11 +53,11 @@ export interface Camera3d {
     zoom?: number;
     rot?: Rot3d;
 }
-interface ChartAreaGroupDecorations {
+export interface ChartAreaGroupDecorations {
     groupIndex: number;
     dropLines?: ChartDecorationLineStyle | null;
 }
-interface ChartBarGroupDecorations {
+export interface ChartBarGroupDecorations {
     groupIndex: number;
     seriesLines?: ChartDecorationLineStyle[] | null;
 }
@@ -114,7 +114,7 @@ export interface ChartDataTable {
     lineDash?: string | null;
     lineHidden?: boolean | null;
 }
-interface ChartDecorationLineStyle {
+export interface ChartDecorationLineStyle {
     color?: string | null;
     widthEmu?: number | null;
     dash?: string | null;
@@ -256,7 +256,7 @@ export interface ChartLabelBox {
     borderColor?: string;
     borderWidthEmu?: number;
 }
-interface ChartLegendEntryOverride {
+export interface ChartLegendEntryOverride {
     idx: number;
     deleted?: boolean | null;
     fontFace?: string | null;
@@ -264,7 +264,7 @@ interface ChartLegendEntryOverride {
     fontSizeHpt?: number | null;
     fontBold?: boolean | null;
 }
-interface ChartLineGroupDecorations {
+export interface ChartLineGroupDecorations {
     groupIndex: number;
     dropLines?: ChartDecorationLineStyle | null;
     hiLowLines?: ChartDecorationLineStyle | null;

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -29,11 +29,16 @@ export {
 } from './element-selection';
 export type {
   ArrowEnd,
+  ChartAreaGroupDecorations,
+  ChartBarGroupDecorations,
   ChartDataLabelOverride,
   ChartDataTable,
   ChartDataPointOverride,
+  ChartDecorationLineStyle,
   ChartErrBars,
   ChartLabelBox,
+  ChartLegendEntryOverride,
+  ChartLineGroupDecorations,
   ChartManualLayout,
   ChartRect,
   ChartSeriesDataLabels,

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -164,11 +164,11 @@ export interface ChartAnchor {
     toRowOff: number;
     chart: ChartModel;
 }
-interface ChartAreaGroupDecorations {
+export interface ChartAreaGroupDecorations {
     groupIndex: number;
     dropLines?: ChartDecorationLineStyle | null;
 }
-interface ChartBarGroupDecorations {
+export interface ChartBarGroupDecorations {
     groupIndex: number;
     seriesLines?: ChartDecorationLineStyle[] | null;
 }
@@ -225,7 +225,7 @@ export interface ChartDataTable {
     lineDash?: string | null;
     lineHidden?: boolean | null;
 }
-interface ChartDecorationLineStyle {
+export interface ChartDecorationLineStyle {
     color?: string | null;
     widthEmu?: number | null;
     dash?: string | null;
@@ -356,7 +356,7 @@ export interface ChartLabelBox {
     borderColor?: string;
     borderWidthEmu?: number;
 }
-interface ChartLegendEntryOverride {
+export interface ChartLegendEntryOverride {
     idx: number;
     deleted?: boolean | null;
     fontFace?: string | null;
@@ -364,7 +364,7 @@ interface ChartLegendEntryOverride {
     fontSizeHpt?: number | null;
     fontBold?: boolean | null;
 }
-interface ChartLineGroupDecorations {
+export interface ChartLineGroupDecorations {
     groupIndex: number;
     dropLines?: ChartDecorationLineStyle | null;
     hiLowLines?: ChartDecorationLineStyle | null;
@@ -938,7 +938,7 @@ export interface ImageAnchor {
     alpha?: number;
     duotone?: Duotone;
 }
-interface ImageFill {
+export interface ImageFill {
     fillType: 'image';
     imagePath: string;
     mimeType: string;
@@ -1097,7 +1097,7 @@ export interface MergeCell {
     bottom: number;
     right: number;
 }
-interface NoFill {
+export interface NoFill {
     fillType: 'none';
 }
 export interface NumFmt {
@@ -1657,7 +1657,7 @@ export interface TableInfo {
     band2HorizontalDxf?: number;
     columns: TableColumnInfo[];
 }
-interface TileInfo {
+export interface TileInfo {
     tx: number;
     ty: number;
     sx: number;

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -36,7 +36,12 @@ export {
 export type { XlsxMatchLocation } from './find.js';
 export type { FindHighlightColors, FindMatch, FindMatchesOptions } from '@silurus/ooxml-core';
 export type {
+  ChartAreaGroupDecorations,
+  ChartBarGroupDecorations,
+  ChartDecorationLineStyle,
   ChartLabelBox,
+  ChartLegendEntryOverride,
+  ChartLineGroupDecorations,
   ChartRect,
   ChartTextBox,
   ChartTextParagraph,
@@ -65,6 +70,7 @@ export type {
   ChartexRegionMapColors,
   ChartexValueColorStop,
   FillRect,
+  ImageFill,
   MathAccent,
   MathArray,
   MathBar,
@@ -89,7 +95,9 @@ export type {
   ChartDisplayUnits,
   ChartDisplayUnitsLabel,
   SecondaryValueAxis,
+  NoFill,
   SpaceLine,
+  TileInfo,
   ViewerContextMenuEvent,
   ZoomableViewer,
 } from '@silurus/ooxml-core';


### PR DESCRIPTION
## Summary

- export shared chart decoration and fill types that are reachable through each format's public model
- keep DOCX, XLSX, and PPTX declaration baselines symmetric
- avoid redundant solid-axis dash-state writes while preserving authored dash patterns and Canvas state restoration

## Verification

- independent adversarial review: no remaining Blocker, High, or Medium findings
- focused export-completeness and renderer-signature tests
- 7,732 non-platform-specific Vitest tests
- TypeScript build and typecheck
- public API baselines and viewer symmetry
- private-corpus harness tests and diff check

Follow-up to #1288.