### PR TITLE
fix(chart): scope data table fills to body text

### DIFF
--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -11974,7 +11974,15 @@ describe('classic chart data table (CT_DTable)', () => {
     expect(text).toContain('Feb-25');
     expect(rec.strokeRects.some(rect => rect.ss === '#445566')).toBe(true);
     expect(rec.strokeRects.find(rect => rect.ss === '#445566')?.dash.length).toBeGreaterThan(0);
-    expect(rec.rects.some(rect => rect.fs === '#FFF2CC')).toBe(true);
+    const textBackgrounds = rec.rects.filter(rect => rect.fs === '#FFF2CC');
+    expect(textBackgrounds).toHaveLength(6); // two category labels plus four values
+    expect(textBackgrounds.every(rect => rect.w < RECT.w / 4)).toBe(true);
+    expect(textBackgrounds.every(rect => rect.h === 12)).toBe(true);
+    const sales = rec.texts.find(call => call.text === 'Sales') as NonNullable<typeof rec.texts[number]>;
+    expect(textBackgrounds.some(rect =>
+      rect.x <= sales.x && rect.x + rect.w >= sales.x
+      && rect.y <= sales.y && rect.y + rect.h >= sales.y,
+    )).toBe(false);
     expect(rec.arcs.length).toBeGreaterThan(0); // line-series key marker
   });
 

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -607,11 +607,28 @@ function drawChartDataTable(
   ctx.beginPath();
   ctx.rect(tableX, tableY, tableWidth, layout.totalHeight);
   ctx.clip();
-  if (table.fillColor) {
-    ctx.fillStyle = `#${table.fillColor}`;
-    ctx.fillRect(tableX, tableY, tableWidth, layout.totalHeight);
-  }
-  ctx.fillStyle = table.fontColor ? `#${table.fontColor}` : '#000000';
+  const fontColor = table.fontColor ? `#${table.fontColor}` : '#000000';
+  const drawBodyText = (text: string, centerX: number, centerY: number): void => {
+    // Desktop Excel scopes a direct dTable/spPr fill to the generated body
+    // text boxes. It does not fill the table frame or the leading series-name
+    // cells. The text layout box is the measured advance by the measured line
+    // height, so this remains tied to authored typography rather than a cell-
+    // or sample-specific inset.
+    if (table.fillColor && text !== '') {
+      const width = ctx.measureText(text).width;
+      ctx.fillStyle = `#${table.fillColor}`;
+      ctx.fillRect(
+        centerX - width / 2,
+        centerY - layout.lineHeight / 2,
+        width,
+        layout.lineHeight,
+      );
+    }
+    ctx.fillStyle = fontColor;
+    ctx.textAlign = 'center';
+    ctx.fillText(text, centerX, centerY);
+  };
+  ctx.fillStyle = fontColor;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
 
@@ -621,7 +638,7 @@ function drawChartDataTable(
     const textBlockHeight = lines.length * layout.lineHeight;
     const firstY = tableY + (layout.headerHeight - textBlockHeight) / 2 + layout.lineHeight / 2;
     lines.forEach((line, lineIndex) => {
-      ctx.fillText(line, centerX, firstY + lineIndex * layout.lineHeight);
+      drawBodyText(line, centerX, firstY + lineIndex * layout.lineHeight);
     });
   }
 
@@ -660,14 +677,13 @@ function drawChartDataTable(
             ptToPx,
           );
         }
-        ctx.fillStyle = table.fontColor ? `#${table.fontColor}` : '#000000';
+        ctx.fillStyle = fontColor;
       }
     }
-    ctx.textAlign = 'center';
     for (let categoryIndex = 0; categoryIndex < categories.length; categoryIndex++) {
       const value = series.values[categoryIndex];
       const text = value == null ? '' : formatChartValWithCode(value, series.valFormatCode);
-      ctx.fillText(text, plotX + (categoryIndex + 0.5) * categoryWidth, rowCenter);
+      drawBodyText(text, plotX + (categoryIndex + 0.5) * categoryWidth, rowCenter);
     }
   }
 

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -707,7 +707,7 @@ export interface ChartDataTable {
   fontColor?: string | null;
   fontBold?: boolean | null;
   fontItalic?: boolean | null;
-  /** Direct table-frame solid fill, painted behind all cells. */
+  /** Direct `<c:dTable><c:spPr>` solid fill, painted behind body text boxes. */
   fillColor?: string | null;
   lineColor?: string | null;
   lineWidthEmu?: number | null;

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -128,7 +128,7 @@ export interface ChartDataTable {
     fontColor?: string | null;
     fontBold?: boolean | null;
     fontItalic?: boolean | null;
-    /** Direct table-frame solid fill, painted behind all cells. */
+    /** Direct `<c:dTable><c:spPr>` solid fill, painted behind body text boxes. */
     fillColor?: string | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -361,8 +361,8 @@ pub struct ChartDataTable {
     pub font_bold: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_italic: Option<bool>,
-    /// Direct `<c:dTable><c:spPr>` solid fill. The data-table frame is one
-    /// DrawingML shape, so Office paints this behind every header/value cell.
+    /// Direct `<c:dTable><c:spPr>` solid fill. Desktop Excel scopes this to
+    /// the generated category/value text boxes rather than the table frame.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fill_color: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -126,7 +126,7 @@ export interface ChartDataTable {
     fontColor?: string | null;
     fontBold?: boolean | null;
     fontItalic?: boolean | null;
-    /** Direct table-frame solid fill, painted behind all cells. */
+    /** Direct `<c:dTable><c:spPr>` solid fill, painted behind body text boxes. */
     fillColor?: string | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -237,7 +237,7 @@ export interface ChartDataTable {
     fontColor?: string | null;
     fontBold?: boolean | null;
     fontItalic?: boolean | null;
-    /** Direct table-frame solid fill, painted behind all cells. */
+    /** Direct `<c:dTable><c:spPr>` solid fill, painted behind body text boxes. */
     fillColor?: string | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;


### PR DESCRIPTION
## Summary
- paint direct classic chart data-table fills only behind generated category and value text
- leave the table frame and leading series-name cells unfilled
- document the behavior as desktop Excel compatibility rather than a normative ECMA-376 cell-fill rule

## Rationale
ECMA-376 defines `CT_DTable.spPr` as DrawingML shape properties, but does not specify the visual extent of generated data-table text/cells. Desktop Excel vector output scopes this fill to the category/value text layout boxes.

## Verification
- `./node_modules/.bin/vitest run packages/core/src/chart/renderer-correctness.test.ts` (924 passed)
- `./node_modules/.pnpm/typescript@7.0.2/node_modules/typescript/bin/tsc --build --pretty false`
- local desktop Excel PDF comparison across applicable classic chart families