### PR TITLE
fix(chart): honor Of-Pie split semantics

### DIFF
--- a/docs/chart-support-matrix.md
+++ b/docs/chart-support-matrix.md
@@ -65,7 +65,7 @@ observed input boundary is recorded in
 | C-PIE-001 | Pie/doughnut point explosion | Yes | Yes | Yes | Supported | Per-point explosion is retained. |
 | C-PIE-002 | Pie/doughnut series-level explosion | Yes | Yes | Yes | Supported | `CT_PieSer/explosion` supplies the default; a point-level `dPt/explosion` overrides it. |
 | C-PIE-003 | First-slice angle and doughnut hole size | Yes | Yes | Yes | Supported | Authored schema bounds are preserved. |
-| C-OFPIE-001 | Pie-of-pie/bar-of-pie split, sizing, and connector geometry | Yes | Yes | Yes | Partial | Position, value, percent, and custom splits render. Automatic split selection remains application-defined. |
+| C-OFPIE-001 | Pie-of-pie/bar-of-pie split, sizing, and connector geometry | Yes | Yes | Yes | Partial | Position, value, percent, and custom splits follow ECMA-376. An omitted `splitType` uses the bounded Office rule in MS-OE376 §2.1.1596(b); the Office-prohibited explicit `auto` value fails closed. Exact connector and gap geometry remains under compatibility audit. |
 | C-BUBBLE-001 | Bubble size, scale, negative bubbles, and size representation | Yes | Yes | Yes | Supported | Resource-bounded and shared across hosts. |
 | C-BUBBLE-002 | `bubble3D` | No | No | No | Missing | The current local corpus only exercises `false`; `true` remains unsupported. |
 | C-SURFACE-001 | Surface/surface3D mesh, bands, camera, and authored band formatting | Yes | Yes | Yes | Partial | Supported camera/material boundaries are recorded in the compatibility evidence document. |

--- a/packages/core/src/chart/of-pie.test.ts
+++ b/packages/core/src/chart/of-pie.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import type { ChartModel, ChartOfPie } from '../types/chart.js';
+import { planOfPieSecondaryIndices } from './of-pie.js';
+import { MAX_CANVAS_CHART_POINTS, sourceChartStructureCount } from './resource-limits.js';
+
+const options = (over: Partial<ChartOfPie>): ChartOfPie => ({
+  type: 'pie',
+  splitType: 'pos',
+  splitPos: 2,
+  secondPieSizePercent: 75,
+  gapWidthPercent: 100,
+  seriesLines: true,
+  ...over,
+});
+
+const planned = (value: Set<number> | null): number[] | null =>
+  value == null ? null : [...value];
+
+describe('pie-of-pie split planning', () => {
+  it('uses the documented Office omission rule instead of a fixed tail size', () => {
+    expect(planned(planOfPieSecondaryIndices(
+      options({ splitType: 'auto', splitTypeAuthored: false, splitPos: null }),
+      [9, 8, 7, 6, 5, 4],
+    ))).toEqual([4, 5]);
+    expect(planned(planOfPieSecondaryIndices(
+      options({ splitType: 'auto', splitTypeAuthored: false, splitPos: null }),
+      [9, 8, 7, 6, 5, 4, 3],
+    ))).toEqual([4, 5, 6]);
+  });
+
+  it('counts source positions rather than filtering zeros, negatives, or ties first', () => {
+    expect(planned(planOfPieSecondaryIndices(
+      options({ splitType: 'auto', splitTypeAuthored: false, splitPos: null }),
+      [10, 10, 0, -1, null, 10],
+    ))).toEqual([4, 5]);
+  });
+
+  it('fails closed for the explicit auto value that Office rejects', () => {
+    expect(planOfPieSecondaryIndices(
+      options({ splitType: 'auto', splitTypeAuthored: true, splitPos: null }),
+      [4, 3, 2, 1],
+    )).toBeNull();
+  });
+
+  it('fails closed when splitPos is paired with omission or a custom split', () => {
+    expect(planOfPieSecondaryIndices(
+      options({ splitType: 'auto', splitTypeAuthored: false, splitPos: 2 }),
+      [4, 3, 2, 1],
+    )).toBeNull();
+    expect(planOfPieSecondaryIndices(
+      options({ splitType: 'cust', splitPos: 2, customSplitIndices: [3] }),
+      [4, 3, 2, 1],
+    )).toBeNull();
+    expect(planOfPieSecondaryIndices(
+      options({
+        splitType: 'auto', splitTypeAuthored: false,
+        splitPos: null, splitPosAuthored: true,
+      }),
+      [4, 3, 2, 1],
+    )).toBeNull();
+    expect(planOfPieSecondaryIndices(
+      options({
+        splitType: 'cust', splitPos: null, splitPosAuthored: true,
+        customSplitIndices: [3],
+      }),
+      [4, 3, 2, 1],
+    )).toBeNull();
+  });
+
+  it('uses strict less-than comparisons for value and percentage splits', () => {
+    expect(planned(planOfPieSecondaryIndices(
+      options({ splitType: 'val', splitPos: 10 }),
+      [9, 10, 11, -2],
+    ))).toEqual([0, 3]);
+    expect(planned(planOfPieSecondaryIndices(
+      options({ splitType: 'percent', splitPos: 20 }),
+      [10, 20, 30, 40],
+    ))).toEqual([0]);
+  });
+
+  it('preserves authored custom indexes and validates positional boundaries', () => {
+    expect(planned(planOfPieSecondaryIndices(
+      options({ splitType: 'cust', splitPos: null, customSplitIndices: [3, 1, 3, 99] }),
+      [5, 4, 3, 2],
+    ))).toEqual([3, 1]);
+    expect(planOfPieSecondaryIndices(
+      options({ splitType: 'cust', splitPos: null, customSplitIndices: null }),
+      [5, 4, 3, 2],
+    )).toBeNull();
+    expect(planOfPieSecondaryIndices(
+      options({ splitType: 'pos', splitPos: 1.5 }),
+      [5, 4, 3, 2],
+    )).toBeNull();
+    expect(planOfPieSecondaryIndices(
+      options({ splitType: 'pos', splitPos: 32_001 }),
+      [5, 4, 3, 2],
+    )).toBeNull();
+  });
+
+  it('charges custom split indexes to the shared source-structure ceiling', () => {
+    const customSplitIndices = Array.from({ length: MAX_CANVAS_CHART_POINTS }, (_, index) => index);
+    const chart = {
+      chartType: 'ofPie',
+      categories: [],
+      series: [{ name: '', color: null, values: [1] }],
+      ofPie: options({ splitType: 'cust', customSplitIndices }),
+    } as unknown as ChartModel;
+    const count = sourceChartStructureCount(chart);
+    expect(count).toBe(MAX_CANVAS_CHART_POINTS + 1);
+  });
+});

--- a/packages/core/src/chart/of-pie.ts
+++ b/packages/core/src/chart/of-pie.ts
@@ -1,0 +1,77 @@
+import type { ChartOfPie } from '../types/chart.js';
+
+/**
+ * Resolve the authored source-point indexes assigned to the secondary plot.
+ *
+ * ECMA-376 Part 1 §21.2.3.45 defines the four explicit split mechanisms.
+ * MS-OE376 §2.1.1596(b) defines Office's omitted-`splitType` behavior as a
+ * positional split of `ceil(pointCount / 3)` points. Office rejects an
+ * explicitly authored `auto` value, so that distinct provenance fails closed.
+ */
+export function planOfPieSecondaryIndices(
+  options: ChartOfPie | null | undefined,
+  values: readonly (number | null)[],
+): Set<number> | null {
+  const splitType = options?.splitType ?? 'auto';
+  const splitPos = options?.splitPos;
+  const selected = new Set<number>();
+
+  // MS-OE376 §2.1.1595(b): splitPos is valid only with an explicitly
+  // authored percent, position, or value split.
+  const splitPosWasAuthored = options?.splitPosAuthored === true || splitPos != null;
+  if (splitPosWasAuthored && (
+    !['percent', 'pos', 'val'].includes(splitType)
+    || splitPos == null
+    || !Number.isFinite(splitPos)
+  )) return null;
+
+  if (splitType === 'auto') {
+    if (options?.splitTypeAuthored === true) return null;
+    const count = Math.ceil(values.length / 3);
+    for (let index = Math.max(0, values.length - count); index < values.length; index++) {
+      selected.add(index);
+    }
+    return selected;
+  }
+
+  if (splitType === 'cust') {
+    if (options?.customSplitIndices == null) return null;
+    for (const index of options.customSplitIndices) {
+      if (Number.isSafeInteger(index) && index >= 0 && index < values.length) selected.add(index);
+    }
+    return selected;
+  }
+
+  if (splitPos == null || !Number.isFinite(splitPos)) return null;
+
+  if (splitType === 'pos') {
+    // MS-OE376 §2.1.1595(a): Office requires an integer in [0, 32000].
+    if (!Number.isInteger(splitPos) || splitPos < 0 || splitPos > 32_000) return null;
+    const count = Math.min(values.length, splitPos);
+    for (let index = values.length - count; index < values.length; index++) selected.add(index);
+    return selected;
+  }
+
+  if (splitType === 'val') {
+    for (let sourceIndex = 0; sourceIndex < values.length; sourceIndex++) {
+      const value = values[sourceIndex];
+      if (value != null && Number.isFinite(value) && value < splitPos) selected.add(sourceIndex);
+    }
+    return selected;
+  }
+
+  // MS-OE376 §2.1.1595(a): Office requires percent in [0, 100]. Pie
+  // geometry uses magnitudes, so percentage shares use the same magnitudes.
+  if (splitPos < 0 || splitPos > 100) return null;
+  let total = 0;
+  for (const value of values) {
+    if (value != null && Number.isFinite(value)) total += Math.abs(value);
+  }
+  if (!(total > 0)) return selected;
+  for (let sourceIndex = 0; sourceIndex < values.length; sourceIndex++) {
+    const value = values[sourceIndex];
+    if (value != null && Number.isFinite(value)
+      && (Math.abs(value) / total) * 100 < splitPos) selected.add(sourceIndex);
+  }
+  return selected;
+}

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -12568,6 +12568,61 @@ describe('ofPie secondary plots (§21.2.2.126)', () => {
     );
     expect(detailBars).toHaveLength(2);
   });
+
+  it('uses the Office omission rule without a fixed three-point tail', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      ...ofPieModel('pie'),
+      ofPie: {
+        ...ofPieModel('pie').ofPie as NonNullable<ChartModel['ofPie']>,
+        splitType: 'auto',
+        splitTypeAuthored: false,
+        splitPos: null,
+      },
+    }), RECT, 1);
+    const arcsPerCenter = new Map<string, number>();
+    for (const arc of rec.arcs) {
+      const center = `${arc.x.toFixed(2)},${arc.y.toFixed(2)}`;
+      arcsPerCenter.set(center, (arcsPerCenter.get(center) ?? 0) + 1);
+    }
+    // Six points => ceil(6 / 3) = two details. The primary has four source
+    // slices plus the aggregate; the secondary has exactly two slices.
+    expect([...arcsPerCenter.values()].sort((a, b) => a - b)).toEqual([2, 5]);
+  });
+
+  it('does not invent a secondary split for Office-prohibited explicit auto', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      ...ofPieModel('pie'),
+      ofPie: {
+        ...ofPieModel('pie').ofPie as NonNullable<ChartModel['ofPie']>,
+        splitType: 'auto',
+        splitTypeAuthored: true,
+        splitPos: null,
+      },
+    }), RECT, 1);
+    const centers = new Set(rec.arcs.map(arc => `${arc.x.toFixed(2)},${arc.y.toFixed(2)}`));
+    expect(centers.size).toBe(1);
+    expect(rec.arcs).toHaveLength(6);
+  });
+
+  it.each([
+    { splitType: 'pos' as const, splitPos: 6, customSplitIndices: null },
+    { splitType: 'cust' as const, splitPos: null, customSplitIndices: [0, 1, 2, 3, 4, 5] },
+  ])('keeps an aggregate-only primary plot when $splitType selects every point', split => {
+    const rec = recordingCtx();
+    const model = ofPieModel('pie');
+    renderChart(rec.ctx, {
+      ...model,
+      ofPie: { ...model.ofPie as NonNullable<ChartModel['ofPie']>, ...split },
+    }, RECT, 1);
+    const arcsPerCenter = new Map<string, number>();
+    for (const arc of rec.arcs) {
+      const center = `${arc.x.toFixed(2)},${arc.y.toFixed(2)}`;
+      arcsPerCenter.set(center, (arcsPerCenter.get(center) ?? 0) + 1);
+    }
+    expect([...arcsPerCenter.values()].sort((a, b) => a - b)).toEqual([1, 6]);
+  });
 });
 
 describe('classic line-chart group decorations', () => {

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -91,6 +91,7 @@ import {
   type CategoryGapPolicy,
 } from './category-spacing.js';
 import { planHistogramBins } from './histogram-binning.js';
+import { planOfPieSecondaryIndices } from './of-pie.js';
 import {
   boxWhiskerGeometry,
   boxWhiskerPointCount,
@@ -8962,41 +8963,6 @@ interface OfPiePoint {
   value: number;
 }
 
-function ofPieSecondaryIndices(chart: ChartModel, values: number[]): Set<number> {
-  const options = chart.ofPie;
-  const finitePositive = values
-    .map((value, sourceIndex) => ({ value, sourceIndex }))
-    .filter(point => Number.isFinite(point.value) && point.value > 0);
-  const selected = new Set<number>();
-  if (finitePositive.length < 2) return selected;
-  const splitType = options?.splitType ?? 'auto';
-  const splitPos = options?.splitPos;
-  if (splitType === 'cust') {
-    for (const index of options?.customSplitIndices ?? []) {
-      if (finitePositive.some(point => point.sourceIndex === index)) selected.add(index);
-    }
-  } else if (splitType === 'val' && splitPos != null && Number.isFinite(splitPos)) {
-    for (const point of finitePositive) if (point.value <= splitPos) selected.add(point.sourceIndex);
-  } else if (splitType === 'percent' && splitPos != null && Number.isFinite(splitPos)) {
-    const total = finitePositive.reduce((sum, point) => sum + point.value, 0);
-    for (const point of finitePositive) {
-      if (total > 0 && (point.value / total) * 100 <= splitPos) selected.add(point.sourceIndex);
-    }
-  } else {
-    // Position is a count from the end. Excel's omitted `auto` currently uses
-    // the same tail split with three detail points; the boundary corpus keeps
-    // this compatibility default observable rather than hiding it in paint.
-    const count = splitType === 'pos' && splitPos != null && Number.isFinite(splitPos)
-      ? Math.max(0, Math.floor(splitPos))
-      : 3;
-    for (const point of finitePositive.slice(-count)) selected.add(point.sourceIndex);
-  }
-  // Both plots must remain non-empty. Malformed/all-point custom splits degrade
-  // deterministically by retaining the first finite point in the primary plot.
-  if (selected.size >= finitePositive.length) selected.delete(finitePositive[0].sourceIndex);
-  return selected;
-}
-
 /** ECMA-376 §21.2.2.126 pie-of-pie / bar-of-pie. Source point identity stays
  * attached to every detail item; only the primary plot receives one aggregate
  * slice. Automatic geometry is deliberately compact and parameterized solely
@@ -9010,9 +8976,8 @@ function renderOfPieChart(
 ): void {
   const source = chart.series[0];
   if (!source) return;
-  const values = source.values.map(value => value == null ? 0 : Math.abs(value));
-  const secondarySet = ofPieSecondaryIndices(chart, values);
-  if (secondarySet.size === 0) {
+  const secondarySet = planOfPieSecondaryIndices(chart.ofPie, source.values);
+  if (secondarySet == null || secondarySet.size === 0) {
     renderPieChart(
       ctx, { ...chart, chartType: 'pie' }, r, false, ptToPx, shapeRotationDeg,
     );
@@ -9020,12 +8985,18 @@ function renderOfPieChart(
   }
   const primary: OfPiePoint[] = [];
   const secondary: OfPiePoint[] = [];
-  for (let sourceIndex = 0; sourceIndex < values.length; sourceIndex++) {
-    const value = values[sourceIndex];
+  for (let sourceIndex = 0; sourceIndex < source.values.length; sourceIndex++) {
+    const sourceValue = source.values[sourceIndex];
+    const value = sourceValue == null ? 0 : Math.abs(sourceValue);
     if (!(value > 0) || !Number.isFinite(value)) continue;
     (secondarySet.has(sourceIndex) ? secondary : primary).push({ sourceIndex, value });
   }
-  if (primary.length === 0 || secondary.length === 0) return;
+  if (secondary.length === 0) {
+    renderPieChart(
+      ctx, { ...chart, chartType: 'pie' }, r, false, ptToPx, shapeRotationDeg,
+    );
+    return;
+  }
 
   const legendChart: ChartModel = { ...chart, chartType: 'pie' };
   const legend = measuredLegendReserve(ctx, legendChart, r.w, r.h, 0.28, ptToPx);

--- a/packages/core/src/chart/resource-limits.ts
+++ b/packages/core/src/chart/resource-limits.ts
@@ -72,6 +72,9 @@ export function sourceChartStructureCount(chart: ChartModel): number {
       if (!add(values.length)) return MAX_CANVAS_CHART_POINTS + 1;
     }
   }
+  if (!add(chart.ofPie?.customSplitIndices?.length ?? 0)) {
+    return MAX_CANVAS_CHART_POINTS + 1;
+  }
   return total;
 }
 

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -1412,7 +1412,11 @@ export interface ChartBarGroupDecorations {
 export interface ChartOfPie {
   type: 'pie' | 'bar';
   splitType: 'auto' | 'cust' | 'percent' | 'pos' | 'val';
+  /** Whether `<c:splitType>` was authored rather than omitted. */
+  splitTypeAuthored?: boolean | null;
   splitPos?: number | null;
+  /** Whether `<c:splitPos>` was authored, including an invalid/missing value. */
+  splitPosAuthored?: boolean | null;
   customSplitIndices?: number[] | null;
   /** Secondary pie diameter relative to the primary pie, 5–200%. */
   secondPieSizePercent: number;

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -553,7 +553,9 @@ export interface ChartModel {
 export interface ChartOfPie {
     type: 'pie' | 'bar';
     splitType: 'auto' | 'cust' | 'percent' | 'pos' | 'val';
+    splitTypeAuthored?: boolean | null;
     splitPos?: number | null;
+    splitPosAuthored?: boolean | null;
     customSplitIndices?: number[] | null;
     secondPieSizePercent: number;
     gapWidthPercent: number;

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -1064,8 +1064,10 @@ pub struct ChartBarGroupDecorations {
 pub struct ChartOfPie {
     pub r#type: String,
     pub split_type: String,
+    pub split_type_authored: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub split_pos: Option<f64>,
+    pub split_pos_authored: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_split_indices: Option<Vec<usize>>,
     pub second_pie_size_percent: f64,
@@ -2218,6 +2220,34 @@ fn child<'a, 'i>(parent: Node<'a, 'i>, name: &str) -> Option<Node<'a, 'i>> {
     parent
         .children()
         .find(|n| n.is_element() && n.tag_name().name() == name)
+}
+
+/// Retain one custom of-pie split atomically. The limit bounds the owned wire
+/// vector before allocation/serialization; an oversized list is unresolved,
+/// never a retained prefix with different split semantics.
+fn parse_of_pie_custom_split_with_limit(
+    chart: Node<'_, '_>,
+    max_points: usize,
+) -> Option<Vec<usize>> {
+    let split = child(chart, "custSplit")?;
+    let mut indices = Vec::new();
+    let mut point_count = 0usize;
+    for point in split
+        .children()
+        .filter(|node| node.is_element() && node.tag_name().name() == "secondPiePt")
+    {
+        point_count = point_count.checked_add(1)?;
+        if point_count > max_points {
+            return None;
+        }
+        if let Some(index) = point
+            .attribute("val")
+            .and_then(|value| value.parse::<usize>().ok())
+        {
+            indices.push(index);
+        }
+    }
+    Some(indices)
 }
 
 /// Read a no-namespace attribute `local` off `node` as an owned `String`.
@@ -10000,11 +10030,13 @@ pub fn parse_chart_part_with_references_style_parts_and_images(
                 .filter(|value| value.is_finite())
                 .unwrap_or(default)
         };
-        let split_type = child(node, "splitType")
+        let split_type_node = child(node, "splitType");
+        let split_type = split_type_node
             .and_then(|value| value.attribute("val"))
             .filter(|value| matches!(*value, "auto" | "cust" | "percent" | "pos" | "val"))
             .unwrap_or("auto")
             .to_string();
+        let split_pos_node = child(node, "splitPos");
         ChartOfPie {
             r#type: child(node, "ofPieType")
                 .and_then(|value| value.attribute("val"))
@@ -10012,18 +10044,16 @@ pub fn parse_chart_part_with_references_style_parts_and_images(
                 .unwrap_or("pie")
                 .to_string(),
             split_type,
-            split_pos: child(node, "splitPos")
+            split_type_authored: split_type_node.is_some(),
+            split_pos: split_pos_node
                 .and_then(|value| value.attribute("val"))
                 .and_then(|value| value.parse::<f64>().ok())
                 .filter(|value| value.is_finite()),
-            custom_split_indices: child(node, "custSplit").map(|split| {
-                split
-                    .children()
-                    .filter(|value| value.is_element() && value.tag_name().name() == "secondPiePt")
-                    .filter_map(|value| value.attribute("val"))
-                    .filter_map(|value| value.parse::<usize>().ok())
-                    .collect()
-            }),
+            split_pos_authored: split_pos_node.is_some(),
+            custom_split_indices: parse_of_pie_custom_split_with_limit(
+                node,
+                MAX_CHART_CACHE_POINTS,
+            ),
             second_pie_size_percent: percent("secondPieSize", 75.0).clamp(5.0, 200.0),
             gap_width_percent: percent("gapWidth", 150.0).max(0.0),
             series_lines: child(node, "serLines").is_some(),
@@ -20178,7 +20208,68 @@ Subtitle</a:t></a:r></a:p>
         let of_pie = m.of_pie.expect("ofPie contract");
         assert_eq!(of_pie.r#type, "pie");
         assert_eq!(of_pie.split_type, "auto");
+        assert!(!of_pie.split_type_authored);
+        assert!(!of_pie.split_pos_authored);
         assert_eq!(of_pie.second_pie_size_percent, 75.0);
+    }
+
+    #[test]
+    fn parse_chart_part_ofpie_retains_invalid_split_pos_pair_for_fail_closed_rendering() {
+        let group = format!(
+            r#"<c:ofPieChart><c:ofPieType val="pie"/><c:varyColors val="1"/>{CH13_SER}<c:splitPos val="2"/></c:ofPieChart>"#
+        );
+        let xml = chart_space_with_group(&group);
+        let document = chart_space_of(&xml);
+        let model =
+            parse_chart_part(document.root_element(), &FixtureResolver).expect("ofPie parses");
+        let of_pie = model.of_pie.expect("ofPie contract");
+        assert_eq!(of_pie.split_type, "auto");
+        assert!(!of_pie.split_type_authored);
+        assert_eq!(of_pie.split_pos, Some(2.0));
+        assert!(of_pie.split_pos_authored);
+    }
+
+    #[test]
+    fn parse_chart_part_ofpie_retains_invalid_split_pos_presence() {
+        for (split_type, split_pos) in [
+            ("", r#"<c:splitPos/>"#),
+            (
+                r#"<c:splitType val="cust"/>"#,
+                r#"<c:splitPos val="NaN"/><c:custSplit><c:secondPiePt val="1"/></c:custSplit>"#,
+            ),
+        ] {
+            let group = format!(
+                r#"<c:ofPieChart><c:ofPieType val="pie"/><c:varyColors val="1"/>{CH13_SER}{split_type}{split_pos}</c:ofPieChart>"#
+            );
+            let xml = chart_space_with_group(&group);
+            let document = chart_space_of(&xml);
+            let model =
+                parse_chart_part(document.root_element(), &FixtureResolver).expect("ofPie parses");
+            let of_pie = model.of_pie.expect("ofPie contract");
+            assert_eq!(of_pie.split_pos, None);
+            assert!(of_pie.split_pos_authored);
+        }
+    }
+
+    #[test]
+    fn ofpie_custom_split_is_atomic_at_the_parser_resource_boundary() {
+        let exact = roxmltree::Document::parse(
+            r#"<ofPieChart><custSplit><secondPiePt val="0"/><secondPiePt val="1"/></custSplit></ofPieChart>"#,
+        )
+        .expect("valid XML");
+        assert_eq!(
+            parse_of_pie_custom_split_with_limit(exact.root_element(), 2),
+            Some(vec![0, 1])
+        );
+
+        let plus_one = roxmltree::Document::parse(
+            r#"<ofPieChart><custSplit><secondPiePt val="0"/><secondPiePt val="1"/><secondPiePt val="2"/></custSplit></ofPieChart>"#,
+        )
+        .expect("valid XML");
+        assert_eq!(
+            parse_of_pie_custom_split_with_limit(plus_one.root_element(), 2),
+            None
+        );
     }
 
     /// Full ofPieChart contract retains secondary-plot controls without
@@ -20228,7 +20319,9 @@ Subtitle</a:t></a:r></a:p>
         let of_pie = m.of_pie.expect("ofPie contract");
         assert_eq!(of_pie.r#type, "bar");
         assert_eq!(of_pie.split_type, "pos");
+        assert!(of_pie.split_type_authored);
         assert_eq!(of_pie.split_pos, Some(2.0));
+        assert!(of_pie.split_pos_authored);
         assert_eq!(of_pie.second_pie_size_percent, 75.0);
         assert_eq!(of_pie.gap_width_percent, 100.0);
         assert!(of_pie.series_lines);

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -562,7 +562,9 @@ export interface ChartModel {
 export interface ChartOfPie {
     type: 'pie' | 'bar';
     splitType: 'auto' | 'cust' | 'percent' | 'pos' | 'val';
+    splitTypeAuthored?: boolean | null;
     splitPos?: number | null;
+    splitPosAuthored?: boolean | null;
     customSplitIndices?: number[] | null;
     secondPieSizePercent: number;
     gapWidthPercent: number;

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -662,7 +662,9 @@ export interface ChartModel {
 export interface ChartOfPie {
     type: 'pie' | 'bar';
     splitType: 'auto' | 'cust' | 'percent' | 'pos' | 'val';
+    splitTypeAuthored?: boolean | null;
     splitPos?: number | null;
+    splitPosAuthored?: boolean | null;
     customSplitIndices?: number[] | null;
     secondPieSizePercent: number;
     gapWidthPercent: number;


### PR DESCRIPTION
## Summary

- preserve authored splitType and splitPos provenance for Of-Pie charts
- implement the ECMA-376 split modes and the documented Office omission behavior in one shared planner
- fail closed for invalid split configurations and bound custom split indices before parser/model expansion
- keep all-selected splits as a valid aggregate-only primary plot

## Specification basis

- ECMA-376 Part 1, 21.2.2.126 and 21.2.3.45
- MS-OE376 2.1.1595, 2.1.1596, and 2.1.1645

No sample-specific branches or visual tuning constants are introduced. Connector and gap geometry remain explicitly Partial in the support matrix.

## Verification

- core focused suites: 808 passed
- ooxml-common full library: 465 passed plus 1 doc-test
- parser Of-Pie focused tests: 5 passed
- TypeScript project build passed
- DOCX/XLSX/PPTX public API checks and public type exports passed
- clippy with warnings denied passed
- diff check passed
- adversarial review: Blocker 0, High 0, Medium 0

## Distribution size

Compared with the parent revision using equivalent optimized WASM and production builds:

- combined relevant raw output: +723 bytes
- combined relevant gzip output: +412 bytes

Closes #1293
