### PR TITLE
feat(pptx): expose ids for non-shape elements

### DIFF
--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -156,6 +156,7 @@ export interface ChartDisplayUnitsLabel {
 }
 export interface ChartElement {
     type: 'chart';
+    id?: string;
     x: number;
     y: number;
     width: number;
@@ -1056,6 +1057,7 @@ export interface MathSvg {
 }
 export interface MediaElement {
     type: 'media';
+    id?: string;
     x: number;
     y: number;
     width: number;
@@ -1214,6 +1216,7 @@ export interface PatternFill {
 }
 export interface PictureElement {
     type: 'picture';
+    id?: string;
     x: number;
     y: number;
     width: number;
@@ -1709,6 +1712,7 @@ export interface TableCell {
 }
 export interface TableElement {
     type: 'table';
+    id?: string;
     x: number;
     y: number;
     width: number;

--- a/packages/pptx/parser/src/chart.rs
+++ b/packages/pptx/parser/src/chart.rs
@@ -133,6 +133,7 @@ pub(crate) fn parse_legacy_chart_with_style_parts_and_images(
         }
     }
     Some(ChartElement {
+        id: None,
         x: 0,
         y: 0,
         width: 0,
@@ -200,6 +201,7 @@ pub(crate) fn parse_chartex_with_images(
         image_resolver,
     )?;
     Some(ChartElement {
+        id: None,
         x: 0,
         y: 0,
         width: 0,

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -3212,6 +3212,7 @@ mod tests {
     #[test]
     fn picture_element_serializes_path_not_data_url() {
         let pic = PictureElement {
+            id: None,
             x: 0,
             y: 0,
             width: 100,
@@ -7005,6 +7006,7 @@ mod tests {
 
         let media = parse_media(pic, "ppt/slides", &rels)
             .expect("p14:media-only .m4v should parse as a MediaElement");
+        assert_eq!(media.id.as_deref(), Some("5"));
         assert_eq!(media.media_kind, "video");
         assert_eq!(media.mime_type, "video/mp4");
         assert_eq!(media.media_path, "ppt/media/clip.m4v");

--- a/packages/pptx/parser/src/shape.rs
+++ b/packages/pptx/parser/src/shape.rs
@@ -163,7 +163,9 @@ mod chartex_sidecar_package_tests {
         let json = crate::parse_pptx_native(&bytes).expect("full PPTX package parses");
         let presentation: serde_json::Value =
             serde_json::from_str(&json).expect("presentation JSON");
-        let chart = &presentation["slides"][0]["elements"][0]["chart"];
+        let element = &presentation["slides"][0]["elements"][0];
+        assert_eq!(element["id"], serde_json::Value::String("2".to_string()));
+        let chart = &element["chart"];
         assert_eq!(
             chart["chartexColorPalette"][0],
             serde_json::Value::String("336699".to_string()),
@@ -1423,6 +1425,7 @@ pub(crate) fn parse_picture(
 
     let (prst_geom, prst_adjust) = parse_pic_prst_geom(sp_pr);
     Some(PictureElement {
+        id: read_cnv_pr(pic_node, rels).id,
         x: t.x,
         y: t.y,
         width: t.cx,
@@ -1487,6 +1490,7 @@ pub(crate) fn parse_ole_preview_picture(
     } = resolve_blip_source(blip_fill, slide_dir, rels, zip)?;
 
     Some(PictureElement {
+        id: read_cnv_pr(pic_node, rels).id,
         x: gf.x,
         y: gf.y,
         width: gf.cx,
@@ -1632,6 +1636,7 @@ pub(crate) fn parse_media(
     .unwrap_or_default();
 
     Some(MediaElement {
+        id: read_cnv_pr(pic_node, rels).id,
         x: t.x,
         y: t.y,
         width: t.cx,
@@ -2145,6 +2150,7 @@ pub(crate) fn parse_table(
     }
 
     Some(TableElement {
+        id: None,
         x: t.x,
         y: t.y,
         width: t.cx,
@@ -2432,6 +2438,7 @@ pub(crate) fn parse_sp_tree_node(
                                     theme_source,
                                 );
                                 out.push(SlideElement::Picture(PictureElement {
+                                    id: read_cnv_pr(node, rels).id,
                                     x: t.x,
                                     y: t.y,
                                     width: t.cx,
@@ -2504,6 +2511,7 @@ pub(crate) fn parse_sp_tree_node(
                                     theme_source,
                                 );
                                 out.push(SlideElement::Picture(PictureElement {
+                                    id: read_cnv_pr(node, rels).id,
                                     x: t.x,
                                     y: t.y,
                                     width: t.cx,
@@ -2608,6 +2616,7 @@ pub(crate) fn parse_sp_tree_node(
                                         theme_source,
                                     );
                                     out.push(SlideElement::Picture(PictureElement {
+                                        id: read_cnv_pr(node, rels).id,
                                         x: t.x,
                                         y: t.y,
                                         width: t.cx,
@@ -2718,7 +2727,10 @@ pub(crate) fn parse_sp_tree_node(
                 .descendants()
                 .find(|n| n.is_element() && n.tag_name().name() == "tbl");
             if let Some(tbl_node) = tbl_node {
-                if let Some(table) = parse_table(tbl_node, &t, theme_source, rels, slide_dir, zip) {
+                if let Some(mut table) =
+                    parse_table(tbl_node, &t, theme_source, rels, slide_dir, zip)
+                {
+                    table.id = read_cnv_pr(node, rels).id;
                     out.push(SlideElement::Table(table));
                 }
                 return;
@@ -2824,6 +2836,7 @@ pub(crate) fn parse_sp_tree_node(
                                 )
                             };
                             if let Some(mut chart) = chart_opt {
+                                chart.id = read_cnv_pr(node, rels).id;
                                 chart.x = t.x;
                                 chart.y = t.y;
                                 chart.width = t.cx;
@@ -3496,6 +3509,43 @@ mod style_ref_tests {
             (100, 200, 300, 400)
         );
     }
+
+    #[test]
+    fn table_element_exposes_graphic_frame_id() {
+        let doc = roxmltree::Document::parse(
+            r#"<p:graphicFrame xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                                xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <p:nvGraphicFramePr><p:cNvPr id="42" name="Table 1"/><p:cNvGraphicFramePr/><p:nvPr/></p:nvGraphicFramePr>
+              <p:xfrm><a:off x="0" y="0"/><a:ext cx="100" cy="100"/></p:xfrm>
+              <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table">
+                <a:tbl><a:tblPr/><a:tblGrid><a:gridCol w="100"/></a:tblGrid>
+                  <a:tr h="100"><a:tc><a:txBody/></a:tc></a:tr>
+                </a:tbl>
+              </a:graphicData></a:graphic>
+            </p:graphicFrame>"#,
+        )
+        .unwrap();
+        let mut zip = empty_zip();
+        let mut out = Vec::new();
+        parse_sp_tree_node(
+            doc.root_element(),
+            &LayoutPlaceholders::default(),
+            "ppt/slides",
+            &HashMap::new(),
+            &HashMap::new(),
+            &mut zip,
+            &PptxTheme::default(),
+            &mut out,
+            false,
+            None,
+            DepthGuard::root(),
+        );
+
+        let SlideElement::Table(table) = out.pop().expect("table output") else {
+            panic!("expected TableElement")
+        };
+        assert_eq!(table.id.as_deref(), Some("42"));
+    }
 }
 
 #[cfg(test)]
@@ -3620,6 +3670,7 @@ mod picture_property_resolution_tests {
             &theme,
             &mut zip,
         );
+        assert_eq!(ordinary.id.as_deref(), Some("1"));
         assert_theme_properties(&ordinary);
 
         let mut zip = image_zip();
@@ -3637,6 +3688,7 @@ mod picture_property_resolution_tests {
             &theme,
             &mut zip,
         );
+        assert_eq!(blip_shape.id.as_deref(), Some("2"));
         assert_theme_properties(&blip_shape);
     }
 

--- a/packages/pptx/parser/src/types.rs
+++ b/packages/pptx/parser/src/types.rs
@@ -142,6 +142,9 @@ pub(crate) enum SlideElement {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ChartElement {
+    /// `<p:nvGraphicFramePr><p:cNvPr @id>` for the chart frame.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) id: Option<String>,
     pub(crate) x: i64,
     pub(crate) y: i64,
     pub(crate) width: i64,
@@ -155,6 +158,9 @@ pub(crate) struct ChartElement {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct TableElement {
+    /// `<p:nvGraphicFramePr><p:cNvPr @id>` for the table frame.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) id: Option<String>,
     pub(crate) x: i64,
     pub(crate) y: i64,
     pub(crate) width: i64,
@@ -458,6 +464,9 @@ pub(crate) struct ShapeElement {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PictureElement {
+    /// The source drawing node's `<p:cNvPr @id>`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) id: Option<String>,
     pub(crate) x: i64,
     pub(crate) y: i64,
     pub(crate) width: i64,
@@ -569,6 +578,9 @@ pub(crate) struct PictureElement {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct MediaElement {
+    /// `<p:nvPicPr><p:cNvPr @id>` for the media frame.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) id: Option<String>,
     pub(crate) x: i64,
     pub(crate) y: i64,
     pub(crate) width: i64,
@@ -1489,6 +1501,7 @@ mod group_transform_tests {
             .expect("minimal chart");
         let mut elements = vec![
             SlideElement::Table(TableElement {
+                id: None,
                 x: 10,
                 y: 20,
                 width: 20,
@@ -1501,6 +1514,7 @@ mod group_transform_tests {
                 rtl: false,
             }),
             SlideElement::Chart(ChartElement {
+                id: None,
                 x: 10,
                 y: 20,
                 width: 20,
@@ -1511,6 +1525,7 @@ mod group_transform_tests {
                 ..chart
             }),
             SlideElement::Media(MediaElement {
+                id: None,
                 x: 10,
                 y: 20,
                 width: 20,

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -235,6 +235,8 @@ export type SlideElement = ShapeElement | PictureElement | TableElement | ChartE
 
 export interface MediaElement {
   type: 'media';
+  /** `<p:nvPicPr><p:cNvPr @id>` for the media frame. */
+  id?: string;
   x: number;
   y: number;
   width: number;
@@ -437,6 +439,8 @@ export interface Sp3d {
 
 export interface TableElement {
   type: 'table';
+  /** `<p:nvGraphicFramePr><p:cNvPr @id>` for the table frame. */
+  id?: string;
   x: number;
   y: number;
   width: number;
@@ -487,6 +491,8 @@ export interface TableCell {
  */
 export interface ChartElement {
   type: 'chart';
+  /** `<p:nvGraphicFramePr><p:cNvPr @id>` for the chart frame. */
+  id?: string;
   /** Frame geometry on the slide, in EMU. */
   x: number;
   y: number;
@@ -507,6 +513,8 @@ export interface ChartElement {
 
 export interface PictureElement {
   type: 'picture';
+  /** The source drawing node's `<p:cNvPr @id>`. */
+  id?: string;
   x: number;
   y: number;
   width: number;


### PR DESCRIPTION
## Summary

- expose optional OOXML `cNvPr` IDs on picture, table, chart, and media elements
- preserve the source ID for picture-like elements emitted from slide drawing nodes
- update the public PPTX type declaration baseline

## Why

Only shape elements surfaced their stable drawing ID. Picture, table, chart, and media parsing discarded the equivalent `cNvPr` identity, so consumers could not construct stable references for those elements.

## Implementation

- picture and media IDs come from `p:nvPicPr/p:cNvPr`
- table and chart IDs come from `p:nvGraphicFramePr/p:cNvPr`
- missing IDs remain omitted from serialized output for backward compatibility

## Verification

- `cargo test -p pptx-parser --no-default-features` (262 passed)
- `cargo fmt --all -- --check`
- `pnpm exec vitest run packages/pptx/src` (669 passed)
- `pnpm --filter @silurus/ooxml-pptx build`
- `git diff --check`
