### PR TITLE
fix(chart): harden release fidelity boundaries

### DIFF
--- a/packages/core/src/chart/chart-ex-renderer.ts
+++ b/packages/core/src/chart/chart-ex-renderer.ts
@@ -909,6 +909,13 @@ function renderParetoChart(
 
 // ─── chartEx: box-and-whisker (CH15, MS 2014 chartex ext) ────────────────────
 
+// Application-defined defaults: the ChartEx schema does not encode these.
+// Keep them named and local to this family so they cannot silently affect the
+// specification-defined classic value-axis planner.
+const BOX_WHISKER_AUTO_INTERVAL_TARGET = 7;
+const BOX_WHISKER_AUTO_PADDING_RATIO = 0.05;
+const BOX_WHISKER_ZERO_ANCHOR_RATIO = 1.2;
+
 /** Compact omitted-axis policy observed in three independent Office vector
  * box/whisker outputs (small, ordinary, and wide numeric ranges). OOXML does
  * not define the automatic major unit. Office consistently chooses the nearest
@@ -929,12 +936,15 @@ function automaticBoxWhiskerAxis(
   const boundedMax = explicitMax ?? dataMax;
   const span = boundedMax - boundedMin;
   if (!(span > 0) || !Number.isFinite(span)) return null;
-  const majorUnit = niceStep(span, 7);
+  const majorUnit = niceStep(span, BOX_WHISKER_AUTO_INTERVAL_TARGET);
   if (!(majorUnit > 0) || !Number.isFinite(majorUnit)) return null;
-  let paddedMin = dataMin - span * 0.05;
-  let paddedMax = dataMax + span * 0.05;
-  if (dataMin >= 0 && (dataMin === 0 || dataMax > 1.2 * dataMin)) paddedMin = 0;
-  if (dataMax <= 0 && (dataMax === 0 || Math.abs(dataMin) > 1.2 * Math.abs(dataMax))) {
+  let paddedMin = dataMin - span * BOX_WHISKER_AUTO_PADDING_RATIO;
+  let paddedMax = dataMax + span * BOX_WHISKER_AUTO_PADDING_RATIO;
+  if (dataMin >= 0
+    && (dataMin === 0 || dataMax > BOX_WHISKER_ZERO_ANCHOR_RATIO * dataMin)) paddedMin = 0;
+  if (dataMax <= 0
+    && (dataMax === 0
+      || Math.abs(dataMin) > BOX_WHISKER_ZERO_ANCHOR_RATIO * Math.abs(dataMax))) {
     paddedMax = 0;
   }
   const min = explicitMin ?? Math.floor(paddedMin / majorUnit) * majorUnit;
@@ -1526,6 +1536,10 @@ function renderBoxWhiskerChart(
   );
 }
 
+/** Application-defined automatic ChartEx sunburst center-hole ratio observed
+ * across the current desktop-Office vector corpus. It is intentionally local
+ * to sunburst and never reused as a generic radial-chart default. */
+const SUNBURST_AUTOMATIC_HOLE_RATIO = 0.18;
 
 /**
  * Render a chartEx sunburst (MS 2014 chartex extension — no ECMA-376 section;
@@ -1612,7 +1626,7 @@ function renderSunburstChart(
   const ringCount = maxDepth + 1;
   // Small center hole (Office draws a modest hole, ~18% of the outer radius);
   // the remaining band is split evenly across the rings.
-  const innerR = outerR * 0.18;
+  const innerR = outerR * SUNBURST_AUTOMATIC_HOLE_RATIO;
   const ringBand = (outerR - innerR) / ringCount;
 
   const branchColor = (bi: number): string => {

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1065,6 +1065,24 @@ describe('chart-space background', () => {
     expect(rec.paintEvents).toContainEqual({ kind: 'stroke', strokeStyle: '#0055AA' });
   });
 
+  it('keeps the application-defined rounded radius in points and clamps tiny frames', () => {
+    const scaled = recordingCtx();
+    renderChart(scaled.ctx, baseModel({
+      roundedCorners: true,
+      chartBg: 'F2F2F2',
+    }), { x: 0, y: 0, w: 200, h: 100 }, 2);
+    // The first corner ends at y = 5pt × 2px/pt.
+    expect(scaled.quadratics[0]?.y).toBe(10);
+
+    const tiny = recordingCtx();
+    renderChart(tiny.ctx, baseModel({
+      roundedCorners: true,
+      chartBg: 'F2F2F2',
+    }), { x: 0, y: 0, w: 8, h: 6 }, 2);
+    // Geometry, not a sample-specific threshold, bounds the radius to h/2.
+    expect(tiny.quadratics[0]?.y).toBe(3);
+  });
+
   it('keeps both compound rails inside the rounded chart-space clip', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, baseModel({
@@ -19479,6 +19497,17 @@ describe('CH15 — chartEx sunburst', () => {
       ],
     };
     expect(chartLabelPaintWorkCount(sparse, undefined)).toBe(4096);
+  });
+
+  it.each([
+    { x: 0, y: 0, w: 640, h: 360 },
+    { x: 0, y: 0, w: 360, h: 640 },
+    { x: 0, y: 0, w: 900, h: 240 },
+  ])('keeps the Office-observed automatic hole ratio local to sunburst (%o)', (rect) => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, sunburstModel(), rect, 1);
+    const radii = rec.arcs.map(arc => arc.r).filter(radius => radius > 0);
+    expect(Math.min(...radii) / Math.max(...radii)).toBeCloseTo(0.18, 5);
   });
 
   it('draws three concentric rings (Branch / Stem / Leaf) with distinct radii', () => {

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1066,13 +1066,22 @@ describe('chart-space background', () => {
   });
 
   it('keeps the application-defined rounded radius in points and clamps tiny frames', () => {
+    for (const [w, h] of [[390, 315], [570, 240], [285, 420]]) {
+      const aspect = recordingCtx();
+      renderChart(aspect.ctx, baseModel({
+        roundedCorners: true,
+        chartBg: 'F2F2F2',
+      }), { x: 0, y: 0, w, h }, 1);
+      expect(aspect.quadratics[0]?.y).toBe(10);
+    }
+
     const scaled = recordingCtx();
     renderChart(scaled.ctx, baseModel({
       roundedCorners: true,
       chartBg: 'F2F2F2',
     }), { x: 0, y: 0, w: 200, h: 100 }, 2);
-    // The first corner ends at y = 5pt × 2px/pt.
-    expect(scaled.quadratics[0]?.y).toBe(10);
+    // Desktop Excel vector output fixes the radius at 10pt across aspect ratios.
+    expect(scaled.quadratics[0]?.y).toBe(20);
 
     const tiny = recordingCtx();
     renderChart(tiny.ctx, baseModel({
@@ -12060,9 +12069,7 @@ describe('classic chart data table (CT_DTable)', () => {
     expect(rec.strokeRects.some(rect => rect.ss === '#445566')).toBe(true);
     expect(rec.strokeRects.find(rect => rect.ss === '#445566')?.dash.length).toBeGreaterThan(0);
     const textBackgrounds = rec.rects.filter(rect => rect.fs === '#FFF2CC');
-    expect(textBackgrounds).toHaveLength(6); // two category labels plus four values
-    expect(textBackgrounds.every(rect => rect.w < RECT.w / 4)).toBe(true);
-    expect(textBackgrounds.every(rect => rect.h === 12)).toBe(true);
+    expect(textBackgrounds).toHaveLength(0); // combo extent has no desktop-Excel evidence
     const sales = rec.texts.find(call => call.text === 'Sales') as NonNullable<typeof rec.texts[number]>;
     expect(textBackgrounds.some(rect =>
       rect.x <= sales.x && rect.x + rect.w >= sales.x
@@ -12128,6 +12135,43 @@ describe('classic chart data table (CT_DTable)', () => {
     };
 
     expect(renderFillRects({}).length).toBeGreaterThan(0);
+    expect(renderFillRects({
+      plotGroups: [{
+        kind: 'line',
+        seriesStart: 0,
+        seriesCount: 1,
+        categoryAxis: 'primary',
+        valueAxis: 'primary',
+        seriesAxis: 'none',
+      }],
+    }).length).toBeGreaterThan(0);
+    expect(renderFillRects({
+      plotGroups: [
+        {
+          kind: 'line',
+          seriesStart: 0,
+          seriesCount: 1,
+          categoryAxis: 'primary',
+          valueAxis: 'primary',
+          seriesAxis: 'none',
+        },
+        {
+          kind: 'bar',
+          seriesStart: 1,
+          seriesCount: 1,
+          categoryAxis: 'primary',
+          valueAxis: 'primary',
+          seriesAxis: 'none',
+          barDirection: 'col',
+        },
+      ],
+    })).toHaveLength(0);
+    expect(renderFillRects({
+      series: [
+        series({ name: 'North', values: [10, 15], seriesType: 'line' }),
+        series({ name: 'South', values: [8, 12], seriesType: 'bar' }),
+      ],
+    })).toHaveLength(0);
     expect(renderFillRects({ chartType: 'clusteredBarH' })).toHaveLength(0);
     expect(renderFillRects({ chartType: 'stock' })).toHaveLength(0);
     expect(renderFillRects({ plotAreaManualLayout: { x: 0.2, y: 0.2 } })).toHaveLength(0);

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -12130,7 +12130,7 @@ describe('classic chart data table (CT_DTable)', () => {
     expect(renderFillRects({}).length).toBeGreaterThan(0);
     expect(renderFillRects({ chartType: 'clusteredBarH' })).toHaveLength(0);
     expect(renderFillRects({ chartType: 'stock' })).toHaveLength(0);
-    expect(renderFillRects({ plotAreaManualLayout: { x: 0.2 } })).toHaveLength(0);
+    expect(renderFillRects({ plotAreaManualLayout: { x: 0.2, y: 0.2 } })).toHaveLength(0);
     expect(renderFillRects({ categories: [
       ['First quarter with wrapped text repeated', 'until it exceeds the category column'].join(' '),
       'Q2',

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -5397,6 +5397,22 @@ describe('bar chart authored layout and fills', () => {
     expect(linked.strokeRects.find(rect => rect.ss === '#445566')?.dash)
       .toEqual([0.9375, 0.5625]);
 
+    const automaticHostFallback = recordingCtx();
+    renderChart(automaticHostFallback.ctx, {
+      ...chart,
+      plotAreaBg: 'FFFFFF',
+      plotAreaFillAutomatic: true,
+    }, RECT, 1, 30);
+    expect(automaticHostFallback.gradients).toHaveLength(1);
+    expect(automaticHostFallback.gradients[0]?.stops).toEqual([
+      { position: 0, color: 'rgba(17,34,51,1)' },
+      { position: 1, color: 'rgba(221,238,255,1)' },
+    ]);
+
+    const compatibilityDirect = recordingCtx();
+    renderChart(compatibilityDirect.ctx, { ...chart, plotAreaBg: 'FFFFFF' }, RECT, 1, 30);
+    expect(compatibilityDirect.gradients).toHaveLength(0);
+
     const directEmptyDash = recordingCtx();
     renderChart(directEmptyDash.ctx, { ...chart, plotAreaLineCustomDash: [] }, RECT, 1, 30);
     expect(directEmptyDash.strokeRects.find(rect => rect.ss === '#445566')?.dash)
@@ -12021,6 +12037,39 @@ describe('classic chart data table (CT_DTable)', () => {
       showOutline: true,
       lineHidden: true,
     })).toEqual({ lineStrokes: 0, outlines: 0 });
+  });
+
+  it('limits the observed text-background compatibility rule to its Excel evidence', () => {
+    const renderFillRects = (over: Partial<ChartModel>) => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType: 'line',
+        categories: ['Q1', 'Q2'],
+        series: [series({ name: 'North', values: [10, 15], seriesType: 'line' })],
+        dataTable: {
+          showHorizontalBorder: true,
+          showVerticalBorder: true,
+          showOutline: true,
+          showKeys: false,
+          fillColor: 'FFF2CC',
+        },
+        ...over,
+      }), RECT, 1);
+      return rec.rects.filter(rect => rect.fs === '#FFF2CC');
+    };
+
+    expect(renderFillRects({}).length).toBeGreaterThan(0);
+    expect(renderFillRects({ chartType: 'clusteredBarH' })).toHaveLength(0);
+    expect(renderFillRects({ chartType: 'stock' })).toHaveLength(0);
+    expect(renderFillRects({ plotAreaManualLayout: { x: 0.2 } })).toHaveLength(0);
+    expect(renderFillRects({ categories: [
+      ['First quarter with wrapped text repeated', 'until it exceeds the category column'].join(' '),
+      'Q2',
+    ] }))
+      .toHaveLength(0);
+    expect(renderFillRects({
+      series: [series({ name: 'North', values: [10, null], seriesType: 'line' })],
+    })).toHaveLength(0);
   });
 
   it('uses the linked dataTable line role only for omitted grid properties', () => {

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -604,6 +604,13 @@ function drawChartDataTable(
     chart.radarStyle,
     chart,
   );
+  const bodyFillColor = table.fillColor
+    && chart.plotAreaManualLayout == null
+    && (chart.chartType === 'clusteredBar' || chart.chartType === 'line' || chart.chartType === 'area')
+    && layout.headerLines.every(lines => lines.length === 1)
+    && chart.series.every(series => series.values.every(value => value != null))
+    ? table.fillColor
+    : null;
   ctx.beginPath();
   ctx.rect(tableX, tableY, tableWidth, layout.totalHeight);
   ctx.clip();
@@ -614,9 +621,9 @@ function drawChartDataTable(
     // cells. The text layout box is the measured advance by the measured line
     // height, so this remains tied to authored typography rather than a cell-
     // or sample-specific inset.
-    if (table.fillColor && text !== '') {
+    if (bodyFillColor && text !== '') {
       const width = ctx.measureText(text).width;
-      ctx.fillStyle = `#${table.fillColor}`;
+      ctx.fillStyle = `#${bodyFillColor}`;
       ctx.fillRect(
         centerX - width / 2,
         centerY - layout.lineHeight / 2,
@@ -6066,7 +6073,8 @@ function chartStyleRolePlotArea(chart: ChartModel): ChartModel {
   let plotAreaBg = chart.plotAreaBg;
   let plotAreaFillHidden = chart.plotAreaFillHidden;
   const directPaint = chart.plotAreaFillPaintAuthored === true
-    || plotAreaFill != null || plotAreaBg != null || plotAreaFillHidden === true;
+    || ((plotAreaFill != null || plotAreaBg != null) && chart.plotAreaFillAutomatic !== true)
+    || plotAreaFillHidden === true;
   if (!directPaint && linked.fillNoStyle !== true) {
     if (linked.fillHidden === true) {
       plotAreaFillHidden = true;

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -604,9 +604,31 @@ function drawChartDataTable(
     chart.radarStyle,
     chart,
   );
+  const dataTableFillPlotGroup = chart.plotGroups?.length === 1
+    ? chart.plotGroups[0]
+    : null;
+  const dataTableFillFamilyMatches = chart.plotGroups == null || (
+    dataTableFillPlotGroup != null
+    && (
+      (chart.chartType === 'clusteredBar'
+        && dataTableFillPlotGroup.kind === 'bar'
+        && dataTableFillPlotGroup.barDirection !== 'bar')
+      || (chart.chartType === 'line' && dataTableFillPlotGroup.kind === 'line')
+      || (chart.chartType === 'area' && dataTableFillPlotGroup.kind === 'area')
+    )
+  );
+  const dataTableFillSeriesFamilyMatches = chart.series.every(series => {
+    if (series.seriesType == null) return true;
+    if (chart.chartType === 'clusteredBar') return series.seriesType === 'bar';
+    if (chart.chartType === 'line') return series.seriesType === 'line';
+    if (chart.chartType === 'area') return series.seriesType === 'area';
+    return false;
+  });
   const bodyFillColor = table.fillColor
     && chart.plotAreaManualLayout == null
     && (chart.chartType === 'clusteredBar' || chart.chartType === 'line' || chart.chartType === 'area')
+    && dataTableFillFamilyMatches
+    && dataTableFillSeriesFamilyMatches
     && layout.headerLines.every(lines => lines.length === 1)
     && chart.series.every(series => series.values.every(value => value != null))
     ? table.fillColor
@@ -15160,11 +15182,10 @@ function drawChartTextBoxes(
 // ─── Background frame + dispatcher ──────────────────────────────────────────
 
 /** ECMA-376 §21.2.2.159 defines only whether chart-space corners are rounded,
- * not the application geometry. Keep the compatibility policy isolated: a
- * fixed 5pt radius is transform-stable, independent of chart aspect ratio, and
- * can be replaced without touching fill/border/clip semantics if a future
- * Office vector boundary establishes a different radius. */
-const CHART_SPACE_CORNER_RADIUS_PT = 5;
+ * not the application geometry. Desktop Excel vector output uses a fixed 10pt
+ * radius across square, wide, and tall chart frames; keep that observed Office
+ * policy isolated from fill, border, and clipping semantics. */
+const CHART_SPACE_CORNER_RADIUS_PT = 10;
 
 function chartSpaceRoundedPath(
   ctx: CanvasRenderingContext2D,

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -707,8 +707,16 @@ export interface ChartDataTable {
   fontColor?: string | null;
   fontBold?: boolean | null;
   fontItalic?: boolean | null;
-  /** Direct `<c:dTable><c:spPr>` solid fill, painted behind body text boxes. */
+  /** Resolved solid compatibility projection of `<c:dTable><c:spPr>`. */
   fillColor?: string | null;
+  /** Direct DrawingML fill recipe. Preserved even where Office's application-
+   * defined data-table paint extent has not been established for that recipe. */
+  fill?: SolidFill | GradientFill | PatternFill | null;
+  /** Explicit `<a:noFill>` on the data-table shape properties. */
+  fillHidden?: boolean | null;
+  /** True when `spPr` authored any DrawingML fill child, including one whose
+   * paint recipe this implementation cannot resolve. */
+  fillPaintAuthored?: boolean | null;
   lineColor?: string | null;
   lineWidthEmu?: number | null;
   lineDash?: string | null;
@@ -777,6 +785,8 @@ export interface ChartModel {
   plotAreaFillHidden?: boolean | null;
   /** A direct plot-area fill paint was authored, even when unresolved. */
   plotAreaFillPaintAuthored?: boolean | null;
+  /** `plotAreaBg` is a host automatic fallback, not direct formatting. */
+  plotAreaFillAutomatic?: boolean | null;
   /** Direct plot-area outline paint and width. */
   plotAreaLineColor?: string | null;
   plotAreaLineFill?: SolidFill | GradientFill | PatternFill | null;

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -128,8 +128,16 @@ export interface ChartDataTable {
     fontColor?: string | null;
     fontBold?: boolean | null;
     fontItalic?: boolean | null;
-    /** Direct `<c:dTable><c:spPr>` solid fill, painted behind body text boxes. */
+    /** Resolved solid compatibility projection of `<c:dTable><c:spPr>`. */
     fillColor?: string | null;
+    /** Direct DrawingML fill recipe. Preserved even where Office's application-
+     * defined data-table paint extent has not been established for that recipe. */
+    fill?: SolidFill | GradientFill | PatternFill | null;
+    /** Explicit `<a:noFill>` on the data-table shape properties. */
+    fillHidden?: boolean | null;
+    /** True when `spPr` authored any DrawingML fill child, including one whose
+     * paint recipe this implementation cannot resolve. */
+    fillPaintAuthored?: boolean | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
     lineDash?: string | null;
@@ -348,6 +356,7 @@ export interface ChartModel {
     plotAreaFill?: Fill | null;
     plotAreaFillHidden?: boolean | null;
     plotAreaFillPaintAuthored?: boolean | null;
+    plotAreaFillAutomatic?: boolean | null;
     plotAreaLineColor?: string | null;
     plotAreaLineFill?: SolidFill | GradientFill | PatternFill | null;
     plotAreaLineWidthEmu?: number | null;

--- a/packages/docx/src/paint/canonical-resource-handlers.test.ts
+++ b/packages/docx/src/paint/canonical-resource-handlers.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import type { ChartModel } from '@silurus/ooxml-core';
+import { describe, expect, it, vi } from 'vitest';
+import type { ChartExRenderer, ChartModel } from '@silurus/ooxml-core';
 import {
   createPaintResourceRegistry,
 } from '../layout/paint-resources.js';
@@ -9,7 +9,10 @@ import {
   unavailablePaintResourceHandle,
 } from './resource-session.js';
 import { createCanvasPaintResourcePainter } from './canvas-page.js';
-import { canonicalCanvasPaintResourceHandlers } from './canonical-resource-handlers.js';
+import {
+  canonicalCanvasPaintResourceHandlers,
+  createCanonicalCanvasPaintResourceHandlers,
+} from './canonical-resource-handlers.js';
 
 function chartModel(): ChartModel {
   return {
@@ -155,5 +158,35 @@ describe('canonical Canvas paint resource handlers', () => {
       { name: 'strokeRect', args: [10.5, 20.5, 119, 79] },
       { name: 'fillText', args: ['(no data)', 70, 60] },
     ]));
+  });
+
+  it('forwards the opt-in ChartEx module through the DOCX chart paint boundary', () => {
+    const resourceKey = 'chart:chartex';
+    const render = vi.fn(() => true);
+    const chartEx = { render } as ChartExRenderer;
+    const registry = createPaintResourceRegistry([{
+      kind: 'chart', resourceKey, intrinsicSize: { widthPt: 120, heightPt: 80 },
+      model: {
+        ...chartModel(),
+        chartType: 'boxWhisker',
+        chartexBox: { categories: [], series: [] },
+      },
+    }]);
+    const paint = createCanvasPaintResourcePainter(
+      createPaintResourceSession(registry, [{ kind: 'chart', resourceKey, handle: null }]),
+      createCanonicalCanvasPaintResourceHandlers(undefined, undefined, undefined, chartEx),
+    );
+    const { ctx } = recordingContext();
+
+    paint.paint(resourceKey, 'chart', { xPt: 10, yPt: 20, widthPt: 120, heightPt: 80 }, ctx);
+
+    expect(render).toHaveBeenCalledOnce();
+    expect(render).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ chartType: 'boxWhisker' }),
+      { x: 10, y: 20, w: 120, h: 80 },
+      1,
+      0,
+    );
   });
 });

--- a/packages/docx/src/worker-renderer-modules.test.ts
+++ b/packages/docx/src/worker-renderer-modules.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { chartEx } from '../../../src/chart-ex.js';
-import { loadWorkerRenderers, workerRendererDescriptors } from '@silurus/ooxml-core/worker';
+import { loadWorkerRenderers } from '@silurus/ooxml-core/worker';
 import type { RenderWorkerRequest } from './worker-protocol.js';
 
 describe('DOCX worker optional renderer wire', () => {
@@ -11,7 +10,12 @@ describe('DOCX worker optional renderer wire', () => {
       data: new ArrayBuffer(0),
       resourcePolicy: {} as never,
       defaultCurrentDateMs: 0,
-      renderers: workerRendererDescriptors({ chartEx }),
+      renderers: {
+        chartEx: {
+          protocol: 'ooxml-worker-renderer-module/v1',
+          builtin: 'chartEx',
+        },
+      },
     } satisfies Extract<RenderWorkerRequest, { type: 'parse' }>;
 
     const cloned = structuredClone(request);

--- a/packages/docx/src/worker-renderer-modules.test.ts
+++ b/packages/docx/src/worker-renderer-modules.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { chartEx } from '../../../src/chart-ex.js';
+import { loadWorkerRenderers, workerRendererDescriptors } from '@silurus/ooxml-core/worker';
+import type { RenderWorkerRequest } from './worker-protocol.js';
+
+describe('DOCX worker optional renderer wire', () => {
+  it('carries and reconstructs the shared ChartEx module without cloning functions', async () => {
+    const request = {
+      type: 'parse',
+      id: 1,
+      data: new ArrayBuffer(0),
+      resourcePolicy: {} as never,
+      defaultCurrentDateMs: 0,
+      renderers: workerRendererDescriptors({ chartEx }),
+    } satisfies Extract<RenderWorkerRequest, { type: 'parse' }>;
+
+    const cloned = structuredClone(request);
+    expect(cloned.renderers?.chartEx).toEqual({
+      protocol: 'ooxml-worker-renderer-module/v1',
+      builtin: 'chartEx',
+    });
+    expect(typeof (await loadWorkerRenderers(cloned.renderers)).chartEx?.render).toBe('function');
+  });
+});

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -4018,6 +4018,9 @@ pub fn extract_chart_data_table(
     resolver: &dyn ColorResolver,
 ) -> Option<ChartDataTable> {
     let table = child(plot_area, "dTable")?;
+    if !chart_data_table_paint_within_limit(table) {
+        return None;
+    }
     let txpr = child(table, "txPr");
     let text_props = txpr.and_then(|body| {
         body.descendants()
@@ -4057,6 +4060,16 @@ pub fn extract_chart_data_table(
         line_dash,
         line_hidden: line_hidden.then_some(true),
     })
+}
+
+/// Preflight the direct data-table fill before gradient-stop expansion and
+/// sorting. CT_DTable reuses DrawingML shape properties, so it shares the same
+/// per-recipe ceiling as every other retained chart paint.
+fn chart_data_table_paint_within_limit(table: Node) -> bool {
+    child(table, "spPr")
+        .and_then(chart_style_paint_component_count)
+        .unwrap_or(0)
+        <= MAX_CHART_PAINT_RECIPE_COMPONENTS
 }
 
 #[derive(Default)]
@@ -11045,6 +11058,11 @@ pub fn parse_chart_part_with_references_style_parts_and_images(
         && plot_area_bg.is_some())
     .then_some(true);
     let plot_area_line_style = extract_direct_shape_line(plot_area, color_resolver);
+    if child(plot_area, "dTable")
+        .is_some_and(|table| !chart_data_table_paint_within_limit(table))
+    {
+        return None;
+    }
     let data_table = extract_chart_data_table(plot_area, color_resolver);
 
     let classic_group_kind = |name: &str| -> Option<&'static str> {
@@ -16739,6 +16757,49 @@ Subtitle</a:t></a:r></a:p>
         assert_eq!(no_fill.fill_color, None);
         assert_eq!(no_fill.fill_hidden, Some(true));
         assert_eq!(no_fill.fill_paint_authored, Some(true));
+    }
+
+    #[test]
+    fn parse_chart_data_table_bounds_gradient_before_expansion() {
+        let chart = |stop_count: usize| {
+            let stops = (0..stop_count)
+                .map(|index| {
+                    format!(
+                        r#"<a:gs pos="{index}"><a:srgbClr val="112233"/></a:gs>"#,
+                    )
+                })
+                .collect::<String>();
+            format!(
+                r#"<c:chartSpace xmlns:c="{C_NS}" xmlns:a="{A_NS}">
+                  <c:chart><c:plotArea>
+                    <c:barChart><c:barDir val="col"/><c:ser><c:idx val="0"/>
+                      <c:cat><c:strCache><c:pt idx="0"><c:v>A</c:v></c:pt></c:strCache></c:cat>
+                      <c:val><c:numCache><c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:val>
+                    </c:ser></c:barChart>
+                    <c:dTable><c:spPr><a:gradFill><a:gsLst>{stops}</a:gsLst></a:gradFill></c:spPr></c:dTable>
+                  </c:plotArea></c:chart>
+                </c:chartSpace>"#,
+            )
+        };
+
+        let exact_xml = chart(MAX_CHART_PAINT_RECIPE_COMPONENTS);
+        let exact = parse_chart_part(
+            chart_space_of(&exact_xml).root_element(),
+            &FixtureResolver,
+        )
+        .expect("paint recipe at the shared ceiling parses");
+        assert!(matches!(
+            exact.data_table.and_then(|table| table.fill),
+            Some(ChartStyleFill::Gradient { ref stops, .. })
+                if stops.len() == MAX_CHART_PAINT_RECIPE_COMPONENTS
+        ));
+
+        let oversized_xml = chart(MAX_CHART_PAINT_RECIPE_COMPONENTS + 1);
+        assert!(parse_chart_part(
+            chart_space_of(&oversized_xml).root_element(),
+            &FixtureResolver,
+        )
+        .is_none());
     }
 
     /// `c:invertIfNegative` and the Office 2010 alternate fill extension are

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -361,10 +361,17 @@ pub struct ChartDataTable {
     pub font_bold: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_italic: Option<bool>,
-    /// Direct `<c:dTable><c:spPr>` solid fill. Desktop Excel scopes this to
-    /// the generated category/value text boxes rather than the table frame.
+    /// Resolved solid compatibility projection of `<c:dTable><c:spPr>`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fill_color: Option<String>,
+    /// Direct DrawingML fill recipe. It is preserved even when the Office-
+    /// defined visual extent for this data-table paint is not yet rendered.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fill: Option<ChartStyleFill>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fill_hidden: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fill_paint_authored: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub line_color: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -455,6 +462,10 @@ pub struct ChartModel {
     /// A direct plot-area fill paint was authored, even when unresolved.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plot_area_fill_paint_authored: Option<bool>,
+    /// The resolved plot-area color is a host automatic fallback rather than
+    /// direct formatting. Linked chart-style paint therefore has precedence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plot_area_fill_automatic: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plot_area_line_color: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -3992,8 +4003,10 @@ pub fn extract_legend_font_color(root: Node, resolver: &dyn ColorResolver) -> Op
 /// Parse the optional classic-chart data table (`CT_DTable`). Each border/key
 /// child is a CT_Boolean: a present bare element means true, while omission
 /// means that feature is not requested. Text and line properties use the same
-/// DrawingML grammar as the surrounding chart. The table `spPr` applies both
-/// its shape fill behind the full table and its line style to the table grid.
+/// DrawingML grammar as the surrounding chart. The direct resolvable solid
+/// fill is retained separately from the table-grid line style; its observed
+/// Excel paint extent is an application compatibility behavior, not defined by
+/// `CT_DTable` itself.
 pub fn extract_chart_data_table(
     plot_area: Node,
     resolver: &dyn ColorResolver,
@@ -4011,7 +4024,7 @@ pub fn extract_chart_data_table(
                 .flatten()
         })
     });
-    let fill_color = child(table, "spPr").and_then(|shape| resolver.resolve_shape_fill(shape));
+    let direct_fill = extract_direct_shape_fill(child(table, "spPr"), resolver);
     let (line_color, line_width_emu, line_hidden) = extract_sp_pr_ln_style(table, resolver);
     let line_dash = child(table, "spPr")
         .and_then(|shape| child(shape, "ln"))
@@ -4029,7 +4042,10 @@ pub fn extract_chart_data_table(
         font_color,
         font_bold: text_props.and_then(|props| chart_text_bool_attr(props, "b")),
         font_italic: text_props.and_then(|props| chart_text_bool_attr(props, "i")),
-        fill_color,
+        fill_color: direct_fill.color,
+        fill: direct_fill.fill,
+        fill_hidden: direct_fill.hidden,
+        fill_paint_authored: direct_fill.paint_authored,
         line_color,
         line_width_emu,
         line_dash,
@@ -7504,6 +7520,7 @@ pub fn parse_chartex_part_with_references_style_parts_and_images(
         plot_area_fill: None,
         plot_area_fill_hidden: None,
         plot_area_fill_paint_authored: None,
+        plot_area_fill_automatic: None,
         plot_area_line_color: None,
         plot_area_line_fill: None,
         plot_area_line_width_emu: None,
@@ -10998,6 +11015,9 @@ pub fn parse_chart_part_with_references_style_parts_and_images(
     } else {
         color_resolver.default_plot_area_bg()
     };
+    let plot_area_fill_automatic = (plot_area_fill_style.paint_authored != Some(true)
+        && plot_area_bg.is_some())
+    .then_some(true);
     let plot_area_line_style = extract_direct_shape_line(plot_area, color_resolver);
     let data_table = extract_chart_data_table(plot_area, color_resolver);
 
@@ -12893,6 +12913,7 @@ pub fn parse_chart_part_with_references_style_parts_and_images(
         plot_area_fill: plot_area_fill_style.fill,
         plot_area_fill_hidden: plot_area_fill_style.hidden,
         plot_area_fill_paint_authored: plot_area_fill_style.paint_authored,
+        plot_area_fill_automatic,
         plot_area_line_color: plot_area_line_style.color,
         plot_area_line_fill: plot_area_line_style.fill,
         plot_area_line_width_emu: plot_area_line_style.width_emu,
@@ -13263,6 +13284,7 @@ mod tests {
             plot_area_fill: None,
             plot_area_fill_hidden: None,
             plot_area_fill_paint_authored: None,
+            plot_area_fill_automatic: None,
             plot_area_line_color: None,
             plot_area_line_fill: None,
             plot_area_line_width_emu: None,
@@ -15701,6 +15723,7 @@ Subtitle</a:t></a:r></a:p>
         )
         .expect("plot-area chart parses");
         assert_eq!(parsed.plot_area_bg.as_deref(), Some("FFFFFF"));
+        assert_eq!(parsed.plot_area_fill_automatic, Some(true));
 
         let no_fill = chart_xml("<c:spPr><a:noFill/></c:spPr>");
         let parsed = parse_chart_part(
@@ -15710,6 +15733,7 @@ Subtitle</a:t></a:r></a:p>
         .expect("noFill plot-area chart parses");
         assert_eq!(parsed.plot_area_bg, None);
         assert_eq!(parsed.plot_area_fill_hidden, Some(true));
+        assert_eq!(parsed.plot_area_fill_automatic, None);
     }
 
     #[test]
@@ -16612,9 +16636,59 @@ Subtitle</a:t></a:r></a:p>
         assert_eq!(table.font_bold, Some(true));
         assert_eq!(table.font_italic, Some(true));
         assert_eq!(table.fill_color.as_deref(), Some("FFF2CC"));
+        assert!(matches!(
+            table.fill,
+            Some(ChartStyleFill::Solid { ref color }) if color == "FFF2CC"
+        ));
+        assert_eq!(table.fill_hidden, None);
+        assert_eq!(table.fill_paint_authored, Some(true));
         assert_eq!(table.line_color.as_deref(), Some("445566"));
         assert_eq!(table.line_width_emu, Some(12700));
         assert_eq!(table.line_dash.as_deref(), Some("dash"));
+    }
+
+    /// DrawingML `spPr` is not a solid-color-only grammar. Preserve the
+    /// authored recipe/noFill provenance in the common model even though the
+    /// desktop-Excel text-box extent is currently rendered only for the
+    /// separately verified solid subset.
+    #[test]
+    fn parse_chart_data_table_preserves_non_solid_fill_provenance() {
+        let parse_table = |shape: &str| {
+            let xml = format!(
+                r#"<c:chartSpace xmlns:c="{C_NS}" xmlns:a="{A_NS}">
+                  <c:chart><c:plotArea>
+                    <c:barChart><c:barDir val="col"/><c:ser><c:idx val="0"/>
+                      <c:cat><c:strCache><c:pt idx="0"><c:v>A</c:v></c:pt></c:strCache></c:cat>
+                      <c:val><c:numCache><c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:val>
+                    </c:ser></c:barChart>
+                    <c:dTable><c:spPr>{shape}</c:spPr></c:dTable>
+                  </c:plotArea></c:chart>
+                </c:chartSpace>"#
+            );
+            parse_chart_part(chart_space_of(&xml).root_element(), &FixtureResolver)
+                .expect("data-table chart parses")
+                .data_table
+                .expect("c:dTable preserved")
+        };
+
+        let gradient = parse_table(
+            r#"<a:gradFill><a:gsLst>
+              <a:gs pos="0"><a:srgbClr val="112233"/></a:gs>
+              <a:gs pos="100000"><a:srgbClr val="AABBCC"/></a:gs>
+            </a:gsLst><a:lin ang="5400000"/></a:gradFill>"#,
+        );
+        assert!(matches!(
+            gradient.fill,
+            Some(ChartStyleFill::Gradient { .. })
+        ));
+        assert_eq!(gradient.fill_hidden, None);
+        assert_eq!(gradient.fill_paint_authored, Some(true));
+
+        let no_fill = parse_table("<a:noFill/>");
+        assert_eq!(no_fill.fill, None);
+        assert_eq!(no_fill.fill_color, None);
+        assert_eq!(no_fill.fill_hidden, Some(true));
+        assert_eq!(no_fill.fill_paint_authored, Some(true));
     }
 
     /// `c:invertIfNegative` and the Office 2010 alternate fill extension are

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -5146,21 +5146,24 @@ fn chart_style_paint_component_count(container: Node) -> Option<usize> {
     if child(container, "noFill").is_some() {
         return Some(0);
     }
-    if child(container, "solidFill").is_some()
-        || child(container, "pattFill").is_some()
-        || child(container, "blipFill").is_some()
-    {
+    if child(container, "solidFill").is_some() {
         return Some(1);
     }
-    child(container, "gradFill").map(|gradient| {
-        child(gradient, "gsLst")
+    if let Some(gradient) = child(container, "gradFill") {
+        return Some(
+            child(gradient, "gsLst")
             .map(|list| {
                 list.children()
                     .filter(|node| node.is_element() && node.tag_name().name() == "gs")
                     .count()
             })
-            .unwrap_or(0)
-    })
+            .unwrap_or(0),
+        );
+    }
+    if child(container, "blipFill").is_some() || child(container, "pattFill").is_some() {
+        return Some(1);
+    }
+    None
 }
 
 /// Parse one classic 3-D series shape only after its direct fill and outline
@@ -16761,7 +16764,7 @@ Subtitle</a:t></a:r></a:p>
 
     #[test]
     fn parse_chart_data_table_bounds_gradient_before_expansion() {
-        let chart = |stop_count: usize| {
+        let chart = |stop_count: usize, trailing_fill: &str| {
             let stops = (0..stop_count)
                 .map(|index| {
                     format!(
@@ -16776,13 +16779,13 @@ Subtitle</a:t></a:r></a:p>
                       <c:cat><c:strCache><c:pt idx="0"><c:v>A</c:v></c:pt></c:strCache></c:cat>
                       <c:val><c:numCache><c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:val>
                     </c:ser></c:barChart>
-                    <c:dTable><c:spPr><a:gradFill><a:gsLst>{stops}</a:gsLst></a:gradFill></c:spPr></c:dTable>
+                    <c:dTable><c:spPr><a:gradFill><a:gsLst>{stops}</a:gsLst></a:gradFill>{trailing_fill}</c:spPr></c:dTable>
                   </c:plotArea></c:chart>
                 </c:chartSpace>"#,
             )
         };
 
-        let exact_xml = chart(MAX_CHART_PAINT_RECIPE_COMPONENTS);
+        let exact_xml = chart(MAX_CHART_PAINT_RECIPE_COMPONENTS, "");
         let exact = parse_chart_part(
             chart_space_of(&exact_xml).root_element(),
             &FixtureResolver,
@@ -16794,12 +16797,21 @@ Subtitle</a:t></a:r></a:p>
                 if stops.len() == MAX_CHART_PAINT_RECIPE_COMPONENTS
         ));
 
-        let oversized_xml = chart(MAX_CHART_PAINT_RECIPE_COMPONENTS + 1);
-        assert!(parse_chart_part(
-            chart_space_of(&oversized_xml).root_element(),
-            &FixtureResolver,
-        )
-        .is_none());
+        for trailing_fill in [
+            "",
+            r#"<a:pattFill prst="diagCross"/>"#,
+            "<a:blipFill/>",
+        ] {
+            let oversized_xml = chart(
+                MAX_CHART_PAINT_RECIPE_COMPONENTS + 1,
+                trailing_fill,
+            );
+            assert!(parse_chart_part(
+                chart_space_of(&oversized_xml).root_element(),
+                &FixtureResolver,
+            )
+            .is_none());
+        }
     }
 
     /// `c:invertIfNegative` and the Office 2010 alternate fill extension are

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -5152,12 +5152,12 @@ fn chart_style_paint_component_count(container: Node) -> Option<usize> {
     if let Some(gradient) = child(container, "gradFill") {
         return Some(
             child(gradient, "gsLst")
-            .map(|list| {
-                list.children()
-                    .filter(|node| node.is_element() && node.tag_name().name() == "gs")
-                    .count()
-            })
-            .unwrap_or(0),
+                .map(|list| {
+                    list.children()
+                        .filter(|node| node.is_element() && node.tag_name().name() == "gs")
+                        .count()
+                })
+                .unwrap_or(0),
         );
     }
     if child(container, "blipFill").is_some() || child(container, "pattFill").is_some() {
@@ -11061,9 +11061,7 @@ pub fn parse_chart_part_with_references_style_parts_and_images(
         && plot_area_bg.is_some())
     .then_some(true);
     let plot_area_line_style = extract_direct_shape_line(plot_area, color_resolver);
-    if child(plot_area, "dTable")
-        .is_some_and(|table| !chart_data_table_paint_within_limit(table))
-    {
+    if child(plot_area, "dTable").is_some_and(|table| !chart_data_table_paint_within_limit(table)) {
         return None;
     }
     let data_table = extract_chart_data_table(plot_area, color_resolver);
@@ -16766,11 +16764,7 @@ Subtitle</a:t></a:r></a:p>
     fn parse_chart_data_table_bounds_gradient_before_expansion() {
         let chart = |stop_count: usize, trailing_fill: &str| {
             let stops = (0..stop_count)
-                .map(|index| {
-                    format!(
-                        r#"<a:gs pos="{index}"><a:srgbClr val="112233"/></a:gs>"#,
-                    )
-                })
+                .map(|index| format!(r#"<a:gs pos="{index}"><a:srgbClr val="112233"/></a:gs>"#,))
                 .collect::<String>();
             format!(
                 r#"<c:chartSpace xmlns:c="{C_NS}" xmlns:a="{A_NS}">
@@ -16786,26 +16780,16 @@ Subtitle</a:t></a:r></a:p>
         };
 
         let exact_xml = chart(MAX_CHART_PAINT_RECIPE_COMPONENTS, "");
-        let exact = parse_chart_part(
-            chart_space_of(&exact_xml).root_element(),
-            &FixtureResolver,
-        )
-        .expect("paint recipe at the shared ceiling parses");
+        let exact = parse_chart_part(chart_space_of(&exact_xml).root_element(), &FixtureResolver)
+            .expect("paint recipe at the shared ceiling parses");
         assert!(matches!(
             exact.data_table.and_then(|table| table.fill),
             Some(ChartStyleFill::Gradient { ref stops, .. })
                 if stops.len() == MAX_CHART_PAINT_RECIPE_COMPONENTS
         ));
 
-        for trailing_fill in [
-            "",
-            r#"<a:pattFill prst="diagCross"/>"#,
-            "<a:blipFill/>",
-        ] {
-            let oversized_xml = chart(
-                MAX_CHART_PAINT_RECIPE_COMPONENTS + 1,
-                trailing_fill,
-            );
+        for trailing_fill in ["", r#"<a:pattFill prst="diagCross"/>"#, "<a:blipFill/>"] {
+            let oversized_xml = chart(MAX_CHART_PAINT_RECIPE_COMPONENTS + 1, trailing_fill);
             assert!(parse_chart_part(
                 chart_space_of(&oversized_xml).root_element(),
                 &FixtureResolver,

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -126,8 +126,16 @@ export interface ChartDataTable {
     fontColor?: string | null;
     fontBold?: boolean | null;
     fontItalic?: boolean | null;
-    /** Direct `<c:dTable><c:spPr>` solid fill, painted behind body text boxes. */
+    /** Resolved solid compatibility projection of `<c:dTable><c:spPr>`. */
     fillColor?: string | null;
+    /** Direct DrawingML fill recipe. Preserved even where Office's application-
+     * defined data-table paint extent has not been established for that recipe. */
+    fill?: SolidFill | GradientFill | PatternFill | null;
+    /** Explicit `<a:noFill>` on the data-table shape properties. */
+    fillHidden?: boolean | null;
+    /** True when `spPr` authored any DrawingML fill child, including one whose
+     * paint recipe this implementation cannot resolve. */
+    fillPaintAuthored?: boolean | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
     lineDash?: string | null;
@@ -357,6 +365,7 @@ export interface ChartModel {
     plotAreaFill?: Fill | null;
     plotAreaFillHidden?: boolean | null;
     plotAreaFillPaintAuthored?: boolean | null;
+    plotAreaFillAutomatic?: boolean | null;
     plotAreaLineColor?: string | null;
     plotAreaLineFill?: SolidFill | GradientFill | PatternFill | null;
     plotAreaLineWidthEmu?: number | null;

--- a/packages/pptx/src/renderer-chart-bubble3d.test.ts
+++ b/packages/pptx/src/renderer-chart-bubble3d.test.ts
@@ -73,7 +73,7 @@ describe('PPTX rotated bubble3D chart', () => {
     const chart = {
       chartType: 'boxWhisker', categories: [], series: [], showLegend: false,
       chartexBox: { categories: [], series: [] },
-    } as ChartModel;
+    } as unknown as ChartModel;
     const slide = {
       index: 0, slideNumber: 1, background: null,
       elements: [{
@@ -82,7 +82,7 @@ describe('PPTX rotated bubble3D chart', () => {
       }],
     } as Slide;
     const rec = recordingCanvas();
-    const render = vi.fn(() => true);
+    const render = vi.fn<ChartExRenderer['render']>(() => true);
     const chartEx = { render } as ChartExRenderer;
 
     await renderSlide(rec.canvas, slide, 9_144_000, 6_858_000, {

--- a/packages/pptx/src/renderer-chart-bubble3d.test.ts
+++ b/packages/pptx/src/renderer-chart-bubble3d.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ChartModel } from '@silurus/ooxml-core';
+import type { ChartExRenderer, ChartModel } from '@silurus/ooxml-core';
 import { renderSlide } from './renderer.js';
 import type { Slide } from './types.js';
 
@@ -67,5 +67,30 @@ describe('PPTX rotated bubble3D chart', () => {
     expect(rec.radialGradients).toHaveLength(3);
     expect(rec.radialGradients.map(gradient => gradient.stops.length)).toEqual([4, 5, 6]);
     expect(rec.compositeModes.filter(mode => mode === 'source-atop')).toHaveLength(3);
+  });
+
+  it('forwards the opt-in ChartEx module through the PPTX chart element boundary', async () => {
+    const chart = {
+      chartType: 'boxWhisker', categories: [], series: [], showLegend: false,
+      chartexBox: { categories: [], series: [] },
+    } as ChartModel;
+    const slide = {
+      index: 0, slideNumber: 1, background: null,
+      elements: [{
+        type: 'chart', x: 500_000, y: 500_000, width: 4_000_000, height: 3_000_000,
+        rotation: 0, flipH: false, flipV: false, chart,
+      }],
+    } as Slide;
+    const rec = recordingCanvas();
+    const render = vi.fn(() => true);
+    const chartEx = { render } as ChartExRenderer;
+
+    await renderSlide(rec.canvas, slide, 9_144_000, 6_858_000, {
+      width: 960, dpr: 1, chartEx,
+    });
+
+    expect(render).toHaveBeenCalledOnce();
+    expect(render.mock.calls[0]?.[1]).toBe(chart);
+    expect(render.mock.calls[0]?.[4]).toBe(0);
   });
 });

--- a/packages/pptx/src/worker-renderer-modules.test.ts
+++ b/packages/pptx/src/worker-renderer-modules.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { chartEx } from '../../../src/chart-ex.js';
+import { loadWorkerRenderers, workerRendererDescriptors } from '@silurus/ooxml-core/worker';
+import type { RenderWorkerRequest } from './worker-protocol.js';
+
+describe('PPTX worker optional renderer wire', () => {
+  it('carries and reconstructs the shared ChartEx module without cloning functions', async () => {
+    const request = {
+      kind: 'parse',
+      id: 1,
+      buffer: new ArrayBuffer(0),
+      resourcePolicy: {} as never,
+      renderers: workerRendererDescriptors({ chartEx }),
+    } satisfies Extract<RenderWorkerRequest, { kind: 'parse' }>;
+
+    const cloned = structuredClone(request);
+    expect(cloned.renderers?.chartEx).toEqual({
+      protocol: 'ooxml-worker-renderer-module/v1',
+      builtin: 'chartEx',
+    });
+    expect(typeof (await loadWorkerRenderers(cloned.renderers)).chartEx?.render).toBe('function');
+  });
+});

--- a/packages/pptx/src/worker-renderer-modules.test.ts
+++ b/packages/pptx/src/worker-renderer-modules.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { chartEx } from '../../../src/chart-ex.js';
-import { loadWorkerRenderers, workerRendererDescriptors } from '@silurus/ooxml-core/worker';
+import { loadWorkerRenderers } from '@silurus/ooxml-core/worker';
 import type { RenderWorkerRequest } from './worker-protocol.js';
 
 describe('PPTX worker optional renderer wire', () => {
@@ -10,7 +9,12 @@ describe('PPTX worker optional renderer wire', () => {
       id: 1,
       buffer: new ArrayBuffer(0),
       resourcePolicy: {} as never,
-      renderers: workerRendererDescriptors({ chartEx }),
+      renderers: {
+        chartEx: {
+          protocol: 'ooxml-worker-renderer-module/v1',
+          builtin: 'chartEx',
+        },
+      },
     } satisfies Extract<RenderWorkerRequest, { kind: 'parse' }>;
 
     const cloned = structuredClone(request);

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -237,8 +237,16 @@ export interface ChartDataTable {
     fontColor?: string | null;
     fontBold?: boolean | null;
     fontItalic?: boolean | null;
-    /** Direct `<c:dTable><c:spPr>` solid fill, painted behind body text boxes. */
+    /** Resolved solid compatibility projection of `<c:dTable><c:spPr>`. */
     fillColor?: string | null;
+    /** Direct DrawingML fill recipe. Preserved even where Office's application-
+     * defined data-table paint extent has not been established for that recipe. */
+    fill?: SolidFill | GradientFill | PatternFill | null;
+    /** Explicit `<a:noFill>` on the data-table shape properties. */
+    fillHidden?: boolean | null;
+    /** True when `spPr` authored any DrawingML fill child, including one whose
+     * paint recipe this implementation cannot resolve. */
+    fillPaintAuthored?: boolean | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
     lineDash?: string | null;
@@ -457,6 +465,7 @@ export interface ChartModel {
     plotAreaFill?: Fill | null;
     plotAreaFillHidden?: boolean | null;
     plotAreaFillPaintAuthored?: boolean | null;
+    plotAreaFillAutomatic?: boolean | null;
     plotAreaLineColor?: string | null;
     plotAreaLineFill?: SolidFill | GradientFill | PatternFill | null;
     plotAreaLineWidthEmu?: number | null;


### PR DESCRIPTION
## Summary

- preserve authored plot-area fill/style precedence separately from automatic host fallback
- retain data-table paint provenance while rendering only the desktop-verified solid, single-family classic-chart subset
- make chart paint resource preflight follow the parser's actual fill-choice precedence and reject oversized resources atomically
- anchor rounded chart-space geometry to desktop Excel vector observations instead of an empirical estimate
- add DOCX and PPTX main-thread and worker-boundary coverage for optional ChartEx renderer forwarding

## Verification

- `cargo test -p ooxml-common` (495 tests plus doctest)
- focused DOCX, PPTX, XLSX, and core Vitest coverage (934 tests)
- `pnpm typecheck`
- `pnpm build`
- `pnpm check:optional-chart-ex`
- `pnpm check:optional-three-d`
- `pnpm check:public-api:built`
- `pnpm --filter @silurus/ooxml-site build`
- complete previous-release private-corpus baseline/candidate run: DOCX remained pixel-identical; XLSX and PPTX differences were enumerated for Office adjudication and are not treated as automatically approved

The aggregate JavaScript suite passes 8,076 tests; two existing order-sensitive Skia effect pixel checks fail only in the aggregate run and pass when isolated.

## Review

An independent adversarial review checked specification fidelity, compatibility-policy scope, heuristic leakage, resource bounds, package boundaries, and DOCX/XLSX/PPTX host wiring. No release blocker remains in the reviewed scope.
