### PR TITLE
fix(chart): simplify compatibility paint rules

### DIFF
--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -202,11 +202,11 @@ it('prefetches and paints one bubble picture for both plot and 3-D legend key', 
   });
   const bitmap = { width: 8, height: 8 } as unknown as CanvasImageSource;
   expect(collectChartMarkerImageFills(model)).toEqual([picture]);
-  expect(classicMarkerPaintWorkCount(model, () => bitmap, 1, RECT)).toBe(32);
+  expect(classicMarkerPaintWorkCount(model, () => bitmap, 1, RECT)).toBe(14);
   const rec = recordingCtx();
   renderChartCore(rec.ctx, model, RECT, 1, 0, testThreeD, undefined, () => bitmap);
   expect(rec.drawImages).toHaveLength(2);
-  expect(rec.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(6);
+  expect(rec.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(4);
 });
 const renderChart: typeof renderChartCore = (
   ctx,
@@ -3797,7 +3797,7 @@ describe('classic 3-D compatibility projection', () => {
     expect(classicMarkerPaintWorkCount(model, undefined, 1, RECT)).toBe(5);
   });
 
-  it('charges every fixed bubble3D material stop for plot, legend, and label keys', () => {
+  it('charges the compact bubble3D lighting model for plot, legend, and label keys', () => {
     const model = baseModel({
       chartType: 'bubble', showLegend: true, categories: ['0'],
       series: [series({
@@ -3809,8 +3809,8 @@ describe('classic 3-D compatibility projection', () => {
       })],
       catAxisMin: 0, catAxisMax: 1, valMin: 0, valMax: 1,
     });
-    // Three fixed gradients consume 4 + 5 + 6 stops per painted bubble.
-    expect(classicMarkerPaintWorkCount(model, undefined, 1, RECT)).toBe(45);
+    // Two three-stop gradients consume six components per painted bubble.
+    expect(classicMarkerPaintWorkCount(model, undefined, 1, RECT)).toBe(18);
 
     model.series[0].chartexStyle = {
       fillHidden: true, fillPaintAuthored: true,
@@ -10314,7 +10314,7 @@ describe('CH9 — bubble scale and numeric-X trendlines', () => {
       valMin: 0,
       valMax: 4,
     }), RECT, 1);
-    expect(seriesTrue.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(9);
+    expect(seriesTrue.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(6);
 
     const seriesFalse = recordingCtx();
     renderChart(seriesFalse.ctx, baseModel({
@@ -10346,10 +10346,10 @@ describe('CH9 — bubble scale and numeric-X trendlines', () => {
       })],
       catAxisMin: 0, catAxisMax: 2, valMin: 0, valMax: 2,
     }), RECT, 1);
-    expect(groupFallback.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(3);
+    expect(groupFallback.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(2);
   });
 
-  it('paints bounded independent diffuse, shade, and lower-rim material layers', () => {
+  it('paints a compact diffuse-and-shade material in bubble-local coordinates', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, baseModel({
       chartType: 'bubble', categories: ['1'],
@@ -10363,8 +10363,8 @@ describe('CH9 — bubble scale and numeric-X trendlines', () => {
     }), RECT, 1);
 
     const materials = rec.gradients.filter(gradient => gradient.kind === 'radial');
-    expect(materials).toHaveLength(3);
-    expect(materials.map(gradient => gradient.stops.length)).toEqual([4, 5, 6]);
+    expect(materials).toHaveLength(2);
+    expect(materials.map(gradient => gradient.stops.length)).toEqual([3, 3]);
     const bubble = rec.arcs.at(-1)!;
     const size = bubble.r * 2;
     const normalizedGradient = (gradient: (typeof materials)[number]) => {
@@ -10379,30 +10379,23 @@ describe('CH9 — bubble scale and numeric-X trendlines', () => {
       };
     };
     expect(normalizedGradient(materials[0])).toMatchObject({
-      x0: expect.closeTo(0.42, 2), y0: expect.closeTo(0.33, 2),
-      innerRadius: 0, x1: expect.closeTo(0.42, 2), y1: expect.closeTo(0.33, 2),
-      outerRadius: expect.closeTo(0.55, 2),
+      x0: expect.closeTo(0.35, 2), y0: expect.closeTo(0.30, 2),
+      innerRadius: 0, x1: expect.closeTo(0.35, 2), y1: expect.closeTo(0.30, 2),
+      outerRadius: expect.closeTo(0.70, 2),
     });
     expect(normalizedGradient(materials[1])).toMatchObject({
-      x0: expect.closeTo(0.42, 2), y0: expect.closeTo(0.32, 2),
-      innerRadius: 0, x1: expect.closeTo(0.42, 2), y1: expect.closeTo(0.32, 2),
-      outerRadius: expect.closeTo(0.78, 2),
+      x0: expect.closeTo(0.35, 2), y0: expect.closeTo(0.30, 2),
+      innerRadius: 0, x1: expect.closeTo(0.35, 2), y1: expect.closeTo(0.30, 2),
+      outerRadius: expect.closeTo(0.85, 2),
     });
-    expect(normalizedGradient(materials[2])).toMatchObject({
-      x0: expect.closeTo(0.30, 2), y0: expect.closeTo(0.05, 2),
-      innerRadius: 0, x1: expect.closeTo(0.30, 2), y1: expect.closeTo(0.05, 2),
-      outerRadius: expect.closeTo(1, 2),
-    });
-    expect(materials[0].stops.some(stop => stop.color === 'rgba(255,255,255,0.72)'))
+    expect(materials[0].stops.some(stop => stop.color === 'rgba(255,255,255,0.55)'))
       .toBe(true);
-    expect(materials[1].stops.some(stop => stop.color === 'rgba(0,0,0,0.62)'))
-      .toBe(true);
-    expect(materials[2].stops.some(stop => stop.color === 'rgba(255,255,255,0.28)'))
+    expect(materials[1].stops.some(stop => stop.color === 'rgba(0,0,0,0.55)'))
       .toBe(true);
     expect(materials.flatMap(material => material.stops).every(stop =>
       /^rgba\((?:255,255,255|0,0,0),/.test(stop.color)
     )).toBe(true);
-    expect(rec.compositeModes.filter(mode => mode === 'source-atop')).toHaveLength(3);
+    expect(rec.compositeModes.filter(mode => mode === 'source-atop')).toHaveLength(2);
   });
 
   it('keeps noFill and outline independent from the bubble3D material', () => {
@@ -10453,7 +10446,7 @@ describe('CH9 — bubble scale and numeric-X trendlines', () => {
     expect(rec.paintEvents.some(event =>
       event.kind === 'fill' && event.fillStyle === '#FFFFFF'
     )).toBe(true);
-    expect(rec.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(3);
+    expect(rec.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(2);
     expect(rec.strokeDetails.filter(stroke => stroke.strokeStyle === '#7F6000')).toHaveLength(2);
   });
 
@@ -10470,7 +10463,7 @@ describe('CH9 — bubble scale and numeric-X trendlines', () => {
     expect(rec.paintEvents.some(event =>
       event.kind === 'fill' && event.fillStyle === '#FFFFFF'
     )).toBe(true);
-    expect(rec.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(3);
+    expect(rec.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(2);
     expect(rec.strokeDetails.some(stroke => stroke.strokeStyle === '#000000')).toBe(true);
 
     const authoredNoLine = recordingCtx();
@@ -10496,7 +10489,7 @@ describe('CH9 — bubble scale and numeric-X trendlines', () => {
       catAxisMin: 0, catAxisMax: 2, valMin: 0, valMax: 2,
     }), RECT, 1);
 
-    expect(rec.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(6);
+    expect(rec.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(4);
   });
 
   it('lists textual bubble x values as point legend entries', () => {
@@ -12069,7 +12062,7 @@ describe('classic chart data table (CT_DTable)', () => {
     expect(rec.strokeRects.some(rect => rect.ss === '#445566')).toBe(true);
     expect(rec.strokeRects.find(rect => rect.ss === '#445566')?.dash.length).toBeGreaterThan(0);
     const textBackgrounds = rec.rects.filter(rect => rect.fs === '#FFF2CC');
-    expect(textBackgrounds).toHaveLength(0); // combo extent has no desktop-Excel evidence
+    expect(textBackgrounds.length).toBeGreaterThan(0);
     const sales = rec.texts.find(call => call.text === 'Sales') as NonNullable<typeof rec.texts[number]>;
     expect(textBackgrounds.some(rect =>
       rect.x <= sales.x && rect.x + rect.w >= sales.x
@@ -12115,7 +12108,7 @@ describe('classic chart data table (CT_DTable)', () => {
     })).toEqual({ lineStrokes: 0, outlines: 0 });
   });
 
-  it('limits the observed text-background compatibility rule to its Excel evidence', () => {
+  it('applies the text-background semantic independently of chart layout details', () => {
     const renderFillRects = (over: Partial<ChartModel>) => {
       const rec = recordingCtx();
       renderChart(rec.ctx, baseModel({
@@ -12146,6 +12139,10 @@ describe('classic chart data table (CT_DTable)', () => {
       }],
     }).length).toBeGreaterThan(0);
     expect(renderFillRects({
+      series: [
+        series({ name: 'North', values: [10, 15], seriesType: 'line' }),
+        series({ name: 'South', values: [8, 12], seriesType: 'bar' }),
+      ],
       plotGroups: [
         {
           kind: 'line',
@@ -12165,24 +12162,25 @@ describe('classic chart data table (CT_DTable)', () => {
           barDirection: 'col',
         },
       ],
-    })).toHaveLength(0);
+    }).length).toBeGreaterThan(0);
     expect(renderFillRects({
       series: [
         series({ name: 'North', values: [10, 15], seriesType: 'line' }),
         series({ name: 'South', values: [8, 12], seriesType: 'bar' }),
       ],
-    })).toHaveLength(0);
-    expect(renderFillRects({ chartType: 'clusteredBarH' })).toHaveLength(0);
-    expect(renderFillRects({ chartType: 'stock' })).toHaveLength(0);
-    expect(renderFillRects({ plotAreaManualLayout: { x: 0.2, y: 0.2 } })).toHaveLength(0);
+    }).length).toBeGreaterThan(0);
+    expect(renderFillRects({ chartType: 'clusteredBarH' }).length).toBeGreaterThan(0);
+    expect(renderFillRects({ chartType: 'stock' }).length).toBeGreaterThan(0);
+    expect(renderFillRects({ plotAreaManualLayout: { x: 0.2, y: 0.2 } }).length)
+      .toBeGreaterThan(0);
     expect(renderFillRects({ categories: [
       ['First quarter with wrapped text repeated', 'until it exceeds the category column'].join(' '),
       'Q2',
-    ] }))
-      .toHaveLength(0);
+    ] }).length)
+      .toBeGreaterThan(0);
     expect(renderFillRects({
       series: [series({ name: 'North', values: [10, null], seriesType: 'line' })],
-    })).toHaveLength(0);
+    }).length).toBeGreaterThan(0);
   });
 
   it('uses the linked dataTable line role only for omitted grid properties', () => {

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -604,35 +604,11 @@ function drawChartDataTable(
     chart.radarStyle,
     chart,
   );
-  const dataTableFillPlotGroup = chart.plotGroups?.length === 1
-    ? chart.plotGroups[0]
-    : null;
-  const dataTableFillFamilyMatches = chart.plotGroups == null || (
-    dataTableFillPlotGroup != null
-    && (
-      (chart.chartType === 'clusteredBar'
-        && dataTableFillPlotGroup.kind === 'bar'
-        && dataTableFillPlotGroup.barDirection !== 'bar')
-      || (chart.chartType === 'line' && dataTableFillPlotGroup.kind === 'line')
-      || (chart.chartType === 'area' && dataTableFillPlotGroup.kind === 'area')
-    )
-  );
-  const dataTableFillSeriesFamilyMatches = chart.series.every(series => {
-    if (series.seriesType == null) return true;
-    if (chart.chartType === 'clusteredBar') return series.seriesType === 'bar';
-    if (chart.chartType === 'line') return series.seriesType === 'line';
-    if (chart.chartType === 'area') return series.seriesType === 'area';
-    return false;
-  });
-  const bodyFillColor = table.fillColor
-    && chart.plotAreaManualLayout == null
-    && (chart.chartType === 'clusteredBar' || chart.chartType === 'line' || chart.chartType === 'area')
-    && dataTableFillFamilyMatches
-    && dataTableFillSeriesFamilyMatches
-    && layout.headerLines.every(lines => lines.length === 1)
-    && chart.series.every(series => series.values.every(value => value != null))
-    ? table.fillColor
-    : null;
+  // A direct solid dTable fill belongs to each generated body-text box. That
+  // semantic is independent of the owning chart family, plot-group count,
+  // manual plot layout, line wrapping, and sparse values. Unsupported fill
+  // recipes remain present in the model but do not masquerade as a solid.
+  const bodyFillColor = table.fillColor ?? null;
   ctx.beginPath();
   ctx.rect(tableX, tableY, tableWidth, layout.totalHeight);
   ctx.clip();
@@ -12901,18 +12877,15 @@ function renderScatterChart(
   drawAxisTitles(ctx, chart, x, y, w, h, px0, py0, pw, ph, legLeftW, legBottomH, catTitlePx, valTitlePx);
 }
 
-// The fixed Office-observed material below is three bounded gradients with
-// 4 + 5 + 6 stops. Keep this exact so marker paint preflight charges every
-// component before any chart-wide work begins.
-const BUBBLE_3D_MATERIAL_COMPONENTS = 15;
+// One three-stop highlight and one three-stop edge shade. Keep the work count
+// aligned with the family-wide lighting rule so paint is bounded atomically.
+const BUBBLE_3D_MATERIAL_COMPONENTS = 6;
 
-/** Paint the bounded application-defined material observed in current Excel
- * vector output for `bubble3D`. A single radial envelope cannot independently
- * express the measured diffuse highlight, right/lower falloff, and narrow
- * lower reflected-light band, so those three fixed components are composited
- * in that order. They remain in shape-local coordinates, so a PPTX host
- * transform rotates the complete bubble without a second lighting model.
- * `source-atop` preserves the authored fill alpha on every pass. */
+/** Paint a compact application-defined material for `bubble3D`: an off-centre
+ * diffuse highlight plus an edge shade from the same upper-left light source.
+ * This family-wide rule preserves the authored fill hue/alpha without fitting
+ * reflected-light bands or stop positions to one Office output. The layers
+ * remain in shape-local coordinates so host transforms rotate them together. */
 function paintBubble3DMaterial(
   ctx: CanvasRenderingContext2D,
   cx: number,
@@ -12929,47 +12902,25 @@ function paintBubble3DMaterial(
     ctx.fillRect(cx - sizePx / 2, cy - sizePx / 2, sizePx, sizePx);
   };
 
-  const diffuseX = cx - sizePx * 0.08;
-  const diffuseY = cy - sizePx * 0.17;
+  const lightX = cx - sizePx * 0.15;
+  const lightY = cy - sizePx * 0.20;
   const diffuse = ctx.createRadialGradient(
-    diffuseX, diffuseY, 0,
-    diffuseX, diffuseY, sizePx * 0.55,
+    lightX, lightY, 0,
+    lightX, lightY, sizePx * 0.70,
   );
-  diffuse.addColorStop(0, 'rgba(255,255,255,0.72)');
-  diffuse.addColorStop(0.14, 'rgba(255,255,255,0.48)');
-  diffuse.addColorStop(0.38, 'rgba(255,255,255,0.1)');
+  diffuse.addColorStop(0, 'rgba(255,255,255,0.55)');
+  diffuse.addColorStop(0.32, 'rgba(255,255,255,0.18)');
   diffuse.addColorStop(1, 'rgba(255,255,255,0)');
   paintLayer(diffuse);
 
-  const shadeX = cx - sizePx * 0.08;
-  const shadeY = cy - sizePx * 0.18;
   const shade = ctx.createRadialGradient(
-    shadeX, shadeY, 0,
-    shadeX, shadeY, sizePx * 0.78,
+    lightX, lightY, 0,
+    lightX, lightY, sizePx * 0.85,
   );
   shade.addColorStop(0, 'rgba(0,0,0,0)');
-  shade.addColorStop(0.3, 'rgba(0,0,0,0)');
-  shade.addColorStop(0.46, 'rgba(0,0,0,0.22)');
-  shade.addColorStop(0.66, 'rgba(0,0,0,0.48)');
-  shade.addColorStop(1, 'rgba(0,0,0,0.62)');
+  shade.addColorStop(0.58, 'rgba(0,0,0,0)');
+  shade.addColorStop(1, 'rgba(0,0,0,0.55)');
   paintLayer(shade);
-
-  // Put the annulus center above and to the left. Its 0.8--0.95 radius band
-  // crosses the lower-left edge and lower center while remaining clear of the
-  // dark lower-right shoulder.
-  const rimX = cx - sizePx * 0.2;
-  const rimY = cy - sizePx * 0.45;
-  const lowerRim = ctx.createRadialGradient(
-    rimX, rimY, 0,
-    rimX, rimY, sizePx,
-  );
-  lowerRim.addColorStop(0, 'rgba(255,255,255,0)');
-  lowerRim.addColorStop(0.76, 'rgba(255,255,255,0)');
-  lowerRim.addColorStop(0.82, 'rgba(255,255,255,0.05)');
-  lowerRim.addColorStop(0.87, 'rgba(255,255,255,0.12)');
-  lowerRim.addColorStop(0.95, 'rgba(255,255,255,0.28)');
-  lowerRim.addColorStop(1, 'rgba(255,255,255,0)');
-  paintLayer(lowerRim);
 
   // Recording contexts used by hosts/tests do not necessarily model a full
   // Canvas state stack, so restore the property explicitly as well.

--- a/packages/pptx/src/renderer-chart-bubble3d.test.ts
+++ b/packages/pptx/src/renderer-chart-bubble3d.test.ts
@@ -44,7 +44,7 @@ function recordingCanvas() {
 }
 
 describe('PPTX rotated bubble3D chart', () => {
-  it('rotates the chart frame while keeping three bounded material layers in local coordinates', async () => {
+  it('rotates the chart frame while keeping compact material layers in local coordinates', async () => {
     const chart = {
       chartType: 'bubble', categories: ['1'], showLegend: false,
       catAxisMin: 0, catAxisMax: 2, valMin: 0, valMax: 2,
@@ -64,9 +64,9 @@ describe('PPTX rotated bubble3D chart', () => {
     await renderSlide(rec.canvas, slide, 9_144_000, 6_858_000, { width: 960, dpr: 1 });
 
     expect(rec.rotations).toContain(Math.PI / 2);
-    expect(rec.radialGradients).toHaveLength(3);
-    expect(rec.radialGradients.map(gradient => gradient.stops.length)).toEqual([4, 5, 6]);
-    expect(rec.compositeModes.filter(mode => mode === 'source-atop')).toHaveLength(3);
+    expect(rec.radialGradients).toHaveLength(2);
+    expect(rec.radialGradients.map(gradient => gradient.stops.length)).toEqual([3, 3]);
+    expect(rec.compositeModes.filter(mode => mode === 'source-atop')).toHaveLength(2);
   });
 
   it('forwards the opt-in ChartEx module through the PPTX chart element boundary', async () => {


### PR DESCRIPTION
## Summary
- apply resolvable solid data-table fills to generated body-text boxes without chart-family or layout heuristics
- replace the fitted three-layer Bubble3D material with a compact two-layer lighting rule
- preserve authored fill/alpha, point and series precedence, outlines, and PPTX host transforms
- reduce shared renderer output by about 1.27 kB raw / 0.30 kB gzip in the local production build

## Verification
- focused core and PPTX chart tests: 932 passed
- pnpm typecheck
- pnpm build
- optional ChartEx and 3-D bundle boundary checks
- built public API and viewer symmetry checks
- full suite: 8,075 passed; two pre-existing local Skia pixel-equality failures reproduce unchanged on the comparison checkout
- local visual verification of data-table text backgrounds and Bubble3D precedence, paint, and outline cases
