### PR TITLE
fix(chart): restore renderer fidelity across optional paths

### DIFF
--- a/packages/core/src/chart/chart-ex-renderer.ts
+++ b/packages/core/src/chart/chart-ex-renderer.ts
@@ -3,6 +3,7 @@
 // module unless the caller imports @silurus/ooxml/chart-ex.
 
 import type {
+  ChartDataPointOverride,
   ChartModel,
   ChartRect,
   ChartSeries,
@@ -77,6 +78,68 @@ import {
   type ChartExStyle,
   type SunburstNode,
 } from './renderer.js';
+
+function chartExStyleAuthorsFill(style: ChartExStyle | null | undefined): boolean {
+  if (!style || style.fillNoStyle === true) return false;
+  return style.fillPaintAuthored === true
+    || style.fillHidden === true
+    || style.fillColors?.some(color => color != null) === true
+    || style.fillPaints?.some(paint => paint != null) === true;
+}
+
+function waterfallPointPaint(
+  chart: ChartModel,
+  point: ChartDataPointOverride | undefined,
+  series: ChartSeries | undefined,
+  semanticIndex: number,
+): Fill | null {
+  const pointAuthorsFill = point?.fillHidden === true
+    || point?.color != null
+    || chartExStyleAuthorsFill(point?.chartexStyle);
+  if (pointAuthorsFill) {
+    const pointStyle = point?.fillHidden === true
+      ? { ...point.chartexStyle, fillHidden: true, fillPaintAuthored: true }
+      : point?.chartexStyle;
+    return chartExMarkerPaint(
+      chart, semanticIndex, 3, pointStyle, point?.color,
+      // Prevent an authored-but-unresolved point paint from reviving a lower
+      // Chart Style or semantic fill.
+      { fillHidden: true, fillPaintAuthored: true },
+    );
+  }
+  if (series?.chartexStyle?.fillPaintAuthored === true) {
+    return chartExMarkerPaint(
+      chart, semanticIndex, 3, series.chartexStyle, series.color,
+      // An explicitly authored CT_Series fill choice owns unresolved/noFill;
+      // the legacy fillHidden-only public shape lacks that provenance and is
+      // intentionally handled by chartExDataPointPaint below.
+      { fillHidden: true, fillPaintAuthored: true },
+    );
+  }
+  // CT_Series.spPr formats the series carrier. ChartEx semantic data points
+  // keep their dataPoint role when that carrier has noFill, while a positive
+  // series paint still wins; chartExDataPointPaint owns that distinction.
+  return chartExDataPointPaint(
+    chart, semanticIndex, 3, series?.chartexStyle, series?.color,
+  );
+}
+
+function waterfallPointAuthorsLine(point: ChartDataPointOverride | undefined): boolean {
+  const style = point?.chartexStyle;
+  return point?.lineHidden != null
+    || point?.lineColor != null
+    || point?.lineWidthEmu != null
+    || point?.lineDash != null
+    || style?.linePaintAuthored === true
+    || style?.lineHidden != null
+    || style?.lineColors?.some(color => color != null) === true
+    || style?.linePaints?.some(paint => paint != null) === true
+    || style?.lineWidthEmu != null
+    || style?.lineDash != null
+    || style?.lineCustomDash != null
+    || style?.lineCap != null
+    || style?.lineJoin != null;
+}
 
 function renderHistogramChart(
   ctx: CanvasRenderingContext2D,
@@ -250,13 +313,14 @@ function renderWaterfallChart(
 
   const series = chart.series[0];
   const labelOverrides = indexPointOverrides(series?.dataLabelOverrides);
+  const pointOverrides = indexPointOverrides(series?.dataPointOverrides);
   const localStyle = series?.chartexStyle;
   const colorPos = `#${series?.color ?? chartExDataPointFill(chart, 0, 3, localStyle)}`;
   const colorNeg = `#${chartExDataPointFill(chart, 1, 3, localStyle)}`;
   const colorSub = `#${chartExDataPointFill(chart, 2, 3, localStyle)}`;
-  const paintPos = chartExDataPointPaint(chart, 0, 3, localStyle, series?.color);
-  const paintNeg = chartExDataPointPaint(chart, 1, 3, localStyle);
-  const paintSub = chartExDataPointPaint(chart, 2, 3, localStyle);
+  const legendPaintPos = chartExDataPointPaint(chart, 0, 3, localStyle, series?.color);
+  const legendPaintNeg = chartExDataPointPaint(chart, 1, 3, localStyle);
+  const legendPaintSub = chartExDataPointPaint(chart, 2, 3, localStyle);
   const legendChart: ChartModel = {
     ...chart,
     chartType: 'clusteredBar',
@@ -410,19 +474,23 @@ function renderWaterfallChart(
     const yBot = Math.max(yOf(bar.start), yOf(bar.end));
     const bh = Math.max(1, yBot - yTop);
 
-    const paint = bar.isSub ? paintSub : bar.isPos ? paintPos : paintNeg;
-    const fallback = bar.isSub ? colorSub : bar.isPos ? colorPos : colorNeg;
+    const accentIndex = bar.isSub ? 2 : bar.isPos ? 0 : 1;
+    const point = pointOverrides.get(i);
+    const paint = waterfallPointPaint(chart, point, series, accentIndex);
+    const fallback = point?.color
+      ? `#${point.color}`
+      : bar.isSub ? colorSub : bar.isPos ? colorPos : colorNeg;
     if (bar.paintSlot && paint) {
       ctx.fillStyle = chartExFillStyle(ctx, paint, bx, yTop, barW, bh, fallback, shapeRotationDeg);
       ctx.fillRect(bx, yTop, barW, bh);
     }
-    const accentIndex = bar.isSub ? 2 : bar.isPos ? 0 : 1;
     const lineColor = chartExStyleColor(chart, chart.chartexDataPointStyle, 'line', accentIndex, 3);
+    const lineCarrier = waterfallPointAuthorsLine(point) ? point : series;
     if (bar.paintSlot && applyChartExSeriesLineStyle(
       ctx,
       chart,
       chart.chartexDataPointStyle,
-      series,
+      lineCarrier,
       accentIndex,
       3,
       lineColor ? `#${lineColor}` : fallback,
@@ -549,7 +617,8 @@ function renderWaterfallChart(
 
   drawLegendForLayout(
     ctx, legendChart, leg, x, y, w, h, px0, py0, pw, ph,
-    titleBand.bandH + 2, ptToPx, [paintPos, paintNeg, paintSub], shapeRotationDeg,
+    titleBand.bandH + 2, ptToPx,
+    [legendPaintPos, legendPaintNeg, legendPaintSub], shapeRotationDeg,
   );
 
   ctx.restore();

--- a/packages/core/src/chart/label-box.ts
+++ b/packages/core/src/chart/label-box.ts
@@ -3,6 +3,19 @@ import { drawingmlLineDashArray } from '../draw/dash.js';
 import { resolveFill } from '../shape/paint.js';
 import { EMU_PER_PT } from '../units.js';
 
+/** Whether a label shape supplies an actual Canvas-visible box paint. A bare
+ * `<c:spPr>` or explicit `noFill`/no-line still carries authored provenance,
+ * but it must not turn an ordinary pie label into a boxed callout. */
+export function chartLabelBoxHasVisiblePaint(
+  box: ChartLabelBox | null | undefined,
+): boolean {
+  if (!box) return false;
+  const hasFill = box.fillHidden !== true && (box.fill != null || box.fillPaint != null);
+  const hasBorder = box.borderHidden !== true
+    && (box.borderColor != null || box.borderFill != null);
+  return hasFill || hasBorder;
+}
+
 /** Merge two directly-authored label shapes property-by-property. The higher
  * precedence shape owns an authored paint/noFill choice even when that choice
  * cannot be resolved to a Canvas paint; omitted geometry continues to inherit

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1275,6 +1275,7 @@ describe('classic 3-D compatibility projection', () => {
     renderChart(rec.ctx, baseModel({
       chartType: 'clusteredBar',
       categories: ['A', 'B'],
+      valAxisMajorGridlines: true,
       threeD: { rotationX: 15, rotationY: 20, depthPercent: 100, perspective: 30 },
       series: [series({ values: [10, 20] })],
     }), RECT, 1);
@@ -1295,6 +1296,22 @@ describe('classic 3-D compatibility projection', () => {
     expect(Math.min(...slopes)).toBeGreaterThan(0.04);
     expect(Math.max(...slopes)).toBeLessThan(0.16);
     expect(Math.max(...slopes) - Math.min(...slopes)).toBeGreaterThan(0.02);
+  });
+
+  it('does not invent 3-D value gridlines when majorGridlines is omitted', () => {
+    const rec = strokedPolylineCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredBar',
+      categories: ['A', 'B'],
+      valAxisGridlineColor: 'FF00FF',
+      valMin: 0,
+      valMax: 20,
+      valAxisMajorUnit: 5,
+      threeD: { rotationX: 15, rotationY: 20, depthPercent: 100, perspective: 30 },
+      series: [series({ values: [5, 15] })],
+    }), RECT, 1);
+
+    expect(rec.strokes.filter(stroke => stroke.ss === '#FF00FF')).toHaveLength(0);
   });
 
   it('draws 6pt major and 4pt minor value ticks as horizontal screen annotations', () => {
@@ -2628,14 +2645,36 @@ describe('classic 3-D compatibility projection', () => {
       ],
     }), RECT, 1);
     const sequence = rec.paintEvents
-      .filter(event => event.kind === 'fill'
-        && ['#FF0000', '#00FF00'].includes(String(event.fillStyle)))
-      .map(event => event.kind === 'fill' ? String(event.fillStyle) : '');
+      .filter((event): event is FillPaintEvent => event.kind === 'fill')
+      .map(event => isMaterialColor(event.fillStyle, 'FF0000')
+        ? 'red'
+        : isMaterialColor(event.fillStyle, '00FF00') ? 'green' : null)
+      .filter((color): color is 'red' | 'green' => color != null);
     expect(sequence.length).toBeGreaterThanOrEqual(6);
     expect(sequence.some((color, index) => index > 0
       && index + 1 < sequence.length
       && color !== sequence[index - 1]
       && color === sequence[index + 1])).toBe(true);
+  });
+
+  it('extrudes each 3-D line stroke through its series depth interval', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: ['A', 'B'],
+      valMin: 0,
+      valMax: 40,
+      threeD: {
+        rotationX: 15, rotationY: 20, depthPercent: 100,
+        gapDepthPercent: 150, perspective: 30,
+      },
+      series: [series({ lineColor: 'FF0000', lineWidthEmu: 38_100, values: [20, 30] })],
+    }), RECT, 1);
+    const redFaces = materialFills(rec, 'FF0000');
+    // A flat stroke emits one screen-space polygon. Excel renders Line3D as a
+    // solid ribbon, so its camera projection exposes multiple shaded faces.
+    expect(redFaces.length).toBeGreaterThan(1);
+    expect(new Set(redFaces.map(event => event.fillStyle)).size).toBeGreaterThan(1);
   });
 
   it('applies a direct 3-D line point style to the segment ending at that point', () => {
@@ -2909,7 +2948,7 @@ describe('classic 3-D compatibility projection', () => {
     });
     const rec = recordingCtx();
     renderChart(rec.ctx, chart, RECT, 1);
-    const lineSegments = rec.filledPaths.filter(path => path.fillStyle === '#FF0000');
+    const lineSegments = rec.filledPaths.filter(path => isMaterialColor(path.fillStyle, 'FF0000'));
     expect(lineSegments.length).toBeGreaterThanOrEqual(2);
     const labels = recordingCtx();
     renderChart(labels.ctx, chart, RECT, 1);
@@ -7837,6 +7876,41 @@ describe('ChartEx flat layouts dispatch to semantic renderers', () => {
     expect(semanticLabels).toEqual(['Increase', 'Decrease', 'Total']);
   });
 
+  it('keeps Waterfall point fill/outline formatting above series noFill and linked colors', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'waterfall',
+      categories: ['Start', 'Increase', 'Decrease A', 'Decrease B', 'Decrease C', 'End'],
+      subtotalIndices: [5],
+      catAxisHidden: true,
+      valAxisHidden: true,
+      chartexDataPointStyle: {
+        fillColors: ['E46970', '8977D7', 'A5A5A5'],
+        fillPaintAuthored: true,
+      },
+      series: [series({
+        values: [245, 235, -52, -40, -108, 280],
+        chartexStyle: {
+          fillHidden: true,
+          fillPaintAuthored: true,
+          lineColors: ['E46970'],
+          linePaintAuthored: true,
+        },
+        dataPointOverrides: [
+          { idx: 0, color: '196ECA', lineHidden: true },
+          { idx: 1, lineColor: '196ECA' },
+          { idx: 5, color: '196ECA', lineHidden: true },
+        ],
+      })],
+    }), RECT, 1);
+
+    expect(rec.rects.filter(rect => rect.fs === '#196ECA')).toHaveLength(2);
+    expect(rec.rects.filter(rect => ['#E46970', '#8977D7', '#A5A5A5'].includes(rect.fs)))
+      .toHaveLength(0);
+    expect(rec.strokeRects.filter(rect => rect.ss === '#196ECA')).toHaveLength(1);
+    expect(rec.strokeRects.filter(rect => rect.ss === '#E46970')).toHaveLength(3);
+  });
+
   const chartExLegendModel = (
     chartType: string,
     localStyle: ChartSeries['chartexStyle'],
@@ -10527,7 +10601,7 @@ describe('showDLblsOverMax (§21.2.2.180)', () => {
     expect(renderedLabelTexts(chart)).toEqual(['5', '15']);
   });
 
-  it('compares stacked endpoints and negative values to the numeric maximum', () => {
+  it('compares each stacked data-point value, not the cumulative endpoint, to the numeric maximum', () => {
     const stacked = {
       chartType: 'stackedBar',
       categories: ['stack'],
@@ -10539,6 +10613,23 @@ describe('showDLblsOverMax (§21.2.2.180)', () => {
       valMax: 10,
       showLegend: false,
     } as ChartModel;
+    expect(renderedLabelTexts(stacked)).toEqual(['8', '8']);
+
+    const roundedPercentTotal = {
+      chartType: 'stackedBarPct',
+      categories: ['rounded'],
+      series: [
+        { name: 'Base', values: [0.18], color: '4472C4' },
+        { name: 'Middle', values: [0.456], color: 'ED7D31' },
+        { name: 'Top', values: [0.365], color: 'A5A5A5', seriesDataLabels: labels },
+      ],
+      valMin: 0,
+      valMax: 1,
+      showLegend: false,
+    } as ChartModel;
+    expect(renderedLabelTexts(roundedPercentTotal)).toEqual(['0.365']);
+
+    stacked.series[1].values = [15];
     expect(renderedLabelTexts(stacked)).toEqual(['8']);
 
     const negative = {

--- a/packages/core/src/chart/renderer-scatter-line-and-pie-labels.test.ts
+++ b/packages/core/src/chart/renderer-scatter-line-and-pie-labels.test.ts
@@ -377,7 +377,7 @@ describe('pie / doughnut ctr data-label radius (§21.2.2.48, PowerPoint layout)'
     }
   });
 
-  it('keeps the complete outEnd text boxes outside the pie, not only their centers', () => {
+  it('keeps automatic outEnd label anchors beyond the pie rim', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, baseModel({
       chartType: 'pie',
@@ -400,16 +400,63 @@ describe('pie / doughnut ctr data-label radius (§21.2.2.48, PowerPoint layout)'
     const categoryLabels = rec.texts.filter(t => t.text.startsWith('Long '));
     expect(categoryLabels).toHaveLength(2);
     for (const label of categoryLabels) {
-      const fontPx = Number(/(\d+(?:\.\d+)?)px/.exec(label.font)?.[1] ?? 12);
-      const halfW = label.text.length * fontPx * 0.6 / 2;
-      const halfH = fontPx / 2;
-      const dx = Math.max(Math.abs(label.x - cx) - halfW, 0);
-      const dy = Math.max(Math.abs(label.y - cy) - halfH, 0);
-      expect(Math.hypot(dx, dy)).toBeGreaterThanOrEqual(outerR);
+      expect(Math.hypot(label.x - cx, label.y - cy)).toBeGreaterThan(outerR);
     }
   });
 
-  it('draws authored leader lines when outEnd labels are displaced to avoid overlap', () => {
+  it('does not invent leader lines when ordinary outEnd labels do not collide', () => {
+    const rec = recordingCtx('#A6A6A6');
+    renderChart(rec.ctx, baseModel({
+      chartType: 'pie',
+      categories: ['Fares and taxes', 'Local funds', 'State funds', 'Federal funds'],
+      plotAreaManualLayout: {
+        xMode: 'edge', yMode: 'edge', x: 0.288247, y: 0.186997, w: 0.402462, h: 0.670347,
+      },
+      series: [series({
+        name: 'Share',
+        values: [43, 27, 23, 7],
+        categories: ['Fares and taxes', 'Local funds', 'State funds', 'Federal funds'],
+        seriesDataLabels: {
+          showVal: true, showCatName: true, showSerName: false, showPercent: false,
+          position: 'outEnd', separator: '\n', fontSizeHpt: 1100,
+          showLeaderLines: true, leaderLineColor: 'A6A6A6', leaderLineWidthEmu: 9525,
+        },
+      })],
+    }), { x: 0, y: 0, w: 740, h: 545 }, 4 / 3);
+
+    expect(rec.counts.polylineStrokes).toBe(0);
+  });
+
+  it('does not treat a transparent data-label spPr as a visible callout box', () => {
+    const rec = recordingCtx('#A6A6A6');
+    renderChart(rec.ctx, baseModel({
+      chartType: 'pie',
+      categories: ['Fares and taxes', 'Local funds', 'State funds', 'Federal funds'],
+      plotAreaManualLayout: {
+        xMode: 'edge', yMode: 'edge', x: 0.288247, y: 0.186997, w: 0.402462, h: 0.670347,
+      },
+      series: [series({
+        name: 'Share',
+        values: [43, 27, 23, 7],
+        categories: ['Fares and taxes', 'Local funds', 'State funds', 'Federal funds'],
+        seriesDataLabels: {
+          showVal: true, showCatName: true, showSerName: false, showPercent: false,
+          position: 'outEnd', separator: '\n', fontSizeHpt: 1100,
+          showLeaderLines: true, leaderLineColor: 'A6A6A6', leaderLineWidthEmu: 9525,
+          labelBox: {
+            fillHidden: true,
+            fillPaintAuthored: true,
+            borderHidden: true,
+            borderPaintAuthored: true,
+          },
+        },
+      })],
+    }), { x: 0, y: 0, w: 740, h: 545 }, 4 / 3);
+
+    expect(rec.counts.polylineStrokes).toBe(0);
+  });
+
+  it('does not synthesize leader lines by moving crowded automatic outEnd labels', () => {
     const rec = recordingCtx('#777777');
     renderChart(rec.ctx, baseModel({
       chartType: 'pie',
@@ -426,7 +473,7 @@ describe('pie / doughnut ctr data-label radius (§21.2.2.48, PowerPoint layout)'
       })],
     }), RECT, 1);
 
-    expect(rec.counts.polylineStrokes).toBeGreaterThan(0);
+    expect(rec.counts.polylineStrokes).toBe(0);
   });
 });
 

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -13,7 +13,11 @@ import {
   withChartImageLookup,
 } from './image-fill.js';
 import { paintChartThreeDSurfacePicture } from './three-d-surface-picture.js';
-import { mergeChartLabelBoxes, paintChartLabelBox } from './label-box.js';
+import {
+  chartLabelBoxHasVisiblePaint,
+  mergeChartLabelBoxes,
+  paintChartLabelBox,
+} from './label-box.js';
 import { strokeChartFrameRect } from './compound-frame.js';
 import {
   anchoredDataLabelPoint,
@@ -3086,10 +3090,12 @@ function dataLabelRectIntersection(a: DataLabelRect, b: DataLabelRect): DataLabe
   return right > x && bottom > y ? { x, y, w: right - x, h: bottom - y } : null;
 }
 
-/** ECMA-376 §21.2.2.180: omission/false suppresses a label whose plotted value
+/** ECMA-376 §21.2.2.180: omission/false suppresses a label whose data-point value
  * is numerically greater than the effective value-axis maximum. This gate runs
  * after the shared axis planner has resolved authored and automatic bounds; it
- * never changes those bounds. */
+ * never changes those bounds. For stacked charts the comparison remains the
+ * point's authored value; the cumulative stack endpoint is layout geometry,
+ * not the value represented by that label. */
 function dataLabelWithinAxisMaximum(
   chart: Pick<ChartModel, 'showDataLabelsOverMax'>,
   plottedValue: number,
@@ -4365,9 +4371,6 @@ export function renderBarChart(
         ? (raw / stackSum) * percentGroupMultiplier(s)
         : raw;
       const negative = sv < 0;
-      const plottedLabelValue = isStackedGroup
-        ? (negative ? negOffset : posOffset) + sv
-        : sv;
       const labelAxisMaximum = secondary && secScale ? secScale.max : plan.max;
       const useNegativeStyle = negative
         && (s.invertIfNegative === true || s.automaticNegativeStyle === true);
@@ -4499,7 +4502,7 @@ export function renderBarChart(
           isPercentGroup ? sv / 100 : undefined,
           s.useSecondaryAxis && sec ? sec.displayUnits : chart.valAxisDisplayUnits,
         );
-        if (label && dataLabelWithinAxisMaximum(chart, plottedLabelValue, labelAxisMaximum)) {
+        if (label && dataLabelWithinAxisMaximum(chart, raw, labelAxisMaximum)) {
           // ECMA-376 §21.2.2.30 / §21.1.2.3.2 — data label font size comes from
           // `<c:dLbls><c:txPr>...<a:defRPr@sz>` (hundredths of a point). When
           // the file specifies one we honor it; otherwise the proportional
@@ -4600,7 +4603,7 @@ export function renderBarChart(
           isPercentGroup ? sv / 100 : undefined,
           s.useSecondaryAxis && sec ? sec.displayUnits : chart.valAxisDisplayUnits,
         );
-        if (label && dataLabelWithinAxisMaximum(chart, plottedLabelValue, labelAxisMaximum)) {
+        if (label && dataLabelWithinAxisMaximum(chart, raw, labelAxisMaximum)) {
           const sizeHpt = label.fontSizeHpt ?? chart.dataLabelFontSizeHpt;
           const lsz = chartTextFontSizePx(sizeHpt, ptToPx)
             ?? Math.max(7, Math.min(11, barW * 0.6));
@@ -10297,7 +10300,9 @@ function drawPieRichLabels(
   for (let index = 0; index < vals.length; index++) {
     const override = overridesByIndex.get(index);
     if (dataLabelIsDeleted(def, override)) continue;
-    if (override?.labelBox || def.labelBox) calloutIndices.add(index);
+    if (chartLabelBoxHasVisiblePaint(mergeChartLabelBoxes(override?.labelBox, def.labelBox))) {
+      calloutIndices.add(index);
+    }
   }
   // Boxed labels have their own paint/collision pass, but only those points are
   // dispatched to it. A per-point spPr must not turn every sibling into a
@@ -10486,22 +10491,14 @@ function drawPieRichLabels(
     );
   }
 
-  drawPieOutsideLabels(
-    ctx, chart, def, outsideLabels, cx2, cy2, outerR, ptToPx,
-    chartX, chartY, chartW, chartH,
-  );
+  drawPieOutsideLabels(ctx, outsideLabels, chartX, chartY, chartW, chartH);
 }
 
-/** Plain `<c:dLblPos val="outEnd">` label block. `outEnd` gives a topological
- * requirement (outside the pie) but no radial-distance formula. Keep the whole
- * measured text rectangle outside the rim; placing only its centre outside lets
- * long category names overlap the slices. */
+/** Plain `<c:dLblPos val="outEnd">` label block. */
 interface PieOutsideLabel {
   lines: string[];
   rich?: RichDataLabelBlock;
   legendKey?: DataLabelLegendKey;
-  rimX: number;
-  rimY: number;
   boxW: number;
   boxH: number;
   unrotatedW: number;
@@ -10515,43 +10512,6 @@ interface PieOutsideLabel {
   font: string;
   cxBox: number;
   cyBox: number;
-  initialCx: number;
-  initialCy: number;
-  leftSide: boolean;
-}
-
-function pointToRectDistance(
-  px: number, py: number,
-  rectCx: number, rectCy: number,
-  halfW: number, halfH: number,
-): number {
-  const dx = Math.max(Math.abs(rectCx - px) - halfW, 0);
-  const dy = Math.max(Math.abs(rectCy - py) - halfH, 0);
-  return Math.hypot(dx, dy);
-}
-
-/** Find the first point on a slice-midpoint ray whose complete text rectangle
- * clears the pie. The monotone binary solve is geometry-only and avoids a
- * label-length or slice-angle tuning constant. */
-function outsideLabelRadialDistance(
-  midAngle: number,
-  outerR: number,
-  halfW: number,
-  halfH: number,
-  clearance: number,
-): number {
-  const ux = Math.cos(midAngle);
-  const uy = Math.sin(midAngle);
-  const target = outerR + clearance;
-  let low = 0;
-  let high = target + Math.hypot(halfW, halfH);
-  for (let i = 0; i < 32; i++) {
-    const mid = (low + high) / 2;
-    const distance = pointToRectDistance(0, 0, ux * mid, uy * mid, halfW, halfH);
-    if (distance >= target) high = mid;
-    else low = mid;
-  }
-  return high;
 }
 
 function createPieOutsideLabel(
@@ -10580,36 +10540,27 @@ function createPieOutsideLabel(
   );
   boxW = rotated.w;
   boxH = rotated.h;
-  const clearance = fontPx * 0.5;
-  const distance = outsideLabelRadialDistance(
-    midAngle, outerR, boxW / 2, boxH / 2, clearance,
-  );
+  // `outEnd` does not define a collision solver. Keep automatic labels on the
+  // slice-midpoint ray just beyond the rim; moving them according to browser
+  // font metrics invents leader lines that Office does not draw for the same
+  // authored labels. The radial offset is the existing Office-observed pie
+  // label placement used before collision handling was introduced.
+  const distance = outerR + Math.max(10, outerR * 0.12);
   const cxBox = pieCx + Math.cos(midAngle) * distance;
   const cyBox = pieCy + Math.sin(midAngle) * distance;
   return {
     lines, rich, legendKey,
-    rimX: pieCx + Math.cos(midAngle) * outerR,
-    rimY: pieCy + Math.sin(midAngle) * outerR,
     boxW, boxH, unrotatedW, unrotatedH, textStyle, ptToPx,
     lineHeight, fontPx, bold, fontColor, font,
-    cxBox, cyBox, initialCx: cxBox, initialCy: cyBox,
-    leftSide: Math.cos(midAngle) < 0,
+    cxBox, cyBox,
   };
 }
 
-/** Paint plain outEnd labels in the chart-space gutters around the authored
- * plot rectangle. Collision adjustment is bounded by chart space, and after a
- * vertical move the horizontal coordinate is solved again so the label cannot
- * be pushed back across the pie rim. */
+/** Paint automatic plain outEnd labels at their authored slice-midpoint anchors.
+ * Rich callout labels retain their separate bounded collision/leader resolver. */
 function drawPieOutsideLabels(
   ctx: CanvasRenderingContext2D,
-  chart: ChartModel,
-  def: ChartSeriesDataLabels,
   labels: PieOutsideLabel[],
-  pieCx: number,
-  pieCy: number,
-  outerR: number,
-  ptToPx: number,
   boundsX: number,
   boundsY: number,
   boundsW: number,
@@ -10617,72 +10568,10 @@ function drawPieOutsideLabels(
 ): void {
   if (labels.length === 0) return;
 
-  const topLimit = boundsY;
-  const bottomLimit = boundsY + boundsH;
-  const separate = (column: PieOutsideLabel[]): void => {
-    column.sort((a, b) => a.cyBox - b.cyBox);
-    for (let i = 1; i < column.length; i++) {
-      const previous = column[i - 1];
-      const current = column[i];
-      const minY = previous.cyBox + (previous.boxH + current.boxH) / 2;
-      if (current.cyBox < minY) current.cyBox = minY;
-    }
-    if (column.length === 0) return;
-    const bottomOverflow = column[column.length - 1].cyBox
-      + column[column.length - 1].boxH / 2 - bottomLimit;
-    if (bottomOverflow > 0) for (const label of column) label.cyBox -= bottomOverflow;
-    const topOverflow = topLimit - (column[0].cyBox - column[0].boxH / 2);
-    if (topOverflow > 0) for (const label of column) label.cyBox += topOverflow;
-  };
-  separate(labels.filter(label => !label.leftSide));
-  separate(labels.filter(label => label.leftSide));
-
-  // Re-solve horizontal placement after collision movement. For a fixed label
-  // y-range, the nearest vertical distance to the pie centre determines the
-  // exact horizontal clearance required for the full rectangle.
-  for (const label of labels) {
-    const target = outerR + label.fontPx * 0.5;
-    const halfW = label.boxW / 2;
-    const halfH = label.boxH / 2;
-    const nearestDy = Math.max(Math.abs(label.cyBox - pieCy) - halfH, 0);
-    if (nearestDy < target) {
-      const requiredDx = Math.sqrt(Math.max(0, target * target - nearestDy * nearestDy));
-      label.cxBox = label.leftSide
-        ? Math.min(label.cxBox, pieCx - requiredDx - halfW)
-        : Math.max(label.cxBox, pieCx + requiredDx + halfW);
-    }
-
-    // Prefer keeping labels inside chart space, but never trade the outEnd
-    // invariant for a clamp that would put text back over the pie.
-    const clampedX = clamp(label.cxBox, boundsX + halfW, boundsX + boundsW - halfW);
-    if (pointToRectDistance(pieCx, pieCy, clampedX, label.cyBox, halfW, halfH) >= target) {
-      label.cxBox = clampedX;
-    }
-  }
-
   ctx.save();
   ctx.beginPath();
   ctx.rect(boundsX, boundsY, boundsW, boundsH);
   ctx.clip();
-  const leader = chartStyleRoleLeaderLine(chart, def);
-  const leaderColor = leader.color ? `#${leader.color}` : '#a6a6a6';
-  const leaderPx = leader.widthEmu
-    ? Math.max(0.5, (leader.widthEmu / EMU_PER_PT) * ptToPx)
-    : 1;
-  ctx.setLineDash(dashPatternForPreset(leader.dash ?? undefined, leaderPx));
-  for (const label of labels) {
-    const moved = Math.abs(label.cxBox - label.initialCx) > 0.5
-      || Math.abs(label.cyBox - label.initialCy) > 0.5;
-    if (!def.showLeaderLines || leader.hidden === true || !moved) continue;
-    const edgeX = clamp(label.rimX, label.cxBox - label.boxW / 2, label.cxBox + label.boxW / 2);
-    const edgeY = clamp(label.rimY, label.cyBox - label.boxH / 2, label.cyBox + label.boxH / 2);
-    ctx.beginPath();
-    ctx.moveTo(label.rimX, label.rimY);
-    ctx.lineTo(edgeX, edgeY);
-    ctx.strokeStyle = leaderColor;
-    ctx.lineWidth = leaderPx;
-    ctx.stroke();
-  }
 
   for (const label of labels) {
     const insets = dataLabelInsets(label.textStyle, label.ptToPx);

--- a/packages/core/src/chart/three-d-mesh.ts
+++ b/packages/core/src/chart/three-d-mesh.ts
@@ -9,7 +9,7 @@ export type ThreeDMeshShape =
   | 'pyramid'
   | 'pyramidToMax';
 
-export type ThreeDMeshKind = ThreeDMeshShape | 'areaStrip' | 'pieSector';
+export type ThreeDMeshKind = ThreeDMeshShape | 'areaStrip' | 'lineRibbon' | 'pieSector';
 
 export type ThreeDMeshFaceRole = 'baseCap' | 'endCap' | 'side';
 
@@ -46,6 +46,13 @@ export interface ThreeDAreaStripMeshOptions {
   readonly farDepth: number;
   readonly capStart: boolean;
   readonly capEnd: boolean;
+}
+
+export interface ThreeDLineRibbonMeshOptions {
+  /** One bounded stroke polygon in the chart's model-space X/Y plane. */
+  readonly outline: readonly { readonly x: number; readonly y: number }[];
+  readonly nearDepth: number;
+  readonly farDepth: number;
 }
 
 export interface ThreeDPieSectorMeshOptions {
@@ -350,6 +357,51 @@ export function buildThreeDAreaStripMeshes(
   }
   const mesh = buildAreaStripMeshSingle(options);
   return mesh ? [mesh] : [];
+}
+
+/** Extrude one already-tessellated line-stroke polygon through its authored
+ * series-depth interval. Line3D is a solid ribbon in Excel, not a flat Canvas
+ * stroke; reusing the bounded stroke polygon preserves dash/cap/join geometry
+ * while the ordinary mesh projector supplies culling, depth order and material
+ * shading exactly like bars and area strips. */
+export function buildThreeDLineRibbonMesh(
+  options: ThreeDLineRibbonMeshOptions,
+): ThreeDMesh | null {
+  const outline = options.outline;
+  if (outline.length < 3
+    || outline.length > 64
+    || ![options.nearDepth, options.farDepth].every(Number.isFinite)
+    || Math.abs(options.nearDepth - options.farDepth) < 1e-9
+    || !outline.every(point => Number.isFinite(point.x) && Number.isFinite(point.y))) {
+    return null;
+  }
+  const z0 = Math.min(options.nearDepth, options.farDepth);
+  const z1 = Math.max(options.nearDepth, options.farDepth);
+  const count = outline.length;
+  const vertices: ThreeDScenePoint[] = [
+    ...outline.map(point => ({ ...point, depth: z0 })),
+    ...outline.map(point => ({ ...point, depth: z1 })),
+  ];
+  const near = Array.from({ length: count }, (_, index) => index);
+  const far = Array.from({ length: count }, (_, index) => count + index).reverse();
+  const faces: ThreeDMeshFace[] = [
+    { indices: near, role: 'side', smoothSurface: false },
+    { indices: far, role: 'side', smoothSurface: false },
+    ...Array.from({ length: count }, (_, index): ThreeDMeshFace => {
+      const next = (index + 1) % count;
+      return {
+        indices: [index, next, count + next, count + index],
+        role: 'side',
+        smoothSurface: false,
+      };
+    }),
+  ];
+  return {
+    shape: 'lineRibbon',
+    vertices,
+    faces: outwardWoundFaces(vertices, faces),
+    silhouetteEdges: [],
+  };
 }
 
 /** Build a closed cylindrical sector in the shared cartesian camera space.

--- a/packages/core/src/chart/three-d-renderer.ts
+++ b/packages/core/src/chart/three-d-renderer.ts
@@ -79,6 +79,7 @@ import {
 } from './category-spacing.js';
 import {
   buildThreeDAreaStripMeshes,
+  buildThreeDLineRibbonMesh,
   buildThreeDPieSectorMesh,
   buildThreeDShapeMesh,
   DEFAULT_THREE_D_ROUND_SEGMENTS,
@@ -2367,7 +2368,11 @@ function walls(
       0.5,
     ), true);
   }
-  if (chart.valAxisMajorGridlines !== false) {
+  // CT_ValAx/majorGridlines is an optional element, not an on-by-default
+  // property. Its absence therefore contributes no value-grid geometry. This
+  // mirrors the 2-D axis path and prevents synthetic back-wall rules from
+  // appearing in 3-D charts that author only the axis line.
+  if (chart.valAxisMajorGridlines === true) {
     drawValueGrid(axis.majorTicks, threeDStroke(
       chart.valAxisGridlineColor,
       chart.valAxisGridlineWidthEmu,
@@ -2375,7 +2380,7 @@ function walls(
       ptToPx,
       '898989',
       1,
-    ), chart.valAxisMajorGridlines === true);
+    ), true);
   }
   // Office retains automatic category-depth rays when majorGridlines is
   // absent. An authored majorGridlines element instead owns the interval-rule
@@ -3447,6 +3452,7 @@ function renderCartesian(
       }
       const lineStrokeRuns: Array<{
         path: ProjectedStrokePoint[];
+        modelPath: Point[];
         ownerIndex: number;
         startClipped: boolean;
         endClipped: boolean;
@@ -3565,6 +3571,13 @@ function renderCartesian(
             );
             const start = projectModelPoint(at(clipped.startT));
             const end = projectModelPoint(at(clipped.endT));
+            const modelStart = at(clipped.startT);
+            const modelEnd = at(clipped.endT);
+            const toModelPoint = (point: ModelLinePoint): Point => ({
+              x: point.x,
+              y: front.y + front.h
+                - Math.max(0, Math.min(1, point.fraction)) * front.h,
+            });
             const continues = visible != null && Math.hypot(
               visible.path.at(-1)!.x - start.x,
               visible.path.at(-1)!.y - start.y,
@@ -3573,6 +3586,7 @@ function renderCartesian(
               finishVisibleRun(visible);
               visible = {
                 path: [start, end],
+                modelPath: [toModelPoint(modelStart), toModelPoint(modelEnd)],
                 ownerIndex: endModel.ownerIndex,
                 startClipped: index > 0 || clipped.startT > 0,
                 endClipped: index + 1 < sampled.length - 1 || clipped.endT < 1,
@@ -3581,6 +3595,7 @@ function renderCartesian(
               };
             } else {
               visible!.path.push(end);
+              visible!.modelPath.push(toModelPoint(modelEnd));
               visible!.endClipped = index + 1 < sampled.length - 1 || clipped.endT < 1;
             }
             traversedLength += modelLength;
@@ -3613,12 +3628,17 @@ function renderCartesian(
           return paint;
         };
         const strokeFaceGroups = new Map<ThreeDDatumPaint, SceneFace[]>();
+        const lineRibbonBudget: ScenePrimitiveBudget = {
+          remaining: MAX_PROJECTED_STROKE_PRIMITIVES,
+          exceeded: false,
+        };
         const pushStrokeGeometry = (
           path: readonly ProjectedStrokePoint[],
           paint: ThreeDDatumPaint,
           startCap: CanvasLineCap,
           endCap: CanvasLineCap = startCap,
           dashOffset = 0,
+          modelPath?: readonly Point[],
         ) => {
           if (paint.lineFill === null) return;
           // Automatic 3-D line/area edges use the darker Chart Style line
@@ -3633,7 +3653,7 @@ function renderCartesian(
           const lineDash = drawingmlLineDashArray(
             paint.lineCustomDash, paint.lineDash, lineWidth,
           );
-          const strokes = buildProjectedStrokePrimitives(path, {
+          const strokeOptions = {
             width: lineWidth,
             dash: lineDash,
             dashOffset,
@@ -3641,7 +3661,52 @@ function renderCartesian(
             startCap,
             endCap,
             lineJoin: paint.lineJoin,
-          });
+          };
+          // ECMA Line3D is a depth-bearing ribbon. Tessellate the same bounded
+          // dash/cap/join polygon in the chart's model X/Y plane, extrude it
+          // through the series interval, then hand every face to the existing
+          // camera/depth/material pipeline. Area ridges remain ordinary edge
+          // strokes because their slab already supplies the depth faces.
+          if (!areaFamily && modelPath && modelPath.length >= 2) {
+            const modelStrokes = buildProjectedStrokePrimitives(
+              modelPath.map(point => ({ ...point, cameraDepth: 0, cameraWeight: 1 })),
+              strokeOptions,
+            );
+            if (modelStrokes == null) {
+              strokeBudgetExceeded = true;
+              return;
+            }
+            const group = strokeFaceGroups.get(paint) ?? [];
+            for (const stroke of modelStrokes) {
+              const mesh = buildThreeDLineRibbonMesh({
+                outline: stroke.points,
+                nearDepth: depthInterval.near,
+                farDepth: depthInterval.far,
+              });
+              if (!mesh) continue;
+              const faces = projectThreeDMesh(
+                projection, mesh, strokeStyle, undefined, lineRibbonBudget,
+              ).map(face => ({ ...face, paintRole: 'outline' as const }));
+              if (lineRibbonBudget.exceeded) {
+                strokeBudgetExceeded = true;
+                return;
+              }
+              group.push(...faces);
+              for (const face of faces) {
+                sceneCommands.push({
+                  points: face.points,
+                  cameraDepth: face.cameraDepth,
+                  cameraDepths: face.cameraDepths,
+                  cameraWeights: face.cameraWeights,
+                  layer: 1,
+                  paint: () => paintSceneFace(ctx, face),
+                });
+              }
+            }
+            strokeFaceGroups.set(paint, group);
+            return;
+          }
+          const strokes = buildProjectedStrokePrimitives(path, strokeOptions);
           if (strokes == null) {
             strokeBudgetExceeded = true;
             return;
@@ -3687,6 +3752,7 @@ function renderCartesian(
               item.startClipped ? 'butt' : paint.lineCap,
               item.endClipped ? 'butt' : paint.lineCap,
               item.dashOffset,
+              item.modelPath,
             );
           }
         }

--- a/packages/docx/src/DocxViewer.stories.ts
+++ b/packages/docx/src/DocxViewer.stories.ts
@@ -4,6 +4,7 @@ import { DocxViewer } from './viewer';
 import { math } from '../../../src/math';
 import { threeD } from '../../../src/three-d';
 import { regionMap } from '../../../src/region-map';
+import { chartEx } from '../../../src/chart-ex';
 
 type Args = {
   width: number;
@@ -74,6 +75,7 @@ export function buildViewerUI(
     math,
     threeD,
     regionMap,
+    chartEx,
     ...extra,
   });
 
@@ -202,6 +204,7 @@ function renderFileUpload(args: Args, mode: 'main' | 'worker'): HTMLElement {
         math,
         threeD,
         regionMap,
+        chartEx,
       });
       try {
         await viewer.load(buffer);

--- a/packages/docx/src/Examples.stories.ts
+++ b/packages/docx/src/Examples.stories.ts
@@ -5,6 +5,12 @@ import { DocxViewer } from './viewer';
 import { DocxScrollViewer } from './scroll-viewer';
 import { buildDocxTextLayer } from './text-layer';
 import type { DocxTextRunInfo } from './renderer';
+import { math } from '../../../src/math';
+import { threeD } from '../../../src/three-d';
+import { regionMap } from '../../../src/region-map';
+import { chartEx } from '../../../src/chart-ex';
+
+const fullRenderers = { math, threeD, regionMap, chartEx } as const;
 
 type DemoArgs = { width: number };
 type LayoutArgs = Record<string, never>;
@@ -70,7 +76,7 @@ export const ScrollView: LayoutStory = {
       'max-height:720px;overflow-y:auto;border:1px solid #ccc;background:#f5f5f5;padding:12px;';
     root.appendChild(scroller);
 
-    DocxDocument.load(SAMPLE_URL)
+    DocxDocument.load(SAMPLE_URL, fullRenderers)
       .then(async (doc) => {
         status.textContent = `Rendering ${doc.pageCount} pages…`;
         const widthPx = 700;
@@ -186,7 +192,7 @@ export const ThumbnailGrid: LayoutStory = {
       'display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:16px;';
     root.appendChild(grid);
 
-    DocxDocument.load(SAMPLE_URL)
+    DocxDocument.load(SAMPLE_URL, fullRenderers)
       .then(async (doc) => {
         status.textContent = `Rendering ${doc.pageCount} thumbnails…`;
         const thumbWidth = 160;
@@ -251,11 +257,12 @@ export const MasterDetail: LayoutStory = {
     const detailViewer = new DocxViewer(detailCanvas, {
       enableTextSelection: true,
       width: 600,
+      ...fullRenderers,
     });
 
     // Load thumbnails using DocxDocument; detail viewer loads independently
     Promise.all([
-      DocxDocument.load(SAMPLE_URL),
+      DocxDocument.load(SAMPLE_URL, fullRenderers),
       detailViewer.load(SAMPLE_URL),
     ])
       .then(async ([doc]) => {

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -7381,7 +7381,9 @@ pub fn parse_chartex_part_with_references_style_parts_and_images(
                 .any(|modifier| modifier == "allowNoLineOverride")
         });
     if chart_space_sp_pr.is_some()
-        && chart_space_sp_pr.and_then(|sp_pr| child(sp_pr, "ln")).is_none()
+        && chart_space_sp_pr
+            .and_then(|sp_pr| child(sp_pr, "ln"))
+            .is_none()
         && chart_area_allows_no_line_override
     {
         chart_line_style.hidden = Some(true);
@@ -11900,10 +11902,8 @@ pub fn parse_chart_part_with_references_style_parts_and_images(
                     ChartImageSource::Chart,
                 )
             });
-            let inverted_fill_authored = matches!(
-                inverted_paint.as_ref(),
-                Some(ChartStylePaint::Fill(_))
-            );
+            let inverted_fill_authored =
+                matches!(inverted_paint.as_ref(), Some(ChartStylePaint::Fill(_)));
             let (mut inverted_fill, mut inverted_fill_hidden) = match inverted_paint {
                 Some(ChartStylePaint::NoFill) => (None, Some(true)),
                 Some(ChartStylePaint::Fill(fill)) => (Some(*fill), None),
@@ -11919,7 +11919,9 @@ pub fn parse_chart_part_with_references_style_parts_and_images(
             // `<a:ln>`. Without that effective outline a white inverted fill
             // disappears against the common white plot-area background.
             if inverted_fill_authored
-                && inverted_shape.and_then(|shape| child(shape, "ln")).is_none()
+                && inverted_shape
+                    .and_then(|shape| child(shape, "ln"))
+                    .is_none()
             {
                 inverted_line_color = Some("000000".to_string());
                 inverted_line_width_emu = Some(9_525);
@@ -18427,10 +18429,7 @@ Subtitle</a:t></a:r></a:p>
 
         // Without the modifier the same fill-only local spPr does not invent
         // a no-line override; the linked outline remains eligible in core.
-        let unmodified = style.replace(
-            " mods=\"allowNoFillOverride allowNoLineOverride\"",
-            "",
-        );
+        let unmodified = style.replace(" mods=\"allowNoFillOverride allowNoLineOverride\"", "");
         let control = parse_chartex_part_with_style_parts(
             document.root_element(),
             &FixtureResolver,

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -7351,7 +7351,7 @@ pub fn parse_chartex_part_with_references_style_parts_and_images(
         extract_legend_text_props(root);
     let legend_font_color = extract_legend_font_color(root, resolver);
     let legend_frame = extract_legend_frame_style(root, resolver);
-    let chart_line_style = extract_direct_shape_line(root, resolver);
+    let mut chart_line_style = extract_direct_shape_line(root, resolver);
 
     // `<cx:catScaling gapWidth>` (chartEx) — same semantics as legacy
     // `<c:gapWidth>` but stored as a *fraction* (e.g. 0.8 ≡ 80%) instead of
@@ -7368,6 +7368,25 @@ pub fn parse_chartex_part_with_references_style_parts_and_images(
     let chart_space_sp_pr = root
         .children()
         .find(|node| node.is_element() && node.tag_name().name() == "spPr");
+    // Chart Style's `allowNoLineOverride` modifier permits a chart-owned
+    // shape-property override to replace the linked chart-area outline with
+    // no line (MS-ODRAWXML §2.8.4.8). PowerPoint-authored ChartEx parts use a
+    // direct chartSpace `spPr` containing only the background fill for that
+    // override; do not revive the linked style's light-grey outline merely
+    // because the local `spPr` has no `a:ln` child.
+    let chart_area_allows_no_line_override = style_element("chartArea")
+        .and_then(|entry| entry.attribute("mods"))
+        .is_some_and(|mods| {
+            mods.split_ascii_whitespace()
+                .any(|modifier| modifier == "allowNoLineOverride")
+        });
+    if chart_space_sp_pr.is_some()
+        && chart_space_sp_pr.and_then(|sp_pr| child(sp_pr, "ln")).is_none()
+        && chart_area_allows_no_line_override
+    {
+        chart_line_style.hidden = Some(true);
+        chart_line_style.paint_authored = Some(true);
+    }
     let chart_fill_style = extract_direct_shape_fill(chart_space_sp_pr, resolver);
     let chart_bg = if chart_fill_style.paint_authored == Some(true) {
         chart_fill_style.color.clone()
@@ -11881,6 +11900,10 @@ pub fn parse_chart_part_with_references_style_parts_and_images(
                     ChartImageSource::Chart,
                 )
             });
+            let inverted_fill_authored = matches!(
+                inverted_paint.as_ref(),
+                Some(ChartStylePaint::Fill(_))
+            );
             let (mut inverted_fill, mut inverted_fill_hidden) = match inverted_paint {
                 Some(ChartStylePaint::NoFill) => (None, Some(true)),
                 Some(ChartStylePaint::Fill(fill)) => (Some(*fill), None),
@@ -11891,6 +11914,16 @@ pub fn parse_chart_part_with_references_style_parts_and_images(
                 inverted_format
                     .map(|format| extract_sp_pr_ln_style(format, color_resolver))
                     .unwrap_or((None, None, false));
+            // Excel retains a visible 0.75pt black boundary when the Office
+            // 2010 negative-bar extension authors an alternate fill but omits
+            // `<a:ln>`. Without that effective outline a white inverted fill
+            // disappears against the common white plot-area background.
+            if inverted_fill_authored
+                && inverted_shape.and_then(|shape| child(shape, "ln")).is_none()
+            {
+                inverted_line_color = Some("000000".to_string());
+                inverted_line_width_emu = Some(9_525);
+            }
 
             // Excel's implicit classic-chart style gives an entirely-negative,
             // otherwise unformatted bar/column series an outline-only marker.
@@ -16346,8 +16379,8 @@ Subtitle</a:t></a:r></a:p>
             })
         );
         assert_eq!(series.inverted_fill_hidden, None);
-        assert_eq!(series.inverted_line_color, None);
-        assert_eq!(series.inverted_line_width_emu, None);
+        assert_eq!(series.inverted_line_color.as_deref(), Some("000000"));
+        assert_eq!(series.inverted_line_width_emu, Some(9_525));
         assert_eq!(series.inverted_line_hidden, None);
     }
 
@@ -18360,6 +18393,53 @@ Subtitle</a:t></a:r></a:p>
                 .fill_hidden,
             Some(true)
         );
+    }
+
+    #[test]
+    fn parse_chartex_chart_space_fill_can_override_an_allowed_linked_outline() {
+        let xml = format!(
+            r#"<cx:chartSpace xmlns:cx="{CX_NS}" xmlns:a="{A_NS}">
+              <cx:chart><cx:plotArea><cx:plotAreaRegion>
+                <cx:series layoutId="boxWhisker"/>
+              </cx:plotAreaRegion></cx:plotArea></cx:chart>
+              <cx:spPr><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></cx:spPr>
+            </cx:chartSpace>"#
+        );
+        let style = format!(
+            r#"<cs:chartStyle xmlns:cs="{CS_NS}" xmlns:a="{A_NS}">
+              <cs:chartArea mods="allowNoFillOverride allowNoLineOverride">
+                <cs:spPr><a:ln w="9525"><a:solidFill><a:srgbClr val="D9D9D9"/></a:solidFill></a:ln></cs:spPr>
+              </cs:chartArea>
+            </cs:chartStyle>"#
+        );
+        let document = chart_space_of(&xml);
+        let model = parse_chartex_part_with_style_parts(
+            document.root_element(),
+            &FixtureResolver,
+            Some(&style),
+            None,
+        )
+        .expect("ChartEx chart area parses");
+
+        assert_eq!(model.chart_fill_paint_authored, Some(true));
+        assert_eq!(model.chart_border_hidden, Some(true));
+        assert_eq!(model.chart_border_paint_authored, Some(true));
+
+        // Without the modifier the same fill-only local spPr does not invent
+        // a no-line override; the linked outline remains eligible in core.
+        let unmodified = style.replace(
+            " mods=\"allowNoFillOverride allowNoLineOverride\"",
+            "",
+        );
+        let control = parse_chartex_part_with_style_parts(
+            document.root_element(),
+            &FixtureResolver,
+            Some(&unmodified),
+            None,
+        )
+        .expect("control ChartEx chart area parses");
+        assert_eq!(control.chart_border_hidden, None);
+        assert_eq!(control.chart_border_paint_authored, None);
     }
 
     #[test]

--- a/packages/pptx/src/Examples.stories.ts
+++ b/packages/pptx/src/Examples.stories.ts
@@ -5,6 +5,12 @@ import { PptxViewer } from './viewer';
 import { PptxScrollViewer } from './scroll-viewer';
 import type { PptxTextRunInfo } from './renderer';
 import { buildPptxTextLayer } from './text-layer';
+import { math } from '../../../src/math';
+import { threeD } from '../../../src/three-d';
+import { regionMap } from '../../../src/region-map';
+import { chartEx } from '../../../src/chart-ex';
+
+const fullRenderers = { math, threeD, regionMap, chartEx } as const;
 
 type DemoArgs = { width: number };
 type LayoutArgs = Record<string, never>;
@@ -68,7 +74,7 @@ export const ScrollView: LayoutStory = {
       'max-height:720px;overflow-y:auto;border:1px solid #ccc;background:#f5f5f5;padding:12px;';
     root.appendChild(scroller);
 
-    PptxPresentation.load(SAMPLE_URL, { useGoogleFonts: true })
+    PptxPresentation.load(SAMPLE_URL, { useGoogleFonts: true, ...fullRenderers })
       .then(async (pres) => {
         status.textContent = `Rendering ${pres.slideCount} slides…`;
         const widthPx = 800;
@@ -182,7 +188,7 @@ export const ThumbnailGrid: LayoutStory = {
       'display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:16px;';
     root.appendChild(grid);
 
-    PptxPresentation.load(SAMPLE_URL, { useGoogleFonts: true })
+    PptxPresentation.load(SAMPLE_URL, { useGoogleFonts: true, ...fullRenderers })
       .then(async (pres) => {
         status.textContent = `Rendering ${pres.slideCount} thumbnails…`;
         const thumbWidth = 240;
@@ -247,11 +253,12 @@ export const MasterDetail: LayoutStory = {
       width: 800,
       useGoogleFonts: true,
       enableTextSelection: true,
+      ...fullRenderers,
     });
 
     // Load thumbnails using PptxPresentation; detail viewer loads independently
     Promise.all([
-      PptxPresentation.load(SAMPLE_URL, { useGoogleFonts: true }),
+      PptxPresentation.load(SAMPLE_URL, { useGoogleFonts: true, ...fullRenderers }),
       detailViewer.load(SAMPLE_URL),
     ])
       .then(async ([pres]) => {

--- a/packages/pptx/src/PptxViewer.stories.ts
+++ b/packages/pptx/src/PptxViewer.stories.ts
@@ -3,6 +3,7 @@ import { PptxViewer } from './viewer';
 import { math } from '../../../src/math';
 import { threeD } from '../../../src/three-d';
 import { regionMap } from '../../../src/region-map';
+import { chartEx } from '../../../src/chart-ex';
 
 type Args = {
   width: number;
@@ -72,6 +73,7 @@ export function buildViewerUI(
     math,
     threeD,
     regionMap,
+    chartEx,
     onSlideChange: (idx, total) => {
       slideInfo.textContent = `Slide ${idx + 1} / ${total}`;
       prevBtn.disabled = idx === 0;
@@ -190,6 +192,7 @@ function renderFileUpload(args: Args, mode: 'main' | 'worker'): HTMLElement {
         math,
         threeD,
         regionMap,
+        chartEx,
         onSlideChange: (idx, total) => {
           slideInfo.textContent = `Slide ${idx + 1} / ${total}`;
           prevBtn.disabled = idx === 0;

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -3955,21 +3955,26 @@ export function renderTextBody(
         maxSizePx = bulletImage.sizePx;
       }
 
-      // PowerPoint's existing natural-line approximation for authored
-      // percentage spacing. The document-font design floor applies only when
-      // line spacing is omitted; an explicit percentage is already the
-      // author's vertical-spacing decision, and `spcPts` remains absolute.
+      // PowerPoint's existing natural-line approximation for painting. Table
+      // row auto-sizing is different: ECMA-376 §21.1.2.2.5/.11 defines
+      // percentage spacing from the largest authored text size, and omitted
+      // spacing from that point size. A substituted font's design-line-height
+      // floor must not enlarge the table structure (the glyphs are still
+      // painted with the normal floor below). This matters for rows whose
+      // authored height already accommodates the text: using Meiryo's taller
+      // design box used to grow every such row even though PowerPoint did not.
       const naturalSingle = maxSizePx * 1.2;
       const implicitSingle = Math.max(naturalSingle, designSingle);
       let lineHeight: number;
       if (para.spaceLine) {
         if (para.spaceLine.type === 'pct') {
-          lineHeight = naturalSingle * (para.spaceLine.val / 100000);
+          const percentageBase = measureOnly ? maxSizePx : naturalSingle;
+          lineHeight = percentageBase * (para.spaceLine.val / 100000);
         } else {
           lineHeight = para.spaceLine.val * PT_TO_EMU * scale;
         }
       } else {
-        lineHeight = implicitSingle;
+        lineHeight = measureOnly ? maxSizePx : implicitSingle;
       }
       // normAutofit lnSpcReduction (ECMA-376 §21.1.2.1.3): PowerPoint reduces
       // each paragraph's line spacing by this fraction alongside the font

--- a/packages/pptx/src/table-border-single-draw.test.ts
+++ b/packages/pptx/src/table-border-single-draw.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { Stroke } from '@silurus/ooxml-core';
 import { renderTable } from './renderer.js';
-import type { TableCell, TableElement, TableRow } from './types';
+import type { TableCell, TableElement, TableRow, TextBody } from './types';
 
 // DrawingML `<a:tbl>` — end-to-end render: an interior gridline SHARED by two
 // adjacent cells is drawn exactly ONCE (not once per cell), and when the two
@@ -112,6 +112,34 @@ function rgba(hex: string): string {
 }
 
 describe('DrawingML <a:tbl> — shared interior gridline drawn once (spec-silent)', () => {
+  it('does not grow an authored row from substituted-font design metrics', () => {
+    // ECMA-376 §21.1.2.2.5/.11: 120% line spacing is based on the largest
+    // authored text size. 16pt * 120% + 3pt after + 2 * 8.5pt insets = 39.2pt,
+    // so the authored 40.6pt row already fits. The old measure-only path used
+    // Meiryo's ~1.596em design line box and moved this boundary down to 42.5pt.
+    const textBody = {
+      verticalAnchor: 'ctr',
+      paragraphs: [{
+        alignment: 'l', marL: 0, marR: 0, indent: 0,
+        spaceBefore: null, spaceAfter: 300,
+        spaceLine: { type: 'pct', val: 120000 },
+        runs: [{ type: 'text', text: '流動負債', fontSize: 16, fontFamily: 'Meiryo' }],
+        bullet: { type: 'none' }, eaLnBrk: true,
+      }],
+      defaultFontSize: null, defaultBold: null, defaultItalic: null,
+      lIns: 108000, rIns: 108000, tIns: 108000, bIns: 108000,
+      wrap: 'square', vert: 'horz', autoFit: 'none',
+    } as unknown as TextBody;
+    const rowH = 40.6 * EMU;
+    const t = tableOf([
+      [cell({ textBody, borderB: ln() })],
+      [cell({ borderT: ln() })],
+    ], [COL]);
+    t.rows[0].height = rowH;
+
+    expect(horizontalAt(render(t), 40.6)).toHaveLength(1);
+  });
+
   it('shared VERTICAL gridline is drawn exactly ONCE (not once per cell)', () => {
     // Left cell right = 1pt; right cell left = 1pt (same). Previously TWO strokes
     // at x=60 (one per cell); now exactly one.

--- a/packages/xlsx/src/XlsxViewer.stories.ts
+++ b/packages/xlsx/src/XlsxViewer.stories.ts
@@ -3,6 +3,7 @@ import { XlsxViewer } from './viewer';
 import { math } from '../../../src/math';
 import { threeD } from '../../../src/three-d';
 import { regionMap } from '../../../src/region-map';
+import { chartEx } from '../../../src/chart-ex';
 
 type Args = {
   scale: number;
@@ -56,6 +57,7 @@ export function buildViewerUI(
     math,
     threeD,
     regionMap,
+    chartEx,
     onReady: (names) => {
       sheetNames = names;
       status.textContent = `Loaded — ${names.length} sheet(s)`;
@@ -123,6 +125,7 @@ function renderFileUpload(args: Args, mode: 'main' | 'worker'): HTMLElement {
         math,
         threeD,
         regionMap,
+        chartEx,
         onReady: (names) => { sheetNames = names; status.textContent = `${names.length} sheet(s)`; },
         onSheetChange: (idx, total) => { status.textContent = `Sheet ${idx + 1} / ${total}: ${sheetNames[idx] ?? ''}`; },
         onError: (err) => { status.textContent = `Error: ${err.message}`; },

--- a/packages/xlsx/src/viewer-reload-orphan.test.ts
+++ b/packages/xlsx/src/viewer-reload-orphan.test.ts
@@ -82,6 +82,21 @@ describe('XlsxViewer.load() — no orphaned workbook on re-load (SC20)', () => {
     expect(b.destroy).toHaveBeenCalledTimes(1);
   });
 
+  it('forwards the opt-in ChartEx renderer to the workbook load', async () => {
+    const chartEx = { render: vi.fn() };
+    const { v } = build({ chartEx });
+    const loaded = fakeWorkbook();
+    const loadSpy = vi.spyOn(XlsxWorkbook, 'load').mockResolvedValueOnce(loaded.wb);
+
+    await v.load('chartex.xlsx');
+
+    expect(loadSpy).toHaveBeenCalledWith(
+      'chartex.xlsx',
+      expect.objectContaining({ chartEx }),
+    );
+    v.destroy();
+  });
+
   it('does not report an old worksheet acquisition rejected by a successful reload', async () => {
     installDom();
     const onError = vi.fn();

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -1091,6 +1091,7 @@ class XlsxViewerEngine implements ZoomableViewer {
           math: this.opts.math,
           threeD: this.opts.threeD,
           regionMap: this.opts.regionMap,
+          chartEx: this.opts.chartEx,
           mode: this._mode,
         }), () => {
           // Claim every async-operation generation before closing the old


### PR DESCRIPTION
## Summary

- keep ChartEx available through viewer reloads and enable the full optional renderer set in Storybook
- preserve direct ChartEx paint/no-line precedence, raw-value label gating, negative-bar outlines, and transparent pie-label semantics
- extrude Line3D strokes through series depth while suppressing unauthored 3-D value gridlines
- align PPTX table auto-size measurement with authored text size

## Verification

- core chart: 34 files / 1,343 tests
- ooxml-common: 488 tests
- focused viewer/table: 19 tests
- workspace TypeScript build and clippy with warnings denied
- production build and Storybook static build
- DOCX/XLSX/PPTX public API baselines and viewer symmetry
- private-corpus self-VRT against the exact main baseline; every changed item was reviewed against the corresponding Office behavior or the reported rendering defect
