### PR TITLE
fix(chart): restore pie outside-label geometry

### DIFF
--- a/packages/core/src/chart/renderer-scatter-line-and-pie-labels.test.ts
+++ b/packages/core/src/chart/renderer-scatter-line-and-pie-labels.test.ts
@@ -404,6 +404,38 @@ describe('pie / doughnut ctr data-label radius (§21.2.2.48, PowerPoint layout)'
     }
   });
 
+  it('keeps the complete outEnd text boxes outside the pie, not only their centers', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'pie',
+      categories: ['Long right-side category', 'Long left-side category'],
+      plotAreaManualLayout: {
+        xMode: 'edge', yMode: 'edge', x: 0.3, y: 0.15, w: 0.4, h: 0.7,
+      },
+      series: [series({
+        name: 'Share',
+        values: [50, 50],
+        categories: ['Long right-side category', 'Long left-side category'],
+        seriesDataLabels: {
+          showVal: true, showCatName: true, showSerName: false, showPercent: false,
+          position: 'outEnd', separator: '\n', fontSizeHpt: 1200,
+        },
+      })],
+    }), RECT, 1);
+
+    const { cx, cy, outerR } = pieGeometry(rec.arcs);
+    const categoryLabels = rec.texts.filter(t => t.text.startsWith('Long '));
+    expect(categoryLabels).toHaveLength(2);
+    for (const label of categoryLabels) {
+      const fontPx = Number(/(\d+(?:\.\d+)?)px/.exec(label.font)?.[1] ?? 12);
+      const halfW = label.text.length * fontPx * 0.6 / 2;
+      const halfH = fontPx / 2;
+      const dx = Math.max(Math.abs(label.x - cx) - halfW, 0);
+      const dy = Math.max(Math.abs(label.y - cy) - halfH, 0);
+      expect(Math.hypot(dx, dy)).toBeGreaterThanOrEqual(outerR);
+    }
+  });
+
   it('does not invent leader lines when ordinary outEnd labels do not collide', () => {
     const rec = recordingCtx('#A6A6A6');
     renderChart(rec.ctx, baseModel({

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -10514,6 +10514,40 @@ interface PieOutsideLabel {
   cyBox: number;
 }
 
+function pointToRectDistance(
+  px: number, py: number,
+  rectCx: number, rectCy: number,
+  halfW: number, halfH: number,
+): number {
+  const dx = Math.max(Math.abs(rectCx - px) - halfW, 0);
+  const dy = Math.max(Math.abs(rectCy - py) - halfH, 0);
+  return Math.hypot(dx, dy);
+}
+
+/** Find the first point on a slice-midpoint ray whose complete visible label
+ * rectangle clears the pie. This restores the release geometry without
+ * reintroducing collision moves or their synthetic leader lines. */
+function outsideLabelRadialDistance(
+  midAngle: number,
+  outerR: number,
+  halfW: number,
+  halfH: number,
+  clearance: number,
+): number {
+  const ux = Math.cos(midAngle);
+  const uy = Math.sin(midAngle);
+  const target = outerR + clearance;
+  let low = 0;
+  let high = target + Math.hypot(halfW, halfH);
+  for (let i = 0; i < 32; i++) {
+    const mid = (low + high) / 2;
+    const distance = pointToRectDistance(0, 0, ux * mid, uy * mid, halfW, halfH);
+    if (distance >= target) high = mid;
+    else low = mid;
+  }
+  return high;
+}
+
 function createPieOutsideLabel(
   lines: string[],
   midAngle: number,
@@ -10532,6 +10566,9 @@ function createPieOutsideLabel(
   textStyle: DataLabelTextStyle = {},
   ptToPx = 1,
 ): PieOutsideLabel {
+  const visibleRotated = rotatedDataLabelSize(
+    boxW, boxH, textStyle.textRotation, textStyle.textVerticalMode,
+  );
   const insets = dataLabelInsets(textStyle, ptToPx);
   const unrotatedW = boxW + insets.left + insets.right;
   const unrotatedH = boxH + insets.top + insets.bottom;
@@ -10540,12 +10577,13 @@ function createPieOutsideLabel(
   );
   boxW = rotated.w;
   boxH = rotated.h;
-  // `outEnd` does not define a collision solver. Keep automatic labels on the
-  // slice-midpoint ray just beyond the rim; moving them according to browser
-  // font metrics invents leader lines that Office does not draw for the same
-  // authored labels. The radial offset is the existing Office-observed pie
-  // label placement used before collision handling was introduced.
-  const distance = outerR + Math.max(10, outerR * 0.12);
+  // `outEnd` requires the visible label content, rather than only its anchor,
+  // to clear the pie. Keep the release-era radial geometry while leaving each
+  // label on its authored slice-midpoint ray; no collision movement means no
+  // synthetic leader line is introduced.
+  const distance = outsideLabelRadialDistance(
+    midAngle, outerR, visibleRotated.w / 2, visibleRotated.h / 2, fontPx * 0.5,
+  );
   const cxBox = pieCx + Math.cos(midAngle) * distance;
   const cyBox = pieCy + Math.sin(midAngle) * distance;
   return {


### PR DESCRIPTION
## Summary
- restore the previous release bounded rectangle-to-rim placement for plain pie and doughnut outEnd labels
- retain the current no-collision path so automatic labels do not invent leader lines
- preserve rich text, rotation, insets, and data-label legend keys

## Root cause
A recent fixed radial offset guaranteed only that the label anchor cleared the pie. Long label rectangles could still overlap the slice and visibly regress workbooks that rendered correctly in the previous release.

## Verification
- core chart Vitest suite: 34 files, 1344 tests
- TypeScript project build
- git diff check
- local-only comparison of the same workbook in v0.80.2 and the candidate Storybook