### PR TITLE
fix(chart): reserve manual top legends in bar plots

### DIFF
--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -4829,6 +4829,41 @@ describe('bar chart authored layout and fills', () => {
     )).toBe(true);
   });
 
+  it('keeps a non-overlay manual top legend outside the automatic bar plot', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredBar',
+      title: 'Revenue',
+      titlePresent: true,
+      titleFontSizeHpt: 1200,
+      categories: ['A'],
+      series: [series({ name: 'Series', values: [10] })],
+      valMin: 0,
+      valMax: 10,
+      valAxisMajorUnit: 5,
+      valAxisFontSizeHpt: 1000,
+      showLegend: true,
+      legendPos: 't',
+      legendOverlay: false,
+      legendFillColor: '123456',
+      legendFontSizeHpt: 1000,
+      legendManualLayout: {
+        xMode: 'edge', yMode: 'edge', wMode: 'factor', hMode: 'factor',
+        x: 0.1, y: 0.25, w: 0.5, h: 0.1,
+      },
+    }), RECT, 1);
+
+    const legend = rec.rects.find(rect => rect.fs === '#123456');
+    if (!legend) throw new Error('expected the authored legend frame');
+    const horizontalGridLines = rec.strokedPaths
+      .filter(path => path.points.length === 2
+        && Math.abs(path.points[0].y - path.points[1].y) < 0.001
+        && Math.abs(path.points[1].x - path.points[0].x) > RECT.w / 2);
+    expect(horizontalGridLines.length).toBeGreaterThan(0);
+    const plotTop = Math.min(...horizontalGridLines.map(path => path.points[0].y));
+    expect(plotTop).toBeGreaterThanOrEqual(legend.y + legend.h);
+  });
+
   it('does not reserve plot space for an overlay legend and retains manual placement', () => {
     const render = (overlay: boolean) => {
       const rec = recordingCtx();

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -1528,6 +1528,44 @@ export function drawLegendForLayout(
     chart.categories, ptToPx, fillPaints, shapeRotationDeg, chart.varyColors !== false, chart, leg);
 }
 
+/** Expand a cartesian plot's automatic top inset around an authored top legend.
+ * A non-overlay manual legend still participates in chart layout: its authored
+ * rectangle replaces the automatic legend rectangle, so the plot must start
+ * below its actual bottom rather than below the shorter measured reserve. Keep
+ * the existing automatic legend-to-plot clearance unchanged. */
+function manualTopLegendPlotInset(
+  chart: ChartModel,
+  legend: MeasuredLegendLayout | null,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  titleBandH: number,
+  automaticInset: number,
+): number {
+  if (!legend
+    || legend.side !== 't'
+    || chart.legendOverlay === true
+    || chart.legendManualLayout == null) return automaticInset;
+  const defaultBox = {
+    x: x + LEGEND_HORIZONTAL_INSET,
+    y: y + titleBandH + 2,
+    w: Math.max(0, w - LEGEND_HORIZONTAL_PADDING),
+    h: legend.reserveH,
+  };
+  const manualBox = resolveManualLayoutRect(
+    chart.legendManualLayout,
+    { x, y, w, h },
+    defaultBox,
+  );
+  if (!manualBox) return automaticInset;
+  const automaticGap = Math.max(0, y + automaticInset - (defaultBox.y + defaultBox.h));
+  return Math.max(
+    automaticInset,
+    manualBox.y + manualBox.h - y + automaticGap,
+  );
+}
+
 export function drawAxisTick(
   ctx: CanvasRenderingContext2D,
   mode: string | null | undefined,
@@ -3782,6 +3820,9 @@ export function renderBarChart(
       )
       : legLeftW + Math.max(valTitleW + valLabelBandW, dataTableHeaderW),
   };
+  pad.t = manualTopLegendPlotInset(
+    chart, leg, x, y, w, h, titleH, pad.t,
+  );
 
   // `layoutTarget="outer"` includes tick labels and axis titles, but not the
   // chart title or legend. Convert only those measured axis bands to the inner
@@ -3847,7 +3888,9 @@ export function renderBarChart(
     titleH = titleBand.bandH;
     padT = titleH + legTopH + valAxLabelFontPx / 2 + 2
       + secondaryCatLabelBandH + secondaryCatTitleBandH;
-    pad.t = padT;
+    pad.t = manualTopLegendPlotInset(
+      chart, leg, x, y, w, h, titleH, padT,
+    );
     frame = computeChartFrame(chart, x, y, w, h, ptToPx, {
       titleBand,
       legendSideReserveFrac: 0.22,


### PR DESCRIPTION
## Summary

- keep a non-overlay manual top legend outside the automatic bar plot
- preserve the existing automatic clearance below the authored legend rectangle
- add a renderer regression that observes the legend frame and plot grid geometry

## Root cause

The legend painter honored the authored CT_ManualLayout rectangle, but the bar frame planner still reserved only the smaller automatic legend band. The plot therefore began inside the manual legend rectangle and appeared taller than PowerPoint output. The outer chart frame geometry was already correct.

## Verification

- full core chart suite: 34 files, 1345 tests
- renderer correctness: 905 tests
- TypeScript project build
- Storybook comparison against Office PDF output
- git diff --check