### PR TITLE
fix(chart): preserve legends across zoom and 3d axis edges

### DIFF
--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1410,7 +1410,7 @@ describe('classic 3-D compatibility projection', () => {
     expect(rec.strokes.filter(stroke => stroke.ss === '#898989')).toHaveLength(0);
   });
 
-  it('keeps the 3-D frame visible while using authored 0.25pt width for ticks', () => {
+  it('uses the authored 0.25pt width for 3-D axis rules and ticks', () => {
     const rec = strokedPolylineCtx();
     renderChart(rec.ctx, baseModel({
       chartType: 'clusteredBar',
@@ -1459,10 +1459,58 @@ describe('classic 3-D compatibility projection', () => {
       const frame = strokes.reduce((longest, stroke) =>
         length(stroke) > length(longest) ? stroke : longest);
       const ticks = strokes.filter(stroke => stroke !== frame);
-      expect(frame.lw).toBe(2);
+      expect(frame.lw).toBe(0.25);
       expect(ticks.length).toBeGreaterThan(0);
       expect(ticks.every(stroke => stroke.lw === 0.25)).toBe(true);
     }
+  });
+
+  it('gives visible axes ownership of coincident 3-D surface edges', () => {
+    const rec = strokedPolylineCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredBar',
+      categories: ['A', 'B'],
+      valMin: 0,
+      valMax: 20,
+      valAxisMajorGridlines: false,
+      catAxisLineColor: 'FF00FF',
+      catAxisLineWidthEmu: 3_175,
+      catAxisLinePaintAuthored: true,
+      valAxisLineColor: '00AA00',
+      valAxisLineWidthEmu: 3_175,
+      valAxisLinePaintAuthored: true,
+      threeD: {
+        rotationX: 15,
+        rotationY: 20,
+        depthPercent: 100,
+        perspective: 30,
+        floor: { lineColor: 'FF0000', lineWidthEmu: 12_700 },
+        sideWall: { lineColor: '0000FF', lineWidthEmu: 12_700 },
+        backWall: { lineColor: '808080', lineWidthEmu: 12_700 },
+      },
+      series: [series({ values: [5, 15], lineHidden: true })],
+    }), RECT, 1);
+
+    const samePoint = (
+      left: { x: number; y: number }, right: { x: number; y: number },
+    ) => Math.hypot(left.x - right.x, left.y - right.y) < 1e-6;
+    const ownsEdge = (
+      axis: (typeof rec.strokes)[number], surface: (typeof rec.strokes)[number],
+    ) => surface.points.some((point, index) => {
+      const next = surface.points[(index + 1) % surface.points.length];
+      return (samePoint(axis.points[0], point) && samePoint(axis.points[1], next))
+        || (samePoint(axis.points[0], next) && samePoint(axis.points[1], point));
+    });
+    const axes = rec.strokes.filter(stroke =>
+      (stroke.ss === '#FF00FF' || stroke.ss === '#00AA00')
+      && stroke.points.length === 2
+    );
+    const surfaces = rec.strokes.filter(stroke =>
+      ['#FF0000', '#0000FF', '#808080'].includes(stroke.ss)
+    );
+
+    expect(axes.length).toBeGreaterThanOrEqual(2);
+    expect(axes.every(axis => surfaces.every(surface => !ownsEdge(axis, surface)))).toBe(true);
   });
 
   it('places standard 3-D category and series ticks on slot boundaries', () => {
@@ -1555,8 +1603,8 @@ describe('classic 3-D compatibility projection', () => {
 
     expect(rec.strokes.filter(stroke => stroke.ss === '#FF00FF')).toHaveLength(0);
     const wallStrokes = rec.strokes.filter(stroke => stroke.ss === '#808080');
-    expect(wallStrokes).toHaveLength(3);
-    expect(wallStrokes.every(stroke => stroke.points.length >= 4)).toBe(true);
+    expect(wallStrokes.length).toBeGreaterThanOrEqual(3);
+    expect(wallStrokes.every(stroke => stroke.points.length >= 2)).toBe(true);
   });
 
   it('draws 6pt major and 4pt minor value ticks as horizontal screen annotations', () => {
@@ -2713,17 +2761,20 @@ describe('classic 3-D compatibility projection', () => {
         series({ name: 'Three', values: [3, 3, 5, 6] }),
       ],
     }), RECT, 1);
-    const floor = rec.strokes.find(stroke => stroke.ss === '#000000' && stroke.points.length === 5);
-    const side = rec.strokes.find(stroke => stroke.ss === '#FF0000' && stroke.points.length === 5);
-    const back = rec.strokes.find(stroke => stroke.ss === '#00FF00' && stroke.points.length === 5);
-    expect(floor).toBeDefined();
-    expect(side).toBeDefined();
-    expect(back).toBeDefined();
-    expect(side?.dash.length).toBeGreaterThan(0);
+    const floor = rec.strokes.filter(stroke => stroke.ss === '#000000');
+    const side = rec.strokes.filter(stroke => stroke.ss === '#FF0000');
+    const back = rec.strokes.filter(stroke => stroke.ss === '#00FF00');
+    expect(floor.length).toBeGreaterThan(0);
+    expect(side.length).toBeGreaterThan(0);
+    expect(back.length).toBeGreaterThan(0);
+    expect(side.every(stroke => stroke.dash.length > 0)).toBe(true);
     const length = (a: { x: number; y: number }, b: { x: number; y: number }) =>
       Math.hypot(a.x - b.x, a.y - b.y);
-    const projectedDepth = length(side!.points[0], side!.points[1]);
-    const projectedHeight = length(side!.points[1], side!.points[2]);
+    const sideEdgeLengths = side.flatMap(stroke =>
+      stroke.points.slice(1).map((point, index) => length(stroke.points[index], point))
+    ).filter(edgeLength => edgeLength > 1e-6).sort((left, right) => left - right);
+    const projectedDepth = sideEdgeLengths[0];
+    const projectedHeight = sideEdgeLengths.at(-1) as number;
     // Office's measured default standard-Bar axes are 8.1:8.1:2.6. Keep the
     // final projected depth/height ratio close to 0.321 without applying this
     // compatibility calibration to clustered/stacked bars.

--- a/packages/core/src/chart/three-d-renderer.ts
+++ b/packages/core/src/chart/three-d-renderer.ts
@@ -108,7 +108,6 @@ import {
   chartStyleLineDecision,
 } from './style-paint.js';
 import { drawingmlLineDashArray } from '../draw/dash.js';
-import { axisLineWidthPx } from './axis-style.js';
 import {
   MAX_CHART_PAINT_COMPONENTS,
   MAX_CHART_PAINT_RECIPE_COMPONENTS,
@@ -2258,12 +2257,13 @@ function threeDAxisStroke(
 ): ThreeDStroke {
   const stroke = threeDStroke(color, widthEmu, dash, ptToPx, '898989', 1);
   if (widthEmu == null || !Number.isFinite(widthEmu) || widthEmu < 0) return stroke;
-  // Excel rasterizes an authored 0.25pt classic 3-D axis as a two-pixel
-  // coordinate-frame rule. A projected Canvas hairline loses coverage on both
-  // the sloped category rule and the value rule, especially beside the 1pt bar
-  // outlines, so retain that measured raster floor only for 3-D axes. Walls,
-  // grids, data outlines, and the shared 2-D axis conversion stay unchanged.
-  const width = Math.max(2, axisLineWidthPx(widthEmu, ptToPx));
+  // `<c:*Ax><c:spPr><a:ln@w>` owns the coordinate-rule width. Keep it in the
+  // same projected point scale as the chart instead of applying a device-pixel
+  // floor; otherwise zoom changes and a thin authored axis can become thicker
+  // than the surrounding CT_Surface rules.
+  const authoredWidth = widthEmu / EMU_PER_PT * ptToPx;
+  if (!(authoredWidth > 0)) return stroke;
+  const width = authoredWidth;
   return { ...stroke, width, dash: pptxPresetDashArray(dash ?? 'solid', width) };
 }
 
@@ -2273,8 +2273,9 @@ function threeDAxisTickStroke(
   dash: string | null | undefined,
   ptToPx: number,
 ): ThreeDStroke {
-  // Ticks use the authored DrawingML line width. The 3-D coordinate-frame
-  // raster floor above is intentionally limited to the long axis rule.
+  // Tick rules use the same authored DrawingML point scale as the coordinate
+  // axes; they are kept separate here because their projected geometry and
+  // default visibility are resolved independently.
   return threeDStroke(color, widthEmu, dash, ptToPx, '898989', 1);
 }
 
@@ -2292,6 +2293,7 @@ function walls(
   orientation: 'vertical' | 'horizontal',
   categoryCount: number,
   categoryBetween: boolean,
+  categoryReversed: boolean,
   ptToPx: number,
 ): void {
   const { front } = projection;
@@ -2301,6 +2303,49 @@ function walls(
   const {
     sideX: farX, floorY, oppositeFloorY, nearDepth, farDepth,
   } = geometry;
+  const axisGeometry = threeDAxisGeometry(
+    chart, projection, axis, categoryCount, categoryBetween, categoryReversed, orientation,
+  );
+  const axisOwnedEdges: Array<readonly [Point, Point]> = [];
+  // Linked chart styles may resolve the same color/width fields without a
+  // direct axis line. Only a direct `<c:*Ax><c:spPr><a:ln>` owns a coincident
+  // CT_Surface perimeter; style-derived axes retain the complete wall frame.
+  const categoryAxisPaintAuthored = chart.catAxisLinePaintAuthored === true;
+  const valueAxisPaintAuthored = chart.valAxisLinePaintAuthored === true;
+  const horizontalAxisVisible = orientation === 'vertical'
+    ? categoryAxisPaintAuthored && !chart.catAxisHidden && !chart.catAxisLineHidden
+    : valueAxisPaintAuthored && !chart.valAxisHidden && !chart.valAxisLineHidden;
+  const verticalAxisVisible = orientation === 'vertical'
+    ? valueAxisPaintAuthored && !chart.valAxisHidden && !chart.valAxisLineHidden
+    : categoryAxisPaintAuthored && !chart.catAxisHidden && !chart.catAxisLineHidden;
+  if (horizontalAxisVisible) {
+    axisOwnedEdges.push([axisGeometry.horizontalStart, axisGeometry.horizontalEnd]);
+  }
+  if (verticalAxisVisible) {
+    axisOwnedEdges.push([axisGeometry.verticalStart, axisGeometry.verticalEnd]);
+  }
+  const seriesAxis = chart.threeD?.seriesAxis;
+  const seriesAxisPaintAuthored = seriesAxis?.linePaintAuthored === true;
+  if (seriesAxis && !seriesAxis.hidden && !seriesAxis.lineHidden
+    && seriesAxisPaintAuthored
+    && chart.threeD?.barGrouping === 'standard' && chart.series.length > 0) {
+    const seriesAxisX = orientation === 'vertical' ? geometry.seriesAxisX : axisGeometry.axisX;
+    const seriesAxisY = orientation === 'horizontal'
+      ? (floorY === projection.front.y
+        ? projection.front.y + projection.front.h : projection.front.y)
+      : floorY;
+    axisOwnedEdges.push([
+      projection.project(seriesAxisX, seriesAxisY, nearDepth),
+      projection.project(seriesAxisX, seriesAxisY, farDepth),
+    ]);
+  }
+  const samePoint = (left: Point, right: Point): boolean =>
+    Math.hypot(left.x - right.x, left.y - right.y) <= 1e-6;
+  const axisOwnsEdge = (start: Point, end: Point): boolean =>
+    axisOwnedEdges.some(([axisStart, axisEnd]) =>
+      (samePoint(start, axisStart) && samePoint(end, axisEnd))
+      || (samePoint(start, axisEnd) && samePoint(end, axisStart))
+    );
   const projectedSurfaceFaces = (
     kind: 'floor' | 'sideWall' | 'backWall',
     surface: NonNullable<ChartModel['threeD']>['floor'],
@@ -2538,6 +2583,25 @@ function walls(
       ? effective.lineJoin : 'miter';
     for (const face of faces) {
       if (face.points.length < 2) continue;
+      const edges = face.points.map((point, index) => ({
+        start: point,
+        end: face.points[(index + 1) % face.points.length],
+      }));
+      if (edges.some(edge => axisOwnsEdge(edge.start, edge.end))) {
+        // A visible axis and a CT_Surface perimeter can describe the same
+        // projected cuboid edge with different authored paints. Office gives
+        // the coordinate axis visual ownership; painting both produces the
+        // gray halo seen around a thinner black axis. Retain every independent
+        // surface edge and omit only the exactly coincident segment.
+        for (const edge of edges) {
+          if (axisOwnsEdge(edge.start, edge.end)) continue;
+          ctx.beginPath();
+          ctx.moveTo(edge.start.x, edge.start.y);
+          ctx.lineTo(edge.end.x, edge.end.y);
+          ctx.stroke();
+        }
+        continue;
+      }
       ctx.beginPath();
       ctx.moveTo(face.points[0].x, face.points[0].y);
       for (let index = 1; index < face.points.length; index++) {
@@ -3019,7 +3083,7 @@ function renderCartesian(
   if (!bars) {
     walls(
       ctx, chart, projection, axis, horizontal ? 'horizontal' : 'vertical',
-      categoryCount, categoryBetween, ptToPx,
+      categoryCount, categoryBetween, categoryReversed, ptToPx,
     );
   }
   const { front } = projection;
@@ -3245,7 +3309,7 @@ function renderCartesian(
     }
     walls(
       ctx, chart, projection, axis, horizontal ? 'horizontal' : 'vertical',
-      categoryCount, categoryBetween, ptToPx,
+      categoryCount, categoryBetween, categoryReversed, ptToPx,
     );
     // Build one scene list and sort every visible face by camera-space depth.
     // A logical series index is not a view depth after rotation, and painting

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -1048,9 +1048,13 @@ export interface ChartModel {
   catAxisLineColor?: string | null;
   catAxisLineWidthEmu?: number | null;
   catAxisLineDash?: string | null;
+  /** A direct `<c:catAx><c:spPr><a:ln>` paint was authored. */
+  catAxisLinePaintAuthored?: boolean | null;
   valAxisLineColor?: string | null;
   valAxisLineWidthEmu?: number | null;
   valAxisLineDash?: string | null;
+  /** A direct `<c:valAx><c:spPr><a:ln>` paint was authored. */
+  valAxisLinePaintAuthored?: boolean | null;
   /**
    * `<c:catAx><c:numFmt@formatCode>` (or scatter X-axis valAx). When set,
    * the renderer formats X-axis tick labels with this code (e.g. dates).
@@ -1566,6 +1570,8 @@ export interface ChartThreeDSeriesAxis {
   lineColor?: string | null;
   lineWidthEmu?: number | null;
   lineDash?: string | null;
+  /** A direct `<c:serAx><c:spPr><a:ln>` paint was authored. */
+  linePaintAuthored?: boolean | null;
   lineHidden: boolean;
   titleFontSizeHpt?: number | null;
   titleFontBold?: boolean | null;

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -457,9 +457,13 @@ export interface ChartModel {
     catAxisLineColor?: string | null;
     catAxisLineWidthEmu?: number | null;
     catAxisLineDash?: string | null;
+    /** A direct `<c:catAx><c:spPr><a:ln>` paint was authored. */
+    catAxisLinePaintAuthored?: boolean | null;
     valAxisLineColor?: string | null;
     valAxisLineWidthEmu?: number | null;
     valAxisLineDash?: string | null;
+    /** A direct `<c:valAx><c:spPr><a:ln>` paint was authored. */
+    valAxisLinePaintAuthored?: boolean | null;
     catAxisFormatCode?: string | null;
     catAxisMin?: number | null;
     catAxisMax?: number | null;
@@ -806,6 +810,8 @@ export interface ChartThreeDSeriesAxis {
     lineColor?: string | null;
     lineWidthEmu?: number | null;
     lineDash?: string | null;
+    /** A direct `<c:serAx><c:spPr><a:ln>` paint was authored. */
+    linePaintAuthored?: boolean | null;
     lineHidden: boolean;
     titleFontSizeHpt?: number | null;
     titleFontBold?: boolean | null;

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -635,11 +635,15 @@ pub struct ChartModel {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cat_axis_line_dash: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_line_paint_authored: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub val_axis_line_color: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub val_axis_line_width_emu: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub val_axis_line_dash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_line_paint_authored: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cat_axis_format_code: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1184,6 +1188,8 @@ pub struct ChartThreeDSeriesAxis {
     pub line_width_emu: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub line_dash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line_paint_authored: Option<bool>,
     pub line_hidden: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title_font_size_hpt: Option<i32>,
@@ -7347,10 +7353,24 @@ pub fn parse_chartex_part_with_references_style_parts_and_images(
         .map(|axis| extract_axis_line_style(axis, resolver))
         .unwrap_or((None, None, false));
     let cat_axis_line_dash = cat_axis.and_then(extract_axis_line_dash);
+    let cat_axis_line_paint_authored = cat_axis
+        .is_some_and(|axis| {
+            child(axis, "spPr")
+                .and_then(|shape| child(shape, "ln"))
+                .is_some()
+        })
+        .then_some(true);
     let (mut val_axis_line_color, mut val_axis_line_width_emu, mut val_axis_line_hidden) = val_axis
         .map(|axis| extract_axis_line_style(axis, resolver))
         .unwrap_or((None, None, false));
     let mut val_axis_line_dash = val_axis.and_then(extract_axis_line_dash);
+    let val_axis_line_paint_authored = val_axis
+        .is_some_and(|axis| {
+            child(axis, "spPr")
+                .and_then(|shape| child(shape, "ln"))
+                .is_some()
+        })
+        .then_some(true);
     if val_axis_line_color.is_none() && val_axis_line_width_emu.is_none() && !val_axis_line_hidden {
         if let Some(style_axis) = style_element("valueAxis") {
             (
@@ -7511,10 +7531,12 @@ pub fn parse_chartex_part_with_references_style_parts_and_images(
         cat_axis_line_color,
         cat_axis_line_width_emu,
         cat_axis_line_dash,
+        cat_axis_line_paint_authored,
         cat_axis_line_hidden,
         val_axis_line_color,
         val_axis_line_width_emu,
         val_axis_line_dash,
+        val_axis_line_paint_authored,
         val_axis_line_hidden,
         data_label_font_size_hpt,
         legend_pos,
@@ -10566,6 +10588,10 @@ pub fn parse_chart_part_with_references_style_parts_and_images(
                 line_color,
                 line_width_emu,
                 line_dash,
+                line_paint_authored: child(axis, "spPr")
+                    .and_then(|shape| child(shape, "ln"))
+                    .is_some()
+                    .then_some(true),
                 line_hidden,
                 title_font_size_hpt,
                 title_font_bold,
@@ -12349,10 +12375,24 @@ pub fn parse_chart_part_with_references_style_parts_and_images(
         .map(|n| extract_axis_line_style(n, color_resolver))
         .unwrap_or((None, None, false));
     let cat_axis_line_dash = cat_ax.and_then(extract_axis_line_dash);
+    let cat_axis_line_paint_authored = cat_ax
+        .is_some_and(|axis| {
+            child(axis, "spPr")
+                .and_then(|shape| child(shape, "ln"))
+                .is_some()
+        })
+        .then_some(true);
     let (mut val_axis_line_color, mut val_axis_line_width_emu, val_axis_line_hidden) = val_ax
         .map(|n| extract_axis_line_style(n, color_resolver))
         .unwrap_or((None, None, false));
     let val_axis_line_dash = val_ax.and_then(extract_axis_line_dash);
+    let val_axis_line_paint_authored = val_ax
+        .is_some_and(|axis| {
+            child(axis, "spPr")
+                .and_then(|shape| child(shape, "ln"))
+                .is_some()
+        })
+        .then_some(true);
     if legacy_chart_style == Some(2) {
         let cat_needs_theme_width = cat_ax.is_some_and(|axis| {
             !cat_axis_line_hidden
@@ -12889,10 +12929,12 @@ pub fn parse_chart_part_with_references_style_parts_and_images(
         cat_axis_line_color,
         cat_axis_line_width_emu,
         cat_axis_line_dash,
+        cat_axis_line_paint_authored,
         cat_axis_line_hidden,
         val_axis_line_color,
         val_axis_line_width_emu,
         val_axis_line_dash,
+        val_axis_line_paint_authored,
         val_axis_line_hidden,
         data_label_font_size_hpt,
         legend_pos,
@@ -13311,9 +13353,11 @@ mod tests {
             cat_axis_line_color: None,
             cat_axis_line_width_emu: None,
             cat_axis_line_dash: None,
+            cat_axis_line_paint_authored: None,
             val_axis_line_color: None,
             val_axis_line_width_emu: None,
             val_axis_line_dash: None,
+            val_axis_line_paint_authored: None,
             cat_axis_format_code: None,
             cat_axis_min: None,
             cat_axis_max: None,
@@ -15816,9 +15860,11 @@ Subtitle</a:t></a:r></a:p>
         assert_eq!(m.cat_axis_gridline_width_emu, None);
         assert_eq!(m.cat_axis_line_color.as_deref(), Some("808080"));
         assert_eq!(m.cat_axis_line_dash.as_deref(), Some("dash"));
+        assert_eq!(m.cat_axis_line_paint_authored, Some(true));
         assert_eq!(m.val_axis_line_color.as_deref(), Some("404040"));
         assert_eq!(m.val_axis_line_width_emu, Some(12700));
         assert_eq!(m.val_axis_line_dash.as_deref(), Some("dot"));
+        assert_eq!(m.val_axis_line_paint_authored, Some(true));
         // The chartSpace border is theme-aware: scheme tx1 resolves through
         // the same color resolver as other DrawingML lines.
         assert_eq!(m.chart_border_color.as_deref(), Some("000000"));
@@ -15976,6 +16022,8 @@ Subtitle</a:t></a:r></a:p>
         assert_eq!(m.val_axis_line_color.as_deref(), Some("000000"));
         assert_eq!(m.cat_axis_line_width_emu, Some(9525));
         assert_eq!(m.val_axis_line_width_emu, Some(9525));
+        assert_eq!(m.cat_axis_line_paint_authored, None);
+        assert_eq!(m.val_axis_line_paint_authored, None);
         assert_eq!(m.val_axis_gridline_color.as_deref(), Some("000000"));
         assert_eq!(m.val_axis_gridline_width_emu, Some(9525));
 
@@ -16074,6 +16122,8 @@ Subtitle</a:t></a:r></a:p>
             assert_eq!(unresolved.val_axis_line_color, None);
             assert_eq!(unresolved.cat_axis_line_width_emu, None);
             assert_eq!(unresolved.val_axis_line_width_emu, None);
+            assert_eq!(unresolved.cat_axis_line_paint_authored, Some(true));
+            assert_eq!(unresolved.val_axis_line_paint_authored, Some(true));
         }
     }
 
@@ -20823,6 +20873,7 @@ Subtitle</a:t></a:r></a:p>
         assert_eq!(series_axis.font_size_hpt, Some(900));
         assert_eq!(series_axis.line_color.as_deref(), Some("445566"));
         assert_eq!(series_axis.line_width_emu, Some(12_700));
+        assert_eq!(series_axis.line_paint_authored, Some(true));
         assert_eq!(series_axis.title_font_size_hpt, Some(800));
         assert_eq!(series_axis.title_font_bold, Some(true));
         assert_eq!(series_axis.title_font_italic, Some(true));

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -466,9 +466,13 @@ export interface ChartModel {
     catAxisLineColor?: string | null;
     catAxisLineWidthEmu?: number | null;
     catAxisLineDash?: string | null;
+    /** A direct `<c:catAx><c:spPr><a:ln>` paint was authored. */
+    catAxisLinePaintAuthored?: boolean | null;
     valAxisLineColor?: string | null;
     valAxisLineWidthEmu?: number | null;
     valAxisLineDash?: string | null;
+    /** A direct `<c:valAx><c:spPr><a:ln>` paint was authored. */
+    valAxisLinePaintAuthored?: boolean | null;
     catAxisFormatCode?: string | null;
     catAxisMin?: number | null;
     catAxisMax?: number | null;
@@ -794,6 +798,8 @@ export interface ChartThreeDSeriesAxis {
     lineColor?: string | null;
     lineWidthEmu?: number | null;
     lineDash?: string | null;
+    /** A direct `<c:serAx><c:spPr><a:ln>` paint was authored. */
+    linePaintAuthored?: boolean | null;
     lineHidden: boolean;
     titleFontSizeHpt?: number | null;
     titleFontBold?: boolean | null;

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -566,9 +566,13 @@ export interface ChartModel {
     catAxisLineColor?: string | null;
     catAxisLineWidthEmu?: number | null;
     catAxisLineDash?: string | null;
+    /** A direct `<c:catAx><c:spPr><a:ln>` paint was authored. */
+    catAxisLinePaintAuthored?: boolean | null;
     valAxisLineColor?: string | null;
     valAxisLineWidthEmu?: number | null;
     valAxisLineDash?: string | null;
+    /** A direct `<c:valAx><c:spPr><a:ln>` paint was authored. */
+    valAxisLinePaintAuthored?: boolean | null;
     catAxisFormatCode?: string | null;
     catAxisMin?: number | null;
     catAxisMax?: number | null;
@@ -894,6 +898,8 @@ export interface ChartThreeDSeriesAxis {
     lineColor?: string | null;
     lineWidthEmu?: number | null;
     lineDash?: string | null;
+    /** A direct `<c:serAx><c:spPr><a:ln>` paint was authored. */
+    linePaintAuthored?: boolean | null;
     lineHidden: boolean;
     titleFontSizeHpt?: number | null;
     titleFontBold?: boolean | null;

--- a/packages/xlsx/src/chart-sheet-render.test.ts
+++ b/packages/xlsx/src/chart-sheet-render.test.ts
@@ -113,4 +113,65 @@ describe('XLSX chart-sheet rendering', () => {
     expect(recording.texts).not.toContain('A');
     expect(recording.texts).not.toContain('1');
   });
+
+  it('keeps a manual chart legend invariant across worksheet zoom', () => {
+    const names = ['First', 'Second', 'Third', 'Fourth'];
+    const chart: ChartModel = {
+      ...CHART,
+      chartType: 'line',
+      categories: ['A', 'B'],
+      series: names.map((name, index) => ({
+        name,
+        color: null,
+        values: [index + 1, index + 2],
+      })),
+      showLegend: true,
+      legendPos: 'b',
+      legendFontSizeHpt: 1200,
+      legendManualLayout: {
+        xMode: 'edge', yMode: 'edge', wMode: 'factor', hMode: 'factor',
+        x: 0.055, y: 0.134, w: 0.9, h: 0.044,
+      },
+    };
+    const worksheet: Worksheet = {
+      name: 'Chart1',
+      isChartSheet: true,
+      rows: [],
+      colWidths: {},
+      rowHeights: {},
+      defaultColWidth: 8.43,
+      defaultRowHeight: 15,
+      mergeCells: [],
+      freezeRows: 0,
+      freezeCols: 0,
+      conditionalFormats: [],
+      images: [],
+      charts: [{
+        fromCol: 0,
+        fromColOff: 0,
+        fromRow: 0,
+        fromRowOff: 0,
+        toCol: 0,
+        toColOff: 640 * EMU_PER_PX,
+        toRow: 0,
+        toRowOff: 600 * EMU_PER_PX,
+        chart,
+      }],
+      defaultFontFamily: 'Calibri',
+      defaultFontSize: 11,
+    } as Worksheet;
+
+    for (const cellScale of [0.1, 0.25, 0.5, 0.75, 1, 2]) {
+      const recording = context(800, 700);
+      renderViewport(
+        recording.ctx,
+        worksheet,
+        STYLES,
+        { row: 1, col: 1, rows: 40, cols: 40 },
+        { cellScale },
+      );
+      expect(recording.texts.filter(text => names.includes(text)), `${cellScale * 100}%`)
+        .toEqual(names);
+    }
+  });
 });

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -5367,23 +5367,30 @@ function renderCharts(
     ctx.rect(clipX, scrollAreaY, scrollAreaW, scrollAreaH);
     ctx.clip();
 
-    // XLSX natural rendering is device-px at 96 DPI where 1pt = 4/3 px. Scale
-    // that by `cs` so OOXML-specified font sizes (title/axes) scale with zoom.
-    const ptToPx = PT_TO_PX * cs;
+    // Render the chart in its natural 96-DPI coordinate space, then let Canvas
+    // scale the complete paint by the worksheet zoom. Passing a smaller rect
+    // and only shrinking `ptToPx` leaves renderer-owned gaps/padding at fixed
+    // screen pixels; that can repack or entirely suppress a manual legend at a
+    // zoom step even though Excel scales the chart as one proportional object.
+    ctx.save();
+    if (cs !== 1) ctx.scale(cs, cs);
     // `anchor.chart` is already the canonical ChartModel emitted by the Rust
     // parser (`ooxml_common::chart::ChartModel`) — the former `adaptChartData`
     // default/mapping logic now lives in the parser's `From<ChartData>`.
     renderChart(
       ctx,
       anchor.chart,
-      { x: cx, y: cy, w: cw, h: ch },
-      ptToPx,
+      cs === 1
+        ? { x: cx, y: cy, w: cw, h: ch }
+        : { x: cx / cs, y: cy / cs, w: cw / cs, h: ch / cs },
+      PT_TO_PX,
       0,
       threeD,
       regionMap,
       fill => loadedImages?.get(chartImageFillKey(fill)),
       chartEx,
     );
+    ctx.restore();
     ctx.restore();
   }
 }


### PR DESCRIPTION
## Summary
- scale each worksheet chart as one natural-coordinate Canvas object so manual legend layout remains stable at every zoom level
- retain direct axis-line authorship through the shared parser model
- render classic 3-D axes at their authored width and give visible authored axes ownership of exactly coincident wall edges
- preserve linked chart-style behavior and all independent surface edges

## Verification
- ooxml-common library tests: 491 passed
- focused chart and XLSX Vitest suite: 1,421 passed
- workspace typecheck
- core and XLSX production builds
- interactive Storybook checks at 25%, 50%, and 100%
- private self-VRT against the full merge-base SHA: intended differences are confined to directly authored 3-D bar-axis and wall cases; one unrelated worksheet capture has 15 grayscale antialias deltas of magnitude 1 and was visually reviewed against its Office PDF; derived surface-paint variants without Office reference output remain explicitly unadjudicated

The implementation follows the OOXML-authored axis and CT_Surface paint ownership rather than sample-specific constants.