### PR TITLE
fix(chart): fail closed for future ChartEx layouts

### DIFF
--- a/docs/chart-support-matrix.md
+++ b/docs/chart-support-matrix.md
@@ -116,13 +116,20 @@ recorded in [Chart compatibility evidence and scope](chart-compatibility-evidenc
 
 ## ChartEx layouts
 
+MS-ODRAWXML §2.24.4.19 defines exactly eight `ST_SeriesLayout` values:
+`boxWhisker`, `clusteredColumn`, `funnel`, `paretoLine`, `regionMap`,
+`sunburst`, `treemap`, and `waterfall`. Histogram and Pareto are semantic
+forms of `clusteredColumn`/`paretoLine`; no additional layout identifier is
+inferred from cached values. A future identifier outside the current schema is
+retained verbatim and reaches the explicit unsupported-chart placeholder.
+
 | ID | Layout | Status | Notes |
 | --- | --- | --- |
-| X-LAYOUT-001 | Waterfall, histogram/Pareto, funnel | Supported | Includes bounded layout data and shared Chart Style paint. |
+| X-LAYOUT-001 | Waterfall, clustered column (including histogram), Pareto/`paretoLine`, funnel | Supported | Includes bounded layout data and shared Chart Style paint. |
 | X-LAYOUT-002 | Box-and-whisker | Supported | Includes mean/outlier/non-outlier roles and visibility controls. |
 | X-LAYOUT-003 | Treemap and sunburst | Supported | Hierarchy depth/slot budgets apply before tree construction. |
 | X-LAYOUT-004 | Region Map | Partial | Deterministic offline country geometry only; external geocoding is out of scope. |
-| X-LAYOUT-005 | Unknown or future `layoutId` values | Missing | Fail closed with a placeholder; no layout is guessed from sample data. |
+| X-LAYOUT-005 | Unknown or future `layoutId` values | Supported | Preserved verbatim and failed closed with a placeholder; no layout is guessed from cached values or a visually similar known family. |
 
 ## Maintenance rules
 

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -5188,6 +5188,28 @@ describe('CH3 — labels are locale-independent (§18.8.30)', () => {
 });
 
 describe('ChartEx flat layouts dispatch to semantic renderers', () => {
+  it('fails closed for an unknown future ChartEx layout without guessing from its data', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'futureLayout',
+      categories: ['A', 'B'],
+      series: [series({ values: [2, -1] })],
+    }), RECT, 1);
+
+    expect(rec.texts.map(text => text.text)).toEqual(['Unsupported chart']);
+    expect(rec.rects).toHaveLength(0);
+    expect(rec.strokeRects).toHaveLength(0);
+    expect(rec.gradients).toHaveLength(0);
+  });
+
+  it('keeps unsupported-layout placeholder work constant for an unbounded public identifier', () => {
+    const rec = recordingCtx();
+    const chartType = 'x'.repeat(1_000_000);
+    renderChart(rec.ctx, baseModel({ chartType, series: [series({ values: [1] })] }), RECT, 1);
+
+    expect(rec.texts.map(text => text.text)).toEqual(['Unsupported chart']);
+  });
+
   it('measures the same semantic ChartEx column legend that it paints', () => {
     const renderPlot = (extraSeries: ChartSeries[]): RectCall => {
       const rec = recordingCtx();

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -15868,7 +15868,11 @@ function renderChartImpl(
         ctx.font = '11px sans-serif';
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
-        ctx.fillText(`Chart: ${chart.chartType}`, x + w / 2, y + h / 2);
+        // The public model can carry a future layout identifier of arbitrary
+        // length. Preserve that identifier in the model, but keep the
+        // fail-closed paint path constant-work instead of shaping attacker-
+        // controlled text that is not part of the rendered document.
+        ctx.fillText('Unsupported chart', x + w / 2, y + h / 2);
     }
     drawChartDisplayUnitLabels(ctx, chart, rect, ptToPx);
     drawChartTextBoxes(ctx, chart, rect, ptToPx);

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -6345,27 +6345,53 @@ pub fn parse_chartex_part_with_references_style_parts_and_images(
             })
             .unwrap_or(0)
     };
+    // MS-ODRAWXML §2.24.4.19 defines this closed set.  Preserve a future
+    // identifier verbatim, but let it own the chart-wide fail-closed result:
+    // otherwise a preceding known series or a trailing `paretoLine` could
+    // silently normalize the chart to a visually similar implemented layout.
+    const KNOWN_SERIES_LAYOUTS: [&str; 8] = [
+        "boxWhisker",
+        "clusteredColumn",
+        "funnel",
+        "paretoLine",
+        "regionMap",
+        "sunburst",
+        "treemap",
+        "waterfall",
+    ];
+    let unknown_series = series_nodes.iter().copied().find(|node| {
+        !attr(node, "layoutId")
+            .is_some_and(|layout| KNOWN_SERIES_LAYOUTS.contains(&layout.as_str()))
+    });
     // A Pareto plot is represented by an ordinary owner series plus an
     // auxiliary `paretoLine` whose `ownerIdx` names the owner's original
     // document-order series index (CT_Series@ownerIdx, [MS-ODRAWXML]
     // 2.24.3.77). This is independent of `formatIdx`; select the linked owner
     // even when a hidden or auxiliary series appears first.
-    let pareto_pair = series_nodes.iter().copied().find_map(|pareto| {
-        if attr(&pareto, "layoutId").as_deref() != Some("paretoLine") {
-            return None;
-        }
-        let owner_idx = attr(&pareto, "ownerIdx")?.parse::<usize>().ok()?;
-        let owner = *all_series_nodes.get(owner_idx)?;
-        let owner_is_hidden = attr(&owner, "hidden")
-            .is_some_and(|value| value == "1" || value.eq_ignore_ascii_case("true"));
-        (owner != pareto
-            && !owner_is_hidden
-            && attr(&owner, "layoutId").as_deref() != Some("paretoLine"))
-        .then_some((owner, pareto))
-    });
-    let (series_node, pareto_series_node) = pareto_pair
-        .map(|(owner, pareto)| (owner, Some(pareto)))
-        .unwrap_or((*series_nodes.first()?, None));
+    let pareto_pair = if unknown_series.is_none() {
+        series_nodes.iter().copied().find_map(|pareto| {
+            if attr(&pareto, "layoutId").as_deref() != Some("paretoLine") {
+                return None;
+            }
+            let owner_idx = attr(&pareto, "ownerIdx")?.parse::<usize>().ok()?;
+            let owner = *all_series_nodes.get(owner_idx)?;
+            let owner_is_hidden = attr(&owner, "hidden")
+                .is_some_and(|value| value == "1" || value.eq_ignore_ascii_case("true"));
+            (owner != pareto
+                && !owner_is_hidden
+                && attr(&owner, "layoutId").as_deref() != Some("paretoLine"))
+            .then_some((owner, pareto))
+        })
+    } else {
+        None
+    };
+    let (series_node, pareto_series_node) = if let Some(unknown) = unknown_series {
+        (unknown, None)
+    } else {
+        pareto_pair
+            .map(|(owner, pareto)| (owner, Some(pareto)))
+            .unwrap_or((*series_nodes.first()?, None))
+    };
     let layout_id = attr(&series_node, "layoutId").unwrap_or_default();
     // [MS-ODRAWXML] represents a histogram as a clusteredColumn series with a
     // CT_Binning child; `histogram` is not an ST_SeriesLayout enumeration.
@@ -18262,6 +18288,39 @@ Subtitle</a:t></a:r></a:p>
                 vec![Some(3.0), Some(2.0), Some(1.0)]
             );
             assert!(model.categories.is_empty());
+        }
+    }
+
+    #[test]
+    fn parse_chartex_preserves_an_unknown_future_layout_without_guessing() {
+        for series_xml in [
+            r#"<cx:series layoutId="futureLayout"><cx:dataId val="0"/></cx:series>"#,
+            r#"<cx:series layoutId="clusteredColumn"><cx:dataId val="0"/></cx:series>
+               <cx:series layoutId="futureLayout"><cx:dataId val="0"/></cx:series>"#,
+            r#"<cx:series layoutId="futureLayout"><cx:dataId val="0"/></cx:series>
+               <cx:series layoutId="paretoLine" ownerIdx="0"><cx:dataId val="0"/></cx:series>"#,
+        ] {
+            let xml = format!(
+                r#"<cx:chartSpace xmlns:cx="{CX_NS}">
+                  <cx:chartData><cx:data id="0">
+                    <cx:strDim type="cat"><cx:lvl ptCount="2"><cx:pt idx="0">A</cx:pt><cx:pt idx="1">B</cx:pt></cx:lvl></cx:strDim>
+                    <cx:numDim type="val"><cx:lvl ptCount="2"><cx:pt idx="0">2</cx:pt><cx:pt idx="1">-1</cx:pt></cx:lvl></cx:numDim>
+                  </cx:data></cx:chartData>
+                  <cx:chart><cx:plotArea><cx:plotAreaRegion>{series_xml}</cx:plotAreaRegion></cx:plotArea></cx:chart>
+                </cx:chartSpace>"#
+            );
+            let document = chart_space_of(&xml);
+            let model = parse_chartex_part(document.root_element(), &FixtureResolver, None)
+                .expect("future ChartEx layout remains inspectable");
+
+            assert_eq!(model.chart_type, "futureLayout");
+            assert_eq!(model.categories, vec!["A", "B"]);
+            assert_eq!(model.series[0].values, vec![Some(2.0), Some(-1.0)]);
+            assert!(model.chartex_histogram_binning.is_none());
+            assert!(model.chartex_box.is_none());
+            assert!(model.chartex_sunburst.is_none());
+            assert!(model.chartex_treemap.is_none());
+            assert!(model.chartex_region_map.is_none());
         }
     }
 


### PR DESCRIPTION
## Summary

- inventory every MS-ODRAWXML `ST_SeriesLayout` value in the support matrix
- preserve an unknown future layout identifier without inferring a known family from its values or sibling series
- prevent a trailing Pareto auxiliary series from normalizing an unknown owner
- render one constant-work unsupported placeholder instead of shaping an unbounded public identifier

## Root cause

The shared parser preserved a lone unknown layout, but a preceding known series or a linked `paretoLine` could select a known renderer instead. The generic placeholder also interpolated the raw layout identifier into Canvas text, making its work proportional to an unbounded public-model string.

## Verification

- 797 core renderer tests
- 462 shared OOXML tests
- shared DOCX/XLSX/PPTX ChartEx host routes
- TypeScript build and ooxml-common clippy
- independent adversarial review: approved
- exact rebuilt-WASM comparison: +787 bytes raw and -149 bytes gzip across all three parsers; shared JS chunk -4 bytes raw / -1 byte gzip

Closes #1297