### PR TITLE
fix(chart): restore OOXML chart regression fidelity

### DIFF
--- a/packages/core/src/chart/chart-ex-renderer.ts
+++ b/packages/core/src/chart/chart-ex-renderer.ts
@@ -1407,7 +1407,10 @@ function renderBoxWhiskerChart(
       }
 
       // Interior sample points. Excel overlays the raw non-outlier values on
-      // the box/whiskers when cx:visibility@nonoutliers is enabled.
+      // the box/whiskers when cx:visibility@nonoutliers is enabled. Their
+      // outline follows the owning box series, not the generic linked marker
+      // role (which may carry a contrasting line intended for ordinary chart
+      // markers).
       if (s.showNonoutliers) {
         const pointSymbol = chart.chartStyleMarkerSymbol ?? chart.chartexMarkerSymbol ?? 'circle';
         for (const point of stats.inner) {
@@ -1421,7 +1424,7 @@ function renderBoxWhiskerChart(
             pointSymbol,
             observationMarkerSizePt,
             markerFillPaint ? (markerFill ? `#${markerFill}` : fill) : 'transparent',
-            markerLineVisible ? (markerEdge ? `#${markerEdge}` : edge) : null,
+            markerLineVisible ? edge : null,
             ptToPx,
             ctx.lineWidth,
             markerFillPaint,
@@ -1456,7 +1459,7 @@ function renderBoxWhiskerChart(
             pointSymbol,
             observationMarkerSizePt,
             markerFillPaint ? (markerFill ? `#${markerFill}` : fill) : 'transparent',
-            markerLineVisible ? (markerEdge ? `#${markerEdge}` : edge) : null,
+            markerLineVisible ? edge : null,
             ptToPx,
             ctx.lineWidth,
             markerFillPaint,

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1410,16 +1410,21 @@ describe('classic 3-D compatibility projection', () => {
     expect(rec.strokes.filter(stroke => stroke.ss === '#898989')).toHaveLength(0);
   });
 
-  it('keeps authored 0.25pt 3-D axes at the two-pixel Office raster floor', () => {
+  it('keeps the 3-D frame visible while using authored 0.25pt width for ticks', () => {
     const rec = strokedPolylineCtx();
     renderChart(rec.ctx, baseModel({
       chartType: 'clusteredBar',
       categories: ['A', 'B'],
+      valMin: 0,
+      valMax: 20,
+      valAxisMajorUnit: 10,
       catAxisLineColor: 'FF00FF',
       catAxisLineWidthEmu: 3_175,
+      catAxisMajorTickMark: 'out',
       catAxisMajorGridlines: false,
       valAxisLineColor: '00AA00',
       valAxisLineWidthEmu: 3_175,
+      valAxisMajorTickMark: 'out',
       valAxisMajorGridlines: false,
       threeD: {
         rotationX: 15,
@@ -1435,17 +1440,92 @@ describe('classic 3-D compatibility projection', () => {
           lineHidden: false,
           lineColor: '0000FF',
           lineWidthEmu: 3_175,
-          majorTickMark: 'none',
+          majorTickMark: 'out',
         },
       },
-      series: [series({ values: [5, 15], lineHidden: true })],
+      series: [
+        series({ values: [5, 15], lineHidden: true }),
+        series({ values: [8, 12], lineHidden: true }),
+      ],
     }), RECT, 1);
 
     for (const color of ['#FF00FF', '#00AA00', '#0000FF']) {
       const strokes = rec.strokes.filter(stroke => stroke.ss === color);
       expect(strokes.length).toBeGreaterThan(0);
-      expect(strokes.every(stroke => stroke.lw === 2)).toBe(true);
+      const length = (stroke: (typeof strokes)[number]) => Math.hypot(
+        stroke.points[1].x - stroke.points[0].x,
+        stroke.points[1].y - stroke.points[0].y,
+      );
+      const frame = strokes.reduce((longest, stroke) =>
+        length(stroke) > length(longest) ? stroke : longest);
+      const ticks = strokes.filter(stroke => stroke !== frame);
+      expect(frame.lw).toBe(2);
+      expect(ticks.length).toBeGreaterThan(0);
+      expect(ticks.every(stroke => stroke.lw === 0.25)).toBe(true);
     }
+  });
+
+  it('places standard 3-D category and series ticks on slot boundaries', () => {
+    const rec = strokedPolylineCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredBar',
+      categories: ['A', 'B', 'C'],
+      catAxisCrossBetween: 'between',
+      catAxisLineColor: 'FF00FF',
+      catAxisMajorTickMark: 'out',
+      catAxisMajorGridlines: false,
+      valAxisHidden: true,
+      threeD: {
+        rotationX: 15,
+        rotationY: 20,
+        depthPercent: 100,
+        perspective: 0,
+        rightAngleAxes: true,
+        barGrouping: 'standard',
+        floor: { lineHidden: true },
+        sideWall: { lineHidden: true },
+        backWall: { lineHidden: true },
+        seriesAxis: {
+          hidden: false,
+          lineHidden: false,
+          lineColor: '0000FF',
+          majorTickMark: 'out',
+        },
+      },
+      series: [
+        series({ name: 'North', values: [5, 10, 15], lineHidden: true }),
+        series({ name: 'South', values: [7, 12, 17], lineHidden: true }),
+      ],
+    }), RECT, 1);
+
+    const tickFractions = (color: string) => {
+      const strokes = rec.strokes.filter(stroke => stroke.ss === color && stroke.points.length === 2);
+      const length = (stroke: (typeof strokes)[number]) => Math.hypot(
+        stroke.points[1].x - stroke.points[0].x,
+        stroke.points[1].y - stroke.points[0].y,
+      );
+      const axis = strokes.reduce((longest, stroke) =>
+        length(stroke) > length(longest) ? stroke : longest);
+      const [start, end] = axis.points;
+      const dx = end.x - start.x;
+      const dy = end.y - start.y;
+      const lengthSquared = dx * dx + dy * dy;
+      return strokes
+        .filter(stroke => stroke !== axis)
+        .map(stroke => {
+          const anchor = stroke.points[1];
+          return ((anchor.x - start.x) * dx + (anchor.y - start.y) * dy) / lengthSquared;
+        })
+        .sort((a, b) => a - b);
+    };
+
+    expect(tickFractions('#FF00FF')).toEqual([
+      expect.closeTo(0, 6), expect.closeTo(1 / 3, 6),
+      expect.closeTo(2 / 3, 6), expect.closeTo(1, 6),
+    ]);
+    expect(tickFractions('#0000FF')).toEqual([
+      expect.closeTo(0, 6), expect.closeTo(0.5, 6), expect.closeTo(1, 6),
+    ]);
   });
 
   it('does not turn a linked gridline style into unauthored 3-D grid geometry', () => {
@@ -15428,6 +15508,14 @@ describe('classic line-chart group decorations', () => {
     const outlines = rec.strokeRects.filter(rect => rect.ss === '#333333');
     expect(outlines).toHaveLength(5);
     expect(new Set(outlines.map(rect => rect.w.toFixed(6))).size).toBe(1);
+    const firstSeries = rec.paintEvents.findIndex(event =>
+      event.kind === 'stroke' && event.strokeStyle === '#4472C4'
+    );
+    const firstBar = rec.paintEvents.findIndex(event =>
+      event.kind === 'rect' && event.fillStyle === '#EEEEEE'
+    );
+    expect(firstSeries).toBeGreaterThanOrEqual(0);
+    expect(firstBar).toBeGreaterThan(firstSeries);
   });
 
   it('fills missing line-group decoration paint from linked Chart Style roles', () => {
@@ -16520,6 +16608,39 @@ describe('CH13 — stock chart (high/low/close)', () => {
     expect(rec.rects.filter(rect => rect.fs === '#3F3F3F')).toHaveLength(3);
     expect(rec.arcs).toHaveLength(4); // three plotted High points + one legend marker
     expect(rec.texts.map(text => text.text)).toEqual(expect.arrayContaining(['High', 'Low', 'Close']));
+  });
+
+  it('paints up/down bars over the high-low rule and owning line series', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, stockModel({
+      stockUpDownBars: true,
+      stockHiLowLineColor: '123456',
+      series: [
+        series({
+          name: 'Open', values: [40], markerSymbol: 'none',
+          lineColor: '4472C4', seriesType: 'line',
+        }),
+        series({
+          name: 'Close', values: [20], markerSymbol: 'none',
+          lineColor: 'C0504D', seriesType: 'line',
+        }),
+      ],
+      plotGroups: [plotGroup('line', 0, 2)],
+    }), RECT, 1);
+
+    const hiLowIndex = rec.paintEvents.findIndex(event =>
+      event.kind === 'stroke' && event.strokeStyle === '#123456'
+    );
+    const owningLineIndex = rec.paintEvents.findIndex(event =>
+      event.kind === 'stroke' && event.strokeStyle === '#4472C4'
+    );
+    const barIndex = rec.paintEvents.findIndex(event =>
+      event.kind === 'rect' && event.fillStyle === '#3F3F3F'
+    );
+    expect(hiLowIndex).toBeGreaterThanOrEqual(0);
+    expect(owningLineIndex).toBeGreaterThanOrEqual(0);
+    expect(barIndex).toBeGreaterThan(hiLowIndex);
+    expect(barIndex).toBeGreaterThan(owningLineIndex);
   });
 });
 
@@ -18923,6 +19044,34 @@ describe('CH15 — chartEx box-and-whisker', () => {
     const outlineSegments = rec.segs.filter(segment => segment.ss.toLowerCase() === '#404040');
     expect(outlineSegments.length).toBeGreaterThanOrEqual(5);
     expect(outlineSegments.every(segment => segment.lw === 2)).toBe(true);
+  });
+
+  it('uses the box-series outline for raw observation markers', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, boxModel({
+      catAxisHidden: true,
+      valAxisHidden: true,
+      chartexDataPointMarkerStyle: {
+        fillColors: ['FFFFFF'],
+        lineColors: ['FFFFFF'],
+        lineWidthEmu: 9525,
+      },
+      chartexBox: {
+        categories: ['A'],
+        series: [{
+          name: 'S', color: 'FFFFFF', lineColor: '000000', lineWidthEmu: 6350,
+          valuesByCategory: [[1, 2, 3]],
+          meanMarker: false, meanLine: false, showOutliers: false, showNonoutliers: true,
+          quartileMethod: 'inclusive',
+        }],
+      },
+    }), RECT, 1);
+
+    expect(rec.arcs).toHaveLength(3);
+    expect(rec.strokeDetails.some(stroke => stroke.strokeStyle.toLowerCase() === '#ffffff'))
+      .toBe(false);
+    expect(rec.strokeDetails.filter(stroke => stroke.strokeStyle.toLowerCase() === '#000000').length)
+      .toBeGreaterThanOrEqual(3);
   });
 
   it('uses the same 14pt omitted-title fallback for classic and ChartEx charts', () => {

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -5026,7 +5026,7 @@ export function renderBarChart(
       series => sec && series.useSecondaryAxis === true ? toYSecondarySeries : toYPrimaryLine,
       () => primaryCatAxisY,
       (series, index) => series.values[index] == null ? null : overlayValue(series, index),
-      catGap, ptToPx, shapeRotationDeg,
+      catGap, ptToPx, shapeRotationDeg, 'background',
     );
     if (dateAxisPlan) {
       ctx.save();
@@ -5128,6 +5128,13 @@ export function renderBarChart(
         },
       );
     }
+    drawLineGroupDecorations(
+      ctx, chart, n, categoryCenterX,
+      series => sec && series.useSecondaryAxis === true ? toYSecondarySeries : toYPrimaryLine,
+      () => primaryCatAxisY,
+      (series, index) => series.values[index] == null ? null : overlayValue(series, index),
+      catGap, ptToPx, shapeRotationDeg, 'foreground',
+    );
     if (dateAxisPlan) ctx.restore();
   }
 
@@ -6473,6 +6480,7 @@ function drawLineGroupDecorations(
   slotWidth: number,
   ptToPx: number,
   shapeRotationDeg: number,
+  phase: 'background' | 'foreground',
 ): void {
   for (const decoration of chart.lineGroupDecorations ?? []) {
     let members = chart.series.filter(series => series.lineGroupIndex === decoration.groupIndex);
@@ -6484,7 +6492,7 @@ function drawLineGroupDecorations(
     }
     if (members.length === 0) continue;
 
-    if (decoration.upDownBars && members.length >= 2) {
+    if (phase === 'foreground' && decoration.upDownBars && members.length >= 2) {
       const first = members[0];
       const last = members[members.length - 1];
       const upDownBars = {
@@ -6505,6 +6513,8 @@ function drawLineGroupDecorations(
         shapeRotationDeg,
       );
     }
+
+    if (phase === 'foreground') continue;
 
     const dropLineStyle = decoration.dropLines
       ? chartStyleRoleLine(chart, decoration.dropLines, 'dropLine')
@@ -7029,7 +7039,7 @@ export function renderLineChart(
       const seriesIndex = lineSeriesIndex.get(series);
       return seriesIndex != null ? plotted(seriesIndex, index) : null;
     },
-    decorationSlotWidth, ptToPx, shapeRotationDeg,
+    decorationSlotWidth, ptToPx, shapeRotationDeg, 'background',
   );
 
   // Line width and marker size come from OOXML in points (<a:ln w=EMU> /
@@ -7224,6 +7234,16 @@ export function renderLineChart(
       },
     );
   }
+
+  drawLineGroupDecorations(
+    ctx, chart, n, toX, yMapFor,
+    categoryAxisYFor,
+    (series, index) => {
+      const seriesIndex = lineSeriesIndex.get(series);
+      return seriesIndex != null ? plotted(seriesIndex, index) : null;
+    },
+    decorationSlotWidth, ptToPx, shapeRotationDeg, 'foreground',
+  );
 
   for (const drawLabels of deferredDataLabels) drawLabels();
 
@@ -7597,31 +7617,6 @@ function renderStockChart(
     }
   }
 
-  // ── First/last-series up-down bars (§21.2.2.218/227). Shared with ordinary
-  // line-chart up/down bars so gap geometry and direct paint cannot drift.
-  if (chart.stockUpDownBars && upDownStartS && upDownEndS) {
-    const directStyle = chart.stockUpDownBarStyle ?? {
-      gapWidthPercent: 150,
-      up: {},
-      down: {},
-    };
-    const style = {
-      ...directStyle,
-      up: chartStyleRoleBarPaint(chart, directStyle.up, 'upBar'),
-      down: chartStyleRoleBarPaint(chart, directStyle.down, 'downBar'),
-    };
-    const slotWidth = dateAxisPlan
-      ? (dateAxisPlan.categoryBandFractions[0] ?? 0) * pw
-      : between ? pw / n : n > 1 ? pw / (n - 1) : pw;
-    drawUpDownBars(
-      ctx,
-      index => upDownStartS.values[index] ?? null,
-      index => upDownEndS.values[index] ?? null,
-      n, toX, toYFor(upDownStartS), toYFor(upDownEndS),
-      slotWidth, style, ptToPx, chart.stockAutomaticStyle ?? undefined, shapeRotationDeg,
-    );
-  }
-
   // ── Hi-lo lines: vertical Low↔High per category. CT_StockChart makes
   // `<c:hiLowLines>` optional, so absence must remain absence; only a present
   // element receives linked or bounded automatic paint. ──
@@ -7805,6 +7800,33 @@ function renderStockChart(
         chart, chartRect: r, plotRect: { x: px0, y: py0, w: pw, h: ph },
         shapeRotationDeg,
       },
+    );
+  }
+
+  // ── First/last-series up-down bars (§21.2.2.218/227). In DrawingML these
+  // decorations follow the line series. Excel paints their opaque bodies over
+  // both the high-low rule and the owning series lines, leaving plot geometry
+  // visible only outside each body.
+  if (chart.stockUpDownBars && upDownStartS && upDownEndS) {
+    const directStyle = chart.stockUpDownBarStyle ?? {
+      gapWidthPercent: 150,
+      up: {},
+      down: {},
+    };
+    const style = {
+      ...directStyle,
+      up: chartStyleRoleBarPaint(chart, directStyle.up, 'upBar'),
+      down: chartStyleRoleBarPaint(chart, directStyle.down, 'downBar'),
+    };
+    const slotWidth = dateAxisPlan
+      ? (dateAxisPlan.categoryBandFractions[0] ?? 0) * pw
+      : between ? pw / n : n > 1 ? pw / (n - 1) : pw;
+    drawUpDownBars(
+      ctx,
+      index => upDownStartS.values[index] ?? null,
+      index => upDownEndS.values[index] ?? null,
+      n, toX, toYFor(upDownStartS), toYFor(upDownEndS),
+      slotWidth, style, ptToPx, chart.stockAutomaticStyle ?? undefined, shapeRotationDeg,
     );
   }
 

--- a/packages/core/src/chart/three-d-renderer.ts
+++ b/packages/core/src/chart/three-d-renderer.ts
@@ -1755,6 +1755,7 @@ function drawThreeDSeriesAxis(
   categoryBetween: boolean,
   categoryReversed: boolean,
   orientation: 'vertical' | 'horizontal',
+  barFamily: boolean,
   ptToPx: number,
 ): void {
   const spec = chart.threeD?.seriesAxis;
@@ -1815,11 +1816,29 @@ function drawThreeDSeriesAxis(
   ctx.fillStyle = spec.fontColor ? `#${spec.fontColor}` : '#595959';
   ctx.textAlign = Math.abs(normal.x) < 0.2 ? 'center' : normal.x < 0 ? 'right' : 'left';
   ctx.textBaseline = Math.abs(normal.y) < 0.2 ? 'middle' : normal.y < 0 ? 'bottom' : 'top';
+  if (barFamily && !spec.lineHidden && tickMode !== 'none') {
+    applyThreeDStroke(ctx, threeDAxisTickStroke(
+      spec.lineColor, spec.lineWidthEmu, spec.lineDash, ptToPx,
+    ));
+    const boundaryCount = chart.series.length;
+    for (let boundaryIndex = 0; boundaryIndex <= boundaryCount; boundaryIndex += markSkip) {
+      const authoredDepth = boundaryIndex / boundaryCount;
+      const depth = spec.orientation === 'maxMin' ? 1 - authoredDepth : authoredDepth;
+      const point = projection.project(seriesAxisX, seriesAxisY, depth);
+      const total = 6 * ptToPx;
+      const outer = tickMode === 'cross' ? total / 2 : tickMode === 'out' ? total : 0;
+      const inner = tickMode === 'cross' ? total / 2 : tickMode === 'in' ? total : 0;
+      ctx.beginPath();
+      ctx.moveTo(point.x + normal.x * outer, point.y + normal.y * outer);
+      ctx.lineTo(point.x - normal.x * inner, point.y - normal.y * inner);
+      ctx.stroke();
+    }
+  }
   for (let seriesIndex = 0; seriesIndex < chart.series.length; seriesIndex++) {
     const authoredDepth = projection.seriesDepth(seriesIndex, chart.series.length, false);
     const depth = spec.orientation === 'maxMin' ? 1 - authoredDepth : authoredDepth;
     const point = projection.project(seriesAxisX, seriesAxisY, depth);
-    if (!spec.lineHidden && seriesIndex % markSkip === 0 && tickMode !== 'none') {
+    if (!barFamily && !spec.lineHidden && seriesIndex % markSkip === 0 && tickMode !== 'none') {
       const total = 6 * ptToPx;
       const outer = tickMode === 'cross' ? total / 2 : tickMode === 'out' ? total : 0;
       const inner = tickMode === 'cross' ? total / 2 : tickMode === 'in' ? total : 0;
@@ -2246,6 +2265,17 @@ function threeDAxisStroke(
   // grids, data outlines, and the shared 2-D axis conversion stay unchanged.
   const width = Math.max(2, axisLineWidthPx(widthEmu, ptToPx));
   return { ...stroke, width, dash: pptxPresetDashArray(dash ?? 'solid', width) };
+}
+
+function threeDAxisTickStroke(
+  color: string | null | undefined,
+  widthEmu: number | null | undefined,
+  dash: string | null | undefined,
+  ptToPx: number,
+): ThreeDStroke {
+  // Ticks use the authored DrawingML line width. The 3-D coordinate-frame
+  // raster floor above is intentionally limited to the long axis rule.
+  return threeDStroke(color, widthEmu, dash, ptToPx, '898989', 1);
 }
 
 function applyThreeDStroke(ctx: CanvasRenderingContext2D, stroke: ThreeDStroke): void {
@@ -2739,6 +2769,7 @@ function cartesianAxisTicks(
   categoryBetween: boolean,
   categoryReversed: boolean,
   orientation: 'vertical' | 'horizontal',
+  barFamily: boolean,
   ptToPx: number,
 ): void {
   const { front } = projection;
@@ -2752,8 +2783,9 @@ function cartesianAxisTicks(
     depth,
   );
   const valueMinorTickMark = chart.valAxisMinorTickMark ?? 'none';
+  const axisTickStroke = barFamily ? threeDAxisTickStroke : threeDAxisStroke;
   if (!chart.valAxisHidden && !chart.valAxisLineHidden) {
-    applyThreeDStroke(ctx, threeDAxisStroke(
+    applyThreeDStroke(ctx, axisTickStroke(
       chart.valAxisLineColor, chart.valAxisLineWidthEmu, chart.valAxisLineDash,
       ptToPx,
     ));
@@ -2778,7 +2810,7 @@ function cartesianAxisTicks(
     }
   }
   if (!chart.catAxisHidden && !chart.catAxisLineHidden) {
-    applyThreeDStroke(ctx, threeDAxisStroke(
+    applyThreeDStroke(ctx, axisTickStroke(
       chart.catAxisLineColor, chart.catAxisLineWidthEmu, chart.catAxisLineDash,
       ptToPx,
     ));
@@ -2787,10 +2819,7 @@ function cartesianAxisTicks(
     const categoryEnd = orientation === 'vertical'
       ? geometry.horizontalEnd : geometry.verticalEnd;
     const tickSkip = Math.max(1, Math.floor(chart.catAxisTickMarkSkip ?? 1));
-    for (let categoryIndex = 0; categoryIndex < categoryCount; categoryIndex += tickSkip) {
-      const fraction = categoryPositionFraction(
-        categoryIndex, categoryCount, categoryBetween, categoryReversed,
-      );
+    const drawCategoryTick = (fraction: number): void => {
       const anchor = orientation === 'vertical'
         ? projection.project(front.x + fraction * front.w, axisY, depth)
         : projection.project(axisX, front.y + fraction * front.h, depth);
@@ -2798,6 +2827,18 @@ function cartesianAxisTicks(
         ctx, chart.catAxisMajorTickMark, anchor, categoryStart, categoryEnd,
         projectedCenter, orientation === 'vertical' ? 'vertical' : 'horizontal', 'major', ptToPx,
       );
+    };
+    if (barFamily) {
+      const boundaries = categoryGridlineFractions(categoryCount, categoryBetween);
+      for (let index = 0; index < boundaries.length; index += tickSkip) {
+        drawCategoryTick(categoryReversed ? 1 - boundaries[index] : boundaries[index]);
+      }
+    } else {
+      for (let index = 0; index < categoryCount; index += tickSkip) {
+        drawCategoryTick(categoryPositionFraction(
+          index, categoryCount, categoryBetween, categoryReversed,
+        ));
+      }
     }
     const minorUnit = chart.catAxisMinorUnit;
     if (chart.catAxisMinorTickMark && chart.catAxisMinorTickMark !== 'none'
@@ -3909,7 +3950,7 @@ function renderCartesian(
   );
   cartesianAxisTicks(
     ctx, chart, projection, axis, categoryCount, categoryBetween, categoryReversed,
-    horizontal ? 'horizontal' : 'vertical', ptToPx,
+    horizontal ? 'horizontal' : 'vertical', bars, ptToPx,
   );
   drawThreeDSeriesAxis(
     ctx,
@@ -3921,6 +3962,7 @@ function renderCartesian(
     categoryBetween,
     categoryReversed,
     horizontal ? 'horizontal' : 'vertical',
+    bars,
     ptToPx,
   );
   const resolvedAxisGeometry = threeDAxisGeometry(

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -9963,7 +9963,17 @@ fn collect_string_source(
         .children()
         .find(|node| node.is_element() && node.tag_name().name() == child_tag)?;
     if has_authored_reference_data(container) {
-        return Some(collect_str_cache_positional(ser_node, child_tag));
+        let authored = collect_str_cache_positional(ser_node, child_tag);
+        if !authored.is_empty() {
+            return Some(authored);
+        }
+        // A zero-point cache carries no usable snapshot. When the host can
+        // resolve the accompanying formula (notably XLSX worksheet cells),
+        // use that live source just as Office does. Keep an unresolved empty
+        // cache explicit so non-XLSX hosts never inherit unrelated data.
+        return reference_formula(container)
+            .and_then(|formula| references.resolve_strings(&formula))
+            .or(Some(authored));
     }
     reference_formula(container).and_then(|formula| references.resolve_strings(&formula))
 }
@@ -9977,7 +9987,13 @@ fn collect_number_source(
         .children()
         .find(|node| node.is_element() && node.tag_name().name() == child_tag)?;
     if has_authored_reference_data(container) {
-        return Some(collect_num_cache_positional(ser_node, child_tag));
+        let authored = collect_num_cache_positional(ser_node, child_tag);
+        if !authored.is_empty() {
+            return Some(authored);
+        }
+        return reference_formula(container)
+            .and_then(|formula| references.resolve_numbers(&formula))
+            .or(Some(authored));
     }
     reference_formula(container).and_then(|formula| references.resolve_numbers(&formula))
 }
@@ -22407,7 +22423,10 @@ Subtitle</a:t></a:r></a:p>
         assert_eq!(chart.categories, vec!["1", "2"]);
         assert_eq!(chart.series[0].categories, None);
         assert_eq!(chart.series[1].categories, Some(Vec::new()));
-        assert_eq!(chart.series[2].categories, Some(Vec::new()));
+        assert_eq!(
+            chart.series[2].categories,
+            Some(vec!["1".into(), "2".into()])
+        );
     }
 
     #[test]

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -1867,6 +1867,11 @@ export interface Worksheet {
         max: number;
         width: number;
     }>;
+    colStyleRanges?: Array<{
+        min: number;
+        max: number;
+        styleIndex: number;
+    }>;
     rowHeights: Record<number, number>;
     colOutlineLevels?: Record<number, number>;
     colCollapsed?: Record<number, boolean>;

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -209,7 +209,7 @@ impl XlsxChartReferenceResolver<'_, '_, '_, '_> {
                             .iter()
                             .find(|cell| cell.row == range.top && cell.col == range.left)
                     })
-                    .map(|cell| cell.style_index);
+                    .map(|cell| cell.style_index.unwrap_or(0));
             }
         }
 
@@ -1535,6 +1535,27 @@ mod worksheet_reference_tests {
         assert_eq!(chart.series[0].name, "المبيعات");
         assert_eq!(chart.categories, vec!["أحمد", "سارة", "خالد"]);
         assert_eq!(chart.series[0].categories, None);
+        assert_eq!(
+            chart.series[0].values,
+            vec![Some(5000.0), Some(6200.0), Some(7500.0)],
+        );
+    }
+
+    #[test]
+    fn zero_point_chart_caches_resolve_cross_sheet_series() {
+        let xml = chart_xml(false)
+            .replace(
+                "</c:strRef>",
+                "<c:strCache><c:ptCount val=\"0\"/></c:strCache></c:strRef>",
+            )
+            .replace(
+                "</c:numRef>",
+                "<c:numCache><c:ptCount val=\"0\"/></c:numCache></c:numRef>",
+            );
+        let chart = load_model(&xml);
+
+        assert_eq!(chart.series[0].name, "المبيعات");
+        assert_eq!(chart.categories, vec!["أحمد", "سارة", "خالد"]);
         assert_eq!(
             chart.series[0].values,
             vec![Some(5000.0), Some(6200.0), Some(7500.0)],

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -3060,9 +3060,7 @@ fn parse_row_cells(
             ),
         };
         let cell_type = c_node.attribute("t").unwrap_or("");
-        let style_index: Option<u32> = c_node
-            .attribute("s")
-            .and_then(|s| s.parse().ok());
+        let style_index: Option<u32> = c_node.attribute("s").and_then(|s| s.parse().ok());
 
         // Inline string: <c t="inlineStr"><is>...</is></c>
         let is_node = c_node.children().find(|n| n.tag_name().name() == "is");
@@ -5167,7 +5165,8 @@ mod strict_namespace_cell_tests {
             other => panic!("expected shared-string reference, got {other:?}"),
         }
         assert_eq!(
-            cells[0].style_index, Some(2),
+            cells[0].style_index,
+            Some(2),
             "the `s` style index must round-trip"
         );
 

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -759,7 +759,7 @@ mod retained_model_limit_tests {
             col: 1,
             row,
             value,
-            style_index: 0,
+            style_index: None,
             formula: formula.map(str::to_string),
             show_phonetic: false,
         }
@@ -1547,6 +1547,7 @@ fn parse_projected_worksheet(
     // All authored width declarations in XML order. The boolean records
     // whether the declaration also needs the compact public wire form.
     let mut authored_col_widths: Vec<(crate::types::ColumnWidthRange, bool)> = Vec::new();
+    let mut authored_col_styles: Vec<crate::types::ColumnStyleRange> = Vec::new();
     let mut row_heights = streamed.row_heights;
     // Outline (grouping) metadata — ECMA-376 §18.3.1.13 (col) / §18.3.1.73
     // (row) / §18.3.1.61 (outlinePr). Only non-default entries are recorded so
@@ -1731,6 +1732,9 @@ fn parse_projected_worksheet(
             "col" if is_x_ns(node.tag_name().namespace()) => {
                 let custom = attr_bool(&node, "customWidth").unwrap_or(false);
                 let hidden = attr_bool(&node, "hidden").unwrap_or(false);
+                let authored_style = node
+                    .attribute("style")
+                    .and_then(|value| value.parse::<u32>().ok());
                 let authored_width = node
                     .attribute("width")
                     .and_then(|s| s.parse::<f64>().ok())
@@ -1750,7 +1754,12 @@ fn parse_projected_worksheet(
                 // Also retain outline-only columns so their gutter metadata
                 // reaches the viewer at the default width.
                 let has_outline = outline_level > 0 || collapsed;
-                if authored_width.is_none() && !custom && !hidden && !has_outline {
+                if authored_width.is_none()
+                    && authored_style.is_none()
+                    && !custom
+                    && !hidden
+                    && !has_outline
+                {
                     continue;
                 }
                 let min: u32 = node
@@ -1765,6 +1774,13 @@ fn parse_projected_worksheet(
                     .clamp(1, 16_384);
                 if full_max < min {
                     continue;
+                }
+                if let Some(style_index) = authored_style {
+                    authored_col_styles.push(crate::types::ColumnStyleRange {
+                        min,
+                        max: full_max,
+                        style_index,
+                    });
                 }
                 let width: f64 = if hidden {
                     0.0
@@ -2217,6 +2233,22 @@ fn parse_projected_worksheet(
         .filter_map(|(range, compact)| compact.then_some(range))
         .collect();
 
+    // ECMA-376 §18.3.1.13: a column style is the default XF for cells in that
+    // column. Resolve it onto sparse authored cells only after every `<col>`
+    // declaration is known; an explicit `c/@s="0"` remains `Some(0)` and wins.
+    for row in &mut rows {
+        for cell in &mut row.cells {
+            if cell.style_index.is_some() {
+                continue;
+            }
+            cell.style_index = authored_col_styles
+                .iter()
+                .rev()
+                .find(|range| cell.col >= range.min && cell.col <= range.max)
+                .map(|range| range.style_index);
+        }
+    }
+
     conditional_formats.extend(x14_icon_formats);
 
     if rows_hidden_by_default {
@@ -2241,6 +2273,7 @@ fn parse_projected_worksheet(
         rows,
         col_widths,
         col_width_ranges,
+        col_style_ranges: authored_col_styles,
         row_heights,
         col_outline_levels,
         col_collapsed,
@@ -3027,10 +3060,9 @@ fn parse_row_cells(
             ),
         };
         let cell_type = c_node.attribute("t").unwrap_or("");
-        let style_index: u32 = c_node
+        let style_index: Option<u32> = c_node
             .attribute("s")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
+            .and_then(|s| s.parse().ok());
 
         // Inline string: <c t="inlineStr"><is>...</is></c>
         let is_node = c_node.children().find(|n| n.tag_name().name() == "is");
@@ -4127,6 +4159,44 @@ mod sheet_view_tests {
     }
 
     #[test]
+    fn column_style_is_preserved_without_expanding_the_range() {
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><cols><col min="1" max="16384" style="17"/></cols><sheetData/></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
+
+        assert_eq!(
+            ws.col_style_ranges,
+            vec![crate::types::ColumnStyleRange {
+                min: 1,
+                max: 16_384,
+                style_index: 17,
+            }],
+        );
+    }
+
+    #[test]
+    fn explicit_zero_cell_style_remains_distinct_from_column_inheritance() {
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><cols><col min="1" max="1" style="17"/></cols><sheetData><row r="1"><c r="A1" s="0"/></row></sheetData></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
+
+        assert_eq!(ws.rows[0].cells[0].style_index, Some(0));
+    }
+
+    #[test]
+    fn cell_without_authored_style_inherits_its_column_style() {
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><cols><col min="1" max="2" style="17"/></cols><sheetData><row r="1"><c r="A1"><v>1</v></c><c r="C1"><v>2</v></c></row></sheetData></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
+
+        assert_eq!(ws.rows[0].cells[0].style_index, Some(17));
+        assert_eq!(ws.rows[0].cells[1].style_index, None);
+    }
+
+    #[test]
     fn later_compact_col_width_range_overrides_legacy_point_projection() {
         let xml = format!(
             r#"<worksheet xmlns="{NS}"><cols>
@@ -5097,7 +5167,7 @@ mod strict_namespace_cell_tests {
             other => panic!("expected shared-string reference, got {other:?}"),
         }
         assert_eq!(
-            cells[0].style_index, 2,
+            cells[0].style_index, Some(2),
             "the `s` style index must round-trip"
         );
 

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -82,6 +82,16 @@ pub struct ColumnWidthRange {
     pub width: f64,
 }
 
+/// Compact `<col min max style>` default formatting. SpreadsheetML applies
+/// this style to cells in the column that do not carry their own `c/@s`.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ColumnStyleRange {
+    pub min: u32,
+    pub max: u32,
+    pub style_index: u32,
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Worksheet {
@@ -98,6 +108,8 @@ pub struct Worksheet {
     pub col_widths: BTreeMap<u32, f64>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub col_width_ranges: Vec<ColumnWidthRange>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub col_style_ranges: Vec<ColumnStyleRange>,
     pub row_heights: BTreeMap<u32, f64>,
     /// Per-column outline (grouping) depth, 0-7 (ECMA-376 §18.3.1.13
     /// `<col outlineLevel>`). Only columns whose level is non-zero are recorded,
@@ -234,6 +246,7 @@ impl Worksheet {
             rows: Vec::new(),
             col_widths: BTreeMap::new(),
             col_width_ranges: Vec::new(),
+            col_style_ranges: Vec::new(),
             row_heights: BTreeMap::new(),
             col_outline_levels: BTreeMap::new(),
             col_collapsed: BTreeMap::new(),
@@ -1371,13 +1384,6 @@ pub struct Row {
     pub hidden: bool,
 }
 
-/// serde `skip_serializing_if` predicate: drop the common unstyled `0` so the
-/// per-cell JSON doesn't carry a redundant `styleIndex` on every plain cell.
-/// The TS side reads it as `styleIndex ?? 0`, so an omitted field is equivalent.
-fn is_zero_u32(v: &u32) -> bool {
-    *v == 0
-}
-
 /// serde `skip_serializing_if` predicate for the common ungrouped `outlineLevel`
 /// of `0`, so a sheet without outlining keeps its byte-identical JSON.
 fn is_zero_u8(v: &u8) -> bool {
@@ -1390,8 +1396,10 @@ pub struct Cell {
     pub col: u32,
     pub row: u32,
     pub value: CellValue,
-    #[serde(skip_serializing_if = "is_zero_u32")]
-    pub style_index: u32,
+    /// Explicit `c/@s`. `None` inherits the owning column's `<col style>`;
+    /// `Some(0)` is intentionally distinct and resets to the Normal XF.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub style_index: Option<u32>,
     /// Raw `<f>` formula text (ECMA-376 §18.3.1.40), when present. The
     /// renderer uses this to recompute volatile functions like TODAY() /
     /// NOW() at display time so the cached `<v>` (frozen when the file was

--- a/packages/xlsx/src/header-outer-border.test.ts
+++ b/packages/xlsx/src/header-outer-border.test.ts
@@ -65,6 +65,52 @@ function recordingCtx(width = 300, height = 120): { ctx: CanvasRenderingContext2
 }
 
 describe('XLSX header frame ownership', () => {
+  it('does not paint sheet gridlines over a cell background fill', () => {
+    const ws = worksheet(false);
+    ws.rows = [{
+      index: 1,
+      height: null,
+      cells: [{ col: 1, row: 1, styleIndex: 1, value: { type: 'empty' } }],
+    }];
+    const styles: Styles = {
+      ...STYLES,
+      fills: [
+        { patternType: 'none', fgColor: null, bgColor: null },
+        { patternType: 'solid', fgColor: 'FFFFFF', bgColor: null },
+      ],
+      cellXfs: [
+        STYLES.cellXfs[0],
+        { ...STYLES.cellXfs[0], fillId: 1 },
+      ],
+    };
+    const { ctx, segments } = recordingCtx();
+
+    renderViewport(ctx, ws, styles, { row: 1, col: 1, rows: 1, cols: 1 });
+
+    expect(segments.filter(segment => segment.stroke === '#d0d0d0')).toEqual([]);
+  });
+
+  it('inherits a column background style for otherwise empty cells', () => {
+    const ws = worksheet(false);
+    ws.colStyleRanges = [{ min: 1, max: 16_384, styleIndex: 1 }];
+    const styles: Styles = {
+      ...STYLES,
+      fills: [
+        { patternType: 'none', fgColor: null, bgColor: null },
+        { patternType: 'solid', fgColor: 'FFFFFF', bgColor: null },
+      ],
+      cellXfs: [
+        STYLES.cellXfs[0],
+        { ...STYLES.cellXfs[0], fillId: 1 },
+      ],
+    };
+    const { ctx, segments } = recordingCtx();
+
+    renderViewport(ctx, ws, styles, { row: 1, col: 1, rows: 1, cols: 1 });
+
+    expect(segments.filter(segment => segment.stroke === '#d0d0d0')).toEqual([]);
+  });
+
   it('bounds frozen-band materialization to the visible canvas', () => {
     const ws = worksheet(false);
     let rowReads = 0;

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -774,6 +774,23 @@ function resolveXf(styles: Styles, styleIndex: number): { font: CellFont; fill: 
   return { font, fill, border, xf };
 }
 
+function columnStyleIndex(worksheet: Worksheet, col: number): number {
+  const ranges = worksheet.colStyleRanges ?? [];
+  for (let index = ranges.length - 1; index >= 0; index--) {
+    const range = ranges[index];
+    if (col >= range.min && col <= range.max) return range.styleIndex;
+  }
+  return 0;
+}
+
+function effectiveCellStyleIndex(
+  worksheet: Worksheet,
+  cell: Cell | undefined,
+  col: number,
+): number {
+  return cell?.styleIndex ?? columnStyleIndex(worksheet, col);
+}
+
 function wrapTextLines(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string[] {
   const lines: string[] = [];
   // Hard line breaks (\n from Alt+Enter) always split regardless of wrapText.
@@ -2021,7 +2038,9 @@ function renderQuadrant(
     aCx = mirrorX(aCx, cW);
     const key = `${aRow}:${aCol}`;
     const cell = rc.cellMap.get(key);
-    const { font, fill, border, xf } = resolveXf(styles, cell?.styleIndex ?? 0);
+    const { font, fill, border, xf } = resolveXf(
+      styles, effectiveCellStyleIndex(rc.worksheet, cell, aCol),
+    );
     const cf = evaluateCf(cell, aRow, aCol, cfContext, styles.dxfs ?? []);
     const effectiveFill = cf.fill ?? fill;
 
@@ -2177,7 +2196,9 @@ function renderQuadrant(
         const ckey = `${rowIndex}:${colIndices[ci]}`;
         if (!mergeSkipSet.has(ckey) && !mergeAnchorMap.has(ckey)) {
           const c = cellMap.get(ckey);
-          const cXf = resolveXf(styles, c?.styleIndex ?? 0).xf;
+          const cXf = resolveXf(
+            styles, effectiveCellStyleIndex(rc.worksheet, c, colIndices[ci]),
+          ).xf;
           isCC = cXf.alignH === 'centerContinuous';
           hasValue = !!(c && c.value && c.value.type !== 'empty');
         }
@@ -2220,7 +2241,7 @@ function renderQuadrant(
       const cx = mirrorX(ltrCx, cellW);
 
       const cell = cellMap.get(key);
-      const styleIndex = cell?.styleIndex ?? 0;
+      const styleIndex = effectiveCellStyleIndex(rc.worksheet, cell, colIndex);
       const { font, fill, border, xf } = resolveXf(styles, styleIndex);
       const cf = evaluateCf(cell, rowIndex, colIndex, cfContext, styles.dxfs ?? []);
       const effectiveFill = cf.fill ?? fill;
@@ -2254,18 +2275,21 @@ function renderQuadrant(
       // - directional hatches (dark/light Horizontal/Vertical/Down/Up/Grid/
       //   Trellis): render via a small repeating tile using createPattern so
       //   the hatch actually shows, rather than approximating as a blend.
-      if (paintCellPatternFill(ctx, effectiveFill, cx, cy, cellW, cellH)) {
+      let hasCellBackground = paintCellPatternFill(ctx, effectiveFill, cx, cy, cellW, cellH);
+      if (hasCellBackground) {
         // own fill painted; tableStyle fallbacks intentionally skipped
       } else if (tableStyle && tableFillDxf?.fill?.fgColor) {
         // Custom or built-in: a resolved table-element dxf fill wins.
         ctx.fillStyle = hexToRgba(tableFillDxf.fill.fgColor);
         ctx.fillRect(cx, cy, cellW, cellH);
+        hasCellBackground = true;
       } else if (tableStyle && !tableStyle.isCustom && tableStyle.isBanded) {
         // Accent-tint banding is an approximation for built-in style names
         // only. Custom styles with no stripe dxf get no banding fill (Excel
         // draws none — §18.5.1.2).
         ctx.fillStyle = stripeColorFor(tableStyle.accent);
         ctx.fillRect(cx, cy, cellW, cellH);
+        hasCellBackground = true;
       }
 
       // Comment indicator triangle — drawn above fill but below borders so
@@ -2297,7 +2321,9 @@ function renderQuadrant(
       // 0.5/dpr offset blurs at even device widths, e.g. dpr=3).
       // Skipped when the sheet has `<sheetView showGridLines="0">` (View →
       // Gridlines unchecked; ECMA-376 §18.3.1.83).
-      if (rc.worksheet.isChartSheet !== true && rc.worksheet.showGridlines !== false) {
+      if (rc.worksheet.isChartSheet !== true
+          && rc.worksheet.showGridlines !== false
+          && !hasCellBackground) {
         ctx.strokeStyle = '#d0d0d0';
         ctx.lineWidth = 0.5;
         ctx.beginPath();
@@ -2359,7 +2385,9 @@ function renderQuadrant(
       // only as the neighbour's bottom/right still shows at the viewport edge.
       const aboveCell = cellMap.get(`${rowIndex - 1}:${colIndex}`);
       const aboveBottom = aboveCell
-        ? resolveXf(styles, aboveCell.styleIndex ?? 0).border.bottom
+        ? resolveXf(
+            styles, effectiveCellStyleIndex(rc.worksheet, aboveCell, colIndex),
+          ).border.bottom
         : null;
       if (aboveBottom?.style && (ri === 0 || mergedBorder.top?.style)) {
         mergedBorder = { ...mergedBorder, top: pickStrongerEdge(mergedBorder.top, aboveBottom) };
@@ -2370,7 +2398,9 @@ function renderQuadrant(
         // neighbour's xf.right re-introduces the internal vertical we just hid.
         const leftCell = cellMap.get(`${rowIndex}:${colIndex - 1}`);
         const leftRight = leftCell
-          ? resolveXf(styles, leftCell.styleIndex ?? 0).border.right
+          ? resolveXf(
+              styles, effectiveCellStyleIndex(rc.worksheet, leftCell, colIndex - 1),
+            ).border.right
           : null;
         if (leftRight?.style && (ci === 0 || mergedBorder.left?.style)) {
           mergedBorder = { ...mergedBorder, left: pickStrongerEdge(mergedBorder.left, leftRight) };
@@ -2515,7 +2545,9 @@ function renderQuadrant(
           if (mergeSkipSet.has(adjKey) || mergeAnchorMap.has(adjKey)) break;
           const adjCell = cellMap.get(adjKey);
           if (adjCell && adjCell.value.type !== 'empty') break;
-          const adjStyleIndex = adjCell?.styleIndex ?? 0;
+          const adjStyleIndex = effectiveCellStyleIndex(
+            rc.worksheet, adjCell, colIndices[oci],
+          );
           const adjXf = resolveXf(styles, adjStyleIndex).xf;
           if (adjXf.alignH !== 'centerContinuous') break;
           centerContinuousW += colWidths[oci];

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -72,6 +72,9 @@ export interface Worksheet {
    *  normalizes overlapping legacy point entries in `colWidths` to the final
    *  effective width; later live point edits can therefore override ranges. */
   colWidthRanges?: Array<{ min: number; max: number; width: number }>;
+  /** Compact `<col style>` defaults. A cell with its own `styleIndex`,
+   * including explicit zero, overrides the owning column range. */
+  colStyleRanges?: Array<{ min: number; max: number; styleIndex: number }>;
   rowHeights: Record<number, number>;
   /** Per-column outline (grouping) depth 0-7 (ECMA-376 §18.3.1.13
    *  `<col outlineLevel>`), keyed by 1-based column index. Present only for
@@ -821,8 +824,9 @@ export interface Cell {
   col: number;
   row: number;
   value: CellValue;
-  /** Style index into the styles table. Omitted on the wire when `0` (the
-   *  common unstyled case), so read it as `styleIndex ?? 0`. */
+  /** Effective style index into the styles table. An omitted `c/@s` inherits
+   *  its column's `<col style>` in the parser; absent here means Normal (0).
+   *  Explicit `c/@s="0"` remains distinct while inheritance is resolved. */
   styleIndex?: number;
   /** Raw `<f>` formula text (ECMA-376 §18.3.1.40), when present. The renderer
    *  uses this to recompute volatile functions (TODAY, NOW) at display time


### PR DESCRIPTION
## Summary

- paint stock and line-group up/down bars above their owning line and high-low geometry, so opaque bars occlude interior strokes
- retain owning-series outlines for ChartEx observation points
- separate authored 3-D tick widths from the visible axis-frame raster rule and place standard bar category/depth ticks at slot boundaries
- resolve worksheet formulas when a chart cache explicitly contains zero points, while preserving nonempty cache precedence
- preserve compact SpreadsheetML column style defaults and suppress default gridlines over painted cell backgrounds

## Root cause

Several regressions came from discarded source semantics rather than missing sample-specific adjustments: line decorations were painted too early, 3-D ticks inherited a coordinate-frame raster floor, zero-point caches blocked worksheet formula resolution, and column-level styles were omitted from the retained worksheet model.

The changes implement those OOXML/Office behaviors at their shared parser or renderer boundary and avoid document-specific heuristics.

## Verification

- focused core/XLSX Vitest suite: 924 tests passed
- XLSX parser Rust suite: 311 tests passed
- core and XLSX TypeScript checks passed
- whitespace validation passed
- complete local private XLSX corpus capture: 139 workbooks, with no runtime or capture failures
- focused Office/PDF comparison for the reported regressions
