### PR TITLE
refactor(chart): make ChartEx renderer opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ pnpm add @silurus/ooxml
 > | `@silurus/ooxml/math` | 3.1 MB | 1.1 MB | Optional MathJax + STIX Two Math engine |
 > | `@silurus/ooxml/three-d` | 92 KB | 27 KB | Optional model-space 3-D chart mesh and camera |
 > | `@silurus/ooxml/region-map` | 236 KB | 66 KB | Optional offline Region Map renderer and fixed country geometry |
+> | `@silurus/ooxml/chart-ex` | 37 KB | 11 KB | Optional Microsoft ChartEx families |
 >
 > These are production-artifact estimates, not initial-load figures: each row
 > sums all assets reachable from that entry, including parser WASM and worker
@@ -104,7 +105,7 @@ pnpm add @silurus/ooxml
 > [Rendering equations](#rendering-equations)). Never import the `math` entry
 > and the loader chunk never enters your graph at all.
 >
-> The 3-D chart and Region Map renderers follow the same dependency-injection
+> The ChartEx, 3-D chart and Region Map renderers follow the same dependency-injection
 > boundary: import and pass only the optional renderer modules an application
 > needs. Their implementations are not eagerly loaded or evaluated in main
 > mode. Worker mode fetches a self-contained render-worker asset that includes
@@ -209,22 +210,30 @@ shapes / text boxes the same way.)
 
 ### Optional chart renderers
 
-Model-space 3-D charts and offline country-level Region Maps are separate
-entries. Inject them once in the same load options object as `math`; omitting a
-renderer keeps it out of the ordinary render path. The built-in renderers work
-in both main and worker modes. Without `threeD`, 3-D chart groups
+Classic DrawingML 2-D chart families are included in every format entry.
+Microsoft ChartEx, model-space 3-D charts and offline country-level Region Maps
+are separate entries. Inject them once in the same load options object as
+`math`; omitting a renderer keeps it out of the ordinary render path. The
+built-in renderers work in both main and worker modes. Without `chartEx`,
+ChartEx families show the standard unsupported-chart placeholder. Without
+`threeD`, 3-D chart groups
 fall back to their canonical 2-D family. Without `regionMap`, Region Maps show
-the standard unsupported-chart placeholder.
+the standard unsupported-chart placeholder. The code-size boundary applies to
+the default main-mode application graph. The separately loaded render-worker
+asset stays self-contained for broad bundler compatibility and therefore
+contains its built-in optional renderer implementations.
 
 ```typescript
 import { XlsxViewer } from '@silurus/ooxml/xlsx';
 import { threeD } from '@silurus/ooxml/three-d';
 import { regionMap } from '@silurus/ooxml/region-map';
+import { chartEx } from '@silurus/ooxml/chart-ex';
 
 const container = document.getElementById('xlsx-container') as HTMLElement;
 const workbookViewer = new XlsxViewer(container, {
   threeD,
   regionMap,
+  chartEx,
   mode: 'worker',
 });
 await workbookViewer.load('/workbook-with-advanced-charts.xlsx');
@@ -737,7 +746,7 @@ file without uploading it.
 | | Charts (scatter — `scatterStyle` marker / line / smooth variants) | ✅ |
 | | Charts (bubble — `bubbleSize` per-point area scaling) | ✅ |
 | | Charts (ordered classic combo groups — observed bar/line/area, scatter/bubble, and stock/line combinations; unsupported mixes fail closed) | ✅ |
-| | Charts (chartEx — funnel / histogram / treemap / sunburst / box &amp; whisker) | ✅ |
+| | Charts (chartEx — funnel / histogram / treemap / sunburst / box &amp; whisker) | ✅ opt-in |
 | | Charts (stock — high / low / close candlesticks) | ✅ |
 | | SmartArt (renders the PowerPoint-saved drawing layout `dsp:drawing`, or a staged fallback to a text list when no drawing part is present; no native diagram layout engine) | ✅ |
 | | OLE embedded objects (`p:oleObj` — the baked preview `p:pic` is drawn; the embedded app is not run) | ✅ |

--- a/docs/chart-support-matrix.md
+++ b/docs/chart-support-matrix.md
@@ -116,6 +116,11 @@ recorded in [Chart compatibility evidence and scope](chart-compatibility-evidenc
 
 ## ChartEx layouts
 
+The ChartEx family renderer is an optional main/worker capability imported from
+`@silurus/ooxml/chart-ex`. Classic DrawingML 2-D chart families remain in each
+format entry. Without the optional renderer, recognized ChartEx models retain
+their parsed data but paint the deterministic unsupported-chart placeholder.
+
 MS-ODRAWXML §2.24.4.19 defines exactly eight `ST_SeriesLayout` values:
 `boxWhisker`, `clusteredColumn`, `funnel`, `paretoLine`, `regionMap`,
 `sunburst`, `treemap`, and `waterfall`. Histogram and Pareto are semantic

--- a/package.json
+++ b/package.json
@@ -73,6 +73,11 @@
       "import": "./dist/region-map.mjs",
       "default": "./dist/region-map.mjs"
     },
+    "./chart-ex": {
+      "types": "./dist/types/chart-ex.d.ts",
+      "import": "./dist/chart-ex.mjs",
+      "default": "./dist/chart-ex.mjs"
+    },
     "./node": {
       "types": "./dist/types/node.d.ts",
       "import": "./dist/node.mjs",
@@ -102,6 +107,7 @@
     "test:production-render-workers": "playwright test --config tests/worker-dist/playwright.config.ts",
     "check:optional-three-d": "node scripts/check-optional-three-d.mjs dist",
     "check:optional-region-map": "node scripts/check-optional-region-map.mjs dist",
+    "check:optional-chart-ex": "node scripts/check-optional-chart-ex.mjs dist",
     "lint": "ast-grep scan",
     "lint:test": "ast-grep test --skip-snapshot-tests",
     "test:docx-boundaries": "node --test scripts/check-docx-layout-boundaries.test.mjs",

--- a/packages/core/src/chart/chart-ex-contract.ts
+++ b/packages/core/src/chart/chart-ex-contract.ts
@@ -1,0 +1,16 @@
+import type { ChartModel, ChartRect } from '../types/chart.js';
+
+/**
+ * Synchronous optional renderer for Microsoft ChartEx (`cx:*`) chart
+ * families. Classic DrawingML (`c:*`) 2-D charts stay in the default renderer;
+ * the newer ChartEx dialect is supplied from `@silurus/ooxml/chart-ex`.
+ */
+export interface ChartExRenderer {
+  render(
+    ctx: CanvasRenderingContext2D,
+    chart: ChartModel,
+    rect: ChartRect,
+    ptToPx: number,
+    shapeRotationDeg?: number,
+  ): boolean;
+}

--- a/packages/core/src/chart/chart-ex-renderer.ts
+++ b/packages/core/src/chart/chart-ex-renderer.ts
@@ -1,0 +1,2134 @@
+// Optional Microsoft ChartEx family renderer. Classic DrawingML chart
+// families remain in renderer.ts so format entry bundles do not pull this
+// module unless the caller imports @silurus/ooxml/chart-ex.
+
+import type {
+  ChartModel,
+  ChartRect,
+  ChartSeries,
+  SecondaryValueAxis,
+} from '../types/chart.js';
+import type { Fill } from '../types/common.js';
+import {
+  AXIS_OUTER_TEXT_MARGIN_PT,
+  catAxisLabelBandH,
+  categoryTickLabelGapPx,
+  chartAxisTitleBands,
+  chartLegendBands,
+  chartTextFontSizePx,
+  computeChartFrame,
+  valueTickLabelGapPx,
+} from './layout.js';
+import { niceStep, planLinearValueAxis } from './axis-scale.js';
+import { axisLineWidthPx, resolveAxisLine } from './axis-style.js';
+import { formatCategoryLabel } from './chart-number-format.js';
+import { resolveCategoryGapWidthPercent } from './category-spacing.js';
+import { planHistogramBins } from './histogram-binning.js';
+import {
+  boxWhiskerGeometry,
+  boxWhiskerPointCount,
+  computeBoxWhiskerStats,
+} from './box-whisker.js';
+import { planParetoLayout } from './pareto-layout.js';
+import { MAX_CANVAS_CHART_POINTS } from './resource-limits.js';
+import { paintPlotAreaFrame } from './plot-area-frame.js';
+import {
+  applyChartExSeriesLineStyle,
+  applyResolvedChartExLineStyle,
+  axisLabelPx,
+  buildSunburstTree,
+  chartColor,
+  chartExDataPointFill,
+  chartExDataPointPaint,
+  chartExFillStyle,
+  chartExLegendSeries,
+  chartExMarkerPaint,
+  chartExSeriesFormatIndex,
+  chartExStyleColor,
+  chartExValueTickLabelOffsetPx,
+  chartFontCss,
+  chartFontFamily,
+  drawAxisTick,
+  drawAxisTitles,
+  drawBoundedDataLabelText,
+  drawChartTitleForLayout,
+  drawLegendForLayout,
+  drawMarker,
+  drawValMajorGridlines,
+  formatPrimaryValueAxisTick,
+  hierarchyInputTooLarge,
+  indexPointOverrides,
+  layoutSunburstAngles,
+  measuredCartesianTitleBand,
+  measuredLegendReserve,
+  planValueAxis,
+  rejectOversizedCanvasChart,
+  renderBarChart,
+  renderLineChart,
+  resolveChartExLabel,
+  resolveChartExSeriesLineStyle,
+  richDataLabelOptions,
+  strokeAxisSegment,
+  strokeValueGridlineH,
+  sunburstMaxDepth,
+  valGridStroke,
+  valMinorGridStroke,
+  wrapMeasuredText,
+  type ChartExStyle,
+  type SunburstNode,
+} from './renderer.js';
+
+function renderHistogramChart(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  rect: ChartRect,
+  ptToPx: number,
+  shapeRotationDeg = 0,
+): void {
+  const source = chart.series[0];
+  if (!source) return;
+  const plan = planHistogramBins(source.values, chart.chartexHistogramBinning ?? {});
+  if (plan.kind === 'tooManyInputPoints') {
+    rejectOversizedCanvasChart(ctx, rect, MAX_CANVAS_CHART_POINTS + 1);
+    return;
+  }
+  renderBarChart(ctx, {
+    ...chart,
+    chartType: 'clusteredBar',
+    categories: plan.categories,
+    series: [{ ...source, categories: undefined, values: plan.counts }],
+  }, rect, ptToPx, { gapPolicy: 'chartex' }, shapeRotationDeg);
+}
+
+function renderWaterfallChart(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  r: ChartRect,
+  ptToPx: number,
+  shapeRotationDeg: number,
+): void {
+  const { x, y, w, h } = r;
+  const vals = chart.series[0]?.values ?? [];
+  const cats = chart.categories;
+  // ChartEx numeric and string dimensions are independent. Preserve the union
+  // of their point indexes: a missing category removes only its label, while a
+  // missing numeric point retains an empty category slot.
+  const n = Math.max(vals.length, cats.length);
+  if (n === 0) return;
+  if (rejectOversizedCanvasChart(ctx, r, n)) return;
+
+  const subSet = new Set(chart.subtotalIndices);
+  let cumulativeOverflow = false;
+  const safeAdd = (left: number, right: number): number => {
+    const sum = left + right;
+    if (Number.isFinite(sum)) return sum;
+    cumulativeOverflow = true;
+    return sum < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
+  };
+  let running = 0;
+  const bars: Array<{
+    start: number;
+    end: number;
+    isSub: boolean;
+    isPos: boolean;
+    hasValue: boolean;
+    paintSlot: boolean;
+  }> = [];
+  let rawMax = Number.NEGATIVE_INFINITY;
+  let rawMin = 0;
+  for (let i = 0; i < n; i++) {
+    const authoredValue = vals[i];
+    const hasValue = authoredValue != null && Number.isFinite(authoredValue);
+    // A missing dimension point still owns its authored category slot (the
+    // historical zero-height placeholder). A present but non-finite value is
+    // invalid numeric input and must not reach axis or Canvas geometry.
+    const paintSlot = authoredValue == null || hasValue;
+    const v = hasValue ? authoredValue as number : 0;
+    const isSub = subSet.has(i);
+    if (isSub) {
+      const bar = { start: 0, end: v, isSub: true, isPos: true, hasValue, paintSlot };
+      bars.push(bar);
+      if (paintSlot) {
+        rawMax = Math.max(rawMax, bar.start, bar.end);
+        rawMin = Math.min(rawMin, bar.start, bar.end);
+      }
+      if (hasValue) {
+        running = v;
+      }
+    } else {
+      const next = safeAdd(running, v);
+      const start = v >= 0 ? running : next;
+      const end   = v >= 0 ? next : running;
+      const bar = { start, end, isSub: false, isPos: v >= 0, hasValue, paintSlot };
+      bars.push(bar);
+      if (paintSlot) {
+        rawMax = Math.max(rawMax, bar.start, bar.end);
+        rawMin = Math.min(rawMin, bar.start, bar.end);
+      }
+      if (hasValue) {
+        running = next;
+      }
+    }
+  }
+
+  if (cumulativeOverflow) {
+    ctx.fillStyle = '#888';
+    ctx.font = '12px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('(chart values out of range)', x + w / 2, y + h / 2);
+    return;
+  }
+
+  if (rawMax <= rawMin) return;
+
+  // Office-observed ChartEx compatibility: an all-increase bridge with no
+  // subtotal/total points keeps its value grid and rule but omits numeric tick
+  // labels. The axis XML is otherwise the same as a subtotal bridge, so keep
+  // this narrow family policy out of the shared linear-axis planner.
+  const suppressImplicitValueTickLabels = subSet.size === 0
+    && bars.every((bar, index) => !bar.hasValue || (vals[index] as number) >= 0);
+  const valueTickLabelsVisible = !chart.valAxisHidden
+    && chart.valAxisTickLabelPos !== 'none'
+    && !suppressImplicitValueTickLabels;
+
+  const titleBand = measuredCartesianTitleBand(ctx, chart, w, h, ptToPx);
+  const axBands = chartAxisTitleBands(chart, w, h, ptToPx);
+  const valFontPx = axisLabelPx(chart.valAxisFontSizeHpt, h, ptToPx);
+  const catFontPx = axisLabelPx(chart.catAxisFontSizeHpt, h, ptToPx);
+  const valFont = chartFontFamily(chart, chart.valAxisFontFace, 'minor');
+  const catFont = chartFontFamily(chart, chart.catAxisFontFace, 'minor');
+  const provisionalPlan = planValueAxis(chart, rawMin, rawMax, h / ptToPx);
+
+  ctx.save();
+  let valLabelBandW = 0;
+  if (valueTickLabelsVisible) {
+    ctx.font = chartFontCss(
+      valFontPx,
+      valFont,
+      chart.valAxisFontBold ?? false,
+      chart.valAxisFontItalic ?? false,
+    );
+    let maxWidth = 0;
+    for (const value of provisionalPlan.majorLines) {
+      maxWidth = Math.max(
+        maxWidth,
+        ctx.measureText(formatPrimaryValueAxisTick(chart, value, false)).width,
+      );
+    }
+    valLabelBandW = maxWidth + 8;
+  }
+
+  // Category labels participate in layout. Measure wrapped lines with the
+  // authored category-axis font and the available category interval rather
+  // than placing every word on its own line or reserving a height fraction.
+  const estimatedPlotW = Math.max(
+    1,
+    w - axBands.valBandW - valLabelBandW - w * 0.02,
+  );
+  const estimatedSlotW = estimatedPlotW / n;
+  ctx.font = chartFontCss(
+    catFontPx,
+    catFont,
+    chart.catAxisFontBold ?? false,
+    chart.catAxisFontItalic ?? false,
+  );
+  const wrappedCategories = cats.slice(0, n).map(category =>
+    wrapMeasuredText(
+      ctx,
+      formatCategoryLabel(category, chart.catAxisFormatCode, chart.date1904),
+      Math.max(1, estimatedSlotW - 8),
+    )
+  );
+  let maxCategoryLines = 0;
+  for (const lines of wrappedCategories) {
+    if (lines.some(Boolean)) maxCategoryLines = Math.max(maxCategoryLines, lines.length);
+  }
+  const categoryLabelBandH = chart.catAxisHidden || maxCategoryLines === 0
+    ? 0
+    : maxCategoryLines * (catFontPx + 2) + 4;
+
+  const series = chart.series[0];
+  const labelOverrides = indexPointOverrides(series?.dataLabelOverrides);
+  const localStyle = series?.chartexStyle;
+  const colorPos = `#${series?.color ?? chartExDataPointFill(chart, 0, 3, localStyle)}`;
+  const colorNeg = `#${chartExDataPointFill(chart, 1, 3, localStyle)}`;
+  const colorSub = `#${chartExDataPointFill(chart, 2, 3, localStyle)}`;
+  const paintPos = chartExDataPointPaint(chart, 0, 3, localStyle, series?.color);
+  const paintNeg = chartExDataPointPaint(chart, 1, 3, localStyle);
+  const paintSub = chartExDataPointPaint(chart, 2, 3, localStyle);
+  const legendChart: ChartModel = {
+    ...chart,
+    chartType: 'clusteredBar',
+    series: [
+      chartExLegendSeries(
+        chart, 'Increase', series, chart.chartexDataPointStyle, 0, 3, colorPos,
+      ),
+      chartExLegendSeries(
+        chart, 'Decrease', series, chart.chartexDataPointStyle, 1, 3, colorNeg,
+      ),
+      chartExLegendSeries(
+        chart, 'Total', series, chart.chartexDataPointStyle, 2, 3, colorSub,
+      ),
+    ],
+  };
+  const leg = measuredLegendReserve(ctx, legendChart, w, h, 0.22, ptToPx);
+  const { legRightW, legLeftW, legTopH, legBottomH } = chartLegendBands(
+    leg, chart.legendOverlay === true,
+  );
+  const pad = {
+    t: titleBand.bandH + legTopH + valFontPx / 2 + 2,
+    r: legRightW + w * 0.02,
+    b: legBottomH + axBands.catBandH + categoryLabelBandH,
+    l: legLeftW + axBands.valBandW + (chart.valAxisHidden
+      ? w * 0.02
+      // Office keeps the visible Waterfall value-axis rule roughly 3% inside
+      // the chart object even when this layout suppresses its implicit numeric
+      // labels. A measured label band may be wider, but never collapses that
+      // automatic edge gutter to zero.
+      : Math.max(w * 0.03, valLabelBandW)),
+  };
+  const frame = computeChartFrame(chart, x, y, w, h, ptToPx, {
+    titleBand,
+    legendSideReserveFrac: 0,
+    legendReserve: leg,
+    pad,
+    honorPlotAreaManualLayout: true,
+  });
+  drawChartTitleForLayout(ctx, chart, x, y, w, h, y + frame.title.topPad, frame.title.fontPx);
+  const { px0, py0, pw, ph } = frame.plotRect;
+  paintPlotAreaFrame(ctx, chart, px0, py0, pw, ph, ptToPx, shapeRotationDeg);
+  const plan = planValueAxis(chart, rawMin, rawMax, ph / ptToPx);
+  const yOf = (value: number): number => py0 + ph - plan.frac(value) * ph;
+
+  const valAxisLine = resolveAxisLine(
+    chart.valAxisLineColor,
+    chart.valAxisLineWidthEmu,
+    ptToPx,
+  );
+  const catAxisLine = resolveAxisLine(
+    chart.catAxisLineColor,
+    chart.catAxisLineWidthEmu,
+    ptToPx,
+  );
+  const valGridline = valGridStroke(chart, ptToPx);
+
+  // ECMA-376 / chartEx §axis@hidden: when the value axis is hidden, skip the
+  // value-axis gridlines, tick labels and the left segment of the L-frame.
+  // This is the canonical PowerPoint look for waterfall analyses where the
+  // value scale is implicit in the data labels on each bar.
+  if (!chart.valAxisHidden) {
+    ctx.font = chartFontCss(
+      valFontPx,
+      valFont,
+      chart.valAxisFontBold ?? false,
+      chart.valAxisFontItalic ?? false,
+    );
+    ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#595959';
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    const minorGridline = valMinorGridStroke(chart, ptToPx);
+    for (const value of plan.minorLines) {
+      strokeValueGridlineH(ctx, px0, pw, yOf(value), false, minorGridline);
+    }
+    for (const value of plan.majorLines) {
+      const gy = yOf(value);
+      if (drawValMajorGridlines(chart)) {
+        ctx.strokeStyle = valGridline.color;
+        ctx.lineWidth = valGridline.width;
+        const previousDash = valGridline.dash.length > 0 && ctx.getLineDash ? ctx.getLineDash() : [];
+        if (valGridline.dash.length > 0) ctx.setLineDash(valGridline.dash);
+        ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
+        if (valGridline.dash.length > 0) ctx.setLineDash(previousDash);
+      }
+      // Locale-independent §18.8.30 formatting (honoring `<c:valAx><c:numFmt>`),
+      // matching the other renderers — `toLocaleString()` grouped by the
+      // viewer's OS locale, so the same chart read differently across machines.
+      if (valueTickLabelsVisible) {
+        ctx.fillText(
+          formatPrimaryValueAxisTick(chart, value, false),
+          px0 - 4,
+          gy,
+        );
+      }
+      drawAxisTick(
+        ctx,
+        chart.valAxisMajorTickMark,
+        'val',
+        px0,
+        gy,
+        valAxisLine.color,
+        valAxisLine.width,
+        false,
+        chart.valAxisLineHidden,
+        'major',
+        ptToPx,
+        chart.valAxisLineDash,
+      );
+    }
+    for (const value of plan.minorTicks) {
+      drawAxisTick(
+        ctx, chart.valAxisMinorTickMark, 'val', px0, yOf(value),
+        valAxisLine.color, valAxisLine.width, false, chart.valAxisLineHidden, 'minor', ptToPx,
+        chart.valAxisLineDash,
+      );
+    }
+  }
+
+  // L-frame: vertical (value-axis) rule + horizontal (category-axis) baseline.
+  // Each segment is independently gated on its axis's `<c:delete>` and on
+  // Office's rule/tick suppression for `<c:spPr><a:ln><a:noFill>`.
+  const drawValLine = !chart.valAxisHidden && !chart.valAxisLineHidden;
+  const drawCatLine = !chart.catAxisHidden && !chart.catAxisLineHidden;
+  if (drawValLine) {
+    strokeAxisSegment(
+      ctx, px0, py0, px0, py0 + ph,
+      valAxisLine.color, valAxisLine.width, chart.valAxisLineDash,
+    );
+  }
+  if (drawCatLine) {
+    strokeAxisSegment(
+      ctx, px0, py0 + ph, px0 + pw, py0 + ph,
+      catAxisLine.color, catAxisLine.width, chart.catAxisLineDash,
+    );
+  }
+
+  // ECMA-376 / chartEx §17.18.34 ST_GapAmount: gapWidth is the gap between
+  // adjacent categories expressed as a percentage of the bar width
+  // (legacy `<c:gapWidth val>`) or as a fraction (chartEx
+  // `<cx:catScaling gapWidth>`, normalised to the same percent form by the
+  // parser). The bar then occupies `catGap / (1 + gapWidth/100)`. Omitted
+  // ChartEx spacing uses the shared ordinal-layout policy; an authored
+  // value remains authoritative after parser normalization.
+  const gapW = pw / n;
+  const gapWidthPct = resolveCategoryGapWidthPercent(chart.barGapWidth, 'chartex');
+  const barW = gapW / (1 + gapWidthPct / 100);
+
+  bars.forEach((bar, i) => {
+    const bx = px0 + gapW * i + (gapW - barW) / 2;
+    const yTop = Math.min(yOf(bar.start), yOf(bar.end));
+    const yBot = Math.max(yOf(bar.start), yOf(bar.end));
+    const bh = Math.max(1, yBot - yTop);
+
+    const paint = bar.isSub ? paintSub : bar.isPos ? paintPos : paintNeg;
+    const fallback = bar.isSub ? colorSub : bar.isPos ? colorPos : colorNeg;
+    if (bar.paintSlot && paint) {
+      ctx.fillStyle = chartExFillStyle(ctx, paint, bx, yTop, barW, bh, fallback, shapeRotationDeg);
+      ctx.fillRect(bx, yTop, barW, bh);
+    }
+    const accentIndex = bar.isSub ? 2 : bar.isPos ? 0 : 1;
+    const lineColor = chartExStyleColor(chart, chart.chartexDataPointStyle, 'line', accentIndex, 3);
+    if (bar.paintSlot && applyChartExSeriesLineStyle(
+      ctx,
+      chart,
+      chart.chartexDataPointStyle,
+      series,
+      accentIndex,
+      3,
+      lineColor ? `#${lineColor}` : fallback,
+      ptToPx,
+    )) {
+      ctx.strokeRect(bx, yTop, barW, bh);
+    }
+
+    if (bar.paintSlot && bars[i + 1]?.paintSlot
+      && i < n - 1 && chart.chartexConnectorLines !== false) {
+      const nextBx = px0 + gapW * (i + 1) + (gapW - barW) / 2;
+      const connY = bar.isPos ? yTop : yBot;
+      ctx.save();
+      const connectorLine = resolveChartExSeriesLineStyle(
+        chart,
+        chart.chartexSeriesLineStyle,
+        series,
+        accentIndex,
+        3,
+        '#000000',
+        { linkedNoStyleFallback: true },
+      );
+      if (applyResolvedChartExLineStyle(ctx, connectorLine, ptToPx)) {
+        // A linked `seriesLine` NoStyle delegates to Waterfall's semantic
+        // connector rather than suppressing it. Office vector output from
+        // both an unstyled bridge and an explicitly styled bridge establishes
+        // the family default as a 0.75pt rule; authored width/color above stay
+        // authoritative.
+        // Apply the semantic 0.75pt width only when the common direct>linked
+        // resolver found no authored width. Looking only at the linked role
+        // here used to overwrite a direct CT_Series width.
+        if (connectorLine.widthEmu == null) ctx.lineWidth = 0.75 * ptToPx;
+        ctx.beginPath();
+        ctx.moveTo(bx + barW, connY);
+        ctx.lineTo(nextBx, connY);
+        ctx.stroke();
+      }
+      ctx.restore();
+    }
+
+    const rawVal = bar.hasValue ? vals[i] as number : 0;
+    const label = resolveChartExLabel(
+      chart, series, i, cats[i] ?? '', rawVal,
+      { visible: chart.showDataLabels, showVal: true, showCatName: false },
+      labelOverrides,
+      !bar.hasValue,
+    );
+    if (label) {
+      const perPointColor = series?.dataLabelColors?.[i] ?? label.fontColor ?? null;
+      const labelColor = perPointColor
+        ? `#${perPointColor}`
+        : chart.dataLabelFontColor
+          ? `#${chart.dataLabelFontColor}`
+          : '#595959';
+      const dataLabelFontPx = chartTextFontSizePx(label.fontSizeHpt, ptToPx)
+        ?? axisLabelPx(chart.dataLabelFontSizeHpt, h, ptToPx);
+      const dataLabelBold = label.fontBold ?? chart.dataLabelFontBold ?? false;
+      const dataLabelFont = chartFontFamily(
+        chart, label.fontFace ?? chart.dataLabelFontFace, 'minor',
+      );
+      ctx.font = `${label.textStyle.fontItalic ? 'italic ' : ''}${dataLabelBold ? 'bold ' : ''}${dataLabelFontPx}px ${dataLabelFont}`;
+      drawBoundedDataLabelText(
+        ctx,
+        label.text,
+        {
+          kind: 'bar',
+          rect: { x: bx, y: yTop, w: barW, h: bh },
+          orientation: 'vertical',
+          negative: rawVal < 0,
+          position: label.position ?? 'outEnd',
+        },
+        { x: px0, y: py0, w: pw, h: ph },
+        dataLabelFontPx,
+        labelColor,
+        label.manualLayout,
+        { x, y, w, h },
+        richDataLabelOptions(
+          chart, label.richRuns, ptToPx, dataLabelFont, dataLabelBold, label.textStyle,
+        ),
+        undefined,
+        label.textStyle,
+        ptToPx,
+        label.labelBox,
+        shapeRotationDeg,
+      );
+    }
+  });
+
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#595959';
+  // Category (transaction) labels below the bars → category-axis face.
+  ctx.font = chartFontCss(
+    catFontPx,
+    catFont,
+    chart.catAxisFontBold ?? false,
+    chart.catAxisFontItalic ?? false,
+  );
+  const labelY = py0 + ph + 4;
+  for (let i = 0; i < n && !chart.catAxisHidden; i++) {
+    const ccx = px0 + gapW * i + gapW / 2;
+    const lines = wrappedCategories[i] ?? [];
+    lines.forEach((line, lineIndex) =>
+      line && ctx.fillText(line, ccx, labelY + lineIndex * (catFontPx + 2))
+    );
+  }
+
+  drawAxisTitles(
+    ctx,
+    chart,
+    x,
+    y,
+    w,
+    h,
+    px0,
+    py0,
+    pw,
+    ph,
+    legLeftW,
+    legBottomH,
+    axBands.catFontPx,
+    axBands.valFontPx,
+  );
+
+  drawLegendForLayout(
+    ctx, legendChart, leg, x, y, w, h, px0, py0, pw, ph,
+    titleBand.bandH + 2, ptToPx, [paintPos, paintNeg, paintSub], shapeRotationDeg,
+  );
+
+  ctx.restore();
+}
+
+/** ChartEx `funnel`: one centered horizontal bar per ordinal category. */
+function renderFunnelChart(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  r: ChartRect,
+  ptToPx: number,
+  shapeRotationDeg: number,
+): void {
+  const values = chart.series[0]?.values ?? [];
+  // ChartEx dimensions carry independent indexed points. Preserve category-only
+  // slots as empty bars and numeric-only slots as unlabeled bars.
+  const n = Math.max(values.length, chart.categories.length);
+  if (n === 0) return;
+  if (rejectOversizedCanvasChart(ctx, r, n)) return;
+  let max = 0;
+  for (let index = 0; index < n; index++) {
+    max = Math.max(max, values[index] ?? 0);
+  }
+  if (!(max > 0)) return;
+  const { x, y, w, h } = r;
+  const titleBand = measuredCartesianTitleBand(ctx, chart, w, h, ptToPx);
+  const series = chart.series[0];
+  const labelOverrides = indexPointOverrides(series?.dataLabelOverrides);
+  const color = `#${series?.color ?? chartExDataPointFill(chart, 0, 1, series?.chartexStyle)}`;
+  const paint = chartExDataPointPaint(chart, 0, 1, series?.chartexStyle, series?.color);
+  const legendChart: ChartModel = {
+    ...chart,
+    series: [chartExLegendSeries(
+      chart,
+      series?.name ?? '',
+      series,
+      chart.chartexDataPointStyle,
+      0,
+      1,
+      color,
+    )],
+  };
+  const leg = measuredLegendReserve(ctx, legendChart, w, h, 0.22, ptToPx);
+  const { legRightW, legLeftW, legTopH, legBottomH } = chartLegendBands(
+    leg, chart.legendOverlay === true,
+  );
+  const catFontPx = axisLabelPx(chart.catAxisFontSizeHpt, h, ptToPx);
+  ctx.save();
+  ctx.font = chartFontCss(
+    catFontPx,
+    chartFontFamily(chart, chart.catAxisFontFace, 'minor'),
+    chart.catAxisFontBold ?? false,
+    chart.catAxisFontItalic ?? false,
+  );
+  let labelW = 0;
+  if (!chart.catAxisHidden) {
+    for (let index = 0; index < Math.min(n, chart.categories.length); index++) {
+      labelW = Math.max(labelW, ctx.measureText(chart.categories[index]).width);
+    }
+    if (chart.categories.length > 0) labelW += 10;
+  }
+  const pad = {
+    t: titleBand.bandH + legTopH + 2,
+    r: legRightW + w * 0.02,
+    b: legBottomH + h * 0.02,
+    l: legLeftW + labelW + w * 0.02,
+  };
+  const frame = computeChartFrame(chart, x, y, w, h, ptToPx, {
+    titleBand,
+    legendSideReserveFrac: 0.22,
+    legendReserve: leg,
+    pad,
+    honorPlotAreaManualLayout: true,
+  });
+  drawChartTitleForLayout(ctx, chart, x, y, w, h, y + frame.title.topPad, frame.title.fontPx);
+  const { px0, py0, pw, ph } = frame.plotRect;
+  paintPlotAreaFrame(ctx, chart, px0, py0, pw, ph, ptToPx, shapeRotationDeg);
+  const rowH = ph / n;
+  const gapWidthPct = resolveCategoryGapWidthPercent(chart.barGapWidth, 'chartex');
+  const barH = rowH / (1 + gapWidthPct / 100);
+  for (let index = 0; index < n; index++) {
+    const value = Math.max(0, values[index] ?? 0);
+    const barW = pw * value / max;
+    const bx = px0 + (pw - barW) / 2;
+    const by = py0 + rowH * index + (rowH - barH) / 2;
+    if (paint) {
+      ctx.fillStyle = chartExFillStyle(ctx, paint, bx, by, barW, barH, color, shapeRotationDeg);
+      ctx.fillRect(bx, by, barW, barH);
+    }
+    if (applyChartExSeriesLineStyle(
+      ctx, chart, chart.chartexDataPointStyle, series, 0, 1, color, ptToPx,
+    )) {
+      ctx.strokeRect(bx, by, barW, barH);
+    }
+    const category = chart.categories[index];
+    if (!chart.catAxisHidden && category != null) {
+      ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#595959';
+      ctx.textAlign = 'right';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(category, px0 - 6, by + barH / 2);
+    }
+    const label = resolveChartExLabel(
+      chart, series, index, category ?? '', value,
+      { visible: false, showVal: false, showCatName: false },
+      labelOverrides,
+    );
+    if (label) {
+      const fontPx = chartTextFontSizePx(label.fontSizeHpt, ptToPx)
+        ?? axisLabelPx(chart.dataLabelFontSizeHpt, h, ptToPx);
+      const labelFont = chartFontFamily(
+        chart, label.fontFace ?? chart.dataLabelFontFace, 'minor',
+      );
+      ctx.font = `${label.textStyle.fontItalic ? 'italic ' : ''}${label.fontBold ? 'bold ' : ''}${fontPx}px ${labelFont}`;
+      drawBoundedDataLabelText(
+        ctx,
+        label.text,
+        {
+          kind: 'bar',
+          rect: { x: bx, y: by, w: barW, h: barH },
+          orientation: 'horizontal',
+          negative: false,
+          position: label.position ?? 'ctr',
+        },
+        { x: px0, y: py0, w: pw, h: ph },
+        fontPx,
+        label.fontColor ? `#${label.fontColor}` : '#ffffff',
+        label.manualLayout,
+        { x, y, w, h },
+        richDataLabelOptions(
+          chart, label.richRuns, ptToPx, labelFont, label.fontBold ?? false, label.textStyle,
+        ),
+        undefined,
+        label.textStyle,
+        ptToPx,
+        label.labelBox,
+        shapeRotationDeg,
+      );
+    }
+  }
+  if (!chart.catAxisHidden && !chart.catAxisLineHidden) {
+    const line = resolveAxisLine(chart.catAxisLineColor, chart.catAxisLineWidthEmu, ptToPx);
+    ctx.strokeStyle = line.color;
+    ctx.lineWidth = line.width;
+    ctx.beginPath(); ctx.moveTo(px0, py0); ctx.lineTo(px0, py0 + ph); ctx.stroke();
+  }
+  drawLegendForLayout(ctx, legendChart, leg, x, y, w, h, px0, py0, pw, ph, titleBand.bandH + 2, ptToPx, [paint], shapeRotationDeg);
+  ctx.restore();
+}
+
+/** ChartEx Pareto line: cumulative share of the source values. */
+function renderParetoLineChart(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  r: ChartRect,
+  ptToPx: number,
+  shapeRotationDeg = 0,
+): void {
+  const source = chart.series[0];
+  if (!source) return;
+  const pointCount = Math.max(
+    chart.categories.length,
+    source.categories?.length ?? 0,
+    source.values.length,
+  );
+  if (rejectOversizedCanvasChart(ctx, r, pointCount)) return;
+  const layout = planParetoLayout(source, chart.categories);
+  if (layout.points.length === 0) return;
+  const styleIndex = chartExSeriesFormatIndex(source, 0);
+  const paretoLine = resolveChartExSeriesLineStyle(
+    chart,
+    chart.chartexDataPointLineStyle,
+    source,
+    styleIndex,
+    1,
+    chartColor(0, source),
+    { linkedNoStyleFallback: true },
+  );
+  renderLineChart(ctx, {
+    ...chart,
+    chartType: 'line',
+    categories: layout.categories,
+    series: [{
+      ...layout.series,
+      showMarker: false,
+      lineHidden: !paretoLine.visible,
+      lineColor: paretoLine.color.replace(/^#/, ''),
+      lineWidthEmu: paretoLine.widthEmu,
+      chartexStyle: {
+        lineDash: paretoLine.dash,
+        lineCap: paretoLine.cap,
+        lineJoin: paretoLine.join,
+      },
+    }],
+    // Pareto's ordinal category labels are suppressed, but its authored
+    // category-axis rule remains visible. Keep those two concerns separate.
+    catAxisHidden: false,
+    catAxisTickLabelPos: 'none',
+    showLegend: false,
+    // A standalone paretoLine carries cumulative fractions as its actual
+    // values, but Office lays them out on an ordinary decimal axis. Two vector
+    // references at different chart sizes use the same omitted-axis contract:
+    // 0..1.2 in 0.2 steps. Keep authored bounds/major units authoritative and
+    // avoid making this semantic cumulative scale depend on pixel height.
+    // The 0..100% secondary-axis convention belongs to owner-backed Pareto.
+    valMin: chart.valMin ?? 0,
+    valMax: chart.valMax ?? 1.2,
+    valAxisMajorUnit: chart.valAxisMajorUnit ?? 0.2,
+  }, r, ptToPx, shapeRotationDeg);
+}
+
+/** Owner-backed ChartEx Pareto: sorted frequency columns plus cumulative line. */
+function renderParetoChart(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  r: ChartRect,
+  ptToPx: number,
+  shapeRotationDeg = 0,
+): void {
+  const owner = chart.series[0];
+  if (!owner) return;
+  const pointCount = Math.max(
+    chart.categories.length,
+    owner.categories?.length ?? 0,
+    owner.values.length,
+  );
+  if (rejectOversizedCanvasChart(ctx, r, pointCount)) return;
+  const layout = planParetoLayout(owner, chart.categories);
+  if (layout.points.length === 0) return;
+
+  const authoredLine = chart.series.find(series => series.seriesType === 'line');
+  const lineStyleIndex = authoredLine?.chartexFormatIdx
+    ?? owner.chartexFormatIdx
+    ?? 0;
+  const cumulativeLine: ChartSeries = {
+    ...(authoredLine ?? layout.series),
+    name: authoredLine?.name || 'Cumulative %',
+    values: layout.series.values,
+    categories: layout.categories,
+    color: authoredLine?.color
+      ?? chartExStyleColor(
+        chart, chart.chartexDataPointLineStyle, 'line', lineStyleIndex, 1,
+      )
+      ?? owner.lineColor
+      ?? owner.color,
+    seriesType: 'line',
+    useSecondaryAxis: true,
+    showMarker: false,
+  };
+  const secondaryAxis: SecondaryValueAxis = {
+    min: chart.secondaryValAxis?.min ?? 0,
+    max: chart.secondaryValAxis?.max ?? 1,
+    title: chart.secondaryValAxis?.title ?? null,
+    hidden: chart.secondaryValAxis?.hidden ?? false,
+    formatCode: chart.secondaryValAxis?.formatCode ?? '0%',
+    fontColor: chart.secondaryValAxis?.fontColor ?? null,
+    fontSizeHpt: chart.secondaryValAxis?.fontSizeHpt ?? null,
+    fontFace: chart.secondaryValAxis?.fontFace ?? null,
+    lineColor: chart.secondaryValAxis?.lineColor ?? null,
+    lineWidthEmu: chart.secondaryValAxis?.lineWidthEmu ?? null,
+    lineHidden: chart.secondaryValAxis?.lineHidden ?? false,
+    majorTickMark: chart.secondaryValAxis?.majorTickMark ?? 'out',
+    minorTickMark: chart.secondaryValAxis?.minorTickMark ?? null,
+    majorUnit: chart.secondaryValAxis?.majorUnit ?? null,
+    minorUnit: chart.secondaryValAxis?.minorUnit ?? null,
+    titleFontSizeHpt: chart.secondaryValAxis?.titleFontSizeHpt ?? null,
+    titleFontBold: chart.secondaryValAxis?.titleFontBold ?? null,
+    titleFontColor: chart.secondaryValAxis?.titleFontColor ?? null,
+    titleFontFace: chart.secondaryValAxis?.titleFontFace ?? null,
+  };
+
+  renderBarChart(ctx, {
+    ...chart,
+    chartType: 'clusteredBar',
+    categories: layout.categories,
+    series: [
+      { ...layout.orderedSeries, seriesType: null, useSecondaryAxis: false },
+      cumulativeLine,
+    ],
+    secondaryValAxis: secondaryAxis,
+  }, r, ptToPx, {
+    gapPolicy: 'chartex',
+    semanticLineNoStyleFallback: true,
+  }, shapeRotationDeg);
+}
+
+// ─── chartEx: box-and-whisker (CH15, MS 2014 chartex ext) ────────────────────
+
+/** Compact omitted-axis policy observed in three independent Office vector
+ * box/whisker outputs (small, ordinary, and wide numeric ranges). OOXML does
+ * not define the automatic major unit. Office consistently chooses the nearest
+ * 1/2/5 ladder to about seven raw-range intervals for this family, then applies the same
+ * 5% padding / zero-threshold rules as the shared planner. */
+function automaticBoxWhiskerAxis(
+  dataMin: number,
+  dataMax: number,
+  explicitMin?: number | null,
+  explicitMax?: number | null,
+): { min: number; max: number; majorUnit: number } | null {
+  // Authored bounds constrain the automatic-unit calculation as well as the
+  // final axis. ChartEx may write min/max while omitting majorUnit; Office then
+  // chooses the box/whisker family unit from that authored span (for example
+  // 1..3 becomes 0.2), rather than deriving a coarse unit from the raw data and
+  // merely clipping it to the authored bounds afterwards.
+  const boundedMin = explicitMin ?? dataMin;
+  const boundedMax = explicitMax ?? dataMax;
+  const span = boundedMax - boundedMin;
+  if (!(span > 0) || !Number.isFinite(span)) return null;
+  const majorUnit = niceStep(span, 7);
+  if (!(majorUnit > 0) || !Number.isFinite(majorUnit)) return null;
+  let paddedMin = dataMin - span * 0.05;
+  let paddedMax = dataMax + span * 0.05;
+  if (dataMin >= 0 && (dataMin === 0 || dataMax > 1.2 * dataMin)) paddedMin = 0;
+  if (dataMax <= 0 && (dataMax === 0 || Math.abs(dataMin) > 1.2 * Math.abs(dataMax))) {
+    paddedMax = 0;
+  }
+  const min = explicitMin ?? Math.floor(paddedMin / majorUnit) * majorUnit;
+  const max = explicitMax ?? Math.ceil(paddedMax / majorUnit) * majorUnit;
+  if (![min, max].every(Number.isFinite) || !(max > min)) return null;
+  return { min, max, majorUnit };
+}
+
+/**
+ * Render a chartEx box-and-whisker chart (MS 2014 chartex extension — there is
+ * no ECMA-376 section; the structure is Microsoft's `<cx:chartSpace>` with a
+ * `<cx:series layoutId="boxWhisker">` per column, each referencing raw sample
+ * points via `<cx:dataId>`). The parser (`parse_chartex_boxwhisker`) groups the
+ * raw points by category and threads the `<cx:layoutPr>` visibility/statistics
+ * flags into `chart.chartexBox`; this renderer derives the five-number summary
+ * per (category, series) and draws, for each box: the IQR rectangle (Q1..Q3),
+ * the median line, whiskers to the non-outlier min/max (with end caps), the
+ * mean `×` marker, and outlier dots. Colors come from the theme accent palette
+ * (`chart.chartexAccents`, cycled by series) — the blue/orange/gray Office
+ * default — falling back to `CHART_PALETTE` when a resolver supplies no palette.
+ */
+function renderBoxWhiskerChart(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  r: ChartRect,
+  ptToPx: number,
+  shapeRotationDeg: number,
+): void {
+  // ChartEx's linked dataPointMarkerLayout is a generic marker recipe. Office
+  // does not use its size for box-and-whisker observations: vector output uses
+  // 3pt observation/outlier dots and a 6pt mean `x`, independent of box width.
+  // The linked recipe still supplies the marker symbol and paint.
+  const observationMarkerSizePt = 3;
+  const meanMarkerRadiusPx = 3 * ptToPx;
+  const box = chart.chartexBox;
+  if (!box || box.categories.length === 0 || box.series.length === 0) return;
+  const { x, y, w, h } = r;
+  const pointCount = boxWhiskerPointCount(
+    box.series.map(series => series.valuesByCategory),
+    MAX_CANVAS_CHART_POINTS,
+  );
+  if (rejectOversizedCanvasChart(ctx, r, pointCount)) return;
+
+  const rejectOutOfRange = (): void => {
+    ctx.fillStyle = '#888';
+    ctx.font = '12px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('(chart values out of range)', x + w / 2, y + h / 2);
+  };
+  const usableScale = (scale: { min: number; max: number; step: number }): boolean => {
+    const span = scale.max - scale.min;
+    const intervalCount = span / scale.step;
+    return Number.isFinite(scale.min)
+      && Number.isFinite(scale.max)
+      && Number.isFinite(scale.step)
+      && Number.isFinite(span)
+      && Number.isFinite(intervalCount)
+      && scale.max > scale.min
+      && scale.step > 0
+      // Axis paint is synchronous. Refuse an authored tiny major unit before
+      // entering a loop whose finite bounds could still imply vast work.
+      && intervalCount <= 1000
+      // A finite positive step may still be too small to advance a large
+      // floating-point bound, which would wedge the major-gridline loop.
+      && scale.min + scale.step > scale.min;
+  };
+
+  // Resolve the value range before laying out the plot. The tick labels are a
+  // real layout input: reserve their measured width instead of a percentage of
+  // the chart width, which made the axis drift right on wide ChartEx charts.
+  let dataMin = Infinity;
+  let dataMax = -Infinity;
+  for (const s of box.series) {
+    for (const group of s.valuesByCategory) {
+      for (const v of group) {
+        if (!Number.isFinite(v)) continue;
+        if (v < dataMin) dataMin = v;
+        if (v > dataMax) dataMax = v;
+      }
+    }
+  }
+  if (!isFinite(dataMin) || !isFinite(dataMax)) return;
+  if (!Number.isFinite(dataMax - dataMin)) {
+    rejectOutOfRange();
+    return;
+  }
+
+  // Authored bounds/unit always win. An omitted unit still receives the compact
+  // family default inferred from the vector corpus, using authored min/max as
+  // the effective span when present.
+  const automaticBoxAxis = chart.valAxisMajorUnit == null
+    ? automaticBoxWhiskerAxis(dataMin, dataMax, chart.valMin, chart.valMax)
+    : null;
+  const boxAxisChart: ChartModel = automaticBoxAxis
+    ? {
+        ...chart,
+        valMin: automaticBoxAxis.min,
+        valMax: automaticBoxAxis.max,
+        valAxisMajorUnit: automaticBoxAxis.majorUnit,
+      }
+    : chart;
+
+  const font = chartFontFamily(chart, chart.valAxisFontFace, 'minor');
+  const valFontPx = axisLabelPx(chart.valAxisFontSizeHpt, h, ptToPx);
+  // Keep the existing font-relative layout reserve so the plot geometry stays
+  // stable; only the painted ChartEx label uses the observed axis-relative
+  // offset below.
+  const valTickLabelLayoutGap = valueTickLabelGapPx(valFontPx);
+  const valTickLabelPaintGap = chartExValueTickLabelOffsetPx(ptToPx);
+  const provisionalScale = planLinearValueAxis({
+    dataMin,
+    dataMax,
+    explicitMin: boxAxisChart.valMin,
+    explicitMax: boxAxisChart.valMax,
+    axisLenPt: h / ptToPx,
+    majorUnit: boxAxisChart.valAxisMajorUnit,
+  });
+  if (!usableScale({
+    min: provisionalScale.min,
+    max: provisionalScale.max,
+    step: provisionalScale.majorUnit,
+  })) {
+    rejectOutOfRange();
+    return;
+  }
+  let valLabelBandW = 0;
+  if (!chart.valAxisHidden) {
+    const previousFont = ctx.font;
+    ctx.font = chartFontCss(
+      valFontPx,
+      font,
+      chart.valAxisFontBold ?? false,
+      chart.valAxisFontItalic ?? false,
+    );
+    let maxLabelW = 0;
+    for (const value of provisionalScale.majorTicks) {
+      const label = formatPrimaryValueAxisTick(chart, value, false);
+      maxLabelW = Math.max(maxLabelW, ctx.measureText(label).width);
+    }
+    ctx.font = previousFont;
+    valLabelBandW = maxLabelW + valTickLabelLayoutGap + AXIS_OUTER_TEXT_MARGIN_PT * ptToPx;
+  }
+
+  // Shared title band + cartesian plot rect. Reserve category/value-axis bands
+  // and, when present in the chart model, the authored legend band.
+  const titleBand = measuredCartesianTitleBand(ctx, chart, w, h, ptToPx);
+  const catAxFontPx0 = axisLabelPx(chart.catAxisFontSizeHpt, h, ptToPx);
+  const valAxFontPx0 = axisLabelPx(chart.valAxisFontSizeHpt, h, ptToPx);
+  const axBands = chartAxisTitleBands(chart, w, h, ptToPx);
+  const nSer = box.series.length;
+  const boxStyleIndices = box.series.map((series, index) =>
+    chartExSeriesFormatIndex(series, index)
+  );
+  const boxLegendSeries = box.series.map((series, index) => {
+    const styleIndex = boxStyleIndices[index];
+    const fill = series.color ?? chartExDataPointFill(
+      chart, styleIndex, nSer, series.chartexStyle,
+    );
+    return chartExLegendSeries(
+      chart,
+      series.name,
+      series,
+      chart.chartexDataPointStyle,
+      styleIndex,
+      nSer,
+      fill,
+      true,
+    );
+  });
+  const legendChart: ChartModel = {
+    ...chart,
+    series: boxLegendSeries,
+  };
+  const leg = measuredLegendReserve(ctx, legendChart, w, h, 0.22, ptToPx);
+  const { legRightW, legLeftW, legTopH, legBottomH } = chartLegendBands(
+    leg, chart.legendOverlay === true,
+  );
+  const pad = {
+    t: titleBand.bandH + legTopH + valAxFontPx0 / 2 + 2,
+    r: legRightW + w * 0.02,
+    b: legBottomH + axBands.catBandH + (chart.catAxisHidden ? h * 0.02 : catAxisLabelBandH(catAxFontPx0)),
+    l: legLeftW + axBands.valBandW + (chart.valAxisHidden ? w * 0.02 : valLabelBandW),
+  };
+  const frame = computeChartFrame(chart, x, y, w, h, ptToPx, {
+    titleBand,
+    legendSideReserveFrac: 0.22,
+    legendReserve: leg,
+    pad,
+    honorPlotAreaManualLayout: true,
+  });
+  const { px0, py0, pw, ph } = frame.plotRect;
+  paintPlotAreaFrame(ctx, chart, px0, py0, pw, ph, ptToPx, shapeRotationDeg);
+
+  const cats = box.categories;
+  const nCat = cats.length;
+
+  // Excel's automatic value axis uses nice-rounded bounds and steps.
+  const boxAxisPlan = planValueAxis(boxAxisChart, dataMin, dataMax, ph / ptToPx);
+  if (!usableScale(boxAxisPlan)) {
+    rejectOutOfRange();
+    return;
+  }
+  drawChartTitleForLayout(ctx, chart, x, y, w, h, y + frame.title.topPad, frame.title.fontPx);
+  const { min: axisMin, max: axisMax } = boxAxisPlan;
+  const span = axisMax - axisMin;
+  const yOf = (v: number): number => py0 + ph * (1 - (v - axisMin) / span);
+
+  const valAxisLine = resolveAxisLine(chart.valAxisLineColor, chart.valAxisLineWidthEmu, ptToPx);
+  const valGridline = valGridStroke(chart, ptToPx);
+
+  // Value-axis gridlines + labels (unless the value axis is hidden).
+  ctx.save();
+  if (!chart.valAxisHidden) {
+    ctx.font = chartFontCss(
+      valFontPx,
+      font,
+      chart.valAxisFontBold ?? false,
+      chart.valAxisFontItalic ?? false,
+    );
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    if (chart.valAxisMinorGridlines) {
+      const minorGridline = valMinorGridStroke(chart, ptToPx);
+      for (const value of boxAxisPlan.minorLines) {
+        strokeValueGridlineH(ctx, px0, pw, yOf(value), false, minorGridline);
+      }
+    }
+    for (const v of boxAxisPlan.majorLines) {
+      const gy = yOf(v);
+      if (chart.valAxisMajorGridlines !== false) {
+        ctx.strokeStyle = valGridline.color;
+        ctx.lineWidth = valGridline.width;
+        const previousDash = valGridline.dash.length > 0 && ctx.getLineDash ? ctx.getLineDash() : [];
+        if (valGridline.dash.length > 0) ctx.setLineDash(valGridline.dash);
+        ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
+        if (valGridline.dash.length > 0) ctx.setLineDash(previousDash);
+      }
+      ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#595959';
+      ctx.fillText(
+        formatPrimaryValueAxisTick(chart, v, false),
+        px0 - valTickLabelPaintGap,
+        gy,
+      );
+      drawAxisTick(
+        ctx,
+        chart.valAxisMajorTickMark,
+        'val',
+        px0,
+        gy,
+        valAxisLine.color,
+        valAxisLine.width,
+        false,
+        chart.valAxisLineHidden,
+        'major',
+        ptToPx,
+        chart.valAxisLineDash,
+      );
+    }
+    for (const value of boxAxisPlan.minorTicks) {
+      drawAxisTick(
+        ctx, chart.valAxisMinorTickMark, 'val', px0, yOf(value),
+        valAxisLine.color, valAxisLine.width, false, chart.valAxisLineHidden, 'minor', ptToPx,
+        chart.valAxisLineDash,
+      );
+    }
+    if (!chart.valAxisLineHidden) {
+      strokeAxisSegment(
+        ctx, px0, py0, px0, py0 + ph,
+        valAxisLine.color, valAxisLine.width, chart.valAxisLineDash,
+      );
+    }
+  }
+  // Category-axis baseline. ChartEx carries the axis rule in the local
+  // `<cx:axis><cx:spPr><a:ln>`; do not replace an authored dark/weighted rule
+  // with the old fixed 1px grey fallback.
+  const catAxisLine = resolveAxisLine(
+    chart.catAxisLineColor,
+    chart.catAxisLineWidthEmu,
+    ptToPx,
+  );
+  if (!chart.catAxisHidden && !chart.catAxisLineHidden) {
+    strokeAxisSegment(
+      ctx, px0, py0 + ph, px0 + pw, py0 + ph,
+      catAxisLine.color, catAxisLine.width, chart.catAxisLineDash,
+    );
+  }
+
+  // ChartEx divides the plot into full category intervals, so the first and
+  // last category centres are half an interval from the plot edges. Every
+  // series owns one stable equal slot in each category group, including
+  // categories where a peer has no retained observations.
+  // Formula-only sources are different: Excel stores every visible box as a
+  // separate series in one category group. In that form `gapWidth` surrounds
+  // the whole group and must not be reapplied between the diagonal entries.
+  const slotW = pw / nCat;
+  const gapWidthPct = resolveCategoryGapWidthPercent(chart.barGapWidth, 'chartex');
+  const paletteOf = (si: number): string => {
+    const fill = box.series[si].color
+      ?? chartExDataPointFill(
+        chart, boxStyleIndices[si], nSer, box.series[si].chartexStyle,
+      );
+    return `#${fill}`;
+  };
+  const paintOf = (si: number): Fill | null => chartExDataPointPaint(
+    chart,
+    boxStyleIndices[si],
+    nSer,
+    box.series[si].chartexStyle,
+    box.series[si].color,
+  );
+  const statsBySeries = box.series.map(series => series.valuesByCategory.map(values => (
+    computeBoxWhiskerStats(values, series.quartileMethod)
+  )));
+  const boxGeometry = (ci: number, si: number): { bx: number; boxW: number; cx: number } => {
+    const geometry = boxWhiskerGeometry(
+      px0,
+      pw,
+      box.oneBoxPerSeries ? 1 : nCat,
+      nSer,
+      box.oneBoxPerSeries ? 0 : ci,
+      si,
+      gapWidthPct,
+    );
+    if (!geometry) return { bx: px0, boxW: 0, cx: px0 };
+    return { bx: geometry.boxX, boxW: geometry.boxWidth, cx: geometry.centerX };
+  };
+
+  // `<cx:visibility meanLine>` connects the category means for one series.
+  // It is a data-point-line role, so it shares the whisker/median style.
+  for (let si = 0; si < nSer; si++) {
+    const series = box.series[si];
+    if (!series.meanLine) continue;
+    const lineStyle = chart.chartexDataPointLineStyle ?? chart.chartexDataPointStyle;
+    const fallback = series.lineColor ? `#${series.lineColor}` : paletteOf(si);
+    ctx.save();
+    const styleLineVisible = applyChartExSeriesLineStyle(
+      ctx, chart, lineStyle, series, boxStyleIndices[si], nSer, fallback, ptToPx,
+    );
+    if (styleLineVisible || series.lineColor != null) {
+      if (series.lineColor) ctx.strokeStyle = fallback;
+      if (series.lineWidthEmu) ctx.lineWidth = axisLineWidthPx(series.lineWidthEmu, ptToPx);
+      let open = false;
+      ctx.beginPath();
+      for (let ci = 0; ci < nCat; ci++) {
+        const stats = statsBySeries[si][ci];
+        if (!stats) {
+          open = false;
+          continue;
+        }
+        const { cx } = boxGeometry(ci, si);
+        const meanY = yOf(stats.mean);
+        if (open) ctx.lineTo(cx, meanY);
+        else ctx.moveTo(cx, meanY);
+        open = true;
+      }
+      ctx.stroke();
+    }
+    ctx.restore();
+  }
+  const catFontPx = axisLabelPx(chart.catAxisFontSizeHpt, h, ptToPx);
+  const catTickLabelGap = categoryTickLabelGapPx(catFontPx);
+  for (let ci = 0; ci < nCat; ci++) {
+    const categoryCenterX = px0 + slotW * (ci + 0.5);
+    if (!chart.catAxisHidden) {
+      drawAxisTick(
+        ctx,
+        chart.catAxisMajorTickMark,
+        'cat',
+        py0 + ph,
+        categoryCenterX,
+        catAxisLine.color,
+        catAxisLine.width,
+        false,
+        chart.catAxisLineHidden,
+        'major',
+        ptToPx,
+        chart.catAxisLineDash,
+      );
+    }
+    for (let si = 0; si < nSer; si++) {
+      const s = box.series[si];
+      const stats = statsBySeries[si][ci];
+      if (!stats) continue;
+      const { bx, boxW, cx } = boxGeometry(ci, si);
+      const fill = paletteOf(si);
+      const fillPaint = paintOf(si);
+      const pointStyle = chart.chartexDataPointStyle;
+      const lineStyle = chart.chartexDataPointLineStyle ?? pointStyle;
+      const markerStyle = chart.chartexDataPointMarkerStyle ?? pointStyle;
+      const styleIndex = boxStyleIndices[si];
+      const styleLine = chartExStyleColor(chart, pointStyle, 'line', styleIndex, nSer);
+      const edge = s.lineColor ? `#${s.lineColor}` : styleLine ? `#${styleLine}` : fill;
+      const edgeWidth = s.lineWidthEmu
+        ? axisLineWidthPx(s.lineWidthEmu, ptToPx)
+        : pointStyle?.lineWidthEmu != null
+          ? axisLineWidthPx(pointStyle.lineWidthEmu, ptToPx)
+          : 1;
+      const lineEdge = chartExStyleColor(chart, lineStyle, 'line', styleIndex, nSer);
+      const markerFill = chartExStyleColor(chart, markerStyle, 'fill', styleIndex, nSer);
+      const markerFillPaint = chartExMarkerPaint(
+        chart, styleIndex, nSer, s.chartexStyle, s.color, markerStyle,
+      );
+      const markerEdge = chartExStyleColor(chart, markerStyle, 'line', styleIndex, nSer);
+      const applySeriesLine = (style: ChartExStyle | null | undefined, fallback: string): boolean => {
+        const local = s.chartexStyle;
+        const hasLocalLine = local?.lineHidden != null
+          || local?.lineColors?.some(Boolean)
+          || local?.lineWidthEmu != null
+          || local?.lineDash != null
+          || local?.lineCap != null
+          || local?.lineJoin != null;
+        const visible = applyChartExSeriesLineStyle(
+          ctx, chart, style, s, styleIndex, nSer, fallback, ptToPx,
+        );
+        // Chart Style `NoStyle` means that this role supplies no decorative
+        // override. Box/whisker's semantic outline still exists. This is
+        // distinct from an authored `<a:noFill>`, which remains suppressed.
+        const semanticNoStyleFallback = style?.lineNoStyle === true
+          && !hasLocalLine && s.lineColor == null && s.lineWidthEmu == null;
+        if (!visible && semanticNoStyleFallback) {
+          ctx.strokeStyle = fallback;
+          ctx.lineWidth = 1;
+          ctx.setLineDash([]);
+        }
+        if (s.lineColor) ctx.strokeStyle = edge;
+        if (s.lineWidthEmu) ctx.lineWidth = edgeWidth;
+        return visible || semanticNoStyleFallback || s.lineColor != null;
+      };
+      const yQ1 = yOf(stats.q1);
+      const yQ3 = yOf(stats.q3);
+      const boxTop = Math.min(yQ1, yQ3);
+      const boxH = Math.max(1, Math.abs(yQ1 - yQ3));
+
+      // Whiskers: vertical line from box edges to whisker ends, with end caps.
+      const capW = boxW * 0.4;
+      if (applySeriesLine(lineStyle, lineEdge ?? edge)) {
+        ctx.beginPath();
+        ctx.moveTo(cx, yOf(stats.whiskerHi)); ctx.lineTo(cx, yQ3);
+        ctx.moveTo(cx, yQ1); ctx.lineTo(cx, yOf(stats.whiskerLo));
+        ctx.moveTo(cx - capW / 2, yOf(stats.whiskerHi)); ctx.lineTo(cx + capW / 2, yOf(stats.whiskerHi));
+        ctx.moveTo(cx - capW / 2, yOf(stats.whiskerLo)); ctx.lineTo(cx + capW / 2, yOf(stats.whiskerLo));
+        ctx.stroke();
+      }
+
+      // IQR box: solid accent fill + a thin accent×0.8 edge.
+      if (fillPaint) {
+        ctx.fillStyle = chartExFillStyle(
+          ctx,
+          fillPaint,
+          bx,
+          boxTop,
+          boxW,
+          boxH,
+          fill,
+          shapeRotationDeg,
+        );
+        ctx.fillRect(bx, boxTop, boxW, boxH);
+      }
+      if (applySeriesLine(pointStyle, edge)) {
+        ctx.strokeRect(
+          bx + edgeWidth / 2,
+          boxTop + edgeWidth / 2,
+          boxW - edgeWidth,
+          boxH - edgeWidth,
+        );
+      }
+
+      // Median line across the box.
+      const yMed = yOf(stats.median);
+      if (applySeriesLine(lineStyle, lineEdge ?? edge)) {
+        ctx.beginPath(); ctx.moveTo(bx, yMed); ctx.lineTo(bx + boxW, yMed); ctx.stroke();
+      }
+
+      // Interior sample points. Excel overlays the raw non-outlier values on
+      // the box/whiskers when cx:visibility@nonoutliers is enabled.
+      if (s.showNonoutliers) {
+        const pointSymbol = chart.chartStyleMarkerSymbol ?? chart.chartexMarkerSymbol ?? 'circle';
+        for (const point of stats.inner) {
+          if (pointSymbol === 'none') continue;
+          const markerLineVisible = applySeriesLine(markerStyle, markerEdge ?? edge);
+          const pointY = yOf(point);
+          drawMarker(
+            ctx,
+            cx,
+            pointY,
+            pointSymbol,
+            observationMarkerSizePt,
+            markerFillPaint ? (markerFill ? `#${markerFill}` : fill) : 'transparent',
+            markerLineVisible ? (markerEdge ? `#${markerEdge}` : edge) : null,
+            ptToPx,
+            ctx.lineWidth,
+            markerFillPaint,
+            shapeRotationDeg,
+          );
+        }
+      }
+
+      // Mean `×` marker (same accent×0.8 as the rest of the outline).
+      if (s.meanMarker) {
+        const mY = yOf(stats.mean);
+        const mR = meanMarkerRadiusPx;
+        if (applySeriesLine(markerStyle, markerEdge ?? edge)) {
+          ctx.beginPath();
+          ctx.moveTo(cx - mR, mY - mR); ctx.lineTo(cx + mR, mY + mR);
+          ctx.moveTo(cx + mR, mY - mR); ctx.lineTo(cx - mR, mY + mR);
+          ctx.stroke();
+        }
+      }
+
+      // Outlier dots.
+      if (s.showOutliers) {
+        const pointSymbol = chart.chartStyleMarkerSymbol ?? chart.chartexMarkerSymbol ?? 'circle';
+        for (const o of stats.outliers) {
+          if (pointSymbol === 'none') continue;
+          const markerLineVisible = applySeriesLine(markerStyle, markerEdge ?? edge);
+          const outlierY = yOf(o);
+          drawMarker(
+            ctx,
+            cx,
+            outlierY,
+            pointSymbol,
+            observationMarkerSizePt,
+            markerFillPaint ? (markerFill ? `#${markerFill}` : fill) : 'transparent',
+            markerLineVisible ? (markerEdge ? `#${markerEdge}` : edge) : null,
+            ptToPx,
+            ctx.lineWidth,
+            markerFillPaint,
+            shapeRotationDeg,
+          );
+        }
+      }
+    }
+
+    // Category label (centered under the slot), word-wrapped like the other
+    // cartesian renderers.
+    if (!chart.catAxisHidden) {
+      ctx.font = chartFontCss(
+        catFontPx,
+        chartFontFamily(chart, chart.catAxisFontFace, 'minor'),
+        chart.catAxisFontBold ?? false,
+        chart.catAxisFontItalic ?? false,
+      );
+      ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#595959';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'top';
+      const label = cats[ci];
+      ctx.fillText(label, categoryCenterX, py0 + ph + catTickLabelGap);
+    }
+  }
+  ctx.restore();
+
+  drawAxisTitles(
+    ctx,
+    chart,
+    x,
+    y,
+    w,
+    h,
+    px0,
+    py0,
+    pw,
+    ph,
+    legLeftW,
+    legBottomH,
+    axBands.catFontPx,
+    axBands.valFontPx,
+  );
+
+  drawLegendForLayout(
+    ctx,
+    legendChart,
+    leg,
+    x,
+    y,
+    w,
+    h,
+    px0,
+    py0,
+    pw,
+    ph,
+    titleBand.bandH + 2,
+    ptToPx,
+    box.series.map((_, index) => paintOf(index)),
+    shapeRotationDeg,
+  );
+}
+
+
+/**
+ * Render a chartEx sunburst (MS 2014 chartex extension — no ECMA-376 section;
+ * the structure is a `<cx:series layoutId="sunburst">` over a `<cx:strDim
+ * type="cat">` of several `<cx:lvl>` and one `<cx:numDim type="size">`). The
+ * parser (`parse_chartex_sunburst`) yields the flat root→leaf `path`/`size`
+ * rows in `chart.chartexSunburst`; this renderer folds them into a ring tree,
+ * lays out each node's angular span proportional to its aggregated size, and
+ * draws concentric rings (inner = root/Branch, outward = Stem, Leaf) from 12
+ * o'clock clockwise. Every node in a branch shares that branch's theme accent
+ * (`chart.chartexAccents`, cycled by top-level index — the blue/orange/gray
+ * Office default). Labels are drawn white and centered in each segment, rotated
+ * to follow the arc and elided when the wedge is too small.
+ */
+function renderSunburstChart(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  r: ChartRect,
+  ptToPx: number,
+  shapeRotationDeg: number,
+): void {
+  const sb = chart.chartexSunburst;
+  if (!sb || sb.rows.length === 0) return;
+  const { x, y, w, h } = r;
+  if (hierarchyInputTooLarge(sb.rows)) {
+    rejectOversizedCanvasChart(ctx, r, MAX_CANVAS_CHART_POINTS + 1);
+    return;
+  }
+  const root = buildSunburstTree(sb.rows);
+  if (root.layoutWeight <= 0 || root.children.length === 0) return;
+  const series = chart.series[0];
+  const labelOverrides = indexPointOverrides(series?.dataLabelOverrides);
+  const legendPaints = root.children.map((_, index) =>
+    chartExDataPointPaint(chart, index, root.children.length, series?.chartexStyle, series?.color)
+  );
+  const legendChart: ChartModel = {
+    ...chart,
+    chartType: 'clusteredBar',
+    series: root.children.map(node => {
+      const fill = chartExDataPointFill(
+        chart, node.branchIndex, root.children.length, series?.chartexStyle,
+      );
+      return chartExLegendSeries(
+        chart,
+        node.label,
+        series,
+        chart.chartexDataPointStyle,
+        node.branchIndex,
+        root.children.length,
+        fill,
+        false,
+        false,
+      );
+    }),
+  };
+  // Reuse the radial frame so an authored top legend reserves space above the
+  // rings instead of being painted over the circle.
+  const leg = measuredLegendReserve(ctx, legendChart, w, h, 0.22, ptToPx);
+  const frame = computeChartFrame(chart, x, y, w, h, ptToPx, {
+    titleTopPadFrac: 0.035,
+    titleBottomPadFrac: 0.035,
+    legendSideReserveFrac: 0,
+    legendReserve: leg,
+    radialGapFrac: 0.02,
+    honorPlotAreaManualLayout: true,
+  });
+  drawChartTitleForLayout(ctx, chart, x, y, w, h, y + frame.title.topPad, frame.title.fontPx);
+  const { px0, py0, pw, ph } = frame.plotRect;
+  paintPlotAreaFrame(ctx, chart, px0, py0, pw, ph, ptToPx, shapeRotationDeg);
+  const cx = px0 + pw / 2;
+  const cy = py0 + ph / 2;
+  const outerR = Math.min(pw, ph) * 0.46;
+
+  // Full circle from 12 o'clock (−90°), clockwise (canvas angles grow CW), each
+  // parent partitioning its range across its children in source (first-seen)
+  // order. This is the natural spec-consistent reading of the `<cx:lvl>` point
+  // order. The extension does not specify an alternative automatic reordering,
+  // so the renderer does not infer one from labels or values.
+  root.a0 = -Math.PI / 2;
+  root.a1 = -Math.PI / 2 + Math.PI * 2;
+  layoutSunburstAngles(root);
+
+  const maxDepth = sunburstMaxDepth(root); // 0-based deepest ring index
+  const ringCount = maxDepth + 1;
+  // Small center hole (Office draws a modest hole, ~18% of the outer radius);
+  // the remaining band is split evenly across the rings.
+  const innerR = outerR * 0.18;
+  const ringBand = (outerR - innerR) / ringCount;
+
+  const branchColor = (bi: number): string => {
+    const hex = chartExDataPointFill(chart, bi, root.children.length, series?.chartexStyle);
+    return `#${hex}`;
+  };
+  const branchPaint = (bi: number): Fill | null => chartExDataPointPaint(
+    chart,
+    bi,
+    root.children.length,
+    series?.chartexStyle,
+    series?.color,
+  );
+
+  const labelDef = series?.seriesDataLabels;
+  const labelFont = chartFontFamily(
+    chart, labelDef?.fontFace ?? chart.dataLabelFontFace, 'minor',
+  );
+  const labelPx = chartTextFontSizePx(labelDef?.fontSizeHpt, ptToPx)
+    ?? Math.max(7, Math.min(13, outerR * 0.075));
+  const labelColor = labelDef?.fontColor ? `#${labelDef.fontColor}` : '#ffffff';
+
+  // Draw every non-root node as a ring segment, deepest-last so borders read on
+  // top. Iterate breadth-first by depth.
+  const byDepth: SunburstNode[][] = Array.from({ length: ringCount }, () => []);
+  const pending = [root];
+  while (pending.length > 0) {
+    const node = pending.pop() as SunburstNode;
+    if (node.depth >= 0) byDepth[node.depth].push(node);
+    for (let index = node.children.length - 1; index >= 0; index--) {
+      pending.push(node.children[index]);
+    }
+  }
+
+  ctx.save();
+  for (let d = 0; d < ringCount; d++) {
+    const rInner = innerR + d * ringBand;
+    const rOuter = rInner + ringBand;
+    for (const node of byDepth[d]) {
+      const sweep = node.a1 - node.a0;
+      if (sweep <= 1e-4) continue;
+      ctx.beginPath();
+      ctx.arc(cx, cy, rOuter, node.a0, node.a1);
+      ctx.arc(cx, cy, rInner, node.a1, node.a0, true);
+      ctx.closePath();
+      const nodePaint = branchPaint(node.branchIndex);
+      if (nodePaint) {
+        ctx.fillStyle = chartExFillStyle(
+          ctx,
+          nodePaint,
+          cx - rOuter,
+          cy - rOuter,
+          rOuter * 2,
+          rOuter * 2,
+          branchColor(node.branchIndex),
+          shapeRotationDeg,
+        );
+        ctx.fill();
+      }
+      if (applyChartExSeriesLineStyle(
+        ctx,
+        chart,
+        chart.chartexDataPointStyle,
+        chart.series[0],
+        node.branchIndex,
+        root.children.length,
+        '#ffffff',
+        ptToPx,
+      )) {
+        ctx.stroke();
+      }
+
+      const label = resolveChartExLabel(
+        chart, series, node.labelIndex, node.label, node.value,
+        { visible: false, showVal: false, showCatName: false },
+        labelOverrides,
+      );
+      if (!label) continue;
+      const labelText = label.text;
+      const nodeLabelPx = chartTextFontSizePx(label.fontSizeHpt, ptToPx) ?? labelPx;
+      const nodeLabelColor = label.fontColor ? `#${label.fontColor}` : labelColor;
+      const nodeLabelFont = label.fontFace
+        ? chartFontFamily(chart, label.fontFace, 'minor')
+        : labelFont;
+
+      // Excel's sunburst category labels run along the radius (not around the
+      // circumference). Center the text at the wedge mid-radius and wrap it to
+      // the available ring-band width; additional lines stack tangentially.
+      const midA = (node.a0 + node.a1) / 2;
+      const midR = (rInner + rOuter) / 2;
+      // Radial room the label may occupy (the ring band, minus padding).
+      const radialRoom = ringBand - 4;
+      // Tangential arc length at the mid radius.
+      const arcLen = sweep * midR;
+      // Skip labels that plainly cannot fit even one glyph.
+      if (!label.manualLayout &&
+          radialRoom < nodeLabelPx * 0.9 && arcLen < nodeLabelPx * 0.9) continue;
+
+      const labelX = cx + Math.cos(midA) * midR;
+      const labelY = cy + Math.sin(midA) * midR;
+      ctx.font = `${label.textStyle.fontItalic ? 'italic ' : ''}${label.fontBold ? 'bold ' : ''}${nodeLabelPx}px ${nodeLabelFont}`;
+      if (label.manualLayout) {
+        drawBoundedDataLabelText(
+          ctx,
+          labelText,
+          { kind: 'point', x: labelX, y: labelY, position: label.position ?? 'ctr' },
+          { x: px0, y: py0, w: pw, h: ph },
+          nodeLabelPx,
+          nodeLabelColor,
+          label.manualLayout,
+          { x, y, w, h },
+          richDataLabelOptions(
+            chart, label.richRuns, ptToPx, nodeLabelFont, label.fontBold ?? false, label.textStyle,
+          ),
+          undefined,
+          label.textStyle,
+          ptToPx,
+          label.labelBox,
+          shapeRotationDeg,
+        );
+        continue;
+      }
+
+      ctx.save();
+      ctx.translate(labelX, labelY);
+      // Orient the text along the radius and flip on the left half so it stays
+      // readable instead of becoming upside-down.
+      let rot = midA;
+      const deg = ((rot * 180) / Math.PI) % 360;
+      if (deg > 90 || deg < -90) rot += Math.PI;
+      ctx.rotate(rot);
+      ctx.font = `${label.textStyle.fontItalic ? 'italic ' : ''}${label.fontBold ? 'bold ' : ''}${nodeLabelPx}px ${nodeLabelFont}`;
+      drawBoundedDataLabelText(
+        ctx,
+        labelText,
+        { kind: 'point', x: 0, y: 0, position: label.position ?? 'ctr' },
+        { x: -radialRoom / 2, y: -arcLen / 2, w: radialRoom, h: arcLen },
+        nodeLabelPx,
+        nodeLabelColor,
+        undefined,
+        { x: -radialRoom / 2, y: -arcLen / 2, w: radialRoom, h: arcLen },
+        richDataLabelOptions(
+          chart, label.richRuns, ptToPx, nodeLabelFont, label.fontBold ?? false, label.textStyle,
+        ),
+        undefined,
+        label.textStyle,
+        ptToPx,
+        label.labelBox,
+        shapeRotationDeg,
+      );
+      ctx.restore();
+    }
+  }
+  ctx.restore();
+
+  drawLegendForLayout(
+    ctx,
+    legendChart,
+    leg,
+    x,
+    y,
+    w,
+    h,
+    px0,
+    py0,
+    pw,
+    ph,
+    frame.title.bandH + 2,
+    ptToPx,
+    legendPaints,
+    shapeRotationDeg,
+  );
+}
+
+// ─── chartEx: treemap (CH15, MS 2014 chartex ext) ───────────────────────────
+
+interface TreemapRect { x: number; y: number; w: number; h: number }
+interface TreemapTile { node: SunburstNode; rect: TreemapRect }
+
+/** Standard squarified-treemap layout. Areas are exactly proportional to node
+ * layout weights; descending stable order keeps the aspect ratios useful
+ * without any document-specific tuning. */
+function layoutTreemapTiles(nodes: SunburstNode[], rect: TreemapRect): TreemapTile[] {
+  const positive = nodes
+    .map((node, index) => ({
+      node,
+      index,
+      value: node.layoutWeight,
+    }))
+    .filter(entry => entry.value > 0)
+    .sort((a, b) => b.value - a.value || a.index - b.index);
+  const total = positive.reduce((sum, entry) => sum + entry.value, 0);
+  if (total <= 0 || rect.w <= 0 || rect.h <= 0) return [];
+
+  const scale = (rect.w * rect.h) / total;
+  const entries = positive.map(entry => ({ ...entry, area: entry.value * scale }));
+  const tiles: TreemapTile[] = [];
+  let remaining = { ...rect };
+  let row: typeof entries = [];
+  let rowArea = 0;
+  let rowMin = Number.POSITIVE_INFINITY;
+  let rowMax = 0;
+
+  const worstRatio = (sum: number, min: number, max: number, shortSide: number): number => {
+    if (sum <= 0 || min <= 0 || shortSide <= 0) return Number.POSITIVE_INFINITY;
+    const side2 = shortSide * shortSide;
+    return Math.max((side2 * max) / (sum * sum), (sum * sum) / (side2 * min));
+  };
+
+  const placeRow = (items: typeof entries, area: number): void => {
+    if (items.length === 0) return;
+    if (remaining.w >= remaining.h) {
+      const colW = remaining.h > 0 ? area / remaining.h : 0;
+      let y = remaining.y;
+      for (let i = 0; i < items.length; i++) {
+        const h = i === items.length - 1 ? remaining.y + remaining.h - y : items[i].area / colW;
+        tiles.push({ node: items[i].node, rect: { x: remaining.x, y, w: colW, h } });
+        y += h;
+      }
+      remaining = { x: remaining.x + colW, y: remaining.y, w: Math.max(0, remaining.w - colW), h: remaining.h };
+    } else {
+      const rowH = remaining.w > 0 ? area / remaining.w : 0;
+      let x = remaining.x;
+      for (let i = 0; i < items.length; i++) {
+        const w = i === items.length - 1 ? remaining.x + remaining.w - x : items[i].area / rowH;
+        tiles.push({ node: items[i].node, rect: { x, y: remaining.y, w, h: rowH } });
+        x += w;
+      }
+      remaining = { x: remaining.x, y: remaining.y + rowH, w: remaining.w, h: Math.max(0, remaining.h - rowH) };
+    }
+  };
+
+  let index = 0;
+  while (index < entries.length) {
+    const next = entries[index];
+    const side = Math.min(remaining.w, remaining.h);
+    const nextArea = rowArea + next.area;
+    const nextMin = Math.min(rowMin, next.area);
+    const nextMax = Math.max(rowMax, next.area);
+    if (row.length === 0
+      || worstRatio(nextArea, nextMin, nextMax, side)
+        <= worstRatio(rowArea, rowMin, rowMax, side)) {
+      row.push(next);
+      rowArea = nextArea;
+      rowMin = nextMin;
+      rowMax = nextMax;
+      index++;
+    } else {
+      placeRow(row, rowArea);
+      row = [];
+      rowArea = 0;
+      rowMin = Number.POSITIVE_INFINITY;
+      rowMax = 0;
+    }
+  }
+  placeRow(row, rowArea);
+  return tiles;
+}
+
+/** Render chartEx `layoutId="treemap"` as nested, area-proportional rectangles.
+ * The chartEx hierarchy is shared with sunburst; `parentLabelLayout="banner"`
+ * reserves a header inside each parent, `none` suppresses parent captions, and
+ * the other/absent modes overlay the caption without changing tile area. */
+function renderTreemapChart(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  r: ChartRect,
+  ptToPx: number,
+  shapeRotationDeg: number,
+): void {
+  const treemap = chart.chartexTreemap;
+  if (!treemap || treemap.rows.length === 0) return;
+  if (hierarchyInputTooLarge(treemap.rows)) {
+    rejectOversizedCanvasChart(ctx, r, MAX_CANVAS_CHART_POINTS + 1);
+    return;
+  }
+  // A treemap data point remains a distinct tile even when its terminal label
+  // repeats. Only parent path components are grouping keys.
+  const root = buildSunburstTree(treemap.rows, true);
+  if (root.layoutWeight <= 0 || root.children.length === 0) return;
+  const series = chart.series[0];
+  const legendPaints = root.children.map(node =>
+    chartExDataPointPaint(
+      chart, node.branchIndex, root.children.length, series?.chartexStyle, series?.color,
+    )
+  );
+  const legendChart: ChartModel = {
+    ...chart,
+    chartType: 'clusteredBar',
+    series: root.children.map(node => {
+      const fill = chartExDataPointFill(
+        chart, node.branchIndex, root.children.length, series?.chartexStyle,
+      );
+      return chartExLegendSeries(
+        chart,
+        node.label,
+        series,
+        chart.chartexDataPointStyle,
+        node.branchIndex,
+        root.children.length,
+        fill,
+        true,
+        false,
+      );
+    }),
+  };
+  const leg = measuredLegendReserve(ctx, legendChart, r.w, r.h, 0.22, ptToPx);
+  const frame = computeChartFrame(chart, r.x, r.y, r.w, r.h, ptToPx, {
+    titleTopPadFrac: 0.035,
+    titleBottomPadFrac: 0.035,
+    legendSideReserveFrac: 0,
+    legendReserve: leg,
+    radialGapFrac: 0.015,
+    honorPlotAreaManualLayout: true,
+  });
+  drawChartTitleForLayout(ctx, chart, r.x, r.y, r.w, r.h, r.y + frame.title.topPad, frame.title.fontPx);
+  const { px0, py0, pw, ph } = frame.plotRect;
+  paintPlotAreaFrame(ctx, chart, px0, py0, pw, ph, ptToPx, shapeRotationDeg);
+  const plotBounds = { x: px0, y: py0, w: pw, h: ph };
+
+  const parentMode = treemap.parentLabelLayout ?? 'overlapping';
+  const labelDef = chart.series[0]?.seriesDataLabels;
+  const fontFamily = chartFontFamily(
+    chart, labelDef?.fontFace ?? chart.dataLabelFontFace, 'minor',
+  );
+  const labelFontPx = chartTextFontSizePx(labelDef?.fontSizeHpt, ptToPx)
+    ?? Math.max(8, Math.min(13, frame.plotRect.ph * 0.025));
+  const labelColor = labelDef?.fontColor ? `#${labelDef.fontColor}` : '#ffffff';
+  const labelOverrides = new Map(
+    (chart.series[0]?.dataLabelOverrides ?? []).map(override => [override.idx, override]),
+  );
+  // With no direct or linked line recipe, use a one-CSS-pixel separator derived
+  // from the chart background. `applyChartExSeriesLineStyle` still resolves
+  // direct series formatting and the linked data-point role before this fallback.
+  const automaticSeparator = chart.chartBg
+    ? (chart.chartBg.startsWith('#') ? chart.chartBg : `#${chart.chartBg}`)
+    : '#ffffff';
+
+  const paint = (node: SunburstNode, tile: TreemapRect): void => {
+    if (tile.w < 0.5 || tile.h < 0.5) return;
+    const base = chartExDataPointFill(
+      chart, node.branchIndex, root.children.length, series?.chartexStyle,
+    );
+    // Every descendant of a top-level branch uses that branch's exact accent.
+    // Hierarchy depth does not tint or whiten ChartEx treemap data points.
+    const color = `#${base}`;
+    const fillPaint = chartExDataPointPaint(
+      chart, node.branchIndex, root.children.length, series?.chartexStyle, series?.color,
+    );
+    const labelOverride = labelOverrides.get(node.labelIndex);
+    const nodeLabelColor = labelOverride?.fontColor ? `#${labelOverride.fontColor}` : labelColor;
+    const nodeLabelFontPx = chartTextFontSizePx(labelOverride?.fontSizeHpt, ptToPx)
+      ?? labelFontPx;
+    const nodeLabelBold = labelOverride?.fontBold ?? labelDef?.fontBold ?? false;
+
+    if (node.children.length > 0) {
+      // `overlapping` captions belong to the top-level branch entries exposed
+      // by the legend; intermediate nodes still partition their descendants.
+      // `banner` remains separate because it reserves a band at each parent.
+      const parentLabel = resolveChartExLabel(
+        chart, series, node.labelIndex, node.label, node.value,
+        { visible: parentMode !== 'none', showVal: false, showCatName: true },
+        labelOverrides,
+      );
+      const showParent = parentLabel != null
+        && (parentMode !== 'overlapping' || node.depth === 0);
+      const fontPx = nodeLabelFontPx;
+      const parentFontFamily = parentLabel?.fontFace
+        ? chartFontFamily(chart, parentLabel.fontFace, 'minor')
+        : fontFamily;
+      const bannerH = parentMode === 'banner' && showParent
+        ? Math.min(tile.h * 0.28, fontPx + 7)
+        : 0;
+      // `overlapping` (MS-ODRAWXML §2.24.3.69 CT_ParentLabelLayout) places the
+      // parent caption over its descendant data points. In Excel it does not
+      // create an additional painted parent rectangle; doing so here produced
+      // a hairline frame around each branch. Banner mode alone reserves and
+      // paints a caption band.
+      if (bannerH > 0 && fillPaint) {
+        ctx.fillStyle = chartExFillStyle(
+          ctx,
+          fillPaint,
+          tile.x,
+          tile.y,
+          tile.w,
+          bannerH,
+          color,
+          shapeRotationDeg,
+        );
+        ctx.fillRect(tile.x, tile.y, tile.w, bannerH);
+      }
+      const content = {
+        x: tile.x,
+        y: tile.y + bannerH,
+        w: tile.w,
+        h: Math.max(0, tile.h - bannerH),
+      };
+      for (const child of layoutTreemapTiles(node.children, content)) paint(child.node, child.rect);
+
+      if (showParent && (parentLabel.manualLayout || (tile.w > fontPx * 2 && tile.h > fontPx + 4))) {
+        ctx.font = `${nodeLabelBold ? 'bold ' : ''}${fontPx}px ${parentFontFamily}`;
+        const labelRect = bannerH > 0
+          ? { x: tile.x, y: tile.y, w: tile.w, h: bannerH }
+          : tile;
+        const automaticBounds = labelRect;
+        // The series-level data-label position describes leaf values. Office
+        // keeps overlapping parent captions at the top-left even when leaves
+        // are authored at inEnd; only an indexed parent override changes it.
+        const parentPosition = labelOverride?.position ?? 'inBase';
+        drawBoundedDataLabelText(
+          ctx,
+          parentLabel.text,
+          parentLabel.manualLayout
+            ? { kind: 'point', x: tile.x + tile.w / 2, y: tile.y + tile.h / 2, position: parentPosition }
+            : { kind: 'box', rect: automaticBounds, position: parentPosition },
+          parentLabel.manualLayout ? plotBounds : automaticBounds,
+          fontPx,
+          nodeLabelColor,
+          parentLabel.manualLayout,
+          r,
+          richDataLabelOptions(
+            chart, parentLabel.richRuns, ptToPx, parentFontFamily, nodeLabelBold,
+            parentLabel.textStyle,
+          ),
+          undefined,
+          parentLabel.textStyle,
+          ptToPx,
+          parentLabel.labelBox,
+          shapeRotationDeg,
+        );
+      }
+      return;
+    }
+
+    if (fillPaint) {
+      ctx.fillStyle = chartExFillStyle(
+        ctx,
+        fillPaint,
+        tile.x,
+        tile.y,
+        tile.w,
+        tile.h,
+        color,
+        shapeRotationDeg,
+      );
+      ctx.fillRect(tile.x, tile.y, tile.w, tile.h);
+    }
+    const hasAuthoredOutline = applyChartExSeriesLineStyle(
+      ctx,
+      chart,
+      chart.chartexDataPointStyle,
+      chart.series[0],
+      node.branchIndex,
+      root.children.length,
+      automaticSeparator,
+      ptToPx,
+      { linkedNoStyleFallback: true },
+    );
+    if (hasAuthoredOutline) {
+      // ChartEx outlines are centered on the tile boundary. An inset stroke
+      // creates a second visible outer frame that Excel does not paint.
+      ctx.strokeRect(tile.x, tile.y, tile.w, tile.h);
+    }
+
+    const leafLabel = resolveChartExLabel(
+      chart, series, node.labelIndex, node.label, node.value,
+      { visible: false, showVal: false, showCatName: false },
+      labelOverrides,
+    );
+    if (!leafLabel) return;
+    const fontPx = chartTextFontSizePx(leafLabel.fontSizeHpt, ptToPx)
+      ?? nodeLabelFontPx;
+    if (!leafLabel.manualLayout && (tile.w <= fontPx * 1.2 || tile.h <= fontPx * 1.2)) return;
+    const leafFontFamily = leafLabel.fontFace
+      ? chartFontFamily(chart, leafLabel.fontFace, 'minor')
+      : fontFamily;
+    ctx.font = `${leafLabel.fontBold ? 'bold ' : ''}${fontPx}px ${leafFontFamily}`;
+    const automaticBounds = tile;
+    // ChartEx uses `outEnd` for treemap value labels but Excel paints that
+    // token inside the tile at its lower-left corner. Keep the family-specific
+    // semantic mapping here; the shared box resolver's generic outEnd remains
+    // right-centred for other chart families.
+    const leafPosition = leafLabel.position === 'outEnd'
+      ? 'inEnd'
+      : (leafLabel.position ?? 'ctr');
+    drawBoundedDataLabelText(
+      ctx,
+      leafLabel.text,
+      leafLabel.manualLayout
+        ? { kind: 'point', x: tile.x + tile.w / 2, y: tile.y + tile.h / 2, position: leafPosition }
+        : { kind: 'box', rect: automaticBounds, position: leafPosition },
+      leafLabel.manualLayout ? plotBounds : automaticBounds,
+      fontPx,
+      leafLabel.fontColor ? `#${leafLabel.fontColor}` : nodeLabelColor,
+      leafLabel.manualLayout,
+      r,
+      richDataLabelOptions(
+        chart, leafLabel.richRuns, ptToPx, leafFontFamily, leafLabel.fontBold ?? false,
+        leafLabel.textStyle,
+      ),
+      undefined,
+      leafLabel.textStyle,
+      ptToPx,
+      leafLabel.labelBox,
+      shapeRotationDeg,
+    );
+  };
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(px0, py0, pw, ph);
+  ctx.clip();
+  for (const tile of layoutTreemapTiles(root.children, { x: px0, y: py0, w: pw, h: ph })) {
+    paint(tile.node, tile.rect);
+  }
+  ctx.restore();
+
+  drawLegendForLayout(
+    ctx,
+    legendChart,
+    leg,
+    r.x,
+    r.y,
+    r.w,
+    r.h,
+    px0,
+    py0,
+    pw,
+    ph,
+    frame.title.bandH + 2,
+    ptToPx,
+    legendPaints,
+    shapeRotationDeg,
+  );
+}
+
+/** Render one supported ChartEx family, returning false for classic or future
+ * chart identifiers that belong to another optional renderer. */
+export function renderChartExChart(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  rect: ChartRect,
+  ptToPx: number,
+  shapeRotationDeg = 0,
+): boolean {
+  switch (chart.chartType) {
+    case 'waterfall':
+      renderWaterfallChart(ctx, chart, rect, ptToPx, shapeRotationDeg);
+      return true;
+    case 'clusteredColumn':
+      renderBarChart(
+        ctx,
+        { ...chart, chartType: 'clusteredBar' },
+        rect,
+        ptToPx,
+        { gapPolicy: 'chartex' },
+        shapeRotationDeg,
+      );
+      return true;
+    case 'histogram':
+      renderHistogramChart(ctx, chart, rect, ptToPx, shapeRotationDeg);
+      return true;
+    case 'funnel':
+      renderFunnelChart(ctx, chart, rect, ptToPx, shapeRotationDeg);
+      return true;
+    case 'paretoLine':
+      renderParetoLineChart(ctx, chart, rect, ptToPx, shapeRotationDeg);
+      return true;
+    case 'pareto':
+      renderParetoChart(ctx, chart, rect, ptToPx, shapeRotationDeg);
+      return true;
+    case 'boxWhisker':
+      renderBoxWhiskerChart(ctx, chart, rect, ptToPx, shapeRotationDeg);
+      return true;
+    case 'sunburst':
+      renderSunburstChart(ctx, chart, rect, ptToPx, shapeRotationDeg);
+      return true;
+    case 'treemap':
+      renderTreemapChart(ctx, chart, rect, ptToPx, shapeRotationDeg);
+      return true;
+    default:
+      return false;
+  }
+}
+
+/** Render text shapes from the chart's related Chart Drawing part.
+ *
+ * `cdr:relSizeAnchor` coordinates are fractions of the full chart space, not
+ * the plot area. Paragraph and run properties are authored DrawingML values.
+ * `a:bodyPr@wrap="square"` (and the application default when omitted) wraps
+ * text inside the authored rectangle; `wrap="none"` keeps a paragraph on one
+ * line. Auto-fit remains deliberately separate because it is a different
+ * DrawingML choice with different font-scaling semantics.
+ */

--- a/packages/core/src/chart/renderer-chartex-gap.test.ts
+++ b/packages/core/src/chart/renderer-chartex-gap.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import type { ChartModel, ChartRect, ChartSeries } from '../types/chart';
+import { renderChartExChart } from './chart-ex-renderer.js';
 import { renderChart } from './renderer.js';
+
+const testChartEx = { render: renderChartExChart };
 
 interface RectCall {
   x: number;
@@ -160,7 +163,17 @@ function familyModel(family: ChartExGapFamily, barGapWidth?: number): ChartModel
 
 function renderRects(chart: ChartModel, bounds: ChartRect): RectCall[] {
   const recording = recordingContext();
-  renderChart(recording.ctx, chart, bounds, 1);
+  renderChart(
+    recording.ctx,
+    chart,
+    bounds,
+    1,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    testChartEx,
+  );
   return recording.rects;
 }
 

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -19,6 +19,7 @@ import {
   classicMarkerPaintWorkCount,
   renderChart as renderChartCore,
 } from './renderer.js';
+import { renderChartExChart } from './chart-ex-renderer.js';
 import { renderSimpleThreeDChart } from './three-d-renderer.js';
 import { formatChartValWithCode } from './chart-number-format.js';
 import { BOX_WHISKER_SLOT_GUTTER_FRACTION } from './box-whisker.js';
@@ -31,6 +32,7 @@ import {
 import { MAX_CANVAS_CHART_POINTS, sourceChartStructureCount } from './resource-limits.js';
 
 const testThreeD = { render: renderSimpleThreeDChart };
+const testChartEx = { render: renderChartExChart };
 
 it('uses collision-free tuple keys for decoded chart image sources', () => {
   expect(chartImageFillKey({
@@ -178,8 +180,26 @@ it('prefetches and paints one bubble picture for both plot and 3-D legend key', 
   expect(rec.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(2);
 });
 const renderChart: typeof renderChartCore = (
-  ctx, chart, rect, ptToPx, shapeRotationDeg, threeD = testThreeD,
-) => renderChartCore(ctx, chart, rect, ptToPx, shapeRotationDeg, threeD);
+  ctx,
+  chart,
+  rect,
+  ptToPx,
+  shapeRotationDeg,
+  threeD = testThreeD,
+  regionMap,
+  imageLookup,
+  chartEx = testChartEx,
+) => renderChartCore(
+  ctx,
+  chart,
+  rect,
+  ptToPx,
+  shapeRotationDeg,
+  threeD,
+  regionMap,
+  imageLookup,
+  chartEx,
+);
 
 interface RectCall { x: number; y: number; w: number; h: number; fs: string }
 interface StrokeRectCall {
@@ -524,6 +544,40 @@ function plotGroup(
 }
 
 const RECT: ChartRect = { x: 0, y: 0, w: 640, h: 360 };
+
+it('keeps classic 2-D charts in the default renderer and ChartEx opt-in', () => {
+  const classic = recordingCtx();
+  renderChartCore(classic.ctx, baseModel({
+    chartType: 'line',
+    categories: ['A', 'B'],
+    series: [series({ values: [1, 2] })],
+  }), RECT, 1);
+  expect(classic.texts.map(item => item.text)).not.toContain('Unsupported chart');
+
+  const omitted = recordingCtx();
+  const waterfall = baseModel({
+    chartType: 'waterfall',
+    categories: ['A', 'B'],
+    series: [series({ values: [1, 2] })],
+  });
+  renderChartCore(omitted.ctx, waterfall, RECT, 1);
+  expect(omitted.texts.map(item => item.text)).toContain('Unsupported chart');
+
+  const enabled = recordingCtx();
+  renderChartCore(
+    enabled.ctx,
+    waterfall,
+    RECT,
+    1,
+    0,
+    undefined,
+    undefined,
+    undefined,
+    testChartEx,
+  );
+  expect(enabled.texts.map(item => item.text)).not.toContain('Unsupported chart');
+  expect(enabled.rects.length).toBeGreaterThan(0);
+});
 
 describe('ordered classic plot groups', () => {
   it.each([

--- a/packages/core/src/chart/renderer-signature.test.ts
+++ b/packages/core/src/chart/renderer-signature.test.ts
@@ -17,7 +17,10 @@
 
 import { describe, it, expect } from 'vitest';
 import type { ChartModel, ChartSeries, ChartRect } from '../types/chart';
+import { renderChartExChart } from './chart-ex-renderer.js';
 import { renderChart } from './renderer.js';
+
+const testChartEx = { render: renderChartExChart };
 
 // ─── Recording mock context ─────────────────────────────────────────────────
 
@@ -477,7 +480,17 @@ describe('renderChart draw-call signature (characterization)', () => {
   for (const [label, model, rect] of batteryModels()) {
     it(`is stable for: ${label}`, () => {
       const ctx = makeRecordingCtx();
-      renderChart(ctx, model, rect, 1.05);
+      renderChart(
+        ctx,
+        model,
+        rect,
+        1.05,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        testChartEx,
+      );
       // Snapshot the full ordered call log. A verbatim layout extraction must
       // not change a single entry.
       expect(ctx.log.join('\n')).toMatchSnapshot();

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -72,8 +72,6 @@ import {
   automaticRadarMajorUnit,
   automaticSurfaceMajorUnit,
   MAX_AXIS_TICKS,
-  niceStep,
-  planLinearValueAxis,
   planNumericValueAxis,
   fitTrendline,
   linearTrendlineStats,
@@ -95,14 +93,8 @@ import {
   resolveCategoryGapWidthPercent,
   type CategoryGapPolicy,
 } from './category-spacing.js';
-import { planHistogramBins } from './histogram-binning.js';
 import { planOfPieSecondaryIndices } from './of-pie.js';
-import {
-  boxWhiskerGeometry,
-  boxWhiskerPointCount,
-  computeBoxWhiskerStats,
-} from './box-whisker.js';
-import { planParetoLayout } from './pareto-layout.js';
+import { computeBoxWhiskerStats } from './box-whisker.js';
 import { planDateCategoryAxis } from './date-axis.js';
 import {
   classicCanvasPointCount,
@@ -122,6 +114,7 @@ import {
   type ChartThreeDRenderer,
 } from './three-d-contract.js';
 import type { ChartRegionMapRenderer } from './region-map-contract.js';
+import type { ChartExRenderer } from './chart-ex-contract.js';
 import {
   paintRichDataLabelBlock,
   resolveRichDataLabelBlock,
@@ -182,14 +175,14 @@ const CHARTEX_DEFAULT_PALETTE = [
   '5B9BD5', 'ED7D31', 'A5A5A5', 'FFC000', '4472C4', '70AD47',
 ] as const;
 
-function chartColor(idx: number, series?: { color?: string | null } | null): string {
+export function chartColor(idx: number, series?: { color?: string | null } | null): string {
   if (series?.color) return `#${series.color}`;
   return `#${CHART_PALETTE[idx % CHART_PALETTE.length]}`;
 }
 
 /** Index point-scoped OOXML overrides once while preserving first-in-document
  * precedence for duplicate indexes. */
-function indexPointOverrides<T extends { idx: number }>(
+export function indexPointOverrides<T extends { idx: number }>(
   values: readonly T[] | null | undefined,
 ): ReadonlyMap<number, T> {
   const indexed = new Map<number, T>();
@@ -234,7 +227,7 @@ function resolveThemeFontRef(chart: ChartModel, face: string | null | undefined)
   return face;
 }
 
-function chartFontFamily(
+export function chartFontFamily(
   chart: ChartModel,
   elementFace: string | null | undefined,
   role: ChartFontRole,
@@ -244,7 +237,7 @@ function chartFontFamily(
   return face ? `"${face}", Calibri, Arial, sans-serif` : 'sans-serif';
 }
 
-function chartFontCss(
+export function chartFontCss(
   fontSizePx: number,
   fontFamily: string,
   bold = false,
@@ -397,7 +390,7 @@ function axisTitleColor(hex: string | null | undefined): string {
  *  DrawingML base fallback. A hand-built public model that leaves bold unset
  *  retains the renderer's established bold compatibility fallback. The
  *  separate 10pt size fallback is the product policy in #1228. */
-function drawAxisTitles(
+export function drawAxisTitles(
   ctx: CanvasRenderingContext2D,
   chart: ChartModel,
   x: number, y: number, w: number, h: number,
@@ -1238,7 +1231,7 @@ interface MeasuredLegendLayout extends ChartLegendReserve {
 }
 
 /** Resolve the shared automatic legend reserve from real Canvas text metrics. */
-function measuredLegendReserve(
+export function measuredLegendReserve(
   ctx: CanvasRenderingContext2D,
   chart: ChartModel,
   w: number,
@@ -1467,7 +1460,7 @@ function legendTextStyle(chart: ChartModel, ptToPx: number): LegendTextStyle {
 type LegendLayout = MeasuredLegendLayout;
 
 /** Draw a legend in the band reserved by {@link chartLegendReserve}. */
-function drawLegendForLayout(
+export function drawLegendForLayout(
   ctx: CanvasRenderingContext2D,
   chart: ChartModel,
   leg: LegendLayout | null,
@@ -1531,7 +1524,7 @@ function drawLegendForLayout(
     chart.categories, ptToPx, fillPaints, shapeRotationDeg, chart.varyColors !== false, chart, leg);
 }
 
-function drawAxisTick(
+export function drawAxisTick(
   ctx: CanvasRenderingContext2D,
   mode: string | null | undefined,
   axis: 'val' | 'cat',
@@ -1593,7 +1586,7 @@ function drawAxisTick(
   ctx.setLineDash(prevDash);
 }
 
-function strokeAxisSegment(
+export function strokeAxisSegment(
   ctx: CanvasRenderingContext2D,
   x1: number,
   y1: number,
@@ -1653,7 +1646,7 @@ function axisTickOutwardExtentPx(
  *  every major gridline in that one color/width uniformly, so the zero-line
  *  override is suppressed. Omitting `grid` reproduces the pre-CH-gridline
  *  default exactly (byte-stable for callers that haven't resolved a style). */
-function strokeValueGridlineH(
+export function strokeValueGridlineH(
   ctx: CanvasRenderingContext2D,
   px0: number,
   pw: number,
@@ -1686,7 +1679,7 @@ function strokeValueGridlineH(
  *  uniformly (no `#aaa` zero-line emphasis), matching PowerPoint. With no
  *  explicit color the resolved `{ color: '#e0e0e0', width: 0.5 }` reproduces the
  *  historical faint hairline (byte-stable). */
-function valGridStroke(
+export function valGridStroke(
   chart: ChartModel,
   ptToPx: number,
 ): { color: string; width: number; explicit: boolean; dash: number[] } {
@@ -1701,7 +1694,7 @@ function valGridStroke(
   };
 }
 
-function valMinorGridStroke(
+export function valMinorGridStroke(
   chart: ChartModel,
   ptToPx: number,
 ): { color: string; width: number; explicit: boolean; dash: number[] } {
@@ -1821,7 +1814,7 @@ function catAxisReversed(chart: ChartModel): boolean {
  *  "draw unless the model explicitly says the element is absent". `undefined`
  *  (parser didn't model it) ⇒ true (byte-stable); `false` (axis present without
  *  the element) ⇒ off. */
-function drawValMajorGridlines(chart: ChartModel): boolean {
+export function drawValMajorGridlines(chart: ChartModel): boolean {
   return chart.valAxisMajorGridlines !== false;
 }
 
@@ -1858,7 +1851,7 @@ function valueAxisUnitInRendererSpace(
 /** Format a primary value-axis tick from the renderer's data space. For a
  * percentStacked chart the plotted values are percentage points, while the
  * axis numFmt still expects the OOXML ratio (0.5 → 50%). */
-function formatPrimaryValueAxisTick(
+export function formatPrimaryValueAxisTick(
   chart: ChartModel,
   value: number,
   percentStacked: boolean,
@@ -1973,7 +1966,7 @@ function drawChartDisplayUnitLabels(
  *  are the raw data extents already massaged by the caller (0-anchoring, pct
  *  normalization, explicit valMin/valMax). `axisLenPt` drives the auto major
  *  unit. Reversal is read from the chart's value-axis orientation. */
-function planValueAxis(
+export function planValueAxis(
   chart: ChartModel,
   dataMin: number,
   dataMax: number,
@@ -2386,7 +2379,7 @@ function legendSeriesWithTrendlines(chart: ChartModel): ChartSeries[] {
 
 /** Resolve an axis label font size (px) from <c:txPr> hpt or a proportional
  *  fallback. ptToPx comes from the host renderer (EMU/px scale at display). */
-function axisLabelPx(sizeHpt: number | null | undefined, h: number, ptToPx: number): number {
+export function axisLabelPx(sizeHpt: number | null | undefined, h: number, ptToPx: number): number {
   return chartTextFontSizePx(sizeHpt, ptToPx) ?? Math.max(8, h * 0.045);
 }
 
@@ -2394,7 +2387,7 @@ function axisLabelPx(sizeHpt: number | null | undefined, h: number, ptToPx: numb
  * Words are kept intact when possible; a single over-wide token is split at
  * measured character boundaries. Used by chart families whose category-label
  * band is an input to plot layout. */
-function wrapMeasuredText(
+export function wrapMeasuredText(
   ctx: CanvasRenderingContext2D,
   text: string,
   maxWidth: number,
@@ -2975,7 +2968,7 @@ function resolveChartTitleLines(
   return lines;
 }
 
-function measuredCartesianTitleBand(
+export function measuredCartesianTitleBand(
   ctx: CanvasRenderingContext2D,
   chart: ChartModel,
   w: number,
@@ -3037,7 +3030,7 @@ function drawChartTitle(
 /** Draw the title at its authored manual-layout position. Office ignores w/h
  * for title descendants and fits the box to text (MS-OI29500 §2.1.1573), while
  * x/y still use the shared factor/edge rules. */
-function drawChartTitleForLayout(
+export function drawChartTitleForLayout(
   ctx: CanvasRenderingContext2D,
   chart: ChartModel,
   x: number, y: number, w: number, h: number,
@@ -3170,11 +3163,11 @@ function drawBarDataLabel(
  * 6.2–7.5 pt from the axis centreline. Keep this compatibility fallback
  * ChartEx-only; classic axes retain their existing font-relative contract.
  */
-function chartExValueTickLabelOffsetPx(ptToPx: number): number {
+export function chartExValueTickLabelOffsetPx(ptToPx: number): number {
   return 7 * ptToPx;
 }
 
-function renderBarChart(
+export function renderBarChart(
   ctx: CanvasRenderingContext2D,
   chart: ChartModel,
   r: ChartRect,
@@ -6524,7 +6517,7 @@ function categoryAxisCrossingValue(chart: ChartModel, min: number, max: number):
   return axisCrossingValue(chart.catAxisCrossesAt, chart.catAxisCrosses, min, max);
 }
 
-function renderLineChart(
+export function renderLineChart(
   ctx: CanvasRenderingContext2D,
   chart: ChartModel,
   r: ChartRect,
@@ -12728,7 +12721,7 @@ function paintBubble3DMaterial(
  *  don't end up double-prefixing into an invalid `##RRGGBB`. `line` may
  *  be null in which case no outline is drawn. `picture` uses the host-warmed
  *  image lookup and fails closed when its authored relationship is unresolved. */
-function drawMarker(
+export function drawMarker(
   ctx: CanvasRenderingContext2D,
   cx: number, cy: number,
   symbol: string,
@@ -13153,7 +13146,7 @@ function customRichDataLabelOptions(
   );
 }
 
-function richDataLabelOptions(
+export function richDataLabelOptions(
   chart: ChartModel,
   runs: ChartDataLabelOverride['richRuns'],
   ptToPx: number,
@@ -13176,7 +13169,7 @@ function richDataLabelOptions(
 }
 
 /** Measure, fit, clip, and paint one label through the shared pure resolver. */
-function drawBoundedDataLabelText(
+export function drawBoundedDataLabelText(
   ctx: CanvasRenderingContext2D,
   text: string,
   anchor: DataLabelAnchor,
@@ -13722,7 +13715,7 @@ function drawCategoryDataLabels(
 // Waterfall chart — subtotal bars filled, delta bars outlined.
 // ═══════════════════════════════════════════════════════════════════════════
 
-type ChartExStyle = NonNullable<ChartModel['chartexDataPointStyle']>;
+export type ChartExStyle = NonNullable<ChartModel['chartexDataPointStyle']>;
 
 interface ResolvedChartExLabel {
   text: string;
@@ -13741,7 +13734,7 @@ interface ResolvedChartExLabel {
 /** Effective CT_Series formatting index. The shared parser preserves authored
  * `formatIdx` and resolves omission to the original document-order index so a
  * hidden series cannot renumber the visible series' linked Chart Style. */
-function chartExSeriesFormatIndex(
+export function chartExSeriesFormatIndex(
   series: Pick<ChartSeries, 'chartexFormatIdx'> | null | undefined,
   fallbackIndex: number,
 ): number {
@@ -13751,7 +13744,7 @@ function chartExSeriesFormatIndex(
 /** Resolve CT_DataLabels + indexed CT_DataLabel/dataLabelHidden without
  * renderer-specific precedence. Defaults describe the semantic label layer of
  * the chart type; authored visibility always overrides those defaults. */
-function resolveChartExLabel(
+export function resolveChartExLabel(
   chart: ChartModel,
   series: ChartSeries | null | undefined,
   index: number,
@@ -13824,7 +13817,7 @@ function resolveChartExLabel(
   };
 }
 
-function chartExStyleColor(
+export function chartExStyleColor(
   _chart: ChartModel,
   style: ChartExStyle | null | undefined,
   kind: 'fill' | 'line',
@@ -13865,7 +13858,7 @@ function chartExSemanticFill(chart: ChartModel, index: number, count: number): s
     ?? CHARTEX_DEFAULT_PALETTE[index % CHARTEX_DEFAULT_PALETTE.length];
 }
 
-function chartExDataPointFill(
+export function chartExDataPointFill(
   chart: ChartModel,
   index: number,
   count: number,
@@ -13918,7 +13911,7 @@ function chartExStylePaintDecision(
   return chartStyleFillDecision(style, index);
 }
 
-function chartExMarkerPaint(
+export function chartExMarkerPaint(
   chart: ChartModel,
   index: number,
   count: number,
@@ -13934,7 +13927,7 @@ function chartExMarkerPaint(
   return { fillType: 'solid', color: chartExSemanticFill(chart, index, count) };
 }
 
-function chartExDataPointPaint(
+export function chartExDataPointPaint(
   chart: ChartModel,
   index: number,
   count: number,
@@ -13958,7 +13951,7 @@ function chartExDataPointPaint(
   return { fillType: 'solid', color: chartExSemanticFill(chart, index, count) };
 }
 
-function chartExFillStyle(
+export function chartExFillStyle(
   ctx: CanvasRenderingContext2D,
   paint: Fill,
   x: number,
@@ -13995,7 +13988,7 @@ type ChartExSeriesStyleCarrier = Pick<
  * Direct CT_Series formatting wins over the linked Chart Style role. `NoStyle`
  * is absence of decoration (and may expose a family semantic outline), while
  * an explicit noFill suppresses the outline. */
-function resolveChartExSeriesLineStyle(
+export function resolveChartExSeriesLineStyle(
   chart: ChartModel,
   linkedStyle: ChartExStyle | null | undefined,
   series: Partial<ChartExSeriesStyleCarrier> | null | undefined,
@@ -14050,7 +14043,7 @@ function resolveChartExSeriesLineStyle(
   return resolved(linkedStyle, fallbackColor);
 }
 
-function applyResolvedChartExLineStyle(
+export function applyResolvedChartExLineStyle(
   ctx: CanvasRenderingContext2D,
   line: ResolvedChartExLineStyle,
   ptToPx: number,
@@ -14070,7 +14063,7 @@ function applyResolvedChartExLineStyle(
  *  [MS-ODRAWXML] 2.24.3.77 makes `<cx:series><cx:spPr>` the series' own
  *  OfficeArt formatting, so an authored line (including `noFill`) overrides
  *  the default data-point recipe instead of being merged underneath it. */
-function applyChartExSeriesLineStyle(
+export function applyChartExSeriesLineStyle(
   ctx: CanvasRenderingContext2D,
   chart: ChartModel,
   style: ChartExStyle | null | undefined,
@@ -14093,7 +14086,7 @@ function applyChartExSeriesLineStyle(
 /** Build a synthetic legend series from the same resolved line contract used
  * by plot paint. `chartexStyle` carries dash/cap/join through the generic
  * legend pipeline without widening the public ChartSeries surface. */
-function chartExLegendSeries(
+export function chartExLegendSeries(
   chart: ChartModel,
   name: string,
   series: Partial<ChartExSeriesStyleCarrier> | null | undefined,
@@ -14142,7 +14135,7 @@ const MAX_CANVAS_LABEL_GRADIENT_STOPS = MAX_CANVAS_MARKER_GRADIENT_STOPS;
 const MAX_CANVAS_LABEL_PAINT_COMPONENTS = MAX_CANVAS_MARKER_PAINT_COMPONENTS;
 // The package parser already applies its XML-depth ceiling. Keep the same kind
 // of stack-safety boundary for caller-constructed public ChartModel objects.
-const MAX_CANVAS_HIERARCHY_DEPTH = 512;
+export const MAX_CANVAS_HIERARCHY_DEPTH = 512;
 
 const CLASSIC_THREE_D_FAMILIES = new Set([
   'pie',
@@ -14429,6 +14422,158 @@ export function classicMarkerPaintWorkCount(
   return total;
 }
 
+// ─── chartEx hierarchy preflight shared with the optional renderer ──────────
+
+/** A node in the shared hierarchy tree. `layoutWeight` is the overflow-safe
+ *  aggregate used for treemap areas and sunburst angles; `value` is the finite,
+ *  saturating aggregate exposed to data-label formatting. `a0`/`a1` are the
+ *  sunburst span (radians, canvas convention) once laid out; `depth` is its
+ *  ring index (0 = innermost / root). */
+export interface SunburstNode {
+  label: string;
+  /** Finite, overflow-safe relative weight used only for geometry. */
+  layoutWeight: number;
+  /** Sanitized display value. Sums saturate when JavaScript cannot represent them. */
+  value: number;
+  depth: number;
+  children: SunburstNode[];
+  /** Root-branch index (which top-level branch this node descends from) — used
+   *  to color the whole sub-tree in one accent. */
+  branchIndex: number;
+  /** ChartEx data-label index. Office numbers hierarchy nodes in pre-order,
+   * excluding the synthetic root, rather than by source leaf row. */
+  labelIndex: number;
+  a0: number;
+  a1: number;
+}
+
+/** Preflight flat hierarchy input before allocating the interned tree. Both
+ * rows and path nodes become paint primitives, so either can exhaust the same
+ * synchronous Canvas budget. */
+export function hierarchyInputTooLarge(rows: readonly { path: readonly string[] }[]): boolean {
+  if (rows.length > MAX_CANVAS_CHART_POINTS) return true;
+  let segments = 0;
+  for (const row of rows) {
+    if (row.path.length > MAX_CANVAS_HIERARCHY_DEPTH) return true;
+    if (segments > MAX_CANVAS_CHART_POINTS - row.path.length) return true;
+    segments += row.path.length;
+  }
+  return false;
+}
+
+/**
+ * Fold the flat `path`/`size` rows into a ring tree. Each row is a root→leaf
+ * label chain; walking the chain interns each label under its parent. The size
+ * is added at the DEEPEST node of the row (a node's `value` is the sum of the
+ * sizes beneath it). Children keep first-seen (source) order so the ring sweep
+ * order matches PowerPoint.
+ */
+export function buildSunburstTree(
+  rows: { path: string[]; size: number }[],
+  preserveTerminalDuplicates = false,
+): SunburstNode {
+  const root: SunburstNode = {
+    label: '', layoutWeight: 0, value: 0, depth: -1, children: [], branchIndex: -1, labelIndex: -1, a0: 0, a1: 0,
+  };
+  const maxRowValue = rows.reduce((max, row) => (
+    Number.isFinite(row.size) && row.size > max ? row.size : max
+  ), 0);
+  const safeSum = (left: number, right: number): number => (
+    left > Number.MAX_VALUE - right ? Number.MAX_VALUE : left + right
+  );
+  // Construction-only indexes keep sibling interning O(1) per path segment;
+  // the WeakMap dies with this function and does not pollute the paint model.
+  const childIndexes = new WeakMap<SunburstNode, Map<string, SunburstNode>>();
+  for (const row of rows) {
+    // ChartEx leaves without a finite positive size remain part of the authored
+    // hierarchy/order, but they do not contribute layout weight. Normalizing at
+    // the shared tree boundary keeps treemap parent areas and sunburst parent
+    // spans consistent; filtering only at either painter would leave ancestors
+    // with contaminated aggregate values.
+    const rowValue = Number.isFinite(row.size) && row.size > 0 ? row.size : 0;
+    // Dividing every positive row by the same maximum preserves all layout
+    // ratios while bounding every later ancestor sum by the source row count.
+    const rowWeight = maxRowValue > 0 ? rowValue / maxRowValue : 0;
+    let node = root;
+    for (let d = 0; d < row.path.length; d++) {
+      const label = row.path[d];
+      let index = childIndexes.get(node);
+      if (!index) {
+        index = new Map();
+        childIndexes.set(node, index);
+      }
+      const preserveNode = preserveTerminalDuplicates && d === row.path.length - 1;
+      let child = preserveNode ? undefined : index.get(label);
+      if (!child) {
+        child = {
+          label,
+          layoutWeight: 0,
+          value: 0,
+          depth: d,
+          children: [],
+          // Top-level nodes (d === 0) define the branch index; deeper nodes
+          // inherit their ancestor's.
+          branchIndex: d === 0 ? node.children.length : node.branchIndex,
+          labelIndex: -1,
+          a0: 0, a1: 0,
+        };
+        node.children.push(child);
+        if (!preserveNode) index.set(label, child);
+      }
+      child.layoutWeight += rowWeight;
+      child.value = safeSum(child.value, rowValue);
+      node = child;
+    }
+  }
+  root.layoutWeight = root.children.reduce((sum, child) => sum + child.layoutWeight, 0);
+  root.value = root.children.reduce((sum, child) => safeSum(sum, child.value), 0);
+  let nextLabelIndex = 0;
+  const pending = [...root.children].reverse();
+  while (pending.length > 0) {
+    const node = pending.pop() as SunburstNode;
+    node.labelIndex = nextLabelIndex++;
+    for (let index = node.children.length - 1; index >= 0; index--) {
+      pending.push(node.children[index]);
+    }
+  }
+  return root;
+}
+
+/** Assign angular spans top-down: each node partitions its `[a0, a1)` range
+ *  across its children proportional to their layout weight, in child (source)
+ *  order. */
+export function layoutSunburstAngles(root: SunburstNode): void {
+  const pending = [root];
+  while (pending.length > 0) {
+    const node = pending.pop() as SunburstNode;
+    let total = 0;
+    for (const child of node.children) total += child.layoutWeight;
+    if (total <= 0) continue;
+    let a = node.a0;
+    for (const child of node.children) {
+      const sweep = ((node.a1 - node.a0) * child.layoutWeight) / total;
+      child.a0 = a;
+      child.a1 = a + sweep;
+      a = child.a1;
+      pending.push(child);
+    }
+  }
+}
+
+/** Maximum ring depth (number of levels below the root). */
+export function sunburstMaxDepth(root: SunburstNode): number {
+  let maxDepth = root.depth;
+  const pending = [root];
+  while (pending.length > 0) {
+    const node = pending.pop() as SunburstNode;
+    maxDepth = Math.max(maxDepth, node.depth);
+    for (let index = node.children.length - 1; index >= 0; index--) {
+      pending.push(node.children[index]);
+    }
+  }
+  return maxDepth;
+}
+
 function chartLabelBoxPaintComponents(box: ChartLabelBox | null | undefined): number | null {
   let total = 0;
   for (const paint of [box?.fillPaint, box?.borderFill]) {
@@ -14628,7 +14773,7 @@ function classicThreeDWorkCount(
   return total;
 }
 
-function rejectOversizedCanvasChart(
+export function rejectOversizedCanvasChart(
   ctx: CanvasRenderingContext2D,
   rect: ChartRect,
   pointCount: number,
@@ -14642,2162 +14787,6 @@ function rejectOversizedCanvasChart(
   return true;
 }
 
-function renderHistogramChart(
-  ctx: CanvasRenderingContext2D,
-  chart: ChartModel,
-  rect: ChartRect,
-  ptToPx: number,
-  shapeRotationDeg = 0,
-): void {
-  const source = chart.series[0];
-  if (!source) return;
-  const plan = planHistogramBins(source.values, chart.chartexHistogramBinning ?? {});
-  if (plan.kind === 'tooManyInputPoints') {
-    rejectOversizedCanvasChart(ctx, rect, MAX_CANVAS_CHART_POINTS + 1);
-    return;
-  }
-  renderBarChart(ctx, {
-    ...chart,
-    chartType: 'clusteredBar',
-    categories: plan.categories,
-    series: [{ ...source, categories: undefined, values: plan.counts }],
-  }, rect, ptToPx, { gapPolicy: 'chartex' }, shapeRotationDeg);
-}
-
-function renderWaterfallChart(
-  ctx: CanvasRenderingContext2D,
-  chart: ChartModel,
-  r: ChartRect,
-  ptToPx: number,
-  shapeRotationDeg: number,
-): void {
-  const { x, y, w, h } = r;
-  const vals = chart.series[0]?.values ?? [];
-  const cats = chart.categories;
-  // ChartEx numeric and string dimensions are independent. Preserve the union
-  // of their point indexes: a missing category removes only its label, while a
-  // missing numeric point retains an empty category slot.
-  const n = Math.max(vals.length, cats.length);
-  if (n === 0) return;
-  if (rejectOversizedCanvasChart(ctx, r, n)) return;
-
-  const subSet = new Set(chart.subtotalIndices);
-  let cumulativeOverflow = false;
-  const safeAdd = (left: number, right: number): number => {
-    const sum = left + right;
-    if (Number.isFinite(sum)) return sum;
-    cumulativeOverflow = true;
-    return sum < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
-  };
-  let running = 0;
-  const bars: Array<{
-    start: number;
-    end: number;
-    isSub: boolean;
-    isPos: boolean;
-    hasValue: boolean;
-    paintSlot: boolean;
-  }> = [];
-  let rawMax = Number.NEGATIVE_INFINITY;
-  let rawMin = 0;
-  for (let i = 0; i < n; i++) {
-    const authoredValue = vals[i];
-    const hasValue = authoredValue != null && Number.isFinite(authoredValue);
-    // A missing dimension point still owns its authored category slot (the
-    // historical zero-height placeholder). A present but non-finite value is
-    // invalid numeric input and must not reach axis or Canvas geometry.
-    const paintSlot = authoredValue == null || hasValue;
-    const v = hasValue ? authoredValue as number : 0;
-    const isSub = subSet.has(i);
-    if (isSub) {
-      const bar = { start: 0, end: v, isSub: true, isPos: true, hasValue, paintSlot };
-      bars.push(bar);
-      if (paintSlot) {
-        rawMax = Math.max(rawMax, bar.start, bar.end);
-        rawMin = Math.min(rawMin, bar.start, bar.end);
-      }
-      if (hasValue) {
-        running = v;
-      }
-    } else {
-      const next = safeAdd(running, v);
-      const start = v >= 0 ? running : next;
-      const end   = v >= 0 ? next : running;
-      const bar = { start, end, isSub: false, isPos: v >= 0, hasValue, paintSlot };
-      bars.push(bar);
-      if (paintSlot) {
-        rawMax = Math.max(rawMax, bar.start, bar.end);
-        rawMin = Math.min(rawMin, bar.start, bar.end);
-      }
-      if (hasValue) {
-        running = next;
-      }
-    }
-  }
-
-  if (cumulativeOverflow) {
-    ctx.fillStyle = '#888';
-    ctx.font = '12px sans-serif';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText('(chart values out of range)', x + w / 2, y + h / 2);
-    return;
-  }
-
-  if (rawMax <= rawMin) return;
-
-  // Office-observed ChartEx compatibility: an all-increase bridge with no
-  // subtotal/total points keeps its value grid and rule but omits numeric tick
-  // labels. The axis XML is otherwise the same as a subtotal bridge, so keep
-  // this narrow family policy out of the shared linear-axis planner.
-  const suppressImplicitValueTickLabels = subSet.size === 0
-    && bars.every((bar, index) => !bar.hasValue || (vals[index] as number) >= 0);
-  const valueTickLabelsVisible = !chart.valAxisHidden
-    && chart.valAxisTickLabelPos !== 'none'
-    && !suppressImplicitValueTickLabels;
-
-  const titleBand = measuredCartesianTitleBand(ctx, chart, w, h, ptToPx);
-  const axBands = chartAxisTitleBands(chart, w, h, ptToPx);
-  const valFontPx = axisLabelPx(chart.valAxisFontSizeHpt, h, ptToPx);
-  const catFontPx = axisLabelPx(chart.catAxisFontSizeHpt, h, ptToPx);
-  const valFont = chartFontFamily(chart, chart.valAxisFontFace, 'minor');
-  const catFont = chartFontFamily(chart, chart.catAxisFontFace, 'minor');
-  const provisionalPlan = planValueAxis(chart, rawMin, rawMax, h / ptToPx);
-
-  ctx.save();
-  let valLabelBandW = 0;
-  if (valueTickLabelsVisible) {
-    ctx.font = chartFontCss(
-      valFontPx,
-      valFont,
-      chart.valAxisFontBold ?? false,
-      chart.valAxisFontItalic ?? false,
-    );
-    let maxWidth = 0;
-    for (const value of provisionalPlan.majorLines) {
-      maxWidth = Math.max(
-        maxWidth,
-        ctx.measureText(formatPrimaryValueAxisTick(chart, value, false)).width,
-      );
-    }
-    valLabelBandW = maxWidth + 8;
-  }
-
-  // Category labels participate in layout. Measure wrapped lines with the
-  // authored category-axis font and the available category interval rather
-  // than placing every word on its own line or reserving a height fraction.
-  const estimatedPlotW = Math.max(
-    1,
-    w - axBands.valBandW - valLabelBandW - w * 0.02,
-  );
-  const estimatedSlotW = estimatedPlotW / n;
-  ctx.font = chartFontCss(
-    catFontPx,
-    catFont,
-    chart.catAxisFontBold ?? false,
-    chart.catAxisFontItalic ?? false,
-  );
-  const wrappedCategories = cats.slice(0, n).map(category =>
-    wrapMeasuredText(
-      ctx,
-      formatCategoryLabel(category, chart.catAxisFormatCode, chart.date1904),
-      Math.max(1, estimatedSlotW - 8),
-    )
-  );
-  let maxCategoryLines = 0;
-  for (const lines of wrappedCategories) {
-    if (lines.some(Boolean)) maxCategoryLines = Math.max(maxCategoryLines, lines.length);
-  }
-  const categoryLabelBandH = chart.catAxisHidden || maxCategoryLines === 0
-    ? 0
-    : maxCategoryLines * (catFontPx + 2) + 4;
-
-  const series = chart.series[0];
-  const labelOverrides = indexPointOverrides(series?.dataLabelOverrides);
-  const localStyle = series?.chartexStyle;
-  const colorPos = `#${series?.color ?? chartExDataPointFill(chart, 0, 3, localStyle)}`;
-  const colorNeg = `#${chartExDataPointFill(chart, 1, 3, localStyle)}`;
-  const colorSub = `#${chartExDataPointFill(chart, 2, 3, localStyle)}`;
-  const paintPos = chartExDataPointPaint(chart, 0, 3, localStyle, series?.color);
-  const paintNeg = chartExDataPointPaint(chart, 1, 3, localStyle);
-  const paintSub = chartExDataPointPaint(chart, 2, 3, localStyle);
-  const legendChart: ChartModel = {
-    ...chart,
-    chartType: 'clusteredBar',
-    series: [
-      chartExLegendSeries(
-        chart, 'Increase', series, chart.chartexDataPointStyle, 0, 3, colorPos,
-      ),
-      chartExLegendSeries(
-        chart, 'Decrease', series, chart.chartexDataPointStyle, 1, 3, colorNeg,
-      ),
-      chartExLegendSeries(
-        chart, 'Total', series, chart.chartexDataPointStyle, 2, 3, colorSub,
-      ),
-    ],
-  };
-  const leg = measuredLegendReserve(ctx, legendChart, w, h, 0.22, ptToPx);
-  const { legRightW, legLeftW, legTopH, legBottomH } = chartLegendBands(
-    leg, chart.legendOverlay === true,
-  );
-  const pad = {
-    t: titleBand.bandH + legTopH + valFontPx / 2 + 2,
-    r: legRightW + w * 0.02,
-    b: legBottomH + axBands.catBandH + categoryLabelBandH,
-    l: legLeftW + axBands.valBandW + (chart.valAxisHidden
-      ? w * 0.02
-      // Office keeps the visible Waterfall value-axis rule roughly 3% inside
-      // the chart object even when this layout suppresses its implicit numeric
-      // labels. A measured label band may be wider, but never collapses that
-      // automatic edge gutter to zero.
-      : Math.max(w * 0.03, valLabelBandW)),
-  };
-  const frame = computeChartFrame(chart, x, y, w, h, ptToPx, {
-    titleBand,
-    legendSideReserveFrac: 0,
-    legendReserve: leg,
-    pad,
-    honorPlotAreaManualLayout: true,
-  });
-  drawChartTitleForLayout(ctx, chart, x, y, w, h, y + frame.title.topPad, frame.title.fontPx);
-  const { px0, py0, pw, ph } = frame.plotRect;
-  paintPlotAreaFrame(ctx, chart, px0, py0, pw, ph, ptToPx, shapeRotationDeg);
-  const plan = planValueAxis(chart, rawMin, rawMax, ph / ptToPx);
-  const yOf = (value: number): number => py0 + ph - plan.frac(value) * ph;
-
-  const valAxisLine = resolveAxisLine(
-    chart.valAxisLineColor,
-    chart.valAxisLineWidthEmu,
-    ptToPx,
-  );
-  const catAxisLine = resolveAxisLine(
-    chart.catAxisLineColor,
-    chart.catAxisLineWidthEmu,
-    ptToPx,
-  );
-  const valGridline = valGridStroke(chart, ptToPx);
-
-  // ECMA-376 / chartEx §axis@hidden: when the value axis is hidden, skip the
-  // value-axis gridlines, tick labels and the left segment of the L-frame.
-  // This is the canonical PowerPoint look for waterfall analyses where the
-  // value scale is implicit in the data labels on each bar.
-  if (!chart.valAxisHidden) {
-    ctx.font = chartFontCss(
-      valFontPx,
-      valFont,
-      chart.valAxisFontBold ?? false,
-      chart.valAxisFontItalic ?? false,
-    );
-    ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#595959';
-    ctx.textAlign = 'right';
-    ctx.textBaseline = 'middle';
-    const minorGridline = valMinorGridStroke(chart, ptToPx);
-    for (const value of plan.minorLines) {
-      strokeValueGridlineH(ctx, px0, pw, yOf(value), false, minorGridline);
-    }
-    for (const value of plan.majorLines) {
-      const gy = yOf(value);
-      if (drawValMajorGridlines(chart)) {
-        ctx.strokeStyle = valGridline.color;
-        ctx.lineWidth = valGridline.width;
-        const previousDash = valGridline.dash.length > 0 && ctx.getLineDash ? ctx.getLineDash() : [];
-        if (valGridline.dash.length > 0) ctx.setLineDash(valGridline.dash);
-        ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
-        if (valGridline.dash.length > 0) ctx.setLineDash(previousDash);
-      }
-      // Locale-independent §18.8.30 formatting (honoring `<c:valAx><c:numFmt>`),
-      // matching the other renderers — `toLocaleString()` grouped by the
-      // viewer's OS locale, so the same chart read differently across machines.
-      if (valueTickLabelsVisible) {
-        ctx.fillText(
-          formatPrimaryValueAxisTick(chart, value, false),
-          px0 - 4,
-          gy,
-        );
-      }
-      drawAxisTick(
-        ctx,
-        chart.valAxisMajorTickMark,
-        'val',
-        px0,
-        gy,
-        valAxisLine.color,
-        valAxisLine.width,
-        false,
-        chart.valAxisLineHidden,
-        'major',
-        ptToPx,
-        chart.valAxisLineDash,
-      );
-    }
-    for (const value of plan.minorTicks) {
-      drawAxisTick(
-        ctx, chart.valAxisMinorTickMark, 'val', px0, yOf(value),
-        valAxisLine.color, valAxisLine.width, false, chart.valAxisLineHidden, 'minor', ptToPx,
-        chart.valAxisLineDash,
-      );
-    }
-  }
-
-  // L-frame: vertical (value-axis) rule + horizontal (category-axis) baseline.
-  // Each segment is independently gated on its axis's `<c:delete>` and on
-  // Office's rule/tick suppression for `<c:spPr><a:ln><a:noFill>`.
-  const drawValLine = !chart.valAxisHidden && !chart.valAxisLineHidden;
-  const drawCatLine = !chart.catAxisHidden && !chart.catAxisLineHidden;
-  if (drawValLine) {
-    strokeAxisSegment(
-      ctx, px0, py0, px0, py0 + ph,
-      valAxisLine.color, valAxisLine.width, chart.valAxisLineDash,
-    );
-  }
-  if (drawCatLine) {
-    strokeAxisSegment(
-      ctx, px0, py0 + ph, px0 + pw, py0 + ph,
-      catAxisLine.color, catAxisLine.width, chart.catAxisLineDash,
-    );
-  }
-
-  // ECMA-376 / chartEx §17.18.34 ST_GapAmount: gapWidth is the gap between
-  // adjacent categories expressed as a percentage of the bar width
-  // (legacy `<c:gapWidth val>`) or as a fraction (chartEx
-  // `<cx:catScaling gapWidth>`, normalised to the same percent form by the
-  // parser). The bar then occupies `catGap / (1 + gapWidth/100)`. Omitted
-  // ChartEx spacing uses the shared ordinal-layout policy; an authored
-  // value remains authoritative after parser normalization.
-  const gapW = pw / n;
-  const gapWidthPct = resolveCategoryGapWidthPercent(chart.barGapWidth, 'chartex');
-  const barW = gapW / (1 + gapWidthPct / 100);
-
-  bars.forEach((bar, i) => {
-    const bx = px0 + gapW * i + (gapW - barW) / 2;
-    const yTop = Math.min(yOf(bar.start), yOf(bar.end));
-    const yBot = Math.max(yOf(bar.start), yOf(bar.end));
-    const bh = Math.max(1, yBot - yTop);
-
-    const paint = bar.isSub ? paintSub : bar.isPos ? paintPos : paintNeg;
-    const fallback = bar.isSub ? colorSub : bar.isPos ? colorPos : colorNeg;
-    if (bar.paintSlot && paint) {
-      ctx.fillStyle = chartExFillStyle(ctx, paint, bx, yTop, barW, bh, fallback, shapeRotationDeg);
-      ctx.fillRect(bx, yTop, barW, bh);
-    }
-    const accentIndex = bar.isSub ? 2 : bar.isPos ? 0 : 1;
-    const lineColor = chartExStyleColor(chart, chart.chartexDataPointStyle, 'line', accentIndex, 3);
-    if (bar.paintSlot && applyChartExSeriesLineStyle(
-      ctx,
-      chart,
-      chart.chartexDataPointStyle,
-      series,
-      accentIndex,
-      3,
-      lineColor ? `#${lineColor}` : fallback,
-      ptToPx,
-    )) {
-      ctx.strokeRect(bx, yTop, barW, bh);
-    }
-
-    if (bar.paintSlot && bars[i + 1]?.paintSlot
-      && i < n - 1 && chart.chartexConnectorLines !== false) {
-      const nextBx = px0 + gapW * (i + 1) + (gapW - barW) / 2;
-      const connY = bar.isPos ? yTop : yBot;
-      ctx.save();
-      const connectorLine = resolveChartExSeriesLineStyle(
-        chart,
-        chart.chartexSeriesLineStyle,
-        series,
-        accentIndex,
-        3,
-        '#000000',
-        { linkedNoStyleFallback: true },
-      );
-      if (applyResolvedChartExLineStyle(ctx, connectorLine, ptToPx)) {
-        // A linked `seriesLine` NoStyle delegates to Waterfall's semantic
-        // connector rather than suppressing it. Office vector output from
-        // both an unstyled bridge and an explicitly styled bridge establishes
-        // the family default as a 0.75pt rule; authored width/color above stay
-        // authoritative.
-        // Apply the semantic 0.75pt width only when the common direct>linked
-        // resolver found no authored width. Looking only at the linked role
-        // here used to overwrite a direct CT_Series width.
-        if (connectorLine.widthEmu == null) ctx.lineWidth = 0.75 * ptToPx;
-        ctx.beginPath();
-        ctx.moveTo(bx + barW, connY);
-        ctx.lineTo(nextBx, connY);
-        ctx.stroke();
-      }
-      ctx.restore();
-    }
-
-    const rawVal = bar.hasValue ? vals[i] as number : 0;
-    const label = resolveChartExLabel(
-      chart, series, i, cats[i] ?? '', rawVal,
-      { visible: chart.showDataLabels, showVal: true, showCatName: false },
-      labelOverrides,
-      !bar.hasValue,
-    );
-    if (label) {
-      const perPointColor = series?.dataLabelColors?.[i] ?? label.fontColor ?? null;
-      const labelColor = perPointColor
-        ? `#${perPointColor}`
-        : chart.dataLabelFontColor
-          ? `#${chart.dataLabelFontColor}`
-          : '#595959';
-      const dataLabelFontPx = chartTextFontSizePx(label.fontSizeHpt, ptToPx)
-        ?? axisLabelPx(chart.dataLabelFontSizeHpt, h, ptToPx);
-      const dataLabelBold = label.fontBold ?? chart.dataLabelFontBold ?? false;
-      const dataLabelFont = chartFontFamily(
-        chart, label.fontFace ?? chart.dataLabelFontFace, 'minor',
-      );
-      ctx.font = `${label.textStyle.fontItalic ? 'italic ' : ''}${dataLabelBold ? 'bold ' : ''}${dataLabelFontPx}px ${dataLabelFont}`;
-      drawBoundedDataLabelText(
-        ctx,
-        label.text,
-        {
-          kind: 'bar',
-          rect: { x: bx, y: yTop, w: barW, h: bh },
-          orientation: 'vertical',
-          negative: rawVal < 0,
-          position: label.position ?? 'outEnd',
-        },
-        { x: px0, y: py0, w: pw, h: ph },
-        dataLabelFontPx,
-        labelColor,
-        label.manualLayout,
-        { x, y, w, h },
-        richDataLabelOptions(
-          chart, label.richRuns, ptToPx, dataLabelFont, dataLabelBold, label.textStyle,
-        ),
-        undefined,
-        label.textStyle,
-        ptToPx,
-        label.labelBox,
-        shapeRotationDeg,
-      );
-    }
-  });
-
-  ctx.textAlign = 'center';
-  ctx.textBaseline = 'top';
-  ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#595959';
-  // Category (transaction) labels below the bars → category-axis face.
-  ctx.font = chartFontCss(
-    catFontPx,
-    catFont,
-    chart.catAxisFontBold ?? false,
-    chart.catAxisFontItalic ?? false,
-  );
-  const labelY = py0 + ph + 4;
-  for (let i = 0; i < n && !chart.catAxisHidden; i++) {
-    const ccx = px0 + gapW * i + gapW / 2;
-    const lines = wrappedCategories[i] ?? [];
-    lines.forEach((line, lineIndex) =>
-      line && ctx.fillText(line, ccx, labelY + lineIndex * (catFontPx + 2))
-    );
-  }
-
-  drawAxisTitles(
-    ctx,
-    chart,
-    x,
-    y,
-    w,
-    h,
-    px0,
-    py0,
-    pw,
-    ph,
-    legLeftW,
-    legBottomH,
-    axBands.catFontPx,
-    axBands.valFontPx,
-  );
-
-  drawLegendForLayout(
-    ctx, legendChart, leg, x, y, w, h, px0, py0, pw, ph,
-    titleBand.bandH + 2, ptToPx, [paintPos, paintNeg, paintSub], shapeRotationDeg,
-  );
-
-  ctx.restore();
-}
-
-/** ChartEx `funnel`: one centered horizontal bar per ordinal category. */
-function renderFunnelChart(
-  ctx: CanvasRenderingContext2D,
-  chart: ChartModel,
-  r: ChartRect,
-  ptToPx: number,
-  shapeRotationDeg: number,
-): void {
-  const values = chart.series[0]?.values ?? [];
-  // ChartEx dimensions carry independent indexed points. Preserve category-only
-  // slots as empty bars and numeric-only slots as unlabeled bars.
-  const n = Math.max(values.length, chart.categories.length);
-  if (n === 0) return;
-  if (rejectOversizedCanvasChart(ctx, r, n)) return;
-  let max = 0;
-  for (let index = 0; index < n; index++) {
-    max = Math.max(max, values[index] ?? 0);
-  }
-  if (!(max > 0)) return;
-  const { x, y, w, h } = r;
-  const titleBand = measuredCartesianTitleBand(ctx, chart, w, h, ptToPx);
-  const series = chart.series[0];
-  const labelOverrides = indexPointOverrides(series?.dataLabelOverrides);
-  const color = `#${series?.color ?? chartExDataPointFill(chart, 0, 1, series?.chartexStyle)}`;
-  const paint = chartExDataPointPaint(chart, 0, 1, series?.chartexStyle, series?.color);
-  const legendChart: ChartModel = {
-    ...chart,
-    series: [chartExLegendSeries(
-      chart,
-      series?.name ?? '',
-      series,
-      chart.chartexDataPointStyle,
-      0,
-      1,
-      color,
-    )],
-  };
-  const leg = measuredLegendReserve(ctx, legendChart, w, h, 0.22, ptToPx);
-  const { legRightW, legLeftW, legTopH, legBottomH } = chartLegendBands(
-    leg, chart.legendOverlay === true,
-  );
-  const catFontPx = axisLabelPx(chart.catAxisFontSizeHpt, h, ptToPx);
-  ctx.save();
-  ctx.font = chartFontCss(
-    catFontPx,
-    chartFontFamily(chart, chart.catAxisFontFace, 'minor'),
-    chart.catAxisFontBold ?? false,
-    chart.catAxisFontItalic ?? false,
-  );
-  let labelW = 0;
-  if (!chart.catAxisHidden) {
-    for (let index = 0; index < Math.min(n, chart.categories.length); index++) {
-      labelW = Math.max(labelW, ctx.measureText(chart.categories[index]).width);
-    }
-    if (chart.categories.length > 0) labelW += 10;
-  }
-  const pad = {
-    t: titleBand.bandH + legTopH + 2,
-    r: legRightW + w * 0.02,
-    b: legBottomH + h * 0.02,
-    l: legLeftW + labelW + w * 0.02,
-  };
-  const frame = computeChartFrame(chart, x, y, w, h, ptToPx, {
-    titleBand,
-    legendSideReserveFrac: 0.22,
-    legendReserve: leg,
-    pad,
-    honorPlotAreaManualLayout: true,
-  });
-  drawChartTitleForLayout(ctx, chart, x, y, w, h, y + frame.title.topPad, frame.title.fontPx);
-  const { px0, py0, pw, ph } = frame.plotRect;
-  paintPlotAreaFrame(ctx, chart, px0, py0, pw, ph, ptToPx, shapeRotationDeg);
-  const rowH = ph / n;
-  const gapWidthPct = resolveCategoryGapWidthPercent(chart.barGapWidth, 'chartex');
-  const barH = rowH / (1 + gapWidthPct / 100);
-  for (let index = 0; index < n; index++) {
-    const value = Math.max(0, values[index] ?? 0);
-    const barW = pw * value / max;
-    const bx = px0 + (pw - barW) / 2;
-    const by = py0 + rowH * index + (rowH - barH) / 2;
-    if (paint) {
-      ctx.fillStyle = chartExFillStyle(ctx, paint, bx, by, barW, barH, color, shapeRotationDeg);
-      ctx.fillRect(bx, by, barW, barH);
-    }
-    if (applyChartExSeriesLineStyle(
-      ctx, chart, chart.chartexDataPointStyle, series, 0, 1, color, ptToPx,
-    )) {
-      ctx.strokeRect(bx, by, barW, barH);
-    }
-    const category = chart.categories[index];
-    if (!chart.catAxisHidden && category != null) {
-      ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#595959';
-      ctx.textAlign = 'right';
-      ctx.textBaseline = 'middle';
-      ctx.fillText(category, px0 - 6, by + barH / 2);
-    }
-    const label = resolveChartExLabel(
-      chart, series, index, category ?? '', value,
-      { visible: false, showVal: false, showCatName: false },
-      labelOverrides,
-    );
-    if (label) {
-      const fontPx = chartTextFontSizePx(label.fontSizeHpt, ptToPx)
-        ?? axisLabelPx(chart.dataLabelFontSizeHpt, h, ptToPx);
-      const labelFont = chartFontFamily(
-        chart, label.fontFace ?? chart.dataLabelFontFace, 'minor',
-      );
-      ctx.font = `${label.textStyle.fontItalic ? 'italic ' : ''}${label.fontBold ? 'bold ' : ''}${fontPx}px ${labelFont}`;
-      drawBoundedDataLabelText(
-        ctx,
-        label.text,
-        {
-          kind: 'bar',
-          rect: { x: bx, y: by, w: barW, h: barH },
-          orientation: 'horizontal',
-          negative: false,
-          position: label.position ?? 'ctr',
-        },
-        { x: px0, y: py0, w: pw, h: ph },
-        fontPx,
-        label.fontColor ? `#${label.fontColor}` : '#ffffff',
-        label.manualLayout,
-        { x, y, w, h },
-        richDataLabelOptions(
-          chart, label.richRuns, ptToPx, labelFont, label.fontBold ?? false, label.textStyle,
-        ),
-        undefined,
-        label.textStyle,
-        ptToPx,
-        label.labelBox,
-        shapeRotationDeg,
-      );
-    }
-  }
-  if (!chart.catAxisHidden && !chart.catAxisLineHidden) {
-    const line = resolveAxisLine(chart.catAxisLineColor, chart.catAxisLineWidthEmu, ptToPx);
-    ctx.strokeStyle = line.color;
-    ctx.lineWidth = line.width;
-    ctx.beginPath(); ctx.moveTo(px0, py0); ctx.lineTo(px0, py0 + ph); ctx.stroke();
-  }
-  drawLegendForLayout(ctx, legendChart, leg, x, y, w, h, px0, py0, pw, ph, titleBand.bandH + 2, ptToPx, [paint], shapeRotationDeg);
-  ctx.restore();
-}
-
-/** ChartEx Pareto line: cumulative share of the source values. */
-function renderParetoLineChart(
-  ctx: CanvasRenderingContext2D,
-  chart: ChartModel,
-  r: ChartRect,
-  ptToPx: number,
-  shapeRotationDeg = 0,
-): void {
-  const source = chart.series[0];
-  if (!source) return;
-  const pointCount = Math.max(
-    chart.categories.length,
-    source.categories?.length ?? 0,
-    source.values.length,
-  );
-  if (rejectOversizedCanvasChart(ctx, r, pointCount)) return;
-  const layout = planParetoLayout(source, chart.categories);
-  if (layout.points.length === 0) return;
-  const styleIndex = chartExSeriesFormatIndex(source, 0);
-  const paretoLine = resolveChartExSeriesLineStyle(
-    chart,
-    chart.chartexDataPointLineStyle,
-    source,
-    styleIndex,
-    1,
-    chartColor(0, source),
-    { linkedNoStyleFallback: true },
-  );
-  renderLineChart(ctx, {
-    ...chart,
-    chartType: 'line',
-    categories: layout.categories,
-    series: [{
-      ...layout.series,
-      showMarker: false,
-      lineHidden: !paretoLine.visible,
-      lineColor: paretoLine.color.replace(/^#/, ''),
-      lineWidthEmu: paretoLine.widthEmu,
-      chartexStyle: {
-        lineDash: paretoLine.dash,
-        lineCap: paretoLine.cap,
-        lineJoin: paretoLine.join,
-      },
-    }],
-    // Pareto's ordinal category labels are suppressed, but its authored
-    // category-axis rule remains visible. Keep those two concerns separate.
-    catAxisHidden: false,
-    catAxisTickLabelPos: 'none',
-    showLegend: false,
-    // A standalone paretoLine carries cumulative fractions as its actual
-    // values, but Office lays them out on an ordinary decimal axis. Two vector
-    // references at different chart sizes use the same omitted-axis contract:
-    // 0..1.2 in 0.2 steps. Keep authored bounds/major units authoritative and
-    // avoid making this semantic cumulative scale depend on pixel height.
-    // The 0..100% secondary-axis convention belongs to owner-backed Pareto.
-    valMin: chart.valMin ?? 0,
-    valMax: chart.valMax ?? 1.2,
-    valAxisMajorUnit: chart.valAxisMajorUnit ?? 0.2,
-  }, r, ptToPx, shapeRotationDeg);
-}
-
-/** Owner-backed ChartEx Pareto: sorted frequency columns plus cumulative line. */
-function renderParetoChart(
-  ctx: CanvasRenderingContext2D,
-  chart: ChartModel,
-  r: ChartRect,
-  ptToPx: number,
-  shapeRotationDeg = 0,
-): void {
-  const owner = chart.series[0];
-  if (!owner) return;
-  const pointCount = Math.max(
-    chart.categories.length,
-    owner.categories?.length ?? 0,
-    owner.values.length,
-  );
-  if (rejectOversizedCanvasChart(ctx, r, pointCount)) return;
-  const layout = planParetoLayout(owner, chart.categories);
-  if (layout.points.length === 0) return;
-
-  const authoredLine = chart.series.find(series => series.seriesType === 'line');
-  const lineStyleIndex = authoredLine?.chartexFormatIdx
-    ?? owner.chartexFormatIdx
-    ?? 0;
-  const cumulativeLine: ChartSeries = {
-    ...(authoredLine ?? layout.series),
-    name: authoredLine?.name || 'Cumulative %',
-    values: layout.series.values,
-    categories: layout.categories,
-    color: authoredLine?.color
-      ?? chartExStyleColor(
-        chart, chart.chartexDataPointLineStyle, 'line', lineStyleIndex, 1,
-      )
-      ?? owner.lineColor
-      ?? owner.color,
-    seriesType: 'line',
-    useSecondaryAxis: true,
-    showMarker: false,
-  };
-  const secondaryAxis: SecondaryValueAxis = {
-    min: chart.secondaryValAxis?.min ?? 0,
-    max: chart.secondaryValAxis?.max ?? 1,
-    title: chart.secondaryValAxis?.title ?? null,
-    hidden: chart.secondaryValAxis?.hidden ?? false,
-    formatCode: chart.secondaryValAxis?.formatCode ?? '0%',
-    fontColor: chart.secondaryValAxis?.fontColor ?? null,
-    fontSizeHpt: chart.secondaryValAxis?.fontSizeHpt ?? null,
-    fontFace: chart.secondaryValAxis?.fontFace ?? null,
-    lineColor: chart.secondaryValAxis?.lineColor ?? null,
-    lineWidthEmu: chart.secondaryValAxis?.lineWidthEmu ?? null,
-    lineHidden: chart.secondaryValAxis?.lineHidden ?? false,
-    majorTickMark: chart.secondaryValAxis?.majorTickMark ?? 'out',
-    minorTickMark: chart.secondaryValAxis?.minorTickMark ?? null,
-    majorUnit: chart.secondaryValAxis?.majorUnit ?? null,
-    minorUnit: chart.secondaryValAxis?.minorUnit ?? null,
-    titleFontSizeHpt: chart.secondaryValAxis?.titleFontSizeHpt ?? null,
-    titleFontBold: chart.secondaryValAxis?.titleFontBold ?? null,
-    titleFontColor: chart.secondaryValAxis?.titleFontColor ?? null,
-    titleFontFace: chart.secondaryValAxis?.titleFontFace ?? null,
-  };
-
-  renderBarChart(ctx, {
-    ...chart,
-    chartType: 'clusteredBar',
-    categories: layout.categories,
-    series: [
-      { ...layout.orderedSeries, seriesType: null, useSecondaryAxis: false },
-      cumulativeLine,
-    ],
-    secondaryValAxis: secondaryAxis,
-  }, r, ptToPx, {
-    gapPolicy: 'chartex',
-    semanticLineNoStyleFallback: true,
-  }, shapeRotationDeg);
-}
-
-// ─── chartEx: box-and-whisker (CH15, MS 2014 chartex ext) ────────────────────
-
-/** Compact omitted-axis policy observed in three independent Office vector
- * box/whisker outputs (small, ordinary, and wide numeric ranges). OOXML does
- * not define the automatic major unit. Office consistently chooses the nearest
- * 1/2/5 ladder to about seven raw-range intervals for this family, then applies the same
- * 5% padding / zero-threshold rules as the shared planner. */
-function automaticBoxWhiskerAxis(
-  dataMin: number,
-  dataMax: number,
-  explicitMin?: number | null,
-  explicitMax?: number | null,
-): { min: number; max: number; majorUnit: number } | null {
-  // Authored bounds constrain the automatic-unit calculation as well as the
-  // final axis. ChartEx may write min/max while omitting majorUnit; Office then
-  // chooses the box/whisker family unit from that authored span (for example
-  // 1..3 becomes 0.2), rather than deriving a coarse unit from the raw data and
-  // merely clipping it to the authored bounds afterwards.
-  const boundedMin = explicitMin ?? dataMin;
-  const boundedMax = explicitMax ?? dataMax;
-  const span = boundedMax - boundedMin;
-  if (!(span > 0) || !Number.isFinite(span)) return null;
-  const majorUnit = niceStep(span, 7);
-  if (!(majorUnit > 0) || !Number.isFinite(majorUnit)) return null;
-  let paddedMin = dataMin - span * 0.05;
-  let paddedMax = dataMax + span * 0.05;
-  if (dataMin >= 0 && (dataMin === 0 || dataMax > 1.2 * dataMin)) paddedMin = 0;
-  if (dataMax <= 0 && (dataMax === 0 || Math.abs(dataMin) > 1.2 * Math.abs(dataMax))) {
-    paddedMax = 0;
-  }
-  const min = explicitMin ?? Math.floor(paddedMin / majorUnit) * majorUnit;
-  const max = explicitMax ?? Math.ceil(paddedMax / majorUnit) * majorUnit;
-  if (![min, max].every(Number.isFinite) || !(max > min)) return null;
-  return { min, max, majorUnit };
-}
-
-/**
- * Render a chartEx box-and-whisker chart (MS 2014 chartex extension — there is
- * no ECMA-376 section; the structure is Microsoft's `<cx:chartSpace>` with a
- * `<cx:series layoutId="boxWhisker">` per column, each referencing raw sample
- * points via `<cx:dataId>`). The parser (`parse_chartex_boxwhisker`) groups the
- * raw points by category and threads the `<cx:layoutPr>` visibility/statistics
- * flags into `chart.chartexBox`; this renderer derives the five-number summary
- * per (category, series) and draws, for each box: the IQR rectangle (Q1..Q3),
- * the median line, whiskers to the non-outlier min/max (with end caps), the
- * mean `×` marker, and outlier dots. Colors come from the theme accent palette
- * (`chart.chartexAccents`, cycled by series) — the blue/orange/gray Office
- * default — falling back to `CHART_PALETTE` when a resolver supplies no palette.
- */
-function renderBoxWhiskerChart(
-  ctx: CanvasRenderingContext2D,
-  chart: ChartModel,
-  r: ChartRect,
-  ptToPx: number,
-  shapeRotationDeg: number,
-): void {
-  // ChartEx's linked dataPointMarkerLayout is a generic marker recipe. Office
-  // does not use its size for box-and-whisker observations: vector output uses
-  // 3pt observation/outlier dots and a 6pt mean `x`, independent of box width.
-  // The linked recipe still supplies the marker symbol and paint.
-  const observationMarkerSizePt = 3;
-  const meanMarkerRadiusPx = 3 * ptToPx;
-  const box = chart.chartexBox;
-  if (!box || box.categories.length === 0 || box.series.length === 0) return;
-  const { x, y, w, h } = r;
-  const pointCount = boxWhiskerPointCount(
-    box.series.map(series => series.valuesByCategory),
-    MAX_CANVAS_CHART_POINTS,
-  );
-  if (rejectOversizedCanvasChart(ctx, r, pointCount)) return;
-
-  const rejectOutOfRange = (): void => {
-    ctx.fillStyle = '#888';
-    ctx.font = '12px sans-serif';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText('(chart values out of range)', x + w / 2, y + h / 2);
-  };
-  const usableScale = (scale: { min: number; max: number; step: number }): boolean => {
-    const span = scale.max - scale.min;
-    const intervalCount = span / scale.step;
-    return Number.isFinite(scale.min)
-      && Number.isFinite(scale.max)
-      && Number.isFinite(scale.step)
-      && Number.isFinite(span)
-      && Number.isFinite(intervalCount)
-      && scale.max > scale.min
-      && scale.step > 0
-      // Axis paint is synchronous. Refuse an authored tiny major unit before
-      // entering a loop whose finite bounds could still imply vast work.
-      && intervalCount <= 1000
-      // A finite positive step may still be too small to advance a large
-      // floating-point bound, which would wedge the major-gridline loop.
-      && scale.min + scale.step > scale.min;
-  };
-
-  // Resolve the value range before laying out the plot. The tick labels are a
-  // real layout input: reserve their measured width instead of a percentage of
-  // the chart width, which made the axis drift right on wide ChartEx charts.
-  let dataMin = Infinity;
-  let dataMax = -Infinity;
-  for (const s of box.series) {
-    for (const group of s.valuesByCategory) {
-      for (const v of group) {
-        if (!Number.isFinite(v)) continue;
-        if (v < dataMin) dataMin = v;
-        if (v > dataMax) dataMax = v;
-      }
-    }
-  }
-  if (!isFinite(dataMin) || !isFinite(dataMax)) return;
-  if (!Number.isFinite(dataMax - dataMin)) {
-    rejectOutOfRange();
-    return;
-  }
-
-  // Authored bounds/unit always win. An omitted unit still receives the compact
-  // family default inferred from the vector corpus, using authored min/max as
-  // the effective span when present.
-  const automaticBoxAxis = chart.valAxisMajorUnit == null
-    ? automaticBoxWhiskerAxis(dataMin, dataMax, chart.valMin, chart.valMax)
-    : null;
-  const boxAxisChart: ChartModel = automaticBoxAxis
-    ? {
-        ...chart,
-        valMin: automaticBoxAxis.min,
-        valMax: automaticBoxAxis.max,
-        valAxisMajorUnit: automaticBoxAxis.majorUnit,
-      }
-    : chart;
-
-  const font = chartFontFamily(chart, chart.valAxisFontFace, 'minor');
-  const valFontPx = axisLabelPx(chart.valAxisFontSizeHpt, h, ptToPx);
-  // Keep the existing font-relative layout reserve so the plot geometry stays
-  // stable; only the painted ChartEx label uses the observed axis-relative
-  // offset below.
-  const valTickLabelLayoutGap = valueTickLabelGapPx(valFontPx);
-  const valTickLabelPaintGap = chartExValueTickLabelOffsetPx(ptToPx);
-  const provisionalScale = planLinearValueAxis({
-    dataMin,
-    dataMax,
-    explicitMin: boxAxisChart.valMin,
-    explicitMax: boxAxisChart.valMax,
-    axisLenPt: h / ptToPx,
-    majorUnit: boxAxisChart.valAxisMajorUnit,
-  });
-  if (!usableScale({
-    min: provisionalScale.min,
-    max: provisionalScale.max,
-    step: provisionalScale.majorUnit,
-  })) {
-    rejectOutOfRange();
-    return;
-  }
-  let valLabelBandW = 0;
-  if (!chart.valAxisHidden) {
-    const previousFont = ctx.font;
-    ctx.font = chartFontCss(
-      valFontPx,
-      font,
-      chart.valAxisFontBold ?? false,
-      chart.valAxisFontItalic ?? false,
-    );
-    let maxLabelW = 0;
-    for (const value of provisionalScale.majorTicks) {
-      const label = formatPrimaryValueAxisTick(chart, value, false);
-      maxLabelW = Math.max(maxLabelW, ctx.measureText(label).width);
-    }
-    ctx.font = previousFont;
-    valLabelBandW = maxLabelW + valTickLabelLayoutGap + AXIS_OUTER_TEXT_MARGIN_PT * ptToPx;
-  }
-
-  // Shared title band + cartesian plot rect. Reserve category/value-axis bands
-  // and, when present in the chart model, the authored legend band.
-  const titleBand = measuredCartesianTitleBand(ctx, chart, w, h, ptToPx);
-  const catAxFontPx0 = axisLabelPx(chart.catAxisFontSizeHpt, h, ptToPx);
-  const valAxFontPx0 = axisLabelPx(chart.valAxisFontSizeHpt, h, ptToPx);
-  const axBands = chartAxisTitleBands(chart, w, h, ptToPx);
-  const nSer = box.series.length;
-  const boxStyleIndices = box.series.map((series, index) =>
-    chartExSeriesFormatIndex(series, index)
-  );
-  const boxLegendSeries = box.series.map((series, index) => {
-    const styleIndex = boxStyleIndices[index];
-    const fill = series.color ?? chartExDataPointFill(
-      chart, styleIndex, nSer, series.chartexStyle,
-    );
-    return chartExLegendSeries(
-      chart,
-      series.name,
-      series,
-      chart.chartexDataPointStyle,
-      styleIndex,
-      nSer,
-      fill,
-      true,
-    );
-  });
-  const legendChart: ChartModel = {
-    ...chart,
-    series: boxLegendSeries,
-  };
-  const leg = measuredLegendReserve(ctx, legendChart, w, h, 0.22, ptToPx);
-  const { legRightW, legLeftW, legTopH, legBottomH } = chartLegendBands(
-    leg, chart.legendOverlay === true,
-  );
-  const pad = {
-    t: titleBand.bandH + legTopH + valAxFontPx0 / 2 + 2,
-    r: legRightW + w * 0.02,
-    b: legBottomH + axBands.catBandH + (chart.catAxisHidden ? h * 0.02 : catAxisLabelBandH(catAxFontPx0)),
-    l: legLeftW + axBands.valBandW + (chart.valAxisHidden ? w * 0.02 : valLabelBandW),
-  };
-  const frame = computeChartFrame(chart, x, y, w, h, ptToPx, {
-    titleBand,
-    legendSideReserveFrac: 0.22,
-    legendReserve: leg,
-    pad,
-    honorPlotAreaManualLayout: true,
-  });
-  const { px0, py0, pw, ph } = frame.plotRect;
-  paintPlotAreaFrame(ctx, chart, px0, py0, pw, ph, ptToPx, shapeRotationDeg);
-
-  const cats = box.categories;
-  const nCat = cats.length;
-
-  // Excel's automatic value axis uses nice-rounded bounds and steps.
-  const boxAxisPlan = planValueAxis(boxAxisChart, dataMin, dataMax, ph / ptToPx);
-  if (!usableScale(boxAxisPlan)) {
-    rejectOutOfRange();
-    return;
-  }
-  drawChartTitleForLayout(ctx, chart, x, y, w, h, y + frame.title.topPad, frame.title.fontPx);
-  const { min: axisMin, max: axisMax } = boxAxisPlan;
-  const span = axisMax - axisMin;
-  const yOf = (v: number): number => py0 + ph * (1 - (v - axisMin) / span);
-
-  const valAxisLine = resolveAxisLine(chart.valAxisLineColor, chart.valAxisLineWidthEmu, ptToPx);
-  const valGridline = valGridStroke(chart, ptToPx);
-
-  // Value-axis gridlines + labels (unless the value axis is hidden).
-  ctx.save();
-  if (!chart.valAxisHidden) {
-    ctx.font = chartFontCss(
-      valFontPx,
-      font,
-      chart.valAxisFontBold ?? false,
-      chart.valAxisFontItalic ?? false,
-    );
-    ctx.textAlign = 'right';
-    ctx.textBaseline = 'middle';
-    if (chart.valAxisMinorGridlines) {
-      const minorGridline = valMinorGridStroke(chart, ptToPx);
-      for (const value of boxAxisPlan.minorLines) {
-        strokeValueGridlineH(ctx, px0, pw, yOf(value), false, minorGridline);
-      }
-    }
-    for (const v of boxAxisPlan.majorLines) {
-      const gy = yOf(v);
-      if (chart.valAxisMajorGridlines !== false) {
-        ctx.strokeStyle = valGridline.color;
-        ctx.lineWidth = valGridline.width;
-        const previousDash = valGridline.dash.length > 0 && ctx.getLineDash ? ctx.getLineDash() : [];
-        if (valGridline.dash.length > 0) ctx.setLineDash(valGridline.dash);
-        ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
-        if (valGridline.dash.length > 0) ctx.setLineDash(previousDash);
-      }
-      ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#595959';
-      ctx.fillText(
-        formatPrimaryValueAxisTick(chart, v, false),
-        px0 - valTickLabelPaintGap,
-        gy,
-      );
-      drawAxisTick(
-        ctx,
-        chart.valAxisMajorTickMark,
-        'val',
-        px0,
-        gy,
-        valAxisLine.color,
-        valAxisLine.width,
-        false,
-        chart.valAxisLineHidden,
-        'major',
-        ptToPx,
-        chart.valAxisLineDash,
-      );
-    }
-    for (const value of boxAxisPlan.minorTicks) {
-      drawAxisTick(
-        ctx, chart.valAxisMinorTickMark, 'val', px0, yOf(value),
-        valAxisLine.color, valAxisLine.width, false, chart.valAxisLineHidden, 'minor', ptToPx,
-        chart.valAxisLineDash,
-      );
-    }
-    if (!chart.valAxisLineHidden) {
-      strokeAxisSegment(
-        ctx, px0, py0, px0, py0 + ph,
-        valAxisLine.color, valAxisLine.width, chart.valAxisLineDash,
-      );
-    }
-  }
-  // Category-axis baseline. ChartEx carries the axis rule in the local
-  // `<cx:axis><cx:spPr><a:ln>`; do not replace an authored dark/weighted rule
-  // with the old fixed 1px grey fallback.
-  const catAxisLine = resolveAxisLine(
-    chart.catAxisLineColor,
-    chart.catAxisLineWidthEmu,
-    ptToPx,
-  );
-  if (!chart.catAxisHidden && !chart.catAxisLineHidden) {
-    strokeAxisSegment(
-      ctx, px0, py0 + ph, px0 + pw, py0 + ph,
-      catAxisLine.color, catAxisLine.width, chart.catAxisLineDash,
-    );
-  }
-
-  // ChartEx divides the plot into full category intervals, so the first and
-  // last category centres are half an interval from the plot edges. Every
-  // series owns one stable equal slot in each category group, including
-  // categories where a peer has no retained observations.
-  // Formula-only sources are different: Excel stores every visible box as a
-  // separate series in one category group. In that form `gapWidth` surrounds
-  // the whole group and must not be reapplied between the diagonal entries.
-  const slotW = pw / nCat;
-  const gapWidthPct = resolveCategoryGapWidthPercent(chart.barGapWidth, 'chartex');
-  const paletteOf = (si: number): string => {
-    const fill = box.series[si].color
-      ?? chartExDataPointFill(
-        chart, boxStyleIndices[si], nSer, box.series[si].chartexStyle,
-      );
-    return `#${fill}`;
-  };
-  const paintOf = (si: number): Fill | null => chartExDataPointPaint(
-    chart,
-    boxStyleIndices[si],
-    nSer,
-    box.series[si].chartexStyle,
-    box.series[si].color,
-  );
-  const statsBySeries = box.series.map(series => series.valuesByCategory.map(values => (
-    computeBoxWhiskerStats(values, series.quartileMethod)
-  )));
-  const boxGeometry = (ci: number, si: number): { bx: number; boxW: number; cx: number } => {
-    const geometry = boxWhiskerGeometry(
-      px0,
-      pw,
-      box.oneBoxPerSeries ? 1 : nCat,
-      nSer,
-      box.oneBoxPerSeries ? 0 : ci,
-      si,
-      gapWidthPct,
-    );
-    if (!geometry) return { bx: px0, boxW: 0, cx: px0 };
-    return { bx: geometry.boxX, boxW: geometry.boxWidth, cx: geometry.centerX };
-  };
-
-  // `<cx:visibility meanLine>` connects the category means for one series.
-  // It is a data-point-line role, so it shares the whisker/median style.
-  for (let si = 0; si < nSer; si++) {
-    const series = box.series[si];
-    if (!series.meanLine) continue;
-    const lineStyle = chart.chartexDataPointLineStyle ?? chart.chartexDataPointStyle;
-    const fallback = series.lineColor ? `#${series.lineColor}` : paletteOf(si);
-    ctx.save();
-    const styleLineVisible = applyChartExSeriesLineStyle(
-      ctx, chart, lineStyle, series, boxStyleIndices[si], nSer, fallback, ptToPx,
-    );
-    if (styleLineVisible || series.lineColor != null) {
-      if (series.lineColor) ctx.strokeStyle = fallback;
-      if (series.lineWidthEmu) ctx.lineWidth = axisLineWidthPx(series.lineWidthEmu, ptToPx);
-      let open = false;
-      ctx.beginPath();
-      for (let ci = 0; ci < nCat; ci++) {
-        const stats = statsBySeries[si][ci];
-        if (!stats) {
-          open = false;
-          continue;
-        }
-        const { cx } = boxGeometry(ci, si);
-        const meanY = yOf(stats.mean);
-        if (open) ctx.lineTo(cx, meanY);
-        else ctx.moveTo(cx, meanY);
-        open = true;
-      }
-      ctx.stroke();
-    }
-    ctx.restore();
-  }
-  const catFontPx = axisLabelPx(chart.catAxisFontSizeHpt, h, ptToPx);
-  const catTickLabelGap = categoryTickLabelGapPx(catFontPx);
-  for (let ci = 0; ci < nCat; ci++) {
-    const categoryCenterX = px0 + slotW * (ci + 0.5);
-    if (!chart.catAxisHidden) {
-      drawAxisTick(
-        ctx,
-        chart.catAxisMajorTickMark,
-        'cat',
-        py0 + ph,
-        categoryCenterX,
-        catAxisLine.color,
-        catAxisLine.width,
-        false,
-        chart.catAxisLineHidden,
-        'major',
-        ptToPx,
-        chart.catAxisLineDash,
-      );
-    }
-    for (let si = 0; si < nSer; si++) {
-      const s = box.series[si];
-      const stats = statsBySeries[si][ci];
-      if (!stats) continue;
-      const { bx, boxW, cx } = boxGeometry(ci, si);
-      const fill = paletteOf(si);
-      const fillPaint = paintOf(si);
-      const pointStyle = chart.chartexDataPointStyle;
-      const lineStyle = chart.chartexDataPointLineStyle ?? pointStyle;
-      const markerStyle = chart.chartexDataPointMarkerStyle ?? pointStyle;
-      const styleIndex = boxStyleIndices[si];
-      const styleLine = chartExStyleColor(chart, pointStyle, 'line', styleIndex, nSer);
-      const edge = s.lineColor ? `#${s.lineColor}` : styleLine ? `#${styleLine}` : fill;
-      const edgeWidth = s.lineWidthEmu
-        ? axisLineWidthPx(s.lineWidthEmu, ptToPx)
-        : pointStyle?.lineWidthEmu != null
-          ? axisLineWidthPx(pointStyle.lineWidthEmu, ptToPx)
-          : 1;
-      const lineEdge = chartExStyleColor(chart, lineStyle, 'line', styleIndex, nSer);
-      const markerFill = chartExStyleColor(chart, markerStyle, 'fill', styleIndex, nSer);
-      const markerFillPaint = chartExMarkerPaint(
-        chart, styleIndex, nSer, s.chartexStyle, s.color, markerStyle,
-      );
-      const markerEdge = chartExStyleColor(chart, markerStyle, 'line', styleIndex, nSer);
-      const applySeriesLine = (style: ChartExStyle | null | undefined, fallback: string): boolean => {
-        const local = s.chartexStyle;
-        const hasLocalLine = local?.lineHidden != null
-          || local?.lineColors?.some(Boolean)
-          || local?.lineWidthEmu != null
-          || local?.lineDash != null
-          || local?.lineCap != null
-          || local?.lineJoin != null;
-        const visible = applyChartExSeriesLineStyle(
-          ctx, chart, style, s, styleIndex, nSer, fallback, ptToPx,
-        );
-        // Chart Style `NoStyle` means that this role supplies no decorative
-        // override. Box/whisker's semantic outline still exists. This is
-        // distinct from an authored `<a:noFill>`, which remains suppressed.
-        const semanticNoStyleFallback = style?.lineNoStyle === true
-          && !hasLocalLine && s.lineColor == null && s.lineWidthEmu == null;
-        if (!visible && semanticNoStyleFallback) {
-          ctx.strokeStyle = fallback;
-          ctx.lineWidth = 1;
-          ctx.setLineDash([]);
-        }
-        if (s.lineColor) ctx.strokeStyle = edge;
-        if (s.lineWidthEmu) ctx.lineWidth = edgeWidth;
-        return visible || semanticNoStyleFallback || s.lineColor != null;
-      };
-      const yQ1 = yOf(stats.q1);
-      const yQ3 = yOf(stats.q3);
-      const boxTop = Math.min(yQ1, yQ3);
-      const boxH = Math.max(1, Math.abs(yQ1 - yQ3));
-
-      // Whiskers: vertical line from box edges to whisker ends, with end caps.
-      const capW = boxW * 0.4;
-      if (applySeriesLine(lineStyle, lineEdge ?? edge)) {
-        ctx.beginPath();
-        ctx.moveTo(cx, yOf(stats.whiskerHi)); ctx.lineTo(cx, yQ3);
-        ctx.moveTo(cx, yQ1); ctx.lineTo(cx, yOf(stats.whiskerLo));
-        ctx.moveTo(cx - capW / 2, yOf(stats.whiskerHi)); ctx.lineTo(cx + capW / 2, yOf(stats.whiskerHi));
-        ctx.moveTo(cx - capW / 2, yOf(stats.whiskerLo)); ctx.lineTo(cx + capW / 2, yOf(stats.whiskerLo));
-        ctx.stroke();
-      }
-
-      // IQR box: solid accent fill + a thin accent×0.8 edge.
-      if (fillPaint) {
-        ctx.fillStyle = chartExFillStyle(
-          ctx,
-          fillPaint,
-          bx,
-          boxTop,
-          boxW,
-          boxH,
-          fill,
-          shapeRotationDeg,
-        );
-        ctx.fillRect(bx, boxTop, boxW, boxH);
-      }
-      if (applySeriesLine(pointStyle, edge)) {
-        ctx.strokeRect(
-          bx + edgeWidth / 2,
-          boxTop + edgeWidth / 2,
-          boxW - edgeWidth,
-          boxH - edgeWidth,
-        );
-      }
-
-      // Median line across the box.
-      const yMed = yOf(stats.median);
-      if (applySeriesLine(lineStyle, lineEdge ?? edge)) {
-        ctx.beginPath(); ctx.moveTo(bx, yMed); ctx.lineTo(bx + boxW, yMed); ctx.stroke();
-      }
-
-      // Interior sample points. Excel overlays the raw non-outlier values on
-      // the box/whiskers when cx:visibility@nonoutliers is enabled.
-      if (s.showNonoutliers) {
-        const pointSymbol = chart.chartStyleMarkerSymbol ?? chart.chartexMarkerSymbol ?? 'circle';
-        for (const point of stats.inner) {
-          if (pointSymbol === 'none') continue;
-          const markerLineVisible = applySeriesLine(markerStyle, markerEdge ?? edge);
-          const pointY = yOf(point);
-          drawMarker(
-            ctx,
-            cx,
-            pointY,
-            pointSymbol,
-            observationMarkerSizePt,
-            markerFillPaint ? (markerFill ? `#${markerFill}` : fill) : 'transparent',
-            markerLineVisible ? (markerEdge ? `#${markerEdge}` : edge) : null,
-            ptToPx,
-            ctx.lineWidth,
-            markerFillPaint,
-            shapeRotationDeg,
-          );
-        }
-      }
-
-      // Mean `×` marker (same accent×0.8 as the rest of the outline).
-      if (s.meanMarker) {
-        const mY = yOf(stats.mean);
-        const mR = meanMarkerRadiusPx;
-        if (applySeriesLine(markerStyle, markerEdge ?? edge)) {
-          ctx.beginPath();
-          ctx.moveTo(cx - mR, mY - mR); ctx.lineTo(cx + mR, mY + mR);
-          ctx.moveTo(cx + mR, mY - mR); ctx.lineTo(cx - mR, mY + mR);
-          ctx.stroke();
-        }
-      }
-
-      // Outlier dots.
-      if (s.showOutliers) {
-        const pointSymbol = chart.chartStyleMarkerSymbol ?? chart.chartexMarkerSymbol ?? 'circle';
-        for (const o of stats.outliers) {
-          if (pointSymbol === 'none') continue;
-          const markerLineVisible = applySeriesLine(markerStyle, markerEdge ?? edge);
-          const outlierY = yOf(o);
-          drawMarker(
-            ctx,
-            cx,
-            outlierY,
-            pointSymbol,
-            observationMarkerSizePt,
-            markerFillPaint ? (markerFill ? `#${markerFill}` : fill) : 'transparent',
-            markerLineVisible ? (markerEdge ? `#${markerEdge}` : edge) : null,
-            ptToPx,
-            ctx.lineWidth,
-            markerFillPaint,
-            shapeRotationDeg,
-          );
-        }
-      }
-    }
-
-    // Category label (centered under the slot), word-wrapped like the other
-    // cartesian renderers.
-    if (!chart.catAxisHidden) {
-      ctx.font = chartFontCss(
-        catFontPx,
-        chartFontFamily(chart, chart.catAxisFontFace, 'minor'),
-        chart.catAxisFontBold ?? false,
-        chart.catAxisFontItalic ?? false,
-      );
-      ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#595959';
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'top';
-      const label = cats[ci];
-      ctx.fillText(label, categoryCenterX, py0 + ph + catTickLabelGap);
-    }
-  }
-  ctx.restore();
-
-  drawAxisTitles(
-    ctx,
-    chart,
-    x,
-    y,
-    w,
-    h,
-    px0,
-    py0,
-    pw,
-    ph,
-    legLeftW,
-    legBottomH,
-    axBands.catFontPx,
-    axBands.valFontPx,
-  );
-
-  drawLegendForLayout(
-    ctx,
-    legendChart,
-    leg,
-    x,
-    y,
-    w,
-    h,
-    px0,
-    py0,
-    pw,
-    ph,
-    titleBand.bandH + 2,
-    ptToPx,
-    box.series.map((_, index) => paintOf(index)),
-    shapeRotationDeg,
-  );
-}
-
-// ─── chartEx: sunburst (CH15, MS 2014 chartex ext) ───────────────────────────
-
-/** A node in the shared hierarchy tree. `layoutWeight` is the overflow-safe
- *  aggregate used for treemap areas and sunburst angles; `value` is the finite,
- *  saturating aggregate exposed to data-label formatting. `a0`/`a1` are the
- *  sunburst span (radians, canvas convention) once laid out; `depth` is its
- *  ring index (0 = innermost / root). */
-interface SunburstNode {
-  label: string;
-  /** Finite, overflow-safe relative weight used only for geometry. */
-  layoutWeight: number;
-  /** Sanitized display value. Sums saturate when JavaScript cannot represent them. */
-  value: number;
-  depth: number;
-  children: SunburstNode[];
-  /** Root-branch index (which top-level branch this node descends from) — used
-   *  to color the whole sub-tree in one accent. */
-  branchIndex: number;
-  /** ChartEx data-label index. Office numbers hierarchy nodes in pre-order,
-   * excluding the synthetic root, rather than by source leaf row. */
-  labelIndex: number;
-  a0: number;
-  a1: number;
-}
-
-/** Preflight flat hierarchy input before allocating the interned tree. Both
- * rows and path nodes become paint primitives, so either can exhaust the same
- * synchronous Canvas budget. */
-function hierarchyInputTooLarge(rows: readonly { path: readonly string[] }[]): boolean {
-  if (rows.length > MAX_CANVAS_CHART_POINTS) return true;
-  let segments = 0;
-  for (const row of rows) {
-    if (row.path.length > MAX_CANVAS_HIERARCHY_DEPTH) return true;
-    if (segments > MAX_CANVAS_CHART_POINTS - row.path.length) return true;
-    segments += row.path.length;
-  }
-  return false;
-}
-
-/**
- * Fold the flat `path`/`size` rows into a ring tree. Each row is a root→leaf
- * label chain; walking the chain interns each label under its parent. The size
- * is added at the DEEPEST node of the row (a node's `value` is the sum of the
- * sizes beneath it). Children keep first-seen (source) order so the ring sweep
- * order matches PowerPoint.
- */
-function buildSunburstTree(
-  rows: { path: string[]; size: number }[],
-  preserveTerminalDuplicates = false,
-): SunburstNode {
-  const root: SunburstNode = {
-    label: '', layoutWeight: 0, value: 0, depth: -1, children: [], branchIndex: -1, labelIndex: -1, a0: 0, a1: 0,
-  };
-  const maxRowValue = rows.reduce((max, row) => (
-    Number.isFinite(row.size) && row.size > max ? row.size : max
-  ), 0);
-  const safeSum = (left: number, right: number): number => (
-    left > Number.MAX_VALUE - right ? Number.MAX_VALUE : left + right
-  );
-  // Construction-only indexes keep sibling interning O(1) per path segment;
-  // the WeakMap dies with this function and does not pollute the paint model.
-  const childIndexes = new WeakMap<SunburstNode, Map<string, SunburstNode>>();
-  for (const row of rows) {
-    // ChartEx leaves without a finite positive size remain part of the authored
-    // hierarchy/order, but they do not contribute layout weight. Normalizing at
-    // the shared tree boundary keeps treemap parent areas and sunburst parent
-    // spans consistent; filtering only at either painter would leave ancestors
-    // with contaminated aggregate values.
-    const rowValue = Number.isFinite(row.size) && row.size > 0 ? row.size : 0;
-    // Dividing every positive row by the same maximum preserves all layout
-    // ratios while bounding every later ancestor sum by the source row count.
-    const rowWeight = maxRowValue > 0 ? rowValue / maxRowValue : 0;
-    let node = root;
-    for (let d = 0; d < row.path.length; d++) {
-      const label = row.path[d];
-      let index = childIndexes.get(node);
-      if (!index) {
-        index = new Map();
-        childIndexes.set(node, index);
-      }
-      const preserveNode = preserveTerminalDuplicates && d === row.path.length - 1;
-      let child = preserveNode ? undefined : index.get(label);
-      if (!child) {
-        child = {
-          label,
-          layoutWeight: 0,
-          value: 0,
-          depth: d,
-          children: [],
-          // Top-level nodes (d === 0) define the branch index; deeper nodes
-          // inherit their ancestor's.
-          branchIndex: d === 0 ? node.children.length : node.branchIndex,
-          labelIndex: -1,
-          a0: 0, a1: 0,
-        };
-        node.children.push(child);
-        if (!preserveNode) index.set(label, child);
-      }
-      child.layoutWeight += rowWeight;
-      child.value = safeSum(child.value, rowValue);
-      node = child;
-    }
-  }
-  root.layoutWeight = root.children.reduce((sum, child) => sum + child.layoutWeight, 0);
-  root.value = root.children.reduce((sum, child) => safeSum(sum, child.value), 0);
-  let nextLabelIndex = 0;
-  const pending = [...root.children].reverse();
-  while (pending.length > 0) {
-    const node = pending.pop() as SunburstNode;
-    node.labelIndex = nextLabelIndex++;
-    for (let index = node.children.length - 1; index >= 0; index--) {
-      pending.push(node.children[index]);
-    }
-  }
-  return root;
-}
-
-/** Assign angular spans top-down: each node partitions its `[a0, a1)` range
- *  across its children proportional to their layout weight, in child (source)
- *  order. */
-function layoutSunburstAngles(root: SunburstNode): void {
-  const pending = [root];
-  while (pending.length > 0) {
-    const node = pending.pop() as SunburstNode;
-    let total = 0;
-    for (const child of node.children) total += child.layoutWeight;
-    if (total <= 0) continue;
-    let a = node.a0;
-    for (const child of node.children) {
-      const sweep = ((node.a1 - node.a0) * child.layoutWeight) / total;
-      child.a0 = a;
-      child.a1 = a + sweep;
-      a = child.a1;
-      pending.push(child);
-    }
-  }
-}
-
-/** Maximum ring depth (number of levels below the root). */
-function sunburstMaxDepth(root: SunburstNode): number {
-  let maxDepth = root.depth;
-  const pending = [root];
-  while (pending.length > 0) {
-    const node = pending.pop() as SunburstNode;
-    maxDepth = Math.max(maxDepth, node.depth);
-    for (let index = node.children.length - 1; index >= 0; index--) {
-      pending.push(node.children[index]);
-    }
-  }
-  return maxDepth;
-}
-
-/**
- * Render a chartEx sunburst (MS 2014 chartex extension — no ECMA-376 section;
- * the structure is a `<cx:series layoutId="sunburst">` over a `<cx:strDim
- * type="cat">` of several `<cx:lvl>` and one `<cx:numDim type="size">`). The
- * parser (`parse_chartex_sunburst`) yields the flat root→leaf `path`/`size`
- * rows in `chart.chartexSunburst`; this renderer folds them into a ring tree,
- * lays out each node's angular span proportional to its aggregated size, and
- * draws concentric rings (inner = root/Branch, outward = Stem, Leaf) from 12
- * o'clock clockwise. Every node in a branch shares that branch's theme accent
- * (`chart.chartexAccents`, cycled by top-level index — the blue/orange/gray
- * Office default). Labels are drawn white and centered in each segment, rotated
- * to follow the arc and elided when the wedge is too small.
- */
-function renderSunburstChart(
-  ctx: CanvasRenderingContext2D,
-  chart: ChartModel,
-  r: ChartRect,
-  ptToPx: number,
-  shapeRotationDeg: number,
-): void {
-  const sb = chart.chartexSunburst;
-  if (!sb || sb.rows.length === 0) return;
-  const { x, y, w, h } = r;
-  if (hierarchyInputTooLarge(sb.rows)) {
-    rejectOversizedCanvasChart(ctx, r, MAX_CANVAS_CHART_POINTS + 1);
-    return;
-  }
-  const root = buildSunburstTree(sb.rows);
-  if (root.layoutWeight <= 0 || root.children.length === 0) return;
-  const series = chart.series[0];
-  const labelOverrides = indexPointOverrides(series?.dataLabelOverrides);
-  const legendPaints = root.children.map((_, index) =>
-    chartExDataPointPaint(chart, index, root.children.length, series?.chartexStyle, series?.color)
-  );
-  const legendChart: ChartModel = {
-    ...chart,
-    chartType: 'clusteredBar',
-    series: root.children.map(node => {
-      const fill = chartExDataPointFill(
-        chart, node.branchIndex, root.children.length, series?.chartexStyle,
-      );
-      return chartExLegendSeries(
-        chart,
-        node.label,
-        series,
-        chart.chartexDataPointStyle,
-        node.branchIndex,
-        root.children.length,
-        fill,
-        false,
-        false,
-      );
-    }),
-  };
-  // Reuse the radial frame so an authored top legend reserves space above the
-  // rings instead of being painted over the circle.
-  const leg = measuredLegendReserve(ctx, legendChart, w, h, 0.22, ptToPx);
-  const frame = computeChartFrame(chart, x, y, w, h, ptToPx, {
-    titleTopPadFrac: 0.035,
-    titleBottomPadFrac: 0.035,
-    legendSideReserveFrac: 0,
-    legendReserve: leg,
-    radialGapFrac: 0.02,
-    honorPlotAreaManualLayout: true,
-  });
-  drawChartTitleForLayout(ctx, chart, x, y, w, h, y + frame.title.topPad, frame.title.fontPx);
-  const { px0, py0, pw, ph } = frame.plotRect;
-  paintPlotAreaFrame(ctx, chart, px0, py0, pw, ph, ptToPx, shapeRotationDeg);
-  const cx = px0 + pw / 2;
-  const cy = py0 + ph / 2;
-  const outerR = Math.min(pw, ph) * 0.46;
-
-  // Full circle from 12 o'clock (−90°), clockwise (canvas angles grow CW), each
-  // parent partitioning its range across its children in source (first-seen)
-  // order. This is the natural spec-consistent reading of the `<cx:lvl>` point
-  // order. The extension does not specify an alternative automatic reordering,
-  // so the renderer does not infer one from labels or values.
-  root.a0 = -Math.PI / 2;
-  root.a1 = -Math.PI / 2 + Math.PI * 2;
-  layoutSunburstAngles(root);
-
-  const maxDepth = sunburstMaxDepth(root); // 0-based deepest ring index
-  const ringCount = maxDepth + 1;
-  // Small center hole (Office draws a modest hole, ~18% of the outer radius);
-  // the remaining band is split evenly across the rings.
-  const innerR = outerR * 0.18;
-  const ringBand = (outerR - innerR) / ringCount;
-
-  const branchColor = (bi: number): string => {
-    const hex = chartExDataPointFill(chart, bi, root.children.length, series?.chartexStyle);
-    return `#${hex}`;
-  };
-  const branchPaint = (bi: number): Fill | null => chartExDataPointPaint(
-    chart,
-    bi,
-    root.children.length,
-    series?.chartexStyle,
-    series?.color,
-  );
-
-  const labelDef = series?.seriesDataLabels;
-  const labelFont = chartFontFamily(
-    chart, labelDef?.fontFace ?? chart.dataLabelFontFace, 'minor',
-  );
-  const labelPx = chartTextFontSizePx(labelDef?.fontSizeHpt, ptToPx)
-    ?? Math.max(7, Math.min(13, outerR * 0.075));
-  const labelColor = labelDef?.fontColor ? `#${labelDef.fontColor}` : '#ffffff';
-
-  // Draw every non-root node as a ring segment, deepest-last so borders read on
-  // top. Iterate breadth-first by depth.
-  const byDepth: SunburstNode[][] = Array.from({ length: ringCount }, () => []);
-  const pending = [root];
-  while (pending.length > 0) {
-    const node = pending.pop() as SunburstNode;
-    if (node.depth >= 0) byDepth[node.depth].push(node);
-    for (let index = node.children.length - 1; index >= 0; index--) {
-      pending.push(node.children[index]);
-    }
-  }
-
-  ctx.save();
-  for (let d = 0; d < ringCount; d++) {
-    const rInner = innerR + d * ringBand;
-    const rOuter = rInner + ringBand;
-    for (const node of byDepth[d]) {
-      const sweep = node.a1 - node.a0;
-      if (sweep <= 1e-4) continue;
-      ctx.beginPath();
-      ctx.arc(cx, cy, rOuter, node.a0, node.a1);
-      ctx.arc(cx, cy, rInner, node.a1, node.a0, true);
-      ctx.closePath();
-      const nodePaint = branchPaint(node.branchIndex);
-      if (nodePaint) {
-        ctx.fillStyle = chartExFillStyle(
-          ctx,
-          nodePaint,
-          cx - rOuter,
-          cy - rOuter,
-          rOuter * 2,
-          rOuter * 2,
-          branchColor(node.branchIndex),
-          shapeRotationDeg,
-        );
-        ctx.fill();
-      }
-      if (applyChartExSeriesLineStyle(
-        ctx,
-        chart,
-        chart.chartexDataPointStyle,
-        chart.series[0],
-        node.branchIndex,
-        root.children.length,
-        '#ffffff',
-        ptToPx,
-      )) {
-        ctx.stroke();
-      }
-
-      const label = resolveChartExLabel(
-        chart, series, node.labelIndex, node.label, node.value,
-        { visible: false, showVal: false, showCatName: false },
-        labelOverrides,
-      );
-      if (!label) continue;
-      const labelText = label.text;
-      const nodeLabelPx = chartTextFontSizePx(label.fontSizeHpt, ptToPx) ?? labelPx;
-      const nodeLabelColor = label.fontColor ? `#${label.fontColor}` : labelColor;
-      const nodeLabelFont = label.fontFace
-        ? chartFontFamily(chart, label.fontFace, 'minor')
-        : labelFont;
-
-      // Excel's sunburst category labels run along the radius (not around the
-      // circumference). Center the text at the wedge mid-radius and wrap it to
-      // the available ring-band width; additional lines stack tangentially.
-      const midA = (node.a0 + node.a1) / 2;
-      const midR = (rInner + rOuter) / 2;
-      // Radial room the label may occupy (the ring band, minus padding).
-      const radialRoom = ringBand - 4;
-      // Tangential arc length at the mid radius.
-      const arcLen = sweep * midR;
-      // Skip labels that plainly cannot fit even one glyph.
-      if (!label.manualLayout &&
-          radialRoom < nodeLabelPx * 0.9 && arcLen < nodeLabelPx * 0.9) continue;
-
-      const labelX = cx + Math.cos(midA) * midR;
-      const labelY = cy + Math.sin(midA) * midR;
-      ctx.font = `${label.textStyle.fontItalic ? 'italic ' : ''}${label.fontBold ? 'bold ' : ''}${nodeLabelPx}px ${nodeLabelFont}`;
-      if (label.manualLayout) {
-        drawBoundedDataLabelText(
-          ctx,
-          labelText,
-          { kind: 'point', x: labelX, y: labelY, position: label.position ?? 'ctr' },
-          { x: px0, y: py0, w: pw, h: ph },
-          nodeLabelPx,
-          nodeLabelColor,
-          label.manualLayout,
-          { x, y, w, h },
-          richDataLabelOptions(
-            chart, label.richRuns, ptToPx, nodeLabelFont, label.fontBold ?? false, label.textStyle,
-          ),
-          undefined,
-          label.textStyle,
-          ptToPx,
-          label.labelBox,
-          shapeRotationDeg,
-        );
-        continue;
-      }
-
-      ctx.save();
-      ctx.translate(labelX, labelY);
-      // Orient the text along the radius and flip on the left half so it stays
-      // readable instead of becoming upside-down.
-      let rot = midA;
-      const deg = ((rot * 180) / Math.PI) % 360;
-      if (deg > 90 || deg < -90) rot += Math.PI;
-      ctx.rotate(rot);
-      ctx.font = `${label.textStyle.fontItalic ? 'italic ' : ''}${label.fontBold ? 'bold ' : ''}${nodeLabelPx}px ${nodeLabelFont}`;
-      drawBoundedDataLabelText(
-        ctx,
-        labelText,
-        { kind: 'point', x: 0, y: 0, position: label.position ?? 'ctr' },
-        { x: -radialRoom / 2, y: -arcLen / 2, w: radialRoom, h: arcLen },
-        nodeLabelPx,
-        nodeLabelColor,
-        undefined,
-        { x: -radialRoom / 2, y: -arcLen / 2, w: radialRoom, h: arcLen },
-        richDataLabelOptions(
-          chart, label.richRuns, ptToPx, nodeLabelFont, label.fontBold ?? false, label.textStyle,
-        ),
-        undefined,
-        label.textStyle,
-        ptToPx,
-        label.labelBox,
-        shapeRotationDeg,
-      );
-      ctx.restore();
-    }
-  }
-  ctx.restore();
-
-  drawLegendForLayout(
-    ctx,
-    legendChart,
-    leg,
-    x,
-    y,
-    w,
-    h,
-    px0,
-    py0,
-    pw,
-    ph,
-    frame.title.bandH + 2,
-    ptToPx,
-    legendPaints,
-    shapeRotationDeg,
-  );
-}
-
-// ─── chartEx: treemap (CH15, MS 2014 chartex ext) ───────────────────────────
-
-interface TreemapRect { x: number; y: number; w: number; h: number }
-interface TreemapTile { node: SunburstNode; rect: TreemapRect }
-
-/** Standard squarified-treemap layout. Areas are exactly proportional to node
- * layout weights; descending stable order keeps the aspect ratios useful
- * without any document-specific tuning. */
-function layoutTreemapTiles(nodes: SunburstNode[], rect: TreemapRect): TreemapTile[] {
-  const positive = nodes
-    .map((node, index) => ({
-      node,
-      index,
-      value: node.layoutWeight,
-    }))
-    .filter(entry => entry.value > 0)
-    .sort((a, b) => b.value - a.value || a.index - b.index);
-  const total = positive.reduce((sum, entry) => sum + entry.value, 0);
-  if (total <= 0 || rect.w <= 0 || rect.h <= 0) return [];
-
-  const scale = (rect.w * rect.h) / total;
-  const entries = positive.map(entry => ({ ...entry, area: entry.value * scale }));
-  const tiles: TreemapTile[] = [];
-  let remaining = { ...rect };
-  let row: typeof entries = [];
-  let rowArea = 0;
-  let rowMin = Number.POSITIVE_INFINITY;
-  let rowMax = 0;
-
-  const worstRatio = (sum: number, min: number, max: number, shortSide: number): number => {
-    if (sum <= 0 || min <= 0 || shortSide <= 0) return Number.POSITIVE_INFINITY;
-    const side2 = shortSide * shortSide;
-    return Math.max((side2 * max) / (sum * sum), (sum * sum) / (side2 * min));
-  };
-
-  const placeRow = (items: typeof entries, area: number): void => {
-    if (items.length === 0) return;
-    if (remaining.w >= remaining.h) {
-      const colW = remaining.h > 0 ? area / remaining.h : 0;
-      let y = remaining.y;
-      for (let i = 0; i < items.length; i++) {
-        const h = i === items.length - 1 ? remaining.y + remaining.h - y : items[i].area / colW;
-        tiles.push({ node: items[i].node, rect: { x: remaining.x, y, w: colW, h } });
-        y += h;
-      }
-      remaining = { x: remaining.x + colW, y: remaining.y, w: Math.max(0, remaining.w - colW), h: remaining.h };
-    } else {
-      const rowH = remaining.w > 0 ? area / remaining.w : 0;
-      let x = remaining.x;
-      for (let i = 0; i < items.length; i++) {
-        const w = i === items.length - 1 ? remaining.x + remaining.w - x : items[i].area / rowH;
-        tiles.push({ node: items[i].node, rect: { x, y: remaining.y, w, h: rowH } });
-        x += w;
-      }
-      remaining = { x: remaining.x, y: remaining.y + rowH, w: remaining.w, h: Math.max(0, remaining.h - rowH) };
-    }
-  };
-
-  let index = 0;
-  while (index < entries.length) {
-    const next = entries[index];
-    const side = Math.min(remaining.w, remaining.h);
-    const nextArea = rowArea + next.area;
-    const nextMin = Math.min(rowMin, next.area);
-    const nextMax = Math.max(rowMax, next.area);
-    if (row.length === 0
-      || worstRatio(nextArea, nextMin, nextMax, side)
-        <= worstRatio(rowArea, rowMin, rowMax, side)) {
-      row.push(next);
-      rowArea = nextArea;
-      rowMin = nextMin;
-      rowMax = nextMax;
-      index++;
-    } else {
-      placeRow(row, rowArea);
-      row = [];
-      rowArea = 0;
-      rowMin = Number.POSITIVE_INFINITY;
-      rowMax = 0;
-    }
-  }
-  placeRow(row, rowArea);
-  return tiles;
-}
-
-/** Render chartEx `layoutId="treemap"` as nested, area-proportional rectangles.
- * The chartEx hierarchy is shared with sunburst; `parentLabelLayout="banner"`
- * reserves a header inside each parent, `none` suppresses parent captions, and
- * the other/absent modes overlay the caption without changing tile area. */
-function renderTreemapChart(
-  ctx: CanvasRenderingContext2D,
-  chart: ChartModel,
-  r: ChartRect,
-  ptToPx: number,
-  shapeRotationDeg: number,
-): void {
-  const treemap = chart.chartexTreemap;
-  if (!treemap || treemap.rows.length === 0) return;
-  if (hierarchyInputTooLarge(treemap.rows)) {
-    rejectOversizedCanvasChart(ctx, r, MAX_CANVAS_CHART_POINTS + 1);
-    return;
-  }
-  // A treemap data point remains a distinct tile even when its terminal label
-  // repeats. Only parent path components are grouping keys.
-  const root = buildSunburstTree(treemap.rows, true);
-  if (root.layoutWeight <= 0 || root.children.length === 0) return;
-  const series = chart.series[0];
-  const legendPaints = root.children.map(node =>
-    chartExDataPointPaint(
-      chart, node.branchIndex, root.children.length, series?.chartexStyle, series?.color,
-    )
-  );
-  const legendChart: ChartModel = {
-    ...chart,
-    chartType: 'clusteredBar',
-    series: root.children.map(node => {
-      const fill = chartExDataPointFill(
-        chart, node.branchIndex, root.children.length, series?.chartexStyle,
-      );
-      return chartExLegendSeries(
-        chart,
-        node.label,
-        series,
-        chart.chartexDataPointStyle,
-        node.branchIndex,
-        root.children.length,
-        fill,
-        true,
-        false,
-      );
-    }),
-  };
-  const leg = measuredLegendReserve(ctx, legendChart, r.w, r.h, 0.22, ptToPx);
-  const frame = computeChartFrame(chart, r.x, r.y, r.w, r.h, ptToPx, {
-    titleTopPadFrac: 0.035,
-    titleBottomPadFrac: 0.035,
-    legendSideReserveFrac: 0,
-    legendReserve: leg,
-    radialGapFrac: 0.015,
-    honorPlotAreaManualLayout: true,
-  });
-  drawChartTitleForLayout(ctx, chart, r.x, r.y, r.w, r.h, r.y + frame.title.topPad, frame.title.fontPx);
-  const { px0, py0, pw, ph } = frame.plotRect;
-  paintPlotAreaFrame(ctx, chart, px0, py0, pw, ph, ptToPx, shapeRotationDeg);
-  const plotBounds = { x: px0, y: py0, w: pw, h: ph };
-
-  const parentMode = treemap.parentLabelLayout ?? 'overlapping';
-  const labelDef = chart.series[0]?.seriesDataLabels;
-  const fontFamily = chartFontFamily(
-    chart, labelDef?.fontFace ?? chart.dataLabelFontFace, 'minor',
-  );
-  const labelFontPx = chartTextFontSizePx(labelDef?.fontSizeHpt, ptToPx)
-    ?? Math.max(8, Math.min(13, frame.plotRect.ph * 0.025));
-  const labelColor = labelDef?.fontColor ? `#${labelDef.fontColor}` : '#ffffff';
-  const labelOverrides = new Map(
-    (chart.series[0]?.dataLabelOverrides ?? []).map(override => [override.idx, override]),
-  );
-  // With no direct or linked line recipe, use a one-CSS-pixel separator derived
-  // from the chart background. `applyChartExSeriesLineStyle` still resolves
-  // direct series formatting and the linked data-point role before this fallback.
-  const automaticSeparator = chart.chartBg
-    ? (chart.chartBg.startsWith('#') ? chart.chartBg : `#${chart.chartBg}`)
-    : '#ffffff';
-
-  const paint = (node: SunburstNode, tile: TreemapRect): void => {
-    if (tile.w < 0.5 || tile.h < 0.5) return;
-    const base = chartExDataPointFill(
-      chart, node.branchIndex, root.children.length, series?.chartexStyle,
-    );
-    // Every descendant of a top-level branch uses that branch's exact accent.
-    // Hierarchy depth does not tint or whiten ChartEx treemap data points.
-    const color = `#${base}`;
-    const fillPaint = chartExDataPointPaint(
-      chart, node.branchIndex, root.children.length, series?.chartexStyle, series?.color,
-    );
-    const labelOverride = labelOverrides.get(node.labelIndex);
-    const nodeLabelColor = labelOverride?.fontColor ? `#${labelOverride.fontColor}` : labelColor;
-    const nodeLabelFontPx = chartTextFontSizePx(labelOverride?.fontSizeHpt, ptToPx)
-      ?? labelFontPx;
-    const nodeLabelBold = labelOverride?.fontBold ?? labelDef?.fontBold ?? false;
-
-    if (node.children.length > 0) {
-      // `overlapping` captions belong to the top-level branch entries exposed
-      // by the legend; intermediate nodes still partition their descendants.
-      // `banner` remains separate because it reserves a band at each parent.
-      const parentLabel = resolveChartExLabel(
-        chart, series, node.labelIndex, node.label, node.value,
-        { visible: parentMode !== 'none', showVal: false, showCatName: true },
-        labelOverrides,
-      );
-      const showParent = parentLabel != null
-        && (parentMode !== 'overlapping' || node.depth === 0);
-      const fontPx = nodeLabelFontPx;
-      const parentFontFamily = parentLabel?.fontFace
-        ? chartFontFamily(chart, parentLabel.fontFace, 'minor')
-        : fontFamily;
-      const bannerH = parentMode === 'banner' && showParent
-        ? Math.min(tile.h * 0.28, fontPx + 7)
-        : 0;
-      // `overlapping` (MS-ODRAWXML §2.24.3.69 CT_ParentLabelLayout) places the
-      // parent caption over its descendant data points. In Excel it does not
-      // create an additional painted parent rectangle; doing so here produced
-      // a hairline frame around each branch. Banner mode alone reserves and
-      // paints a caption band.
-      if (bannerH > 0 && fillPaint) {
-        ctx.fillStyle = chartExFillStyle(
-          ctx,
-          fillPaint,
-          tile.x,
-          tile.y,
-          tile.w,
-          bannerH,
-          color,
-          shapeRotationDeg,
-        );
-        ctx.fillRect(tile.x, tile.y, tile.w, bannerH);
-      }
-      const content = {
-        x: tile.x,
-        y: tile.y + bannerH,
-        w: tile.w,
-        h: Math.max(0, tile.h - bannerH),
-      };
-      for (const child of layoutTreemapTiles(node.children, content)) paint(child.node, child.rect);
-
-      if (showParent && (parentLabel.manualLayout || (tile.w > fontPx * 2 && tile.h > fontPx + 4))) {
-        ctx.font = `${nodeLabelBold ? 'bold ' : ''}${fontPx}px ${parentFontFamily}`;
-        const labelRect = bannerH > 0
-          ? { x: tile.x, y: tile.y, w: tile.w, h: bannerH }
-          : tile;
-        const automaticBounds = labelRect;
-        // The series-level data-label position describes leaf values. Office
-        // keeps overlapping parent captions at the top-left even when leaves
-        // are authored at inEnd; only an indexed parent override changes it.
-        const parentPosition = labelOverride?.position ?? 'inBase';
-        drawBoundedDataLabelText(
-          ctx,
-          parentLabel.text,
-          parentLabel.manualLayout
-            ? { kind: 'point', x: tile.x + tile.w / 2, y: tile.y + tile.h / 2, position: parentPosition }
-            : { kind: 'box', rect: automaticBounds, position: parentPosition },
-          parentLabel.manualLayout ? plotBounds : automaticBounds,
-          fontPx,
-          nodeLabelColor,
-          parentLabel.manualLayout,
-          r,
-          richDataLabelOptions(
-            chart, parentLabel.richRuns, ptToPx, parentFontFamily, nodeLabelBold,
-            parentLabel.textStyle,
-          ),
-          undefined,
-          parentLabel.textStyle,
-          ptToPx,
-          parentLabel.labelBox,
-          shapeRotationDeg,
-        );
-      }
-      return;
-    }
-
-    if (fillPaint) {
-      ctx.fillStyle = chartExFillStyle(
-        ctx,
-        fillPaint,
-        tile.x,
-        tile.y,
-        tile.w,
-        tile.h,
-        color,
-        shapeRotationDeg,
-      );
-      ctx.fillRect(tile.x, tile.y, tile.w, tile.h);
-    }
-    const hasAuthoredOutline = applyChartExSeriesLineStyle(
-      ctx,
-      chart,
-      chart.chartexDataPointStyle,
-      chart.series[0],
-      node.branchIndex,
-      root.children.length,
-      automaticSeparator,
-      ptToPx,
-      { linkedNoStyleFallback: true },
-    );
-    if (hasAuthoredOutline) {
-      // ChartEx outlines are centered on the tile boundary. An inset stroke
-      // creates a second visible outer frame that Excel does not paint.
-      ctx.strokeRect(tile.x, tile.y, tile.w, tile.h);
-    }
-
-    const leafLabel = resolveChartExLabel(
-      chart, series, node.labelIndex, node.label, node.value,
-      { visible: false, showVal: false, showCatName: false },
-      labelOverrides,
-    );
-    if (!leafLabel) return;
-    const fontPx = chartTextFontSizePx(leafLabel.fontSizeHpt, ptToPx)
-      ?? nodeLabelFontPx;
-    if (!leafLabel.manualLayout && (tile.w <= fontPx * 1.2 || tile.h <= fontPx * 1.2)) return;
-    const leafFontFamily = leafLabel.fontFace
-      ? chartFontFamily(chart, leafLabel.fontFace, 'minor')
-      : fontFamily;
-    ctx.font = `${leafLabel.fontBold ? 'bold ' : ''}${fontPx}px ${leafFontFamily}`;
-    const automaticBounds = tile;
-    // ChartEx uses `outEnd` for treemap value labels but Excel paints that
-    // token inside the tile at its lower-left corner. Keep the family-specific
-    // semantic mapping here; the shared box resolver's generic outEnd remains
-    // right-centred for other chart families.
-    const leafPosition = leafLabel.position === 'outEnd'
-      ? 'inEnd'
-      : (leafLabel.position ?? 'ctr');
-    drawBoundedDataLabelText(
-      ctx,
-      leafLabel.text,
-      leafLabel.manualLayout
-        ? { kind: 'point', x: tile.x + tile.w / 2, y: tile.y + tile.h / 2, position: leafPosition }
-        : { kind: 'box', rect: automaticBounds, position: leafPosition },
-      leafLabel.manualLayout ? plotBounds : automaticBounds,
-      fontPx,
-      leafLabel.fontColor ? `#${leafLabel.fontColor}` : nodeLabelColor,
-      leafLabel.manualLayout,
-      r,
-      richDataLabelOptions(
-        chart, leafLabel.richRuns, ptToPx, leafFontFamily, leafLabel.fontBold ?? false,
-        leafLabel.textStyle,
-      ),
-      undefined,
-      leafLabel.textStyle,
-      ptToPx,
-      leafLabel.labelBox,
-      shapeRotationDeg,
-    );
-  };
-
-  ctx.save();
-  ctx.beginPath();
-  ctx.rect(px0, py0, pw, ph);
-  ctx.clip();
-  for (const tile of layoutTreemapTiles(root.children, { x: px0, y: py0, w: pw, h: ph })) {
-    paint(tile.node, tile.rect);
-  }
-  ctx.restore();
-
-  drawLegendForLayout(
-    ctx,
-    legendChart,
-    leg,
-    r.x,
-    r.y,
-    r.w,
-    r.h,
-    px0,
-    py0,
-    pw,
-    ph,
-    frame.title.bandH + 2,
-    ptToPx,
-    legendPaints,
-    shapeRotationDeg,
-  );
-}
-
-/** Render text shapes from the chart's related Chart Drawing part.
- *
- * `cdr:relSizeAnchor` coordinates are fractions of the full chart space, not
- * the plot area. Paragraph and run properties are authored DrawingML values.
- * `a:bodyPr@wrap="square"` (and the application default when omitted) wraps
- * text inside the authored rectangle; `wrap="none"` keeps a paragraph on one
- * line. Auto-fit remains deliberately separate because it is a different
- * DrawingML choice with different font-scaling semantics.
- */
 function drawChartTextBoxes(
   ctx: CanvasRenderingContext2D,
   chart: ChartModel,
@@ -16982,6 +14971,8 @@ function renderChartImpl(
   regionMap?: ChartRegionMapRenderer,
   /** Host-warmed image cache used by picture-fill availability preflight. */
   imageLookup?: ChartImageLookup,
+  /** Optional Microsoft ChartEx family renderer. */
+  chartEx?: ChartExRenderer,
 ): void {
   // The per-family renderers (and the early-return/default text paths below)
   // mutate shared canvas state — textAlign, textBaseline, font, fillStyle,
@@ -17145,6 +15136,11 @@ function renderChartImpl(
       drawChartTextBoxes(ctx, chart, rect, ptToPx);
       return;
     }
+    if (chartEx?.render(ctx, chart, rect, ptToPx, shapeRotationDeg)) {
+      drawChartDisplayUnitLabels(ctx, chart, rect, ptToPx);
+      drawChartTextBoxes(ctx, chart, rect, ptToPx);
+      return;
+    }
 
     switch (chart.chartType) {
       case 'clusteredBar':
@@ -17173,36 +15169,11 @@ function renderChartImpl(
       case 'scatter':
       case 'bubble':
         renderScatterChart(ctx, chart, rect, ptToPx, shapeRotationDeg); break;
-      case 'waterfall':
-        renderWaterfallChart(ctx, chart, rect, ptToPx, shapeRotationDeg); break;
-      case 'clusteredColumn':
-        renderBarChart(
-          ctx,
-          { ...chart, chartType: 'clusteredBar' },
-          rect,
-          ptToPx,
-          { gapPolicy: 'chartex' },
-          shapeRotationDeg,
-        ); break;
-      case 'histogram':
-        renderHistogramChart(ctx, chart, rect, ptToPx, shapeRotationDeg); break;
-      case 'funnel':
-        renderFunnelChart(ctx, chart, rect, ptToPx, shapeRotationDeg); break;
-      case 'paretoLine':
-        renderParetoLineChart(ctx, chart, rect, ptToPx, shapeRotationDeg); break;
-      case 'pareto':
-        renderParetoChart(ctx, chart, rect, ptToPx, shapeRotationDeg); break;
       case 'stock':
         renderStockChart(ctx, chart, rect, ptToPx, shapeRotationDeg); break;
       case 'surface':
       case 'surface3D':
         renderSurfaceChart(ctx, chart, rect, ptToPx, shapeRotationDeg); break;
-      case 'boxWhisker':
-        renderBoxWhiskerChart(ctx, chart, rect, ptToPx, shapeRotationDeg); break;
-      case 'sunburst':
-        renderSunburstChart(ctx, chart, rect, ptToPx, shapeRotationDeg); break;
-      case 'treemap':
-        renderTreemapChart(ctx, chart, rect, ptToPx, shapeRotationDeg); break;
       default:
         ctx.fillStyle = '#888';
         ctx.font = '11px sans-serif';
@@ -17230,10 +15201,11 @@ export function renderChart(
   threeD?: ChartThreeDRenderer,
   regionMap?: ChartRegionMapRenderer,
   imageLookup?: ChartImageLookup,
+  chartEx?: ChartExRenderer,
 ): void {
   withChartImageLookup(imageLookup, () => {
     renderChartImpl(
-      ctx, chart, rect, ptToPx, shapeRotationDeg, threeD, regionMap, imageLookup,
+      ctx, chart, rect, ptToPx, shapeRotationDeg, threeD, regionMap, imageLookup, chartEx,
     );
   });
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -386,6 +386,7 @@ export {
   type ChartThreeDRenderer,
 } from './chart/three-d-contract';
 export type { ChartRegionMapRenderer } from './chart/region-map-contract';
+export type { ChartExRenderer } from './chart/chart-ex-contract';
 export { workerRendererDescriptors } from './worker/renderer-module-contract';
 export {
   mathToMathML,

--- a/packages/core/src/types/load-options.ts
+++ b/packages/core/src/types/load-options.ts
@@ -1,6 +1,7 @@
 import type { MathRenderer } from '../math/mathjax';
 import type { ChartThreeDRenderer } from '../chart/three-d-contract';
 import type { ChartRegionMapRenderer } from '../chart/region-map-contract';
+import type { ChartExRenderer } from '../chart/chart-ex-contract';
 import type { OoxmlResourceMetrics } from './resource-metrics.js';
 
 /** A positive safe-integer byte count, or `null` to disable one public limit. */
@@ -163,4 +164,12 @@ export interface LoadOptions {
    * The on-demand render-worker asset includes its worker-side implementation.
    */
   regionMap?: ChartRegionMapRenderer;
+  /**
+   * Opt in to Microsoft ChartEx (`cx:*`) chart families. Import `chartEx`
+   * from `@silurus/ooxml/chart-ex` and inject it once. Classic DrawingML 2-D
+   * charts remain available without this module. In main mode the implementation
+   * stays outside the format entry; the on-demand render-worker asset remains
+   * self-contained and includes its worker-side implementation.
+   */
+  chartEx?: ChartExRenderer;
 }

--- a/packages/core/src/worker/renderer-module-contract.ts
+++ b/packages/core/src/worker/renderer-module-contract.ts
@@ -4,7 +4,7 @@
  * public renderer interfaces. */
 const WORKER_RENDERER_MODULE_PROTOCOL = 'ooxml-worker-renderer-module/v1' as const;
 
-export type WorkerBuiltinRendererName = 'math' | 'threeD' | 'regionMap';
+export type WorkerBuiltinRendererName = 'math' | 'threeD' | 'regionMap' | 'chartEx';
 
 interface WorkerBuiltinRendererDescriptorBase {
   readonly protocol: typeof WORKER_RENDERER_MODULE_PROTOCOL;
@@ -19,7 +19,7 @@ interface WorkerMathRendererDescriptor extends WorkerBuiltinRendererDescriptorBa
 }
 
 interface WorkerChartRendererDescriptor extends WorkerBuiltinRendererDescriptorBase {
-  readonly builtin: 'threeD' | 'regionMap';
+  readonly builtin: 'threeD' | 'regionMap' | 'chartEx';
 }
 
 export type WorkerRendererDescriptor =
@@ -30,12 +30,14 @@ export interface WorkerRendererDescriptors {
   readonly math?: WorkerRendererDescriptor;
   readonly threeD?: WorkerRendererDescriptor;
   readonly regionMap?: WorkerRendererDescriptor;
+  readonly chartEx?: WorkerRendererDescriptor;
 }
 
 export interface WorkerRendererSources {
   readonly math?: object;
   readonly threeD?: object;
   readonly regionMap?: object;
+  readonly chartEx?: object;
 }
 
 const workerRendererRegistry = new WeakMap<object, WorkerRendererDescriptor>();
@@ -46,7 +48,7 @@ function createBuiltinWorkerRendererDescriptor(
   engineAssetUrl: string,
 ): WorkerMathRendererDescriptor;
 function createBuiltinWorkerRendererDescriptor(
-  builtin: 'threeD' | 'regionMap',
+  builtin: 'threeD' | 'regionMap' | 'chartEx',
 ): WorkerChartRendererDescriptor;
 function createBuiltinWorkerRendererDescriptor(
   builtin: WorkerBuiltinRendererName,
@@ -70,7 +72,7 @@ export function registerBuiltinWorkerRenderer<T extends object>(
 ): T;
 export function registerBuiltinWorkerRenderer<T extends object>(
   renderer: T,
-  builtin: 'threeD' | 'regionMap',
+  builtin: 'threeD' | 'regionMap' | 'chartEx',
 ): T;
 export function registerBuiltinWorkerRenderer<T extends object>(
   renderer: T,
@@ -92,7 +94,8 @@ export function assertWorkerRendererDescriptor(
   }
   if (descriptor.builtin !== 'math'
     && descriptor.builtin !== 'threeD'
-    && descriptor.builtin !== 'regionMap') {
+    && descriptor.builtin !== 'regionMap'
+    && descriptor.builtin !== 'chartEx') {
     throw new TypeError(`Unsupported built-in worker renderer: ${String(descriptor.builtin)}`);
   }
   if (descriptor.builtin === 'math' && typeof descriptor.engineAssetUrl !== 'string') {
@@ -110,10 +113,12 @@ export function workerRendererDescriptors(
   const math = sources.math ? workerRendererRegistry.get(sources.math) : undefined;
   const threeD = sources.threeD ? workerRendererRegistry.get(sources.threeD) : undefined;
   const regionMap = sources.regionMap ? workerRendererRegistry.get(sources.regionMap) : undefined;
+  const chartEx = sources.chartEx ? workerRendererRegistry.get(sources.chartEx) : undefined;
   const descriptors: WorkerRendererDescriptors = {
     ...(math ? { math } : {}),
     ...(threeD ? { threeD } : {}),
     ...(regionMap ? { regionMap } : {}),
+    ...(chartEx ? { chartEx } : {}),
   };
   return Object.keys(descriptors).length > 0 ? Object.freeze(descriptors) : undefined;
 }

--- a/packages/core/src/worker/renderer-module.test.ts
+++ b/packages/core/src/worker/renderer-module.test.ts
@@ -60,6 +60,7 @@ describe('worker renderer module descriptors', () => {
       }),
       threeD: registerBuiltinWorkerRenderer({}, 'threeD'),
       regionMap: registerBuiltinWorkerRenderer({}, 'regionMap'),
+      chartEx: registerBuiltinWorkerRenderer({}, 'chartEx'),
     };
 
     const loaded = await loadWorkerRenderers(workerRendererDescriptors(sources));
@@ -67,6 +68,7 @@ describe('worker renderer module descriptors', () => {
     expect(typeof loaded.math?.mathMLToSvg).toBe('function');
     expect(typeof loaded.threeD?.render).toBe('function');
     expect(typeof loaded.regionMap?.render).toBe('function');
+    expect(typeof loaded.chartEx?.render).toBe('function');
   });
 
   it('carries the consumer-resolved math asset URL without exposing it on the renderer', () => {

--- a/packages/core/src/worker/renderer-module.ts
+++ b/packages/core/src/worker/renderer-module.ts
@@ -1,5 +1,6 @@
 import type { ChartRegionMapRenderer } from '../chart/region-map-contract.js';
 import type { ChartThreeDRenderer } from '../chart/three-d-contract.js';
+import type { ChartExRenderer } from '../chart/chart-ex-contract.js';
 import type { MathRenderer } from '../math/mathjax.js';
 import {
   assertWorkerRendererDescriptor,
@@ -11,6 +12,7 @@ export interface LoadedWorkerRenderers {
   readonly math?: MathRenderer;
   readonly threeD?: ChartThreeDRenderer;
   readonly regionMap?: ChartRegionMapRenderer;
+  readonly chartEx?: ChartExRenderer;
 }
 
 /** Import a renderer's named export in the calling realm (normally a render
@@ -41,6 +43,10 @@ async function loadBuiltinRenderer(descriptor: WorkerRendererDescriptor): Promis
       const renderer = await import('../chart/region-map-renderer.js');
       return Object.freeze({ render: renderer.renderRegionMapChart });
     }
+    case 'chartEx': {
+      const renderer = await import('../chart/chart-ex-renderer.js');
+      return Object.freeze({ render: renderer.renderChartExChart });
+    }
   }
 }
 
@@ -65,10 +71,11 @@ function requireRendererMethods<T extends object>(
 export async function loadWorkerRenderers(
   descriptors: WorkerRendererDescriptors | undefined,
 ): Promise<LoadedWorkerRenderers> {
-  const [math, threeD, regionMap] = await Promise.all([
+  const [math, threeD, regionMap, chartEx] = await Promise.all([
     descriptors?.math ? loadWorkerRenderer(descriptors.math) : undefined,
     descriptors?.threeD ? loadWorkerRenderer(descriptors.threeD) : undefined,
     descriptors?.regionMap ? loadWorkerRenderer(descriptors.regionMap) : undefined,
+    descriptors?.chartEx ? loadWorkerRenderer(descriptors.chartEx) : undefined,
   ]);
   return Object.freeze({
     ...(math ? {
@@ -87,6 +94,9 @@ export async function loadWorkerRenderers(
         regionMap,
         ['render'],
       ),
+    } : {}),
+    ...(chartEx ? {
+      chartEx: requireRendererMethods<ChartExRenderer>('chartEx', chartEx, ['render']),
     } : {}),
   });
 }

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -570,6 +570,9 @@ export interface ChartRect {
     w: number;
     h: number;
 }
+export interface ChartExRenderer {
+    render(ctx: CanvasRenderingContext2D, chart: ChartModel, rect: ChartRect, ptToPx: number, shapeRotationDeg?: number): boolean;
+}
 export interface ChartRegionMapRenderer {
     render(ctx: CanvasRenderingContext2D, chart: ChartModel, rect: ChartRect, ptToPx: number, shapeRotationDeg?: number): boolean;
 }
@@ -1482,6 +1485,7 @@ interface LoadOptions__emitterCollision1 {
     math?: MathRenderer;
     threeD?: ChartThreeDRenderer;
     regionMap?: ChartRegionMapRenderer;
+    chartEx?: ChartExRenderer;
 }
 export interface MatchRunSlice {
     runIndex: number;

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -15,6 +15,7 @@ import {
   type MathRenderer,
   type ChartThreeDRenderer,
   type ChartRegionMapRenderer,
+  type ChartExRenderer,
   type OoxmlResourceMetrics,
   workerRendererDescriptors,
 } from '@silurus/ooxml-core';
@@ -114,6 +115,7 @@ export class DocxDocument {
   private _mode: 'main' | 'worker' = 'main';
   private _threeD: ChartThreeDRenderer | undefined;
   private _regionMap: ChartRegionMapRenderer | undefined;
+  private _chartEx: ChartExRenderer | undefined;
   private _worker: Worker;
   private _bridge: WorkerBridge<WorkerResponse | RenderWorkerResponse>;
   private readonly _rawParts = new BoundedRawPartCache({
@@ -258,6 +260,12 @@ export class DocxDocument {
         );
       }
       doc._regionMap = doc._mode === 'worker' ? undefined : opts.regionMap;
+      if (opts.chartEx && doc._mode === 'worker' && !rendererDescriptors?.chartEx) {
+        console.warn(
+          "[ooxml] a custom ChartEx renderer cannot cross the worker boundary; ChartEx charts use the unsupported-chart placeholder in mode: 'worker'. Use the renderer from @silurus/ooxml/chart-ex.",
+        );
+      }
+      doc._chartEx = doc._mode === 'worker' ? undefined : opts.chartEx;
       if (doc._mode === 'main' && opts.useGoogleFonts && doc._document) {
         doc._googleFontFaces = await preloadGoogleFonts(
           docxFontPreloadNames(doc._document),
@@ -640,6 +648,7 @@ export class DocxDocument {
       defaultCurrentDateMs: documentLayoutRuntimeOf(this).defaultCurrentDateMs,
       threeD: this._threeD,
       regionMap: this._regionMap,
+      chartEx: this._chartEx,
     });
   }
 

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -52,6 +52,7 @@ export type {
   ChartThreeDSeriesAxis,
   ChartThreeDRenderer,
   ChartRegionMapRenderer,
+  ChartExRenderer,
   ChartExElementStyle,
   ChartLineDashSegment,
   ChartexHistogramBinning,

--- a/packages/docx/src/paint/canonical-resource-handlers.ts
+++ b/packages/docx/src/paint/canonical-resource-handlers.ts
@@ -1,5 +1,10 @@
 import { drawImageCropped, renderChart } from '@silurus/ooxml-core';
-import type { ChartImageLookup, ChartThreeDRenderer, ChartRegionMapRenderer } from '@silurus/ooxml-core';
+import type {
+  ChartImageLookup,
+  ChartThreeDRenderer,
+  ChartRegionMapRenderer,
+  ChartExRenderer,
+} from '@silurus/ooxml-core';
 import type {
   ImagePaintResourceDescriptor,
   LayoutRect,
@@ -91,6 +96,7 @@ export function createCanonicalCanvasPaintResourceHandlers(
   threeD?: ChartThreeDRenderer,
   regionMap?: ChartRegionMapRenderer,
   chartImageLookup?: ChartImageLookup,
+  chartEx?: ChartExRenderer,
 ): CanvasPaintResourceHandlers {
   return Object.freeze({
   image(resource, bounds, ctx) {
@@ -108,6 +114,7 @@ export function createCanonicalCanvasPaintResourceHandlers(
       threeD,
       regionMap,
       chartImageLookup,
+      chartEx,
     );
   },
   math(resource, bounds, ctx) {

--- a/packages/docx/src/paint/canvas-document.ts
+++ b/packages/docx/src/paint/canvas-document.ts
@@ -13,7 +13,7 @@ import {
   preferVectorBlip,
 } from '@silurus/ooxml-core';
 import type { Duotone } from '@silurus/ooxml-core';
-import type { ChartThreeDRenderer, ChartRegionMapRenderer } from '@silurus/ooxml-core';
+import type { ChartThreeDRenderer, ChartRegionMapRenderer, ChartExRenderer } from '@silurus/ooxml-core';
 import type {
   DocumentLayout,
   LayoutPage,
@@ -52,6 +52,7 @@ export interface CanvasDocumentPaintOptions<TTextRun> {
   readonly onTextRun?: (run: TTextRun) => void;
   readonly threeD?: ChartThreeDRenderer;
   readonly regionMap?: ChartRegionMapRenderer;
+  readonly chartEx?: ChartExRenderer;
 }
 
 /** Per-canvas cancellation token: only the newest asynchronous image preload
@@ -250,11 +251,12 @@ export async function renderSelectedDocumentPage<TTextRun>(
     });
     const resources = createCanvasPaintResourcePainter(
       session,
-      options.threeD || options.regionMap || chartImages.size > 0
+      options.threeD || options.regionMap || options.chartEx || chartImages.size > 0
         ? createCanonicalCanvasPaintResourceHandlers(
             options.threeD,
             options.regionMap,
             fill => chartImages.get(chartImageFillKey(fill)),
+            options.chartEx,
           )
         : canonicalCanvasPaintResourceHandlers,
     );

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -276,6 +276,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerWireRequest>) => {
         defaultCurrentDateMs: doc.defaultCurrentDateMs,
         threeD: renderers.threeD,
         regionMap: renderers.regionMap,
+        chartEx: renderers.chartEx,
       });
       const runs = textRunsForSelectedPage(doc.layoutServices, req.pageIndex, {
         ...req.opts,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,6 +1,6 @@
 import type { DocxDocumentModel, BodyElement, DocxTextRunInfo } from './types';
 import type { LayoutServices, MathRenderer } from './layout/types.js';
-import type { ChartThreeDRenderer, ChartRegionMapRenderer } from '@silurus/ooxml-core';
+import type { ChartThreeDRenderer, ChartRegionMapRenderer, ChartExRenderer } from '@silurus/ooxml-core';
 export type { DocxTextRunInfo } from './types';
 import { bodyMathOccurrences } from './layout/resources.js';
 import { paintResourceRegistryOf, privateResourceLookupOf } from './layout/runtime-state.js';
@@ -65,6 +65,8 @@ export interface RenderDocumentOptions {
   threeD?: ChartThreeDRenderer;
   /** Internal load-time optional Region Map renderer retained by DocxDocument. */
   regionMap?: ChartRegionMapRenderer;
+  /** Internal load-time optional ChartEx renderer retained by DocxDocument. */
+  chartEx?: ChartExRenderer;
 }
 
 export function dropColorReplacedCache(
@@ -119,6 +121,7 @@ function normalizeRenderOptions(
       onTextRun: options.onTextRun,
       threeD: options.threeD,
       regionMap: options.regionMap,
+      chartEx: options.chartEx,
     },
   };
 }

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -485,6 +485,7 @@ export class DocxScrollViewer implements ZoomableViewer {
         math: this._opts.math,
         threeD: this._opts.threeD,
         regionMap: this._opts.regionMap,
+        chartEx: this._opts.chartEx,
         mode: this._mode,
       }), (ownedDocument) => {
         this._invalidateElementContext(false);

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -246,6 +246,7 @@ export class DocxViewer implements ZoomableViewer {
         math: this._opts.math,
         threeD: this._opts.threeD,
         regionMap: this._opts.regionMap,
+        chartEx: this._opts.chartEx,
         mode: this._mode,
       }), () => {
         // Invalidate operations owned by the old document before its worker is

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -579,6 +579,9 @@ export interface ChartRect {
     w: number;
     h: number;
 }
+export interface ChartExRenderer {
+    render(ctx: CanvasRenderingContext2D, chart: ChartModel, rect: ChartRect, ptToPx: number, shapeRotationDeg?: number): boolean;
+}
 export interface ChartRegionMapRenderer {
     render(ctx: CanvasRenderingContext2D, chart: ChartModel, rect: ChartRect, ptToPx: number, shapeRotationDeg?: number): boolean;
 }
@@ -988,6 +991,7 @@ interface LoadOptions__emitterCollision1 {
     math?: MathRenderer;
     threeD?: ChartThreeDRenderer;
     regionMap?: ChartRegionMapRenderer;
+    chartEx?: ChartExRenderer;
 }
 export interface MatchRunSlice {
     runIndex: number;
@@ -1696,6 +1700,7 @@ export type SlideRenderOptions = RenderOptions & {
     math?: MathRenderer;
     threeD?: ChartThreeDRenderer;
     regionMap?: ChartRegionMapRenderer;
+    chartEx?: ChartExRenderer;
     dim?: DimOptions;
 };
 export interface SoftEdge {

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -60,6 +60,7 @@ export type {
   ChartThreeDSeriesAxis,
   ChartThreeDRenderer,
   ChartRegionMapRenderer,
+  ChartExRenderer,
   ChartExElementStyle,
   ChartLineDashSegment,
   ChartexHistogramBinning,

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -20,6 +20,7 @@ import {
   type MathRenderer,
   type ChartThreeDRenderer,
   type ChartRegionMapRenderer,
+  type ChartExRenderer,
   type OoxmlResourceMetrics,
   workerRendererDescriptors,
 } from '@silurus/ooxml-core';
@@ -186,6 +187,7 @@ export class PptxPresentation {
   private _math: MathRenderer | undefined;
   private _threeD: ChartThreeDRenderer | undefined;
   private _regionMap: ChartRegionMapRenderer | undefined;
+  private _chartEx: ChartExRenderer | undefined;
 
   private constructor(worker: Worker, mode: 'main' | 'worker', wasmUrlOverride?: string | URL) {
     this._worker = worker;
@@ -294,6 +296,12 @@ export class PptxPresentation {
         );
       }
       pres._regionMap = mode === 'worker' ? undefined : opts.regionMap;
+      if (opts.chartEx && mode === 'worker' && !rendererDescriptors?.chartEx) {
+        console.warn(
+          "[ooxml] a custom ChartEx renderer cannot cross the worker boundary; ChartEx charts use the unsupported-chart placeholder in mode: 'worker'. Use the renderer from @silurus/ooxml/chart-ex.",
+        );
+      }
+      pres._chartEx = mode === 'worker' ? undefined : opts.chartEx;
       await pres._parse(
         buffer,
         resourceOptions.policy,
@@ -541,6 +549,7 @@ export class PptxPresentation {
             math: this._math,
             threeD: this._threeD,
             regionMap: this._regionMap,
+            chartEx: this._chartEx,
           },
           opts.onTextRun,
         );

--- a/packages/pptx/src/render-worker.ts
+++ b/packages/pptx/src/render-worker.ts
@@ -231,6 +231,7 @@ self.onmessage = async (event: MessageEvent<RenderWorkerRequest>) => {
           math: renderers.math,
           threeD: renderers.threeD,
           regionMap: renderers.regionMap,
+          chartEx: renderers.chartEx,
         }, (run) => runs.push(run));
         return { bitmap: canvas.transferToImageBitmap(), runs };
       });
@@ -255,6 +256,7 @@ self.onmessage = async (event: MessageEvent<RenderWorkerRequest>) => {
           math: renderers.math,
           threeD: renderers.threeD,
           regionMap: renderers.regionMap,
+          chartEx: renderers.chartEx,
         }, (run) => runs.push(run));
         return runs;
       });

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -103,7 +103,14 @@ import {
 } from '@silurus/ooxml-core';
 import type { WarpEnvelope, WarpGlyphTransform } from '@silurus/ooxml-core';
 import type { CameraInput, Vec2, BevelInput, ExtrusionInput, BevelRegion } from '@silurus/ooxml-core';
-import type { MathNode, MathRenderer, RasterizedMathSvg, ChartThreeDRenderer, ChartRegionMapRenderer } from '@silurus/ooxml-core';
+import type {
+  MathNode,
+  MathRenderer,
+  RasterizedMathSvg,
+  ChartThreeDRenderer,
+  ChartRegionMapRenderer,
+  ChartExRenderer,
+} from '@silurus/ooxml-core';
 import type { HyperlinkTarget } from '@silurus/ooxml-core';
 import { paintDistanceAwareReflectionBlur } from './reflection-blur';
 import { classifyPptxHyperlink } from './hyperlink';
@@ -6149,6 +6156,7 @@ export type SlideRenderOptions = RenderOptions & {
   math?: MathRenderer;
   threeD?: ChartThreeDRenderer;
   regionMap?: ChartRegionMapRenderer;
+  chartEx?: ChartExRenderer;
   dim?: DimOptions;
 };
 
@@ -6546,6 +6554,7 @@ async function renderSlideLeased(
         fill => chartMarkerImages.get(
           chartImageFillKey(fill),
         ),
+        opts.chartEx,
       );
       ctx.restore();
     }

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -521,6 +521,7 @@ export class PptxScrollViewer implements ZoomableViewer {
         math: this._opts.math,
         threeD: this._opts.threeD,
         regionMap: this._opts.regionMap,
+        chartEx: this._opts.chartEx,
         mode: this._mode,
       }), (ownedPresentation) => {
         // Invalidate before TerminalResourceOwner installs the candidate and

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -317,6 +317,7 @@ export class PptxViewer implements ZoomableViewer {
         math: this.opts.math,
         threeD: this.opts.threeD,
         regionMap: this.opts.regionMap,
+        chartEx: this.opts.chartEx,
         mode: this._mode,
       }), () => {
         // Retire old-engine hit promises before install() destroys that engine:

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -679,6 +679,9 @@ export interface ChartRect {
     w: number;
     h: number;
 }
+export interface ChartExRenderer {
+    render(ctx: CanvasRenderingContext2D, chart: ChartModel, rect: ChartRect, ptToPx: number, shapeRotationDeg?: number): boolean;
+}
 export interface ChartRegionMapRenderer {
     render(ctx: CanvasRenderingContext2D, chart: ChartModel, rect: ChartRect, ptToPx: number, shapeRotationDeg?: number): boolean;
 }
@@ -1138,6 +1141,7 @@ interface LoadOptions__emitterCollision1 {
     math?: MathRenderer;
     threeD?: ChartThreeDRenderer;
     regionMap?: ChartRegionMapRenderer;
+    chartEx?: ChartExRenderer;
 }
 export interface MathAccent {
     kind: 'accent';

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -61,6 +61,7 @@ export type {
   ChartThreeDSeriesAxis,
   ChartThreeDRenderer,
   ChartRegionMapRenderer,
+  ChartExRenderer,
   ChartExElementStyle,
   ChartLineDashSegment,
   ChartexHistogramBinning,

--- a/packages/xlsx/src/render-orchestrator.ts
+++ b/packages/xlsx/src/render-orchestrator.ts
@@ -13,6 +13,7 @@ import {
   type MathRenderer,
   type ChartThreeDRenderer,
   type ChartRegionMapRenderer,
+  type ChartExRenderer,
   type SrcRect,
   type Duotone,
   type OffscreenFactory,
@@ -407,6 +408,7 @@ export interface RenderDeps {
   math?: MathRenderer;
   threeD?: ChartThreeDRenderer;
   regionMap?: ChartRegionMapRenderer;
+  chartEx?: ChartExRenderer;
 }
 
 const autoHeightProjectionCache = new WeakMap<Worksheet, Worksheet>();
@@ -578,6 +580,7 @@ async function renderWorksheetViewportLeased(
     loadedImages: imageCache,
     threeD: deps.threeD,
     regionMap: deps.regionMap,
+    chartEx: deps.chartEx,
   });
 }
 

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -6,7 +6,12 @@ import type {
   SlicerItem, SlicerStyle, SlicerElementStyle,
   PhoneticRun, PhoneticProperties, PhoneticAlignment, Duotone,
 } from './types.js';
-import type { Stroke, ChartThreeDRenderer, ChartRegionMapRenderer } from '@silurus/ooxml-core';
+import type {
+  Stroke,
+  ChartThreeDRenderer,
+  ChartRegionMapRenderer,
+  ChartExRenderer,
+} from '@silurus/ooxml-core';
 import { chartImageFillKey } from '@silurus/ooxml-core';
 import { placePhoneticRuns } from './phonetic.js';
 import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, rasterizeMathSvg, tintMathRaster, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, isUax14NoBreakPair, containsSeaScript, isGraphemeFillText, seaMixedBreakOffsets, fitSeaWordPrefix, graphemeClusterOffsets, xlsxBorderDashArray, drawImageCropped, hexToRgba, intendedSingleLinePx, verticalTrLongMark, verticalVertGlyphReachable, applyStroke, resolveFill, type SparklineModel, type MathNode, type MathRenderer, type RasterizedMathSvg } from '@silurus/ooxml-core';
@@ -3807,7 +3812,7 @@ export function renderViewport(
     ctx, worksheet, colAxis, rowAxis, opts.loadedImages, cs,
     startRow, startCol, scrollOffsetX, scrollOffsetY,
     scrollAreaX, scrollAreaY, scrollAreaW, scrollAreaH,
-    worksheet.rightToLeft === true, canvasW, opts.threeD, opts.regionMap,
+    worksheet.rightToLeft === true, canvasW, opts.threeD, opts.regionMap, opts.chartEx,
   );
 
   // ── Anchored slicers (Office 2010+ pivot/table filter buttons) ──
@@ -4113,6 +4118,7 @@ function renderAnchoredDrawings(
   canvasW: number,
   threeD?: ChartThreeDRenderer,
   regionMap?: ChartRegionMapRenderer,
+  chartEx?: ChartExRenderer,
 ): void {
   const drawings: AnchoredDrawing[] = [];
   let fallbackOrder = 0;
@@ -4156,6 +4162,7 @@ function renderAnchoredDrawings(
         [drawing.anchor],
         threeD,
         regionMap,
+        chartEx,
       );
     }
   }
@@ -5293,6 +5300,7 @@ function renderCharts(
   anchors: readonly ChartAnchor[] = ws.charts,
   threeD?: ChartThreeDRenderer,
   regionMap?: ChartRegionMapRenderer,
+  chartEx?: ChartExRenderer,
 ): void {
   if (scrollAreaW <= 0 || scrollAreaH <= 0) return;
 
@@ -5342,6 +5350,7 @@ function renderCharts(
       threeD,
       regionMap,
       fill => loadedImages?.get(chartImageFillKey(fill)),
+      chartEx,
     );
     ctx.restore();
   }

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -7,6 +7,7 @@ import type {
   ArrowEnd,
   ChartThreeDRenderer,
   ChartRegionMapRenderer,
+  ChartExRenderer,
 } from '@silurus/ooxml-core';
 
 export type ShapeFill = Exclude<Fill, { fillType: 'image' } | { fillType: 'none' }>;
@@ -1099,6 +1100,8 @@ export interface RenderViewportOptions extends XlsxRenderViewportOptions {
   threeD?: ChartThreeDRenderer;
   /** @internal Optional synchronous offline Region Map renderer. */
   regionMap?: ChartRegionMapRenderer;
+  /** @internal Optional Microsoft ChartEx renderer. */
+  chartEx?: ChartExRenderer;
 }
 
 export type WorkerRequest =

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -13,6 +13,7 @@ import {
   type MathRenderer,
   type ChartThreeDRenderer,
   type ChartRegionMapRenderer,
+  type ChartExRenderer,
   OoxmlResourceLimitError,
   type OoxmlResourceMetrics,
   workerRendererDescriptors,
@@ -143,6 +144,8 @@ export class XlsxWorkbook {
   /** Optional synchronous Region Map renderer. Worker mode reconstructs the
    * built-in implementation from its serializable identity. */
   private regionMap: ChartRegionMapRenderer | undefined;
+  /** Optional Microsoft ChartEx renderer. */
+  private chartEx: ChartExRenderer | undefined;
   /** Web-font registrations are per FontFaceSet. Same-origin child windows have
    * their own set even when they share this workbook instance. */
   private googleFontNames: string[] = [];
@@ -281,6 +284,7 @@ export class XlsxWorkbook {
     this.math = this._mode === 'worker' ? undefined : opts.math;
     this.threeD = this._mode === 'worker' ? undefined : opts.threeD;
     this.regionMap = this._mode === 'worker' ? undefined : opts.regionMap;
+    this.chartEx = this._mode === 'worker' ? undefined : opts.chartEx;
     const rendererDescriptors = this._mode === 'worker'
       ? workerRendererDescriptors(opts)
       : undefined;
@@ -297,6 +301,11 @@ export class XlsxWorkbook {
     if (opts.regionMap && this._mode === 'worker' && !rendererDescriptors?.regionMap) {
       console.warn(
         "[ooxml] a custom Region Map renderer cannot cross the worker boundary; geospatial charts use the unsupported-chart placeholder in mode: 'worker'. Use the renderer from @silurus/ooxml/region-map.",
+      );
+    }
+    if (opts.chartEx && this._mode === 'worker' && !rendererDescriptors?.chartEx) {
+      console.warn(
+        "[ooxml] a custom ChartEx renderer cannot cross the worker boundary; ChartEx charts use the unsupported-chart placeholder in mode: 'worker'. Use the renderer from @silurus/ooxml/chart-ex.",
       );
     }
     // In worker mode the worker preloads fonts before its first render
@@ -755,7 +764,14 @@ export class XlsxWorkbook {
         GridGeometry.forWorksheet(ws, extracted.layoutMetrics.maximumDigitWidth);
       }
       return renderWorksheetViewport(
-        { ws, styles, math: this.math, threeD: this.threeD, regionMap: this.regionMap },
+        {
+          ws,
+          styles,
+          math: this.math,
+          threeD: this.threeD,
+          regionMap: this.regionMap,
+          chartEx: this.chartEx,
+        },
         target,
         viewport,
         // The stable closure uses the archive operation already reserved by

--- a/packages/xlsx/src/worker-render-deps.test.ts
+++ b/packages/xlsx/src/worker-render-deps.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type {
   ChartRegionMapRenderer,
   ChartThreeDRenderer,
+  ChartExRenderer,
   MathRenderer,
 } from '@silurus/ooxml-core';
 import type { ParsedWorkbook, Worksheet } from './types.js';
@@ -14,13 +15,15 @@ describe('worker render dependencies', () => {
     const math = {} as MathRenderer;
     const threeD = { render: vi.fn() } as unknown as ChartThreeDRenderer;
     const regionMap = { render: vi.fn() } as unknown as ChartRegionMapRenderer;
+    const chartEx = { render: vi.fn() } as unknown as ChartExRenderer;
 
-    expect(workerRenderDeps(ws, styles, { math, threeD, regionMap })).toEqual({
+    expect(workerRenderDeps(ws, styles, { math, threeD, regionMap, chartEx })).toEqual({
       ws,
       styles,
       math,
       threeD,
       regionMap,
+      chartEx,
     });
   });
 });

--- a/packages/xlsx/src/worker-render-deps.ts
+++ b/packages/xlsx/src/worker-render-deps.ts
@@ -16,5 +16,6 @@ export function workerRenderDeps(
     math: renderers.math,
     threeD: renderers.threeD,
     regionMap: renderers.regionMap,
+    chartEx: renderers.chartEx,
   };
 }

--- a/scripts/bundle-declarations.mjs
+++ b/scripts/bundle-declarations.mjs
@@ -10,7 +10,17 @@ import { dts } from 'rolldown-plugin-dts';
 const require = createRequire(new URL('../package.json', import.meta.url));
 const ts = require('typescript-compiler-api');
 
-const entries = ['index', 'docx', 'xlsx', 'pptx', 'math', 'three-d', 'region-map', 'node'];
+const entries = [
+  'index',
+  'docx',
+  'xlsx',
+  'pptx',
+  'math',
+  'three-d',
+  'region-map',
+  'chart-ex',
+  'node',
+];
 const dist = path.resolve(process.cwd(), 'dist');
 const workDir = path.join(dist, '.types-work');
 const outDir = path.join(dist, 'types');

--- a/scripts/check-docx-layout-boundaries.mjs
+++ b/scripts/check-docx-layout-boundaries.mjs
@@ -138,6 +138,7 @@ const SHARED_PAINT_IMPORTS = new Map([
     // layout acquisition or permit a renderer back-edge.
     ['ChartThreeDRenderer', 'type'],
     ['ChartRegionMapRenderer', 'type'],
+    ['ChartExRenderer', 'type'],
     ['ChartImageLookup', 'type'],
     ['Duotone', 'type'],
     ['MathRenderer', 'type'],

--- a/scripts/check-optional-chart-ex.mjs
+++ b/scripts/check-optional-chart-ex.mjs
@@ -1,0 +1,44 @@
+import { readFile } from 'node:fs/promises';
+import { basename, dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const distDir = resolve(process.argv[2] ?? 'dist');
+const implementationMarker = 'packages/core/src/chart/chart-ex-renderer.ts';
+
+async function dependencyClosure(entry) {
+  const pending = [join(distDir, entry)];
+  const visited = new Set();
+  const contents = [];
+  while (pending.length > 0) {
+    const file = pending.pop();
+    if (!file || visited.has(file)) continue;
+    visited.add(file);
+    const source = await readFile(file, 'utf8');
+    contents.push({ file, source });
+    for (const match of source.matchAll(/(?:from\s*|import\s*)["'](\.\/[^"']+?\.(?:js|mjs))["']/g)) {
+      pending.push(resolve(dirname(file), match[1]));
+    }
+  }
+  return contents;
+}
+
+function assertAbsent(files, marker, entry) {
+  const hit = files.find(({ source }) => source.includes(marker));
+  if (hit) throw new Error(`${entry} unexpectedly reaches ${marker} via ${basename(hit.file)}`);
+}
+
+const rendererClosure = await dependencyClosure('chart-ex.mjs');
+const rendererModule = await import(pathToFileURL(join(distDir, 'chart-ex.mjs')).href);
+if (typeof rendererModule.chartEx?.render !== 'function') {
+  throw new Error('chart-ex.mjs does not export a usable ChartEx renderer');
+}
+if (!rendererClosure.some(({ source }) => source.includes(implementationMarker))) {
+  throw new Error('chart-ex.mjs does not reach the ChartEx family implementation');
+}
+
+for (const entry of ['index.mjs', 'docx.mjs', 'xlsx.mjs', 'pptx.mjs']) {
+  const files = await dependencyClosure(entry);
+  assertAbsent(files, implementationMarker, entry);
+}
+
+console.log('optional ChartEx bundle boundary verified');

--- a/scripts/check-public-type-exports.mjs
+++ b/scripts/check-public-type-exports.mjs
@@ -9,7 +9,7 @@ const require = createRequire(new URL('../package.json', import.meta.url));
 const ts = require('typescript-compiler-api');
 const typesDir = path.resolve(process.cwd(), 'dist/types');
 const formats = ['docx', 'pptx', 'xlsx'];
-const files = ['index', ...formats, 'math', 'three-d', 'region-map']
+const files = ['index', ...formats, 'math', 'three-d', 'region-map', 'chart-ex']
   .map((entry) => path.join(typesDir, `${entry}.d.ts`));
 
 const program = ts.createProgram(files, {

--- a/site/src/components/ApiReference.astro
+++ b/site/src/components/ApiReference.astro
@@ -23,11 +23,13 @@ const formatModeNote = formatRenderModeGuidance[format];
 const rendererExample = `import { ${viewerName} } from '@silurus/ooxml/${format}';
 import { threeD } from '@silurus/ooxml/three-d';
 import { regionMap } from '@silurus/ooxml/region-map';
+import { chartEx } from '@silurus/ooxml/chart-ex';
 
 const viewer = new ${viewerName}(${viewerTarget}, {
   mode: 'worker',
   threeD,
   regionMap,
+  chartEx,
 });`;
 ---
 <section class="api" data-reveal>
@@ -69,7 +71,7 @@ const viewer = new ${viewerName}(${viewerTarget}, {
           <tr>
             <th>Equations and advanced charts</th>
             <td>Built-in and custom renderer objects.</td>
-            <td>Built-in math, 3-D and Region Map renderers; arbitrary custom renderer objects cannot be transferred.</td>
+            <td>Built-in math, ChartEx, 3-D and Region Map renderers; arbitrary custom renderer objects cannot be transferred.</td>
           </tr>
         </tbody>
       </table>
@@ -133,11 +135,12 @@ const viewer = new ${viewerName}(${viewerTarget}, {
   </div>
 
   <div id="chart-rendering-addons" class="api-addons">
-    <h4>3-D charts and Region Maps</h4>
+    <h4>ChartEx, 3-D charts and Region Maps</h4>
     <p>
       Import these capabilities from their separate package entries when a document needs them.
-      The same exports work with DOCX, XLSX and PPTX in both render modes. If omitted, authored 3-D
-      charts use the canonical 2-D fallback, while Region Maps are not drawn.
+      The same exports work with DOCX, XLSX and PPTX in both render modes. Classic 2-D charts need no
+      add-on. If omitted, ChartEx and Region Maps are not drawn, while authored 3-D charts use the
+      canonical 2-D fallback.
     </p>
     <pre><code>{rendererExample}</code></pre>
     <div class="api-addon-table-wrap">

--- a/site/src/lib/api-reference.test.ts
+++ b/site/src/lib/api-reference.test.ts
@@ -10,6 +10,11 @@ describe('official-site API reference', () => {
     expect(optionalChartRenderers.map(({ entry, exportName, contract }) => ({ entry, exportName, contract })))
       .toEqual([
         {
+          entry: '@silurus/ooxml/chart-ex',
+          exportName: 'chartEx',
+          contract: 'ChartExRenderer',
+        },
+        {
           entry: '@silurus/ooxml/three-d',
           exportName: 'threeD',
           contract: 'ChartThreeDRenderer',
@@ -30,6 +35,8 @@ describe('official-site API reference', () => {
           .toBe('ChartThreeDRenderer');
         expect(options.find(({ name }) => name === 'regionMap')?.type, apiClass.name)
           .toBe('ChartRegionMapRenderer');
+        expect(options.find(({ name }) => name === 'chartEx')?.type, apiClass.name)
+          .toBe('ChartExRenderer');
       }
     }
   });

--- a/site/src/lib/api-reference.ts
+++ b/site/src/lib/api-reference.ts
@@ -43,6 +43,13 @@ export const formatRenderModeGuidance: Readonly<Record<'docx' | 'xlsx' | 'pptx',
 
 export const optionalChartRenderers: readonly OptionalRendererReference[] = [
   {
+    name: 'Microsoft ChartEx renderer',
+    entry: '@silurus/ooxml/chart-ex',
+    exportName: 'chartEx',
+    contract: 'ChartExRenderer',
+    desc: 'Renders the newer cx:* waterfall, histogram, Pareto, funnel, box-and-whisker, sunburst and treemap families. Classic c:* 2-D charts remain in the format entries.',
+  },
+  {
     name: '3-D chart renderer',
     entry: '@silurus/ooxml/three-d',
     exportName: 'threeD',
@@ -71,6 +78,7 @@ const WORKER_TIMEOUT = { name: 'workerTimeoutMs', type: 'number', def: 'unlimite
 const MATH = { name: 'math', type: 'MathRenderer', def: 'undefined', desc: 'Opt-in OMML equation engine (MathJax + STIX Two Math, ~3 MB). Import it from the separate @silurus/ooxml/math entry — `import { math } from "@silurus/ooxml/math"` — and pass it to render equations in either mode. Omit it and equations are skipped; the MathJax asset is not fetched. When passed, that standalone asset is fetched lazily the first time a document contains an equation.', emphasis: 'Opt-in OMML equation engine (MathJax + STIX Two Math, ~3 MB).' };
 const THREE_D = { name: 'threeD', type: 'ChartThreeDRenderer', def: 'undefined', desc: 'Opt-in model-space 3-D chart renderer. Import `threeD` from the separate `@silurus/ooxml/three-d` entry and inject it once. Omit it to use the canonical 2-D fallback and avoid loading or evaluating the mesh/camera implementation in main mode. The self-contained worker asset retains the worker-side implementation. It renders the view angle authored in OOXML in main and worker modes.', emphasis: 'Opt-in model-space 3-D chart renderer.', detailsHref: '/announcements/v079-chart-rendering-addons#one-3-d-scene-for-axes-and-data', detailsLabel: '3-D scope' };
 const REGION_MAP = { name: 'regionMap', type: 'ChartRegionMapRenderer', def: 'undefined', desc: 'Opt-in offline ChartEx Region Map renderer using a pinned, public-domain Natural Earth country asset. Import `regionMap` from `@silurus/ooxml/region-map` and inject it once. Unsupported cached or sub-country views fail closed. The built-in renderer works in main and worker modes.', emphasis: 'Opt-in offline ChartEx Region Map renderer', detailsHref: '/announcements/v079-chart-rendering-addons#offline-country-region-maps', detailsLabel: 'Region Map scope' };
+const CHART_EX = { name: 'chartEx', type: 'ChartExRenderer', def: 'undefined', desc: 'Opt-in renderer for Microsoft ChartEx (`cx:*`) chart families. Import `chartEx` from `@silurus/ooxml/chart-ex` and inject it once. Classic 2-D charts stay in the default format entries; ChartEx is opt-in. The built-in renderer works in main and worker modes.', emphasis: 'Classic 2-D charts stay in the default format entries; ChartEx is opt-in.' };
 const MODE = { name: 'mode', type: "'main' | 'worker'", def: "'main'", desc: "Use 'main' for the smallest worker download, the lowest single-frame overhead or custom renderer objects; parsing still runs in a Worker, while Canvas rendering runs on the main thread. Use 'worker' when document layout and paint would compete with application UI responsiveness. It requires Worker and OffscreenCanvas, downloads a larger render worker and transfers an ImageBitmap per frame. Built-in math, 3-D and Region Map renderers use the same options in both modes. In worker mode, use the bitmap render methods instead of methods that accept a Canvas.", emphasis: "Use 'worker' when document layout and paint would compete with application UI responsiveness." };
 const VIEWER_MODE = { name: 'mode', type: "'main' | 'worker'", def: "'main'", desc: "Use 'main' for ordinary previews, the smallest worker download or custom renderer objects. Use 'worker' when rendering larger or more complex documents would compete with scrolling, navigation or other application UI. Worker mode requires Worker and OffscreenCanvas, downloads a larger render worker and transfers an ImageBitmap per frame. Viewer navigation, zoom, virtualized scrolling, selection, find, hyperlinks and the built-in math, 3-D and Region Map renderers remain available in both modes.", emphasis: "Use 'worker' when rendering larger or more complex documents would compete with scrolling, navigation or other application UI." };
 const ZOOM_MIN_MAX = { name: 'zoomMin / zoomMax', type: 'number', def: '0.1 / 4', desc: 'Zoom factor bounds for setScale / fitWidth / fitPage (10%–400%).' };
@@ -145,6 +153,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         MATH,
         THREE_D,
         REGION_MAP,
+        CHART_EX,
         VIEWER_MODE,
         ZOOM_MIN_MAX,
         ON_SCALE_CHANGE,
@@ -177,7 +186,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
       name: 'PptxPresentation',
       ctor: 'await PptxPresentation.load(source, options?)',
       note: 'Headless engine — parse once, render any slide into any canvas you supply (scroll views, thumbnail grids, master–detail).',
-      options: [GFONTS, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, MODE],
+      options: [GFONTS, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, MODE],
       methods: [
         { sig: 'static load(source, options?): Promise<PptxPresentation>', desc: 'Parse a deck from a URL or ArrayBuffer.' },
         { sig: 'get slideCount(): number', desc: 'Total slides.' },
@@ -227,6 +236,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         MATH,
         THREE_D,
         REGION_MAP,
+        CHART_EX,
         DPR,
         MODE,
         { name: 'onVisibleSlideChange', type: '(topIndex: number, total: number) => void', desc: 'Fires when the top-most visible slide changes.' },
@@ -270,6 +280,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         MATH,
         THREE_D,
         REGION_MAP,
+        CHART_EX,
         VIEWER_MODE,
         ZOOM_MIN_MAX,
         ON_SCALE_CHANGE,
@@ -298,7 +309,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
       name: 'DocxDocument',
       ctor: 'await DocxDocument.load(source, options?)',
       note: 'Headless engine — render any page into any canvas you supply.',
-      options: [GFONTS, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, MODE],
+      options: [GFONTS, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, MODE],
       methods: [
         { sig: 'static load(source, options?): Promise<DocxDocument>', desc: 'Parse a document from a URL or ArrayBuffer.' },
         { sig: 'get pageCount(): number', desc: 'Total pages.' },
@@ -342,6 +353,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         MATH,
         THREE_D,
         REGION_MAP,
+        CHART_EX,
         DPR,
         MODE,
         { name: 'onVisiblePageChange', type: '(topIndex: number, total: number) => void', desc: 'Fires when the top-most visible page changes.' },
@@ -387,6 +399,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         MATH,
         THREE_D,
         REGION_MAP,
+        CHART_EX,
         VIEWER_MODE,
         ON_SCALE_CHANGE,
         ON_HYPERLINK_CLICK,
@@ -455,6 +468,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         MATH,
         THREE_D,
         REGION_MAP,
+        CHART_EX,
         VIEWER_MODE,
         ON_SCALE_CHANGE,
         ON_HYPERLINK_CLICK,
@@ -495,7 +509,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
       name: 'XlsxWorkbook',
       ctor: 'await XlsxWorkbook.load(source, options?)',
       note: 'Headless engine — parse once, render any sheet viewport into any canvas you supply.',
-      options: [GFONTS, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, MODE],
+      options: [GFONTS, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, MODE],
       methods: [
         { sig: 'static load(source, options?): Promise<XlsxWorkbook>', desc: 'Parse a workbook from a URL or ArrayBuffer.' },
         { sig: 'get sheetNames(): string[]', desc: 'Names of all sheets.' },

--- a/site/src/lib/try.test.ts
+++ b/site/src/lib/try.test.ts
@@ -109,6 +109,7 @@ vi.mock('../../../packages/core/src/math/engine', () => ({
 
 vi.mock('../../../src/three-d', () => ({ threeD: mocks.threeD }));
 vi.mock('../../../src/region-map', () => ({ regionMap: mocks.regionMap }));
+vi.mock('../../../src/chart-ex', () => ({ chartEx: { render: vi.fn() } }));
 
 import { disposeRenderedFile, renderFile } from './try';
 

--- a/site/src/lib/try.ts
+++ b/site/src/lib/try.ts
@@ -15,11 +15,12 @@ import { XlsxViewer } from '@silurus/ooxml-xlsx';
 import { loadMathJax, mathMLToSvg } from '../../../packages/core/src/math/engine';
 import { threeD } from '../../../src/three-d';
 import { regionMap } from '../../../src/region-map';
+import { chartEx } from '../../../src/chart-ex';
 
 // Opt-in OMML equation engine — enabled here so user-supplied docx/pptx with
 // equations render. (In the published library this is `@silurus/ooxml/math`.)
 const math = { loadMathJax, mathMLToSvg };
-const advancedChartRenderers = { threeD, regionMap };
+const advancedChartRenderers = { threeD, regionMap, chartEx };
 
 const VIEWER_GAP = 26;
 const MIN_SCALE = 0.5;

--- a/src/chart-ex.ts
+++ b/src/chart-ex.ts
@@ -1,0 +1,12 @@
+// Opt-in Microsoft ChartEx renderer entry point.
+
+import { renderChartExChart } from '../packages/core/src/chart/chart-ex-renderer.js';
+import type { ChartExRenderer } from '../packages/core/src/chart/chart-ex-contract.js';
+import { registerBuiltinWorkerRenderer } from '../packages/core/src/worker/renderer-module-contract.js';
+
+/** Optional renderer for the newer Microsoft ChartEx (`cx:*`) families. */
+export const chartEx: ChartExRenderer = registerBuiltinWorkerRenderer({
+  render: renderChartExChart,
+}, 'chartEx');
+
+export type { ChartExRenderer } from '../packages/core/src/chart/chart-ex-contract.js';

--- a/tests/worker-dist/consumer/main.js
+++ b/tests/worker-dist/consumer/main.js
@@ -4,8 +4,9 @@ import { PptxPresentation } from '@silurus/ooxml/pptx';
 import { math } from '@silurus/ooxml/math';
 import { threeD } from '@silurus/ooxml/three-d';
 import { regionMap } from '@silurus/ooxml/region-map';
+import { chartEx } from '@silurus/ooxml/chart-ex';
 
-const renderers = { math, threeD, regionMap };
+const renderers = { math, threeD, regionMap, chartEx };
 const paint = (id, bitmap) => {
   const canvas = document.getElementById(id);
   canvas.width = bitmap.width;

--- a/tests/worker-dist/fixture.html
+++ b/tests/worker-dist/fixture.html
@@ -12,8 +12,9 @@
     import { math } from '/dist/math.mjs';
     import { threeD } from '/dist/three-d.mjs';
     import { regionMap } from '/dist/region-map.mjs';
+    import { chartEx } from '/dist/chart-ex.mjs';
 
-    const renderers = { math, threeD, regionMap };
+    const renderers = { math, threeD, regionMap, chartEx };
     const paint = (id, bitmap) => {
       const canvas = document.getElementById(id);
       canvas.width = bitmap.width;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -115,6 +115,9 @@ export default defineConfig(({ command, mode }) => ({
         'three-d': resolve(__dirname, 'src/three-d.ts'),
         // Opt-in offline ChartEx Region Map geometry/projector.
         'region-map': resolve(__dirname, 'src/region-map.ts'),
+        // Opt-in Microsoft ChartEx family renderer. Classic 2-D charts remain
+        // part of every format entry.
+        'chart-ex': resolve(__dirname, 'src/chart-ex.ts'),
         // Node-only bounded sessions and server render helpers. Kept as a
         // separate entry so browser consumers never load Node built-ins.
         node:  resolve(__dirname, 'src/node.ts'),


### PR DESCRIPTION
## Summary\n\n- keep classic DrawingML 2-D chart families in the default format bundles\n- move Microsoft ChartEx family painting behind the @silurus/ooxml/chart-ex entry and ChartExRenderer contract\n- wire the opt-in renderer through DOCX, XLSX, PPTX, and built-in render workers without splitting parser WASM\n- document the main-mode size boundary and the self-contained worker behavior\n\n## Size impact\n\nMeasured with the same minified consumer-bundle setup against the previous main revision:\n\n- DOCX default: -27,778 B raw / -7,895 B gzip\n- XLSX default: -27,726 B raw / -7,715 B gzip\n- PPTX default: -27,764 B raw / -7,924 B gzip\n- ChartEx opt-in entry: 36.90 KB raw / 11.26 KB gzip\n\nThe self-contained worker assets remain intact for bundler compatibility.\n\n## Verification\n\n- 8,018 Vitest tests passed; 25 skipped, excluding two unrelated pre-existing Skia crop pixel-oracle failures\n- focused ChartEx/core/worker/site suite: 953 passed\n- production worker Playwright integration: 2 passed\n- TypeScript project build\n- Vite production build and declaration bundling\n- DOCX architecture final audit: 88 passed\n- DOCX/XLSX/PPTX public API baselines and viewer symmetry\n- optional ChartEx, 3-D, and Region Map bundle boundaries\n- no-inline-WASM and production-worker checks\n- git diff --check