### PR TITLE
fix(pptx): restore automatic table line height

### DIFF
--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -3599,6 +3599,11 @@ export function renderTextBody(
   // `vert`/`vert270` (whose spec meaning IS to rotate every glyph), keeping those
   // paths byte-identical.
   eaVertUpright = false,
+  // A zero-height table row asks PowerPoint to derive its height from the
+  // natural line box. A positive a:tr@h is instead an authored minimum: use the
+  // glyph-size box when checking whether content actually exceeds that minimum,
+  // so implicit leading alone does not enlarge an already-sufficient row.
+  measureNaturalLineSpacing = measureOnly,
 ): number | void {
   // Vertical text: rotate rendering context so text flows top-to-bottom.
   // "vert" and "eaVert" both approximate to 90° clockwise rotation.
@@ -3955,14 +3960,14 @@ export function renderTextBody(
         maxSizePx = bulletImage.sizePx;
       }
 
-      // PowerPoint's existing natural-line approximation for painting. Table
-      // row auto-sizing is different: ECMA-376 §21.1.2.2.5/.11 defines
-      // percentage spacing from the largest authored text size, and omitted
-      // spacing from that point size. A substituted font's design-line-height
-      // floor must not enlarge the table structure (the glyphs are still
-      // painted with the normal floor below). This matters for rows whose
-      // authored height already accommodates the text: using Meiryo's taller
-      // design box used to grow every such row even though PowerPoint did not.
+      // PowerPoint's natural single-line box is 120% of the authored text size.
+      // An explicit percentage is instead based directly on that authored size
+      // (ECMA-376 §21.1.2.2.5/.11). Table measurement therefore retains the
+      // natural 120% box only when line spacing is omitted in an auto-height
+      // row. A positive a:tr@h remains a minimum and uses the glyph-size box for
+      // overflow measurement. Both exclude a substituted font's larger
+      // design-metric floor; glyph painting may keep that floor below without
+      // enlarging the table structure.
       const naturalSingle = maxSizePx * 1.2;
       const implicitSingle = Math.max(naturalSingle, designSingle);
       let lineHeight: number;
@@ -3974,7 +3979,9 @@ export function renderTextBody(
           lineHeight = para.spaceLine.val * PT_TO_EMU * scale;
         }
       } else {
-        lineHeight = measureOnly ? maxSizePx : implicitSingle;
+        lineHeight = measureOnly
+          ? (measureNaturalLineSpacing ? naturalSingle : maxSizePx)
+          : implicitSingle;
       }
       // normAutofit lnSpcReduction (ECMA-376 §21.1.2.1.3): PowerPoint reduces
       // each paragraph's line spacing by this fraction alongside the font
@@ -5824,7 +5831,7 @@ export function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, sca
       const cellW = spannedWidth(ci, cell.gridSpan || 1);
       const needed = (renderTextBody(
         ctx, cell.textBody, 0, 0, cellW, 0, scale, null, 0, false, false,
-        '#000000', slideNumber, rc, undefined, true,
+        '#000000', slideNumber, rc, undefined, true, undefined, false, row.height === 0,
       ) as number) || 0;
       if (needed > rowHeights[ri]) rowHeights[ri] = needed;
     }
@@ -5841,9 +5848,12 @@ export function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, sca
       const span = cell.rowSpan || 1;
       if (span <= 1 || !cell.textBody) continue;
       const cellW = spannedWidth(ci, cell.gridSpan || 1);
+      const hasAutoHeightRow = el.rows
+        .slice(ri, Math.min(el.rows.length, ri + span))
+        .some((spannedRow) => spannedRow.height === 0);
       const needed = (renderTextBody(
         ctx, cell.textBody, 0, 0, cellW, 0, scale, null, 0, false, false,
-        '#000000', slideNumber, rc, undefined, true,
+        '#000000', slideNumber, rc, undefined, true, undefined, false, hasAutoHeightRow,
       ) as number) || 0;
       let have = 0;
       for (let s = 0; s < span && ri + s < rowHeights.length; s++) have += rowHeights[ri + s];

--- a/packages/pptx/src/table-border-single-draw.test.ts
+++ b/packages/pptx/src/table-border-single-draw.test.ts
@@ -140,6 +140,53 @@ describe('DrawingML <a:tbl> — shared interior gridline drawn once (spec-silent
     expect(horizontalAt(render(t), 40.6)).toHaveLength(1);
   });
 
+  it('uses the natural 120% line box when table line spacing is omitted', () => {
+    // ECMA-376 leaves omitted line spacing to the text font. Current
+    // PowerPoint grows a zero-height table row from the natural single-line
+    // box: 16pt * 120% + 1pt top + 1pt bottom = 21.2pt. This is distinct from
+    // an authored `<a:spcPct val="120000"/>`, whose percentage base is the
+    // authored 16pt size rather than a second 120% multiplication.
+    const textBody = {
+      verticalAnchor: 'ctr',
+      paragraphs: [{
+        alignment: 'l', marL: 0, marR: 0, indent: 0,
+        spaceBefore: null, spaceAfter: null, spaceLine: null,
+        runs: [{ type: 'text', text: 'auto', fontSize: 16, fontFamily: 'Arial' }],
+        bullet: { type: 'none' }, eaLnBrk: true,
+      }],
+      defaultFontSize: null, defaultBold: null, defaultItalic: null,
+      lIns: 0, rIns: 0, tIns: EMU, bIns: EMU,
+      wrap: 'square', vert: 'horz', autoFit: 'none',
+    } as unknown as TextBody;
+    const t = tableOf([[cell({ textBody, borderB: ln() })]], [COL]);
+    t.rows[0].height = 0;
+
+    expect(horizontalAt(render(t), 21.2)).toHaveLength(1);
+  });
+
+  it('keeps a positive authored row height when the glyph box and insets fit', () => {
+    // ECMA-376 §21.1.3.18 makes a:tr@h a minimum, not an auto-height request.
+    // PowerPoint keeps this 18pt minimum because the 16pt glyph box plus 1pt
+    // top/bottom insets fits. Applying the auto-row 120% leading here would
+    // incorrectly enlarge the row to 21.2pt.
+    const textBody = {
+      verticalAnchor: 'ctr',
+      paragraphs: [{
+        alignment: 'l', marL: 0, marR: 0, indent: 0,
+        spaceBefore: null, spaceAfter: null, spaceLine: null,
+        runs: [{ type: 'text', text: 'fixed', fontSize: 16, fontFamily: 'Arial' }],
+        bullet: { type: 'none' }, eaLnBrk: true,
+      }],
+      defaultFontSize: null, defaultBold: null, defaultItalic: null,
+      lIns: 0, rIns: 0, tIns: EMU, bIns: EMU,
+      wrap: 'square', vert: 'horz', autoFit: 'none',
+    } as unknown as TextBody;
+    const t = tableOf([[cell({ textBody, borderB: ln() })]], [COL]);
+    t.rows[0].height = 18 * EMU;
+
+    expect(horizontalAt(render(t), 18)).toHaveLength(1);
+  });
+
   it('shared VERTICAL gridline is drawn exactly ONCE (not once per cell)', () => {
     // Left cell right = 1pt; right cell left = 1pt (same). Previously TWO strokes
     // at x=60 (one per cell); now exactly one.


### PR DESCRIPTION
## Summary
- retain the natural 120% line box for omitted spacing in zero-height auto rows
- keep positive authored row minima when the glyph box and insets already fit
- keep authored percentage spacing based directly on the authored point size
- avoid substituted-font design metrics changing structural row height
- add focused zero-height and positive-height boundary tests

## Root cause
A recent table measurement change correctly isolated explicit percentage spacing from fallback font metrics, but also reduced omitted single-line spacing from the natural line box to 100% of the authored point size. Rows with `a:tr@h=0` therefore auto-grew too little, including vertically merged tables. Applying the natural leading indiscriminately would instead enlarge positive authored row minima, so the fix preserves the two authoring states separately.

## Verification
- `./node_modules/.bin/vitest run packages/pptx/src` (101 files, 673 tests)
- `./node_modules/.bin/tsc --build --pretty false`
- `git diff --check`
- private self-VRT against the exact previous revision: 15 presentations / 151 slides; one intended table slide differed and all other slides were pixel-identical
- the intended difference was compared with an Office-produced PDF at matched scale; table top, row boundaries, and bottom align