### PR TITLE
fix(chart): restore classic chart and surface fidelity

### DIFF
--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -11667,6 +11667,17 @@ describe('CH11 — line/area/scatter data labels honor <c:dLblPos> (§21.2.2.48)
 });
 
 describe('CH9 — line/area smooth splines (§21.2.2.194)', () => {
+  it('uses Excel automatic smooth lines for an unformatted marker scatter', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'scatter',
+      scatterStyle: 'marker',
+      categories: ['1', '2', '3', '4'],
+      series: [series({ name: 'S', values: [10, 15, 12, 22], showMarker: true })],
+    }), RECT, 1);
+    expect(rec.beziers).toBeGreaterThan(0);
+  });
+
   for (const chartType of ['line', 'area'] as const) {
     it(`${chartType}: smooth series draws a bezier spline; non-smooth draws straight segments`, () => {
       const smooth = markerRecordingCtx();
@@ -11950,6 +11961,7 @@ describe('classic chart data table (CT_DTable)', () => {
         lineColor: '445566',
         lineWidthEmu: 12700,
         lineDash: 'dash',
+        fillColor: 'FFF2CC',
       },
     }), RECT, 1);
 
@@ -11962,6 +11974,7 @@ describe('classic chart data table (CT_DTable)', () => {
     expect(text).toContain('Feb-25');
     expect(rec.strokeRects.some(rect => rect.ss === '#445566')).toBe(true);
     expect(rec.strokeRects.find(rect => rect.ss === '#445566')?.dash.length).toBeGreaterThan(0);
+    expect(rec.rects.some(rect => rect.fs === '#FFF2CC')).toBe(true);
     expect(rec.arcs.length).toBeGreaterThan(0); // line-series key marker
   });
 
@@ -16812,6 +16825,25 @@ describe('surface contour charts', () => {
     expect(wireframe).toHaveLength(4);
   });
 
+  it('adds interpolated band-boundary contours across wireframe cells', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, wireframeSurfaceModel({
+      categories: ['X1', 'X2', 'X3'],
+      valMax: 20,
+      valAxisMajorUnit: 10,
+      series: [
+        series({ name: 'Y1', values: [0, 0, 0], lineColor: 'AA0000' }),
+        series({ name: 'Y2', values: [0, 20, 0] }),
+        series({ name: 'Y3', values: [0, 0, 0] }),
+      ],
+    }), RECT, 1);
+
+    // The uniform line style keeps the 3x3 source mesh at 12 segments. Its
+    // four cells each contribute two interpolated contours at value 10.
+    expect(rec.strokeDetails.filter(stroke => stroke.strokeStyle === '#AA0000'))
+      .toHaveLength(20);
+  });
+
   it('keeps unresolved, no-fill, and compound dataPointWireframe lines fail-closed', () => {
     for (const role of [
       { linePaintAuthored: true, lineColorIndex: 0 },
@@ -16877,13 +16909,13 @@ describe('surface contour charts', () => {
       stroke.strokeStyle === '#AA0000' || stroke.strokeStyle === '#00FFFF'
     );
     expect(mesh.filter(stroke => stroke.strokeStyle === '#AA0000')).toHaveLength(3);
-    expect(mesh.filter(stroke => stroke.strokeStyle === '#00FFFF')).toHaveLength(3);
+    expect(mesh.filter(stroke => stroke.strokeStyle === '#00FFFF')).toHaveLength(5);
     expect(mesh.every(stroke => stroke.dash.length > 0)).toBe(true);
     expect(rec.strokeDetails.some(stroke => stroke.strokeStyle === '#00AA00')).toBe(false);
     expect(rec.strokeDetails.some(stroke => stroke.strokeStyle === '#123456')).toBe(false);
   });
 
-  it('keeps a uniform first-series wireframe as one path per source-grid line', () => {
+  it('keeps a uniform first-series wireframe on the source grid and contours', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, wireframeSurfaceModel({
       valMax: 20,
@@ -16898,7 +16930,7 @@ describe('surface contour charts', () => {
     }), RECT, 1);
 
     expect(rec.strokeDetails.filter(stroke => stroke.strokeStyle === '#AA0000'))
-      .toHaveLength(4);
+      .toHaveLength(6);
     expect(rec.strokeDetails.some(stroke => stroke.strokeStyle === '#00AA00')).toBe(false);
   });
 
@@ -16930,7 +16962,7 @@ describe('surface contour charts', () => {
     expect(rec.strokeDetails.filter(stroke => stroke.strokeStyle === '[object Object]'))
       .toHaveLength(3);
     expect(rec.strokeDetails.filter(stroke => stroke.strokeStyle === '#00FFFF'))
-      .toHaveLength(3);
+      .toHaveLength(5);
   });
 
   it('keeps first-series no-line and direct band no-line authoritative per band', () => {

--- a/packages/core/src/chart/renderer-gridline-zorder.test.ts
+++ b/packages/core/src/chart/renderer-gridline-zorder.test.ts
@@ -147,6 +147,21 @@ describe('CH — value-axis gridlines paint under the data series', () => {
     expect(firstGridline).toBeLessThan(firstSeriesFill);
   });
 
+  it('paints a standard area chart in document order so the later series is on top', () => {
+    const rec = orderedRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'area',
+      categories: ['Q1', 'Q2'],
+      series: [
+        series({ name: 'North', color: '156082', values: [10, 15] }),
+        series({ name: 'South', color: 'E97132', values: [18, 13] }),
+      ],
+    }), RECT, 1);
+
+    expect(rec.events.filter(event => event.op === 'fill').map(event => event.fillStyle))
+      .toEqual(['#156082', '#E97132']);
+  });
+
   it('a stacked area/line combo stacks only area series and paints the line as an overlay', () => {
     const rec = orderedRecordingCtx();
     renderChart(rec.ctx, baseModel({

--- a/packages/core/src/chart/renderer-scatter-legend-key.test.ts
+++ b/packages/core/src/chart/renderer-scatter-legend-key.test.ts
@@ -167,11 +167,10 @@ const scatterModel = (over: Partial<ChartModel>, serOver: Partial<ChartSeries> =
   });
 
 describe('scatter legend key reflects the plotted mark (#803, §21.2.2.42/.198)', () => {
-  it('draws a MARKER key for a markers-only scatter (scatterStyle default)', () => {
+  it('draws a LINE + MARKER key for Excel automatic marker scatter style', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, scatterModel({ scatterStyle: 'marker' }), RECT, 1);
-    expect(rec.keys).toContain('marker');
-    expect(rec.keys).not.toContain('line');
+    expect(rec.keys).toContain('line-marker');
   });
 
   it('draws a MARKER key when a series line is noFill (lineHidden) despite lineMarker style', () => {
@@ -194,7 +193,7 @@ describe('scatter legend key reflects the plotted mark (#803, §21.2.2.42/.198)'
       scatterModel({ scatterStyle: 'marker' }, { markerSymbol: 'square' }),
       RECT, 1,
     );
-    expect(rec.keys).toEqual(['marker']);
+    expect(rec.keys).toEqual(['line-marker']);
   });
 
   it('draws a LINE + MARKER key for a lineMarker scatter', () => {

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -136,7 +136,10 @@ import {
   chartStyleLineDecision,
   chartStyleLinePaint,
 } from './style-paint.js';
-import { applyPlotVisibleOnly } from './source-visibility.js';
+import {
+  applyPlotVisibleOnly,
+  EXCEL_AUTOMATIC_SCATTER_MARKERS,
+} from './source-visibility.js';
 import {
   boundDataLabelText,
   resolveDataLabelPlacement,
@@ -604,6 +607,10 @@ function drawChartDataTable(
   ctx.beginPath();
   ctx.rect(tableX, tableY, tableWidth, layout.totalHeight);
   ctx.clip();
+  if (table.fillColor) {
+    ctx.fillStyle = `#${table.fillColor}`;
+    ctx.fillRect(tableX, tableY, tableWidth, layout.totalHeight);
+  }
   ctx.fillStyle = table.fontColor ? `#${table.fontColor}` : '#000000';
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
@@ -748,7 +755,7 @@ function scatterSeriesDrawsLine(
   if (chartType !== 'scatter') return false;
   const style = scatterStyle ?? 'marker';
   const styleDrawsLine =
-    style === 'line' || style === 'lineMarker' || style === 'lineNoMarker' ||
+    style === 'marker' || style === 'line' || style === 'lineMarker' || style === 'lineNoMarker' ||
     style === 'smooth' || style === 'smoothMarker' || style === 'smoothNoMarker';
   return styleDrawsLine && series.lineHidden !== true;
 }
@@ -777,7 +784,9 @@ function legendMarkerFor(
   const isScatter = family === 'scatter' || isBubble;
   if (!isLineFamily && !isScatter) return null;
   if (!seriesLegendMarkerIsVisible(chartType, scatterStyle, s, radarStyle)) return null;
-  const symbol = s.markerSymbol ?? (isStock ? 'none' : 'circle');
+  const symbol = s.markerSymbol
+    ?? s.automaticMarkerSymbol
+    ?? (isStock ? 'none' : 'circle');
   const base = chartColor(entryIndex, s); // '#RRGGBB'
   const fill = seriesMarkerFillColor(s, base.replace(/^#/, ''));
   const withLine = isBubble ? false : isScatter
@@ -7987,6 +7996,13 @@ function renderStockChart(
 
 interface SurfaceVertex extends ThreeDScenePoint { value: number }
 
+const surfaceCellTriangleIndices = (
+  values: readonly [number, number, number, number],
+): readonly [readonly [number, number, number], readonly [number, number, number]] =>
+  values[0] + values[2] > values[1] + values[3]
+    ? [[0, 1, 2], [0, 2, 3]]
+    : [[0, 1, 3], [1, 2, 3]];
+
 const MAX_SURFACE_PAINT_POLYGONS = 200_000;
 const SURFACE_SCENE_DEPTH_SCALE = 1.25;
 
@@ -8352,6 +8368,37 @@ function renderSurfaceChart(
         if (!chargeEdge(rows[row].values[column], rows[row + 1].values[column])) return;
       }
     }
+    // A wireframe Surface contains both the source row/column mesh and the
+    // contour at each value-band boundary. Charge the latter before any
+    // projection or paint allocation, using the same cell triangulation as
+    // the renderer below.
+    for (let row = 0; row < rowCount - 1; row++) {
+      for (let column = 0; column < columnCount - 1; column++) {
+        const values = [
+          rows[row].values[column],
+          rows[row].values[column + 1],
+          rows[row + 1].values[column + 1],
+          rows[row + 1].values[column],
+        ];
+        if (values.some(value => value == null || !Number.isFinite(value))) continue;
+        const finiteValues = values as [number, number, number, number];
+        for (const indices of surfaceCellTriangleIndices(finiteValues)) {
+          const triangleMin = Math.min(...indices.map(index => finiteValues[index]));
+          const triangleMax = Math.max(...indices.map(index => finiteValues[index]));
+          const firstBoundary = Math.max(
+            1,
+            Math.floor((triangleMin - surfaceMin) / step) + 1,
+          );
+          const lastBoundary = Math.min(
+            bandCount - 1,
+            Math.ceil((triangleMax - surfaceMin) / step) - 1,
+          );
+          if (lastBoundary < firstBoundary) continue;
+          wireframeSegmentCount += lastBoundary - firstBoundary + 1;
+          if (wireframeSegmentCount > MAX_SURFACE_PAINT_POLYGONS) return;
+        }
+      }
+    }
   }
   const usesBaseWireframeLine = directBandLineDecisions.some(
     decision => decision === undefined,
@@ -8496,8 +8543,64 @@ function renderSurfaceChart(
       });
     }
   };
+  const appendWireframeContours = (triangle: readonly SurfaceVertex[]): void => {
+    const triangleMin = Math.min(...triangle.map(vertex => vertex.value));
+    const triangleMax = Math.max(...triangle.map(vertex => vertex.value));
+    const firstBoundary = Math.max(
+      1,
+      Math.floor((triangleMin - surfaceMin) / step) + 1,
+    );
+    const lastBoundary = Math.min(
+      bandCount - 1,
+      Math.ceil((triangleMax - surfaceMin) / step) - 1,
+    );
+    for (let boundary = firstBoundary; boundary <= lastBoundary; boundary++) {
+      const threshold = surfaceMin + boundary * step;
+      const intersections: SurfaceVertex[] = [];
+      const addIntersection = (vertex: SurfaceVertex): void => {
+        if (intersections.some(existing =>
+          Math.abs(existing.x - vertex.x) < 1e-9
+          && Math.abs(existing.y - vertex.y) < 1e-9
+          && Math.abs(existing.depth - vertex.depth) < 1e-9
+        )) return;
+        intersections.push(vertex);
+      };
+      for (let index = 0; index < triangle.length; index++) {
+        const start = triangle[index];
+        const end = triangle[(index + 1) % triangle.length];
+        if (start.value === threshold) addIntersection(start);
+        if ((start.value < threshold && end.value > threshold)
+          || (start.value > threshold && end.value < threshold)) {
+          const fraction = (threshold - start.value) / (end.value - start.value);
+          addIntersection({
+            x: start.x + (end.x - start.x) * fraction,
+            y: start.y + (end.y - start.y) * fraction,
+            depth: start.depth + (end.depth - start.depth) * fraction,
+            value: threshold,
+          });
+        }
+      }
+      if (intersections.length !== 2) continue;
+      wireframeSegments.push({
+        points: [
+          projection.project(
+            intersections[0].x, intersections[0].y, intersections[0].depth,
+          ),
+          projection.project(
+            intersections[1].x, intersections[1].y, intersections[1].depth,
+          ),
+        ],
+        // A boundary closes the band below it. This keeps c:bandFmt indexing
+        // consistent with the lower-inclusive clipping used by filled Surface.
+        band: boundary - 1,
+      });
+    }
+  };
   const paintTriangle = (triangle: SurfaceVertex[]): void => {
-    if (chart.surfaceWireframe === true) return;
+    if (chart.surfaceWireframe === true) {
+      appendWireframeContours(triangle);
+      return;
+    }
     const triangleMin = Math.min(...triangle.map(vertex => vertex.value));
     const triangleMax = Math.max(...triangle.map(vertex => vertex.value));
     const firstBand = Math.max(0, Math.floor((triangleMin - surfaceMin) / step));
@@ -8807,14 +8910,11 @@ function renderSurfaceChart(
       // three cases: equal opposing sums retain the source-grid B-D diagonal;
       // otherwise the opposing pair with the larger value sum forms the ridge.
       // This is an application rendering rule — OOXML stores only the matrix.
-      const forwardDiagonalSum = rowColumn.value + rowNextColumnNext.value;
-      const reverseDiagonalSum = rowColumnNext.value + rowNextColumn.value;
-      if (forwardDiagonalSum > reverseDiagonalSum) {
-        paintTriangle([rowColumn, rowColumnNext, rowNextColumnNext]);
-        paintTriangle([rowColumn, rowNextColumnNext, rowNextColumn]);
-      } else {
-        paintTriangle([rowColumn, rowColumnNext, rowNextColumn]);
-        paintTriangle([rowColumnNext, rowNextColumnNext, rowNextColumn]);
+      const vertices = [
+        rowColumn, rowColumnNext, rowNextColumnNext, rowNextColumn,
+      ] as const;
+      for (const indices of surfaceCellTriangleIndices(values as [number, number, number, number])) {
+        paintTriangle(indices.map(index => vertices[index]));
       }
     }
   }
@@ -9529,13 +9629,10 @@ function renderAreaChart(
   // Draw the series area fills ON TOP of the gridlines laid down above.
   // In a stacked area chart, series order is the stacking order: series 0 is
   // adjacent to the category axis, then series 1, and so on (CT_AreaChart's
-  // ordered `ser` sequence). Plain unstacked area retains the historical
-  // back-to-front painting so the first series remains visually on top.
-  const seriesOrder = areaGroupMembers.flatMap(({ group, areaIndices }) =>
-    group.grouping === 'stacked' || group.grouping === 'percentStacked'
-      ? areaIndices
-      : [...areaIndices].reverse()
-  );
+  // ordered `ser` sequence). Standard areas use the same document paint order:
+  // a later series is painted later and therefore overlays earlier series,
+  // matching Excel's vector output at their intersections.
+  const seriesOrder = areaGroupMembers.flatMap(({ areaIndices }) => areaIndices);
   const plottedAreaValue = (areaIndex: number, categoryIndex: number): number =>
     areaTopValues[areaIndex]?.[categoryIndex] ?? 0;
   for (const areaIndex of seriesOrder) {
@@ -11907,6 +12004,31 @@ function makeScatterSeriesLayer(
   };
 }
 
+function isFilteredScatterAutomaticPointStyle(
+  chart: ChartModel,
+  series: ChartSeries,
+): boolean {
+  const accents = chart.themeAccentColors;
+  const hidden = series.sourceHidden;
+  const colors = series.dataPointColors;
+  const points = series.dataPointOverrides;
+  if (chart.chartType !== 'scatter'
+    || chart.plotVisibleOnly !== true
+    || chart.scatterStyle !== 'marker'
+    || hidden?.length !== series.values.length
+    || colors?.length !== series.values.length
+    || points?.length !== series.values.length
+    || !accents?.length) return false;
+  return hidden.every(isHidden => !isHidden)
+    && colors.every((color, index) => color === accents[index % accents.length])
+    && points.every((point, index) =>
+      point.idx === index
+      && point.markerSymbol === EXCEL_AUTOMATIC_SCATTER_MARKERS[
+        index % EXCEL_AUTOMATIC_SCATTER_MARKERS.length
+      ]
+    );
+}
+
 /** One `<c:bubbleChart>` group has one size scale: every series must therefore
  * be normalized against the same maximum bubble magnitude. */
 function bubbleSizeToDiameterScale(
@@ -11967,8 +12089,13 @@ function drawScatterSeriesLayer(
   shapeRotationDeg = 0,
   bubbleSettings?: BubbleGroupSettings,
 ): void {
-  const drawLines = style === 'line' || style === 'lineMarker' || style === 'lineNoMarker';
-  const drawSmooth = style === 'smooth' || style === 'smoothMarker' || style === 'smoothNoMarker';
+  const markerStyleHasAutomaticPointColors = style === 'marker'
+    && entries.some(({ series }) => isFilteredScatterAutomaticPointStyle(chart, series));
+  const drawLines = markerStyleHasAutomaticPointColors
+    || style === 'line' || style === 'lineMarker' || style === 'lineNoMarker';
+  const drawSmooth = ((style === 'marker' && !markerStyleHasAutomaticPointColors)
+    && !isBubble)
+    || style === 'smooth' || style === 'smoothMarker' || style === 'smoothNoMarker';
   const hideMarkersByStyle = markersSuppressedByChartStyle(
     'scatter', chart.chartType, style, chart.radarStyle,
   );
@@ -12005,29 +12132,40 @@ function drawScatterSeriesLayer(
       }
       if (pts.length >= 2) {
         ctx.save();
-        ctx.strokeStyle = s.color ? `#${s.color}` : fallbackColor;
-        ctx.lineWidth = 1.5;
-        ctx.beginPath();
-        ctx.moveTo(pts[0].x, pts[0].y);
-        if (drawSmooth && pts.length >= 3) {
-          for (let i = 0; i < pts.length - 1; i++) {
-            const p0 = pts[i - 1] ?? pts[i];
-            const p1 = pts[i];
-            const p2 = pts[i + 1];
-            const p3 = pts[i + 2] ?? p2;
-            ctx.bezierCurveTo(
-              p1.x + (p2.x - p0.x) / 6,
-              p1.y + (p2.y - p0.y) / 6,
-              p2.x - (p3.x - p1.x) / 6,
-              p2.y - (p3.y - p1.y) / 6,
-              p2.x,
-              p2.y,
-            );
+        if (markerStyleHasAutomaticPointColors && s.dataPointColors?.some(Boolean)) {
+          ctx.lineWidth = 1.5;
+          for (let i = 1; i < pts.length; i++) {
+            ctx.strokeStyle = `#${s.dataPointColors[i] ?? s.color ?? fallbackColor.replace(/^#/, '')}`;
+            ctx.beginPath();
+            ctx.moveTo(pts[i - 1].x, pts[i - 1].y);
+            ctx.lineTo(pts[i].x, pts[i].y);
+            ctx.stroke();
           }
         } else {
-          for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
+          ctx.strokeStyle = s.color ? `#${s.color}` : fallbackColor;
+          ctx.lineWidth = 1.5;
+          ctx.beginPath();
+          ctx.moveTo(pts[0].x, pts[0].y);
+          if (drawSmooth && pts.length >= 3) {
+            for (let i = 0; i < pts.length - 1; i++) {
+              const p0 = pts[i - 1] ?? pts[i];
+              const p1 = pts[i];
+              const p2 = pts[i + 1];
+              const p3 = pts[i + 2] ?? p2;
+              ctx.bezierCurveTo(
+                p1.x + (p2.x - p0.x) / 6,
+                p1.y + (p2.y - p0.y) / 6,
+                p2.x - (p3.x - p1.x) / 6,
+                p2.y - (p3.y - p1.y) / 6,
+                p2.x,
+                p2.y,
+              );
+            }
+          } else {
+            for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
+          }
+          ctx.stroke();
         }
-        ctx.stroke();
         ctx.restore();
       }
     }
@@ -12044,7 +12182,8 @@ function drawScatterSeriesLayer(
         const xv = scatterXValue(cats, ci, useIndexX);
         if (xv == null) continue;
         const dpt = pointOverrides.get(ci);
-        const symbol = effectiveMarkerSymbol(s, dpt, 'circle', seriesMarkersVisible);
+        const defaultSymbol = isBubble ? 'circle' : (s.automaticMarkerSymbol ?? 'circle');
+        const symbol = effectiveMarkerSymbol(s, dpt, defaultSymbol, seriesMarkersVisible);
         if (symbol === 'none') continue;
         let sizePt = dpt?.markerSize ?? s.markerSize ?? 5;
         if (isBubble) {

--- a/packages/core/src/chart/source-visibility.test.ts
+++ b/packages/core/src/chart/source-visibility.test.ts
@@ -130,4 +130,29 @@ describe('plotVisOnly source filtering', () => {
       dataPointOverrides: [{ idx: 1, markerSize: 9 }],
     });
   });
+
+  it('applies Excel automatic point styles after hidden scatter points are removed', () => {
+    const filtered = applyPlotVisibleOnly(chart({
+      chartType: 'scatter',
+      scatterStyle: 'marker',
+      plotVisibleOnly: true,
+      themeAccentColors: ['156082', 'E97132', '196B24', '0F9ED5', 'A02B93', '4EA72E'],
+      series: [series({
+        color: '156082',
+        categories: ['1', '2', '3', '4', '5'],
+        values: [10, 20, 90, 40, 50],
+        sourceHidden: [false, false, true, false, false],
+      })],
+    }));
+
+    expect(filtered.series[0].dataPointColors).toEqual([
+      '156082', 'E97132', '196B24', '0F9ED5',
+    ]);
+    expect(filtered.series[0].dataPointOverrides).toMatchObject([
+      { idx: 0, markerSymbol: 'diamond' },
+      { idx: 1, markerSymbol: 'square' },
+      { idx: 2, markerSymbol: 'triangle' },
+      { idx: 3, markerSymbol: 'x' },
+    ]);
+  });
 });

--- a/packages/core/src/chart/source-visibility.ts
+++ b/packages/core/src/chart/source-visibility.ts
@@ -111,6 +111,45 @@ function allSourcePointsHidden(series: ChartSeries): boolean {
   return hidden != null && hidden.length > 0 && hidden.every(Boolean);
 }
 
+export const EXCEL_AUTOMATIC_SCATTER_MARKERS = [
+  'diamond', 'square', 'triangle', 'x', 'star', 'circle',
+] as const;
+
+function applyExcelFilteredScatterAutomaticStyle(
+  chart: ChartModel,
+  series: ChartSeries,
+): ChartSeries {
+  const accents = chart.themeAccentColors;
+  const hasDirectPointStyle = series.dataPointColors?.some(color => color != null) === true
+    || (series.dataPointOverrides?.length ?? 0) > 0;
+  const hasDirectMarkerStyle = series.markerSymbol != null
+    || series.markerFill != null
+    || series.markerFillPaintAuthored === true
+    || series.markerLine != null;
+  if (
+    chart.scatterStyle !== 'marker'
+    || !accents?.length
+    || hasDirectPointStyle
+    || hasDirectMarkerStyle
+    || series.lineHidden === true
+  ) return series;
+
+  // Current Excel restyles the compacted visible points of an otherwise
+  // unformatted `scatterStyle="marker"` series as consecutive automatic
+  // theme entries. Keep this compatibility behavior after the normative
+  // plotVisOnly filtering step so hidden source slots consume no palette entry.
+  return {
+    ...series,
+    dataPointColors: series.values.map((_, index) => accents[index % accents.length]),
+    dataPointOverrides: series.values.map((_, index) => ({
+      idx: index,
+      markerSymbol: EXCEL_AUTOMATIC_SCATTER_MARKERS[
+        index % EXCEL_AUTOMATIC_SCATTER_MARKERS.length
+      ],
+    })),
+  };
+}
+
 /**
  * Apply ECMA-376 §21.2.2.146 once, before any chart-family extent, stacking,
  * trendline, error-bar, or label work. Hosts only contribute aligned source
@@ -129,7 +168,11 @@ export function applyPlotVisibleOnly(chart: ChartModel): ChartModel {
         const hidden = effective.sourceHidden;
         const plan = hidden && makeVisibilityPlan(hidden, pointCount(effective));
         if (!plan) return [effective];
-        return plan.keep.length > 0 ? [applyPlanToSeries(effective, plan)] : [];
+        if (plan.keep.length === 0) return [];
+        const filtered = applyPlanToSeries(effective, plan);
+        return chart.chartType === 'scatter'
+          ? [applyExcelFilteredScatterAutomaticStyle(chart, filtered)]
+          : [filtered];
       }),
     };
   }

--- a/packages/core/src/chart/three-d-surface-picture.test.ts
+++ b/packages/core/src/chart/three-d-surface-picture.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import type { ImageFill } from '../types/common.js';
-import { paintChartThreeDSurfacePicture } from './three-d-surface-picture.js';
+import {
+  chartThreeDSurfacePictureSceneFace,
+  paintChartThreeDSurfacePicture,
+} from './three-d-surface-picture.js';
 
 function paint(
   fill: ImageFill,
@@ -124,6 +127,29 @@ const imageFill = {
 };
 
 describe('CT_Surface stretch source and destination rectangles', () => {
+  it('rotates only the positive-thickness back-wall top face to Office texture order', () => {
+    const topFace = [
+      { x: 0, y: 0, depth: 0 },
+      { x: 1, y: 0, depth: 0 },
+      { x: 1, y: 1, depth: 0 },
+      { x: 0, y: 1, depth: 0 },
+    ];
+    const geometry = {
+      thickness: 1,
+      inner: topFace,
+      outer: topFace,
+      faces: [[], [], [], [], topFace, []],
+      pictureStackAspect: 1,
+      modelDepth: 1,
+    };
+    const identity = (point: { x: number; y: number }) => point;
+
+    expect(chartThreeDSurfacePictureSceneFace(geometry, 'backWall', 4, identity))
+      .toEqual([topFace[1], topFace[2], topFace[3], topFace[0]]);
+    expect(chartThreeDSurfacePictureSceneFace(geometry, 'sideWall', 4, identity))
+      .toEqual(topFace);
+  });
+
   it('maps the complete source into the authored projected fillRect', () => {
     const { draws, transforms } = paint({
       ...imageFill,
@@ -276,6 +302,27 @@ describe('CT_Surface plain stacked pictures', () => {
     const exceeded = paint(imageFill, { ...common, imageWidth: 400 * 1_365 });
     expect(exceeded.painted).toBe(false);
     expect(exceeded.draws).toHaveLength(0);
+  });
+});
+
+describe('CT_Surface DrawingML tiles', () => {
+  it('sizes back-wall tiles against the projected face instead of shrinking them twice', () => {
+    const result = paint({
+      ...imageFill,
+      stretch: false,
+      dpi: 96,
+      tile: { tx: 0, ty: 0, sx: 1, sy: 1, flip: 'none', algn: 'ctr' },
+    }, {
+      imageWidth: 100,
+      imageHeight: 100,
+      faceWidth: 100,
+      faceHeight: 100,
+      projectXScale: 0.5,
+    });
+    const projectedCanvas = result.draws
+      .map(call => call[0] as { width?: number })
+      .find(source => source && source !== result.sourceDraws[0]?.[0] && source.width != null);
+    expect(projectedCanvas?.width).toBe(50);
   });
 });
 

--- a/packages/core/src/chart/three-d-surface-picture.ts
+++ b/packages/core/src/chart/three-d-surface-picture.ts
@@ -57,15 +57,22 @@ function screenAlignedFace(
   return [top[0].scenePoint, top[1].scenePoint, bottom[1].scenePoint, bottom[0].scenePoint];
 }
 
-function surfacePictureSceneFace(
+export function chartThreeDSurfacePictureSceneFace(
   geometry: ChartThreeDSurfaceGeometry,
+  kind: ChartThreeDSurfaceKind,
   faceIndex: number,
   project: (point: ThreeDScenePoint) => SurfacePicturePoint,
 ): [ThreeDScenePoint, ThreeDScenePoint, ThreeDScenePoint, ThreeDScenePoint] | null {
   if (geometry.thickness === 0 && faceIndex === 0) {
     return [geometry.inner[3], geometry.inner[2], geometry.inner[1], geometry.inner[0]];
   }
-  return screenAlignedFace(geometry.faces[faceIndex] ?? [], project);
+  const aligned = screenAlignedFace(geometry.faces[faceIndex] ?? [], project);
+  if (!aligned || kind !== 'backWall' || faceIndex !== 4) return aligned;
+  // Office maps the back-wall slab's top joining face from its left-back
+  // scene corner, whereas the generic screen-upright ordering starts at the
+  // following corner and rotates the texture by one quadrant. Other back-wall
+  // faces and every floor/side-wall face retain the generic ordering.
+  return [aligned[1], aligned[2], aligned[3], aligned[0]];
 }
 
 /** Office plain-stack observation: derive one repetition height from the
@@ -165,7 +172,7 @@ export function paintChartThreeDSurfacePicture(
     let hasFace = false;
     for (const faceIndex of visibleFaceIndices) {
       if (!surfacePictureFaceIsEnabled(plan, faceIndex)) continue;
-      const face = surfacePictureSceneFace(geometry, faceIndex, project);
+      const face = chartThreeDSurfacePictureSceneFace(geometry, kind, faceIndex, project);
       if (!face) continue;
       const repetitions = surfacePictureFaceUsesStackedMapping(plan, faceIndex)
         ? Math.ceil(1 / stackFraction)
@@ -185,10 +192,19 @@ export function paintChartThreeDSurfacePicture(
     let hasFace = false;
     for (const faceIndex of visibleFaceIndices) {
       if (!surfacePictureFaceIsEnabled(plan, faceIndex)) continue;
-      const face = surfacePictureSceneFace(geometry, faceIndex, project);
+      const face = chartThreeDSurfacePictureSceneFace(geometry, kind, faceIndex, project);
       if (!face) continue;
-      const width = sceneMetricDistance(face[0], face[1], geometry.modelDepth);
-      const height = sceneMetricDistance(face[0], face[3], geometry.modelDepth);
+      const projected = face.map(project);
+      // A DrawingML tile's DPI-scaled natural size is a device-space measure.
+      // Back-wall tiles therefore use the projected face dimensions; using
+      // the model-space dimensions and projecting the completed tile canvas
+      // shrinks every tile a second time under perspective.
+      const width = kind === 'backWall'
+        ? Math.hypot(projected[0].x - projected[1].x, projected[0].y - projected[1].y)
+        : sceneMetricDistance(face[0], face[1], geometry.modelDepth);
+      const height = kind === 'backWall'
+        ? Math.hypot(projected[0].x - projected[3].x, projected[0].y - projected[3].y)
+        : sceneMetricDistance(face[0], face[3], geometry.modelDepth);
       if (!(width > 0) || !(height > 0)) continue;
       const origin = chartImageTileOrigin(tileMetrics, width, height);
       const firstColumn = Math.floor(-origin.x / tileMetrics.tileW);
@@ -233,10 +249,10 @@ export function paintChartThreeDSurfacePicture(
   if (plan.mode === 'stretch') {
     for (const faceIndex of visibleFaceIndices) {
       if (!surfacePictureFaceIsEnabled(plan, faceIndex)) continue;
-      const aligned = screenAlignedFace(geometry.faces[faceIndex] ?? [], project);
+      const sceneFace = chartThreeDSurfacePictureSceneFace(geometry, kind, faceIndex, project);
       const quad = geometry.thickness === 0 && faceIndex === 0
         ? fullQuad
-        : aligned?.map(project) as SurfacePictureQuad | undefined;
+        : sceneFace?.map(project) as SurfacePictureQuad | undefined;
       if (!quad) continue;
       const fillDestination = relativeRectQuad(quad, fill.fillRect);
       if (!fillDestination) continue;
@@ -261,7 +277,7 @@ export function paintChartThreeDSurfacePicture(
   } else {
     for (const faceIndex of visibleFaceIndices) {
       if (!surfacePictureFaceIsEnabled(plan, faceIndex)) continue;
-      const face = surfacePictureSceneFace(geometry, faceIndex, project);
+      const face = chartThreeDSurfacePictureSceneFace(geometry, kind, faceIndex, project);
       if (!face) continue;
       const quad = face.map(project) as SurfacePictureQuad;
       ctx.save();

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -162,6 +162,8 @@ export interface ChartSeries {
    * showMarker is true).
    */
   markerSymbol?: string | null;
+  /** Host-resolved automatic scatter marker when no `<c:marker>` symbol is authored. */
+  automaticMarkerSymbol?: string | null;
   /**
    * `<c:marker><c:size val>` (ECMA-376 §21.2.2.34) — marker side length in
    * points. null = renderer default (~5 pt).
@@ -705,6 +707,8 @@ export interface ChartDataTable {
   fontColor?: string | null;
   fontBold?: boolean | null;
   fontItalic?: boolean | null;
+  /** Direct table-frame solid fill, painted behind all cells. */
+  fillColor?: string | null;
   lineColor?: string | null;
   lineWidthEmu?: number | null;
   lineDash?: string | null;

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -128,6 +128,8 @@ export interface ChartDataTable {
     fontColor?: string | null;
     fontBold?: boolean | null;
     fontItalic?: boolean | null;
+    /** Direct table-frame solid fill, painted behind all cells. */
+    fillColor?: string | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
     lineDash?: string | null;
@@ -641,6 +643,8 @@ export interface ChartSeries {
     catFormatBuiltinId?: number | null;
     catFormatCodes?: (string | null)[] | null;
     markerSymbol?: string | null;
+    /** Host-resolved automatic scatter marker when no `<c:marker>` symbol is authored. */
+    automaticMarkerSymbol?: string | null;
     markerSize?: number | null;
     markerFill?: string | null;
     markerFillPaint?: Fill | null;

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -361,6 +361,10 @@ pub struct ChartDataTable {
     pub font_bold: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_italic: Option<bool>,
+    /// Direct `<c:dTable><c:spPr>` solid fill. The data-table frame is one
+    /// DrawingML shape, so Office paints this behind every header/value cell.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fill_color: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub line_color: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1482,6 +1486,11 @@ pub struct ChartSeries {
     pub cat_format_codes: Option<Vec<Option<String>>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub marker_symbol: Option<String>,
+    /// Application automatic scatter marker when the series omits a direct
+    /// `<c:marker><c:symbol>`. Kept separate from `marker_symbol` so source
+    /// filtering can distinguish automatic style from authored formatting.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub automatic_marker_symbol: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub marker_size: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2527,6 +2536,13 @@ pub trait ColorResolver {
         None
     }
 
+    /// Plot-area background to use when `<c:plotArea><c:spPr>` omits a fill
+    /// choice. Excel supplies an automatic opaque-white plot-area fill while
+    /// PowerPoint/Word hosts keep their existing transparent behavior.
+    fn default_plot_area_bg(&self) -> Option<String> {
+        None
+    }
+
     /// Whether this host applies Excel's observed implicit outline-only style
     /// to a narrowly-defined, otherwise-unformatted negative column series.
     /// This is not an OOXML default: hosts opt in only after their own Office
@@ -2755,6 +2771,10 @@ impl ColorResolver for ChartMappedColorResolver<'_> {
 
     fn default_chart_bg(&self) -> Option<String> {
         self.base.default_chart_bg()
+    }
+
+    fn default_plot_area_bg(&self) -> Option<String> {
+        self.base.default_plot_area_bg()
     }
 
     fn implicit_outline_only_negative_column_style(&self) -> bool {
@@ -3766,7 +3786,11 @@ pub fn extract_axis_title_with_props_resolved(
             Some(text),
             extract_axis_title_size(axis_node),
             extract_axis_title_bold(axis_node),
-            extract_axis_title_color(axis_node, resolver),
+            // The axis `txPr` is the inherited text default for both its tick
+            // labels and an axis title whose own rich-text runs omit color.
+            // Direct title run/default properties remain more specific.
+            extract_axis_title_color(axis_node, resolver)
+                .or_else(|| extract_axis_tick_label_color(axis_node, resolver)),
         ),
     }
 }
@@ -3968,10 +3992,8 @@ pub fn extract_legend_font_color(root: Node, resolver: &dyn ColorResolver) -> Op
 /// Parse the optional classic-chart data table (`CT_DTable`). Each border/key
 /// child is a CT_Boolean: a present bare element means true, while omission
 /// means that feature is not requested. Text and line properties use the same
-/// DrawingML grammar as the surrounding chart. Office applies `spPr/a:ln` to
-/// the table grid but does not paint an authored `spPr` fill behind the cells;
-/// preserve the effective grid stroke rather than treating the table as a
-/// generic filled shape.
+/// DrawingML grammar as the surrounding chart. The table `spPr` applies both
+/// its shape fill behind the full table and its line style to the table grid.
 pub fn extract_chart_data_table(
     plot_area: Node,
     resolver: &dyn ColorResolver,
@@ -3989,6 +4011,7 @@ pub fn extract_chart_data_table(
                 .flatten()
         })
     });
+    let fill_color = child(table, "spPr").and_then(|shape| resolver.resolve_shape_fill(shape));
     let (line_color, line_width_emu, line_hidden) = extract_sp_pr_ln_style(table, resolver);
     let line_dash = child(table, "spPr")
         .and_then(|shape| child(shape, "ln"))
@@ -4006,6 +4029,7 @@ pub fn extract_chart_data_table(
         font_color,
         font_bold: text_props.and_then(|props| chart_text_bool_attr(props, "b")),
         font_italic: text_props.and_then(|props| chart_text_bool_attr(props, "i")),
+        fill_color,
         line_color,
         line_width_emu,
         line_dash,
@@ -7049,6 +7073,7 @@ pub fn parse_chartex_part_with_references_style_parts_and_images(
         use_secondary_axis: None,
         show_marker: None,
         marker_symbol: None,
+        automatic_marker_symbol: None,
         marker_size: None,
         marker_fill: None,
         marker_fill_paint: None,
@@ -10968,7 +10993,11 @@ pub fn parse_chart_part_with_references_style_parts_and_images(
         image_resolver,
         ChartImageSource::Chart,
     );
-    let plot_area_bg = plot_area_fill_style.color;
+    let plot_area_bg = if plot_area_fill_style.paint_authored == Some(true) {
+        plot_area_fill_style.color.clone()
+    } else {
+        color_resolver.default_plot_area_bg()
+    };
     let plot_area_line_style = extract_direct_shape_line(plot_area, color_resolver);
     let data_table = extract_chart_data_table(plot_area, color_resolver);
 
@@ -11915,6 +11944,12 @@ pub fn parse_chart_part_with_references_style_parts_and_images(
                 (None, true) => true,
                 _ => chart_marker_default,
             };
+            let automatic_marker_symbol = (chart_type == "scatter" && marker_symbol.is_none())
+                .then(|| {
+                    const SYMBOLS: [&str; 6] =
+                        ["diamond", "square", "triangle", "x", "star", "circle"];
+                    SYMBOLS[series_idx % SYMBOLS.len()].to_string()
+                });
 
             // Series-level `<c:dLbls>` defaults + per-idx custom labels, and
             // error bars (§21.2.2.20, resolved to absolute plus/minus arrays).
@@ -12137,6 +12172,7 @@ pub fn parse_chart_part_with_references_style_parts_and_images(
                 // markers, dLbls and errBars from the one parse path.
                 show_marker: Some(show_marker),
                 marker_symbol,
+                automatic_marker_symbol,
                 marker_size,
                 marker_fill,
                 marker_fill_paint,
@@ -13193,6 +13229,7 @@ mod tests {
                 cat_format_builtin_id: None,
                 cat_format_codes: None,
                 marker_symbol: None,
+                automatic_marker_symbol: None,
                 marker_size: None,
                 marker_fill: None,
                 marker_fill_paint: None,
@@ -14261,6 +14298,19 @@ Subtitle</a:t></a:r></a:p>
             extract_axis_title_with_props_resolved(d.root_element(), &StubResolver);
         assert_eq!(text.as_deref(), Some("Value"));
         assert_eq!(color.as_deref(), Some("accent1"));
+    }
+
+    #[test]
+    fn axis_title_inherits_the_axis_text_color_when_its_runs_omit_color() {
+        let xml = r#"<c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+            <c:axPos val="l"/>
+            <c:title><c:tx><c:rich><a:p><a:r><a:t>Values</a:t></a:r></a:p></c:rich></c:tx></c:title>
+            <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="000000"/></a:solidFill></a:defRPr></a:pPr></a:p></c:txPr>
+        </c:valAx>"#;
+        let d = root_of(xml);
+        let (_text, _size, _bold, color) =
+            extract_axis_title_with_props_resolved(d.root_element(), &StubResolver);
+        assert_eq!(color.as_deref(), Some("000000"));
     }
 
     #[test]
@@ -15489,6 +15539,10 @@ Subtitle</a:t></a:r></a:p>
         fn default_chart_bg(&self) -> Option<String> {
             Some("FFFFFF".to_string())
         }
+
+        fn default_plot_area_bg(&self) -> Option<String> {
+            Some("FFFFFF".to_string())
+        }
     }
 
     struct FormatSchemeFixtureResolver {
@@ -15624,6 +15678,38 @@ Subtitle</a:t></a:r></a:p>
         assert_eq!(parsed.chart_bg, None);
         assert_eq!(parsed.chart_fill_hidden, Some(true));
         assert_eq!(parsed.chart_fill_paint_authored, Some(true));
+    }
+
+    #[test]
+    fn plot_area_omitted_fill_uses_the_host_default_but_no_fill_remains_explicit() {
+        let chart_xml = |plot_shape_properties: &str| {
+            format!(
+                r#"<c:chartSpace xmlns:c="{C_NS}" xmlns:a="{A_NS}">
+              <c:chart><c:plotArea>
+                <c:barChart><c:barDir val="col"/><c:ser><c:idx val="0"/>
+                  <c:cat><c:strLit><c:pt idx="0"><c:v>A</c:v></c:pt></c:strLit></c:cat>
+                  <c:val><c:numLit><c:pt idx="0"><c:v>1</c:v></c:pt></c:numLit></c:val>
+                </c:ser></c:barChart>{plot_shape_properties}
+              </c:plotArea></c:chart>
+            </c:chartSpace>"#
+            )
+        };
+        let omitted = chart_xml("");
+        let parsed = parse_chart_part(
+            chart_space_of(&omitted).root_element(),
+            &WhiteChartFixtureResolver,
+        )
+        .expect("plot-area chart parses");
+        assert_eq!(parsed.plot_area_bg.as_deref(), Some("FFFFFF"));
+
+        let no_fill = chart_xml("<c:spPr><a:noFill/></c:spPr>");
+        let parsed = parse_chart_part(
+            chart_space_of(&no_fill).root_element(),
+            &WhiteChartFixtureResolver,
+        )
+        .expect("noFill plot-area chart parses");
+        assert_eq!(parsed.plot_area_bg, None);
+        assert_eq!(parsed.plot_area_fill_hidden, Some(true));
     }
 
     #[test]
@@ -16507,7 +16593,7 @@ Subtitle</a:t></a:r></a:p>
                   <c:showVertBorder val="0"/>
                   <c:showOutline val="1"/>
                   <c:showKeys val="1"/>
-                  <c:spPr><a:ln w="12700"><a:solidFill><a:srgbClr val="445566"/></a:solidFill><a:prstDash val="dash"/></a:ln></c:spPr>
+                  <c:spPr><a:solidFill><a:srgbClr val="FFF2CC"/></a:solidFill><a:ln w="12700"><a:solidFill><a:srgbClr val="445566"/></a:solidFill><a:prstDash val="dash"/></a:ln></c:spPr>
                   <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="1000" b="1" i="1"><a:solidFill><a:srgbClr val="112233"/></a:solidFill><a:latin typeface="Aptos"/></a:defRPr></a:pPr></a:p></c:txPr>
                 </c:dTable>
               </c:plotArea></c:chart>
@@ -16525,6 +16611,7 @@ Subtitle</a:t></a:r></a:p>
         assert_eq!(table.font_color.as_deref(), Some("112233"));
         assert_eq!(table.font_bold, Some(true));
         assert_eq!(table.font_italic, Some(true));
+        assert_eq!(table.fill_color.as_deref(), Some("FFF2CC"));
         assert_eq!(table.line_color.as_deref(), Some("445566"));
         assert_eq!(table.line_width_emu, Some(12700));
         assert_eq!(table.line_dash.as_deref(), Some("dash"));
@@ -16899,6 +16986,15 @@ Subtitle</a:t></a:r></a:p>
         assert_eq!(
             m.series[1].line_hidden, None,
             "a series with a solid line must NOT set line_hidden"
+        );
+        assert_eq!(m.series[0].marker_symbol, None);
+        assert_eq!(
+            m.series[0].automatic_marker_symbol.as_deref(),
+            Some("diamond")
+        );
+        assert_eq!(
+            m.series[1].automatic_marker_symbol.as_deref(),
+            Some("square")
         );
     }
 

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -126,6 +126,8 @@ export interface ChartDataTable {
     fontColor?: string | null;
     fontBold?: boolean | null;
     fontItalic?: boolean | null;
+    /** Direct table-frame solid fill, painted behind all cells. */
+    fillColor?: string | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
     lineDash?: string | null;
@@ -629,6 +631,8 @@ export interface ChartSeries {
     catFormatBuiltinId?: number | null;
     catFormatCodes?: (string | null)[] | null;
     markerSymbol?: string | null;
+    /** Host-resolved automatic scatter marker when no `<c:marker>` symbol is authored. */
+    automaticMarkerSymbol?: string | null;
     markerSize?: number | null;
     markerFill?: string | null;
     markerFillPaint?: Fill | null;

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -237,6 +237,8 @@ export interface ChartDataTable {
     fontColor?: string | null;
     fontBold?: boolean | null;
     fontItalic?: boolean | null;
+    /** Direct table-frame solid fill, painted behind all cells. */
+    fillColor?: string | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
     lineDash?: string | null;
@@ -729,6 +731,8 @@ export interface ChartSeries {
     catFormatBuiltinId?: number | null;
     catFormatCodes?: (string | null)[] | null;
     markerSymbol?: string | null;
+    /** Host-resolved automatic scatter marker when no `<c:marker>` symbol is authored. */
+    automaticMarkerSymbol?: string | null;
     markerSize?: number | null;
     markerFill?: string | null;
     markerFillPaint?: Fill | null;

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -888,6 +888,13 @@ impl ooxml_common::chart::ColorResolver for XlsxColorResolver<'_> {
         Some("FFFFFF".to_string())
     }
 
+    /// Excel's automatic plot-area paint is opaque white even when the chart
+    /// area itself has a different authored fill. A direct plot-area fill or
+    /// noFill remains authoritative in the shared parser.
+    fn default_plot_area_bg(&self) -> Option<String> {
+        Some("FFFFFF".to_string())
+    }
+
     fn implicit_outline_only_negative_column_style(&self) -> bool {
         true
     }


### PR DESCRIPTION
## Summary

- preserve Excel plot-area defaults, chart data-table fill, axis text inheritance, automatic scatter presentation, and standard area series paint order
- generate wireframe Surface band-boundary contours from the same bounded triangulation used by filled Surface charts
- correct the positive-thickness back-wall top-face picture orientation and size back-wall tiles in projected device space
- keep the shared chart model and DOCX/XLSX/PPTX public declaration baselines in sync

## Implementation notes

The changes follow the authored DrawingML properties where present. Excel-only automatic behavior is selected by the XLSX host resolver or by a narrowly bounded post-plotVisOnly compatibility step. Surface contours use value-axis major boundaries and the existing cell diagonal policy; no sample-name checks or empirical geometry constants were added. The contour work is included in the existing resource preflight.

## Verification

- core chart tests: 34 files, 1,373 tests
- shared chart parser tests: 267 tests
- XLSX parser chart tests: 27 tests
- TypeScript project build
- production Vite build
- DOCX/XLSX/PPTX public API baseline checks
- viewer API symmetry check
- local comparisons against desktop Office-produced PDF/image references