### PR TITLE
fix(chart): support fractional date-axis units

### DIFF
--- a/docs/chart-compatibility-evidence.md
+++ b/docs/chart-compatibility-evidence.md
@@ -30,6 +30,7 @@ of the repository.
 | --- | ---: | --- |
 | Fully automatic linear value axes | 6,354 | Finite classic linear axes; strict 1.2 zero-pin boundary; 1/2/5 ceiling ladder; automatic minor unit is major/5. Twenty-four unstable tiny-offset outputs were not emulated. |
 | Explicit min/max with omitted major unit | 297 | Classic linear, non-percent axes. Vertical and horizontal axes use separately observed density classes. Authored units always win. |
+| Fractional classic date-axis units | month and year units 1.01, 1.5, 1.9, 1.99, 2.0, 2.01, 2.1, 2.5, and 3.1 with explicit bounds | ECMA-376 retains positive doubles, while MS-OE376 requires Office date-axis units to be at least one. Within the observed `1 <= value < 4` boundary, Excel advances integral `n.0` by `n` calendar units and any observed non-zero fractional part by `floor(n)^2` units. Larger fractional values, values below one, and omitted automatic intervals are not inferred; fractional day units remain elapsed-day intervals. |
 | Percent-stacked automatic units | 48 | Horizontal/vertical and positive/signed percentage axes, with the observed 120 pt vertical density boundary. |
 | Radar automatic units | 36 | Small, ordinary, and large spoke lengths. |
 | Pie Style 2 repeated colors | point counts 1–48 | ECMA-376 Style 2 accent order plus Office-observed repeated-set luminance transforms. Point formatting and `noFill` remain authoritative. Counts above 48 use the same documented repeat-set rule but are not claimed as byte-exact Office observations. |

--- a/docs/chart-support-matrix.md
+++ b/docs/chart-support-matrix.md
@@ -77,7 +77,7 @@ observed input boundary is recorded in
 
 | ID | Property | Parser | Model | Renderer | Status | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| C-AXIS-001 | Linear/date/log axes, authored bounds and units | Yes | Yes | Yes | Partial | Fractional month/year date-axis units require an Office compatibility boundary. |
+| C-AXIS-001 | Linear/date/log axes, authored bounds and units | Yes | Yes | Yes | Partial | Explicit fractional month/year units in the retained `1 <= value < 4` compatibility boundary are rendered. Other fractional and application-defined automatic date intervals remain unsupported. |
 | C-AXIS-002 | Category `lblAlgn` and `lblOffset` | Yes | Yes | Yes | Supported | Category/date and auxiliary category axes retain both properties; the shared renderer applies interval alignment and the specified percentage of its family-specific default label gap. |
 | C-AXIS-003 | Axis crossing (`crosses`, `crossesAt`, and `crossBetween`) | Yes | Yes | Partial | Partial | Bar/column, line, area, and Surface use one effective crossing for axis geometry, ticks, labels, and group decorations. Remaining numeric-X and arbitrary combination boundaries are still under audit. |
 | C-LABEL-001 | Value/category/series/percent labels, separators, leader lines, and manual layout | Yes | Yes | Yes | Supported | Per-point and series-level overrides are retained. |

--- a/packages/core/src/chart/date-axis.test.ts
+++ b/packages/core/src/chart/date-axis.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { excelSerialToUtcDate } from '../excel-date.js';
+import { excelSerialToUtcDate, utcDateToExcelSerial } from '../excel-date.js';
+import { MAX_AXIS_TICKS } from './axis-scale.js';
 import { planDateCategoryAxis } from './date-axis.js';
 
 describe('classic chart date-axis planning', () => {
@@ -38,6 +39,164 @@ describe('classic chart date-axis planning', () => {
     const minorMonths = plan!.minorTicks.map(tick =>
       excelSerialToUtcDate(tick.serial).getUTCMonth());
     expect(minorMonths).toEqual([1, 3, 5]);
+  });
+
+  it.each([
+    [1.01, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]],
+    [1.5, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]],
+    [1.9, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]],
+    [1.99, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]],
+    [2, [0, 2, 4, 6, 8]],
+    [2.01, [0, 4, 8]],
+    [2.1, [0, 4, 8]],
+    [2.5, [0, 4, 8]],
+    [3.1, [0, 9]],
+  ] as const)('uses the Office-observed month cadence for majorUnit=%s', (majorUnit, expected) => {
+    const plan = planDateCategoryAxis({
+      categories: ['45292', '45566'],
+      baseTimeUnit: 'days',
+      majorTimeUnit: 'months',
+      majorUnit,
+      explicitMin: 45292,
+      explicitMax: 45566,
+      crossBetween: false,
+    });
+
+    expect(plan).not.toBeNull();
+    expect(plan!.majorTicks.map(tick =>
+      excelSerialToUtcDate(tick.serial).getUTCMonth()))
+      .toEqual(expected);
+  });
+
+  it.each([
+    [1.01, [2022, 2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030, 2031]],
+    [1.5, [2022, 2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030, 2031]],
+    [1.9, [2022, 2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030, 2031]],
+    [1.99, [2022, 2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030, 2031]],
+    [2, [2022, 2024, 2026, 2028, 2030]],
+    [2.01, [2022, 2026, 2030]],
+    [2.1, [2022, 2026, 2030]],
+    [2.5, [2022, 2026, 2030]],
+    [3.1, [2022, 2031]],
+  ] as const)('uses the Office-observed year cadence for majorUnit=%s', (majorUnit, expected) => {
+    const min = utcDateToExcelSerial(new Date(Date.UTC(2022, 0, 1)), false);
+    const max = utcDateToExcelSerial(new Date(Date.UTC(2031, 0, 1)), false);
+    const plan = planDateCategoryAxis({
+      categories: [String(min), String(max)],
+      baseTimeUnit: 'days',
+      majorTimeUnit: 'years',
+      majorUnit,
+      explicitMin: min,
+      explicitMax: max,
+      crossBetween: false,
+    });
+
+    expect(plan).not.toBeNull();
+    expect(plan!.majorTicks.map(tick =>
+      excelSerialToUtcDate(tick.serial).getUTCFullYear()))
+      .toEqual(expected);
+  });
+
+  it('fails closed for sub-unit month/year intervals outside the Office constraint', () => {
+    const plan = planDateCategoryAxis({
+      categories: ['45292', '45383'],
+      baseTimeUnit: 'days',
+      majorTimeUnit: 'months',
+      majorUnit: 0.5,
+      minorTimeUnit: 'years',
+      minorUnit: 0.5,
+      crossBetween: false,
+    });
+
+    expect(plan?.majorTicks).toEqual([]);
+    expect(plan?.minorTicks).toEqual([]);
+  });
+
+  it('keeps the integer boundary and fails closed beyond the observed fractional range', () => {
+    const integral = planDateCategoryAxis({
+      categories: ['45292', '45536'],
+      baseTimeUnit: 'days',
+      majorTimeUnit: 'months',
+      majorUnit: 4,
+      explicitMin: 45292,
+      explicitMax: 45536,
+      crossBetween: false,
+    });
+    const fractional = planDateCategoryAxis({
+      categories: ['45292', '46753'],
+      baseTimeUnit: 'days',
+      majorTimeUnit: 'months',
+      majorUnit: 4.1,
+      minorTimeUnit: 'years',
+      minorUnit: 4.1,
+      crossBetween: false,
+    });
+
+    expect(integral?.majorTicks.map(tick =>
+      excelSerialToUtcDate(tick.serial).getUTCMonth()))
+      .toEqual([0, 4, 8]);
+    expect(fractional?.majorTicks).toEqual([]);
+    expect(fractional?.minorTicks).toEqual([]);
+  });
+
+  it('deduplicates coincident fractional calendar major/minor ticks', () => {
+    const plan = planDateCategoryAxis({
+      categories: ['45292', '45444'],
+      baseTimeUnit: 'days',
+      majorTimeUnit: 'months',
+      majorUnit: 2.5,
+      minorTimeUnit: 'months',
+      minorUnit: 1.5,
+      explicitMin: 45292,
+      explicitMax: 45444,
+      crossBetween: false,
+    });
+
+    expect(plan).not.toBeNull();
+    expect(plan!.majorTicks.map(tick =>
+      excelSerialToUtcDate(tick.serial).getUTCMonth()))
+      .toEqual([0, 4]);
+    expect(plan!.minorTicks.map(tick =>
+      excelSerialToUtcDate(tick.serial).getUTCMonth()))
+      .toEqual([1, 2, 3, 5]);
+  });
+
+  it('keeps reversed fractional ticks and 1904 dates on the same calendar boundaries', () => {
+    const min1904 = utcDateToExcelSerial(new Date(Date.UTC(2023, 0, 1)), true);
+    const max1904 = utcDateToExcelSerial(new Date(Date.UTC(2025, 0, 1)), true);
+    const plan = planDateCategoryAxis({
+      categories: [String(min1904), String(max1904)],
+      date1904: true,
+      baseTimeUnit: 'days',
+      majorTimeUnit: 'years',
+      majorUnit: 1.5,
+      explicitMin: min1904,
+      explicitMax: max1904,
+      crossBetween: false,
+      reversed: true,
+    });
+
+    expect(plan).not.toBeNull();
+    expect(plan!.majorTicks.map(tick =>
+      excelSerialToUtcDate(tick.serial, true).getUTCFullYear()))
+      .toEqual([2023, 2024, 2025]);
+    expect(plan!.majorTicks[0]?.fraction).toBe(1);
+    expect(plan!.majorTicks[1]?.fraction).toBeCloseTo(366 / 731);
+    expect(plan!.majorTicks[2]?.fraction).toBe(0);
+  });
+
+  it('atomically suppresses an authored date tick layer above the shared ceiling', () => {
+    const plan = planDateCategoryAxis({
+      categories: ['1', String(MAX_AXIS_TICKS + 2)],
+      baseTimeUnit: 'days',
+      majorTimeUnit: 'days',
+      majorUnit: 1,
+      explicitMin: 1,
+      explicitMax: MAX_AXIS_TICKS + 2,
+      crossBetween: false,
+    });
+
+    expect(plan?.majorTicks).toEqual([]);
   });
 
   it('honors authored bounds and reversed orientation', () => {

--- a/packages/core/src/chart/date-axis.ts
+++ b/packages/core/src/chart/date-axis.ts
@@ -1,4 +1,5 @@
 import { excelSerialToUtcDate, utcDateToExcelSerial } from '../excel-date.js';
+import { MAX_AXIS_TICKS } from './axis-scale.js';
 
 export type ChartDateTimeUnit = 'days' | 'months' | 'years';
 
@@ -22,8 +23,6 @@ export interface DateCategoryAxisOptions {
   crossBetween?: boolean;
   reversed?: boolean;
 }
-
-const MAX_DATE_AXIS_TICKS = 10_000;
 
 function timeUnit(value: string | null | undefined): ChartDateTimeUnit | null {
   return value === 'days' || value === 'months' || value === 'years' ? value : null;
@@ -80,12 +79,22 @@ export function planDateCategoryAxis(
     unit: ChartDateTimeUnit,
   ): number | null => {
     if (value == null || !(value > 0) || !Number.isFinite(value)) return null;
-    // ST_AxisUnit permits positive fractional values, but OOXML does not state
-    // how a fraction of a variable-length month/year maps onto the calendar.
-    // Preserve calendar coordinates but leave that valid-yet-unsupported
-    // authored interval unresolved until an Office boundary establishes it.
-    if (unit !== 'days' && !Number.isInteger(value)) return null;
-    return value;
+    if (unit === 'days') return value;
+    // ST_AxisUnit permits positive doubles, but MS-OE376 requires Office date
+    // axes to use values >= 1 and does not define fractional calendar
+    // arithmetic. Excel's retained vector boundary is discontinuous: integral
+    // n.0 advances by n units, while non-integral n.f advances by floor(n)^2
+    // units (observed at 1.01/1.5/1.9, 2.1/2.5, and 3.1 for both months and
+    // years). Apply that compatibility rule only inside its observed
+    // 1 <= value < 4 boundary; larger non-integral values remain unsupported.
+    // Keep this separate from omitted, application-defined automatic interval
+    // selection.
+    if (value < 1) return null;
+    if (Number.isInteger(value)) return value;
+    if (value >= 4) return null;
+    const calendarPart = Math.floor(value);
+    const calendarStep = calendarPart * calendarPart;
+    return Number.isFinite(calendarStep) ? calendarStep : null;
   };
   const majorStep = authoredStep(options.majorUnit, majorUnit);
   const minorStep = authoredStep(options.minorUnit, minorUnit);
@@ -153,7 +162,7 @@ export function planDateCategoryAxis(
     if (step == null) return [];
     let tickDate = floorToUnit(excelSerialToUtcDate(tickMinSerial, date1904), unit);
     let tickSerial = utcDateToExcelSerial(tickDate, date1904);
-    for (let count = 0; tickSerial < tickMinSerial && count < MAX_DATE_AXIS_TICKS; count++) {
+    for (let count = 0; tickSerial < tickMinSerial && count < MAX_AXIS_TICKS; count++) {
       const nextDate = addUnits(tickDate, step, unit);
       const nextSerial = utcDateToExcelSerial(nextDate, date1904);
       if (!(nextSerial > tickSerial)) return [];
@@ -162,7 +171,11 @@ export function planDateCategoryAxis(
     }
     if (tickSerial < tickMinSerial) return [];
     const ticks: DateCategoryAxisPlan['majorTicks'] = [];
-    for (let count = 0; tickSerial <= tickMaxSerial && count < MAX_DATE_AXIS_TICKS; count++) {
+    while (tickSerial <= tickMaxSerial) {
+      // An authored interval remains authored: when it exceeds the shared
+      // tick-layer ceiling, omit the whole layer instead of painting a prefix
+      // or inventing a coarser interval.
+      if (ticks.length === MAX_AXIS_TICKS) return [];
       ticks.push({ serial: tickSerial, fraction: axisFraction(tickSerial) });
       const nextDate = addUnits(tickDate, step, unit);
       const nextSerial = utcDateToExcelSerial(nextDate, date1904);

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -4669,6 +4669,46 @@ describe('CH5 — category axis numFmt applies to category tick labels (§21.2.2
     expect(range[0].x + range[0].w).toBeCloseTo(range[1].x);
   });
 
+  it('shares fractional calendar ticks across primary and secondary series', () => {
+    const rec = strokedPolylineCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: ['45292', '45302', '45383'],
+      catAxisIsDate: true,
+      catAxisBaseTimeUnit: 'days',
+      catAxisMajorTimeUnit: 'months',
+      catAxisMajorUnit: 1.5,
+      catAxisMin: 45292,
+      catAxisMax: 45383,
+      catAxisFormatCode: 'm/d/yyyy',
+      series: [
+        series({ color: '4472C4', lineColor: '4472C4', values: [10, 20, 30], showMarker: false }),
+        series({
+          color: 'ED7D31', lineColor: 'ED7D31', values: [30, 20, 10], showMarker: false,
+          useSecondaryAxis: true,
+        }),
+      ],
+      secondaryValAxis: {
+        min: 0, max: 40, title: null, hidden: false, lineHidden: false,
+        majorTickMark: 'none',
+      },
+    }), RECT, 1);
+
+    const labels = rec.texts.map(text => text.text);
+    expect(labels).toContain('1/1/2024');
+    expect(labels).toContain('2/1/2024');
+    expect(labels).toContain('3/1/2024');
+    expect(labels).toContain('4/1/2024');
+    const primary = rec.strokes.find(stroke => stroke.ss === '#4472C4' && stroke.points.length === 3);
+    const secondary = rec.strokes.find(stroke => stroke.ss === '#ED7D31' && stroke.points.length === 3);
+    expect(primary).toBeDefined();
+    expect(secondary).toBeDefined();
+    expect(secondary!.points.map(point => point.x))
+      .toEqual(primary!.points.map(point => point.x));
+    expect(primary!.points[1]!.x - primary!.points[0]!.x)
+      .toBeLessThan(primary!.points[2]!.x - primary!.points[1]!.x);
+  });
+
   it('positions horizontal bar clusters within their owning group', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, baseModel({

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -15363,9 +15363,9 @@ Subtitle</a:t></a:r></a:p>
                   <c:axPos val="b"/>
                   <c:numFmt formatCode="m/d/yyyy"/>
                   <c:baseTimeUnit val="months"/>
-                  <c:majorUnit val="2"/>
+                  <c:majorUnit val="1.5"/>
                   <c:majorTimeUnit val="months"/>
-                  <c:minorUnit val="1"/>
+                  <c:minorUnit val="0.5"/>
                   <c:minorTimeUnit val="months"/>
                 </c:dateAx>
                 <c:valAx><c:axPos val="l"/></c:valAx>
@@ -15381,9 +15381,9 @@ Subtitle</a:t></a:r></a:p>
         assert_eq!(m.cat_axis_format_code.as_deref(), Some("m/d/yyyy"));
         assert_eq!(m.cat_axis_is_date, Some(true));
         assert_eq!(m.cat_axis_base_time_unit.as_deref(), Some("months"));
-        assert_eq!(m.cat_axis_major_unit, Some(2.0));
+        assert_eq!(m.cat_axis_major_unit, Some(1.5));
         assert_eq!(m.cat_axis_major_time_unit.as_deref(), Some("months"));
-        assert_eq!(m.cat_axis_minor_unit, Some(1.0));
+        assert_eq!(m.cat_axis_minor_unit, Some(0.5));
         assert_eq!(m.cat_axis_minor_time_unit.as_deref(), Some("months"));
         assert!(!m.cat_axis_hidden);
     }


### PR DESCRIPTION
## Summary

- preserve fractional classic date-axis units through the shared OOXML parser/model
- render the bounded Excel month/year cadence observed for `1 <= value < 4`
- keep unobserved fractional ranges fail-closed and reuse the shared 512-tick ceiling atomically
- document the ECMA-376 / MS-OE376 boundary and remaining automatic-interval gap

## Root cause

The parser retained date-axis units as doubles, but the shared calendar planner rejected every non-integral month/year interval. OOXML does not define fractional calendar arithmetic, and Office applies a discontinuous compatibility behavior, so the fix is limited to the measured boundary instead of extrapolating globally.

## Validation

- core chart suite: 31 files, 1,189 tests
- ooxml-common: 459 tests plus doctest
- TypeScript project build
- production Vite build
- independent adversarial review
- main comparison: XLSX production chunk -40 bytes raw / -39 bytes gzip

Closes #1292