### PR TITLE
fix(chart): restore bubble, stock, and surface fidelity

### DIFF
--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -202,11 +202,11 @@ it('prefetches and paints one bubble picture for both plot and 3-D legend key', 
   });
   const bitmap = { width: 8, height: 8 } as unknown as CanvasImageSource;
   expect(collectChartMarkerImageFills(model)).toEqual([picture]);
-  expect(classicMarkerPaintWorkCount(model, () => bitmap, 1, RECT)).toBe(14);
+  expect(classicMarkerPaintWorkCount(model, () => bitmap, 1, RECT)).toBe(32);
   const rec = recordingCtx();
   renderChartCore(rec.ctx, model, RECT, 1, 0, testThreeD, undefined, () => bitmap);
   expect(rec.drawImages).toHaveLength(2);
-  expect(rec.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(4);
+  expect(rec.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(6);
 });
 const renderChart: typeof renderChartCore = (
   ctx,
@@ -3797,7 +3797,7 @@ describe('classic 3-D compatibility projection', () => {
     expect(classicMarkerPaintWorkCount(model, undefined, 1, RECT)).toBe(5);
   });
 
-  it('charges the compact bubble3D lighting model for plot, legend, and label keys', () => {
+  it('charges every bounded bubble3D material stop for plot, legend, and label keys', () => {
     const model = baseModel({
       chartType: 'bubble', showLegend: true, categories: ['0'],
       series: [series({
@@ -3809,8 +3809,8 @@ describe('classic 3-D compatibility projection', () => {
       })],
       catAxisMin: 0, catAxisMax: 1, valMin: 0, valMax: 1,
     });
-    // Two three-stop gradients consume six components per painted bubble.
-    expect(classicMarkerPaintWorkCount(model, undefined, 1, RECT)).toBe(18);
+    // Three gradients consume 4 + 5 + 6 components per painted bubble.
+    expect(classicMarkerPaintWorkCount(model, undefined, 1, RECT)).toBe(45);
 
     model.series[0].chartexStyle = {
       fillHidden: true, fillPaintAuthored: true,
@@ -10314,7 +10314,7 @@ describe('CH9 — bubble scale and numeric-X trendlines', () => {
       valMin: 0,
       valMax: 4,
     }), RECT, 1);
-    expect(seriesTrue.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(6);
+    expect(seriesTrue.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(9);
 
     const seriesFalse = recordingCtx();
     renderChart(seriesFalse.ctx, baseModel({
@@ -10346,10 +10346,10 @@ describe('CH9 — bubble scale and numeric-X trendlines', () => {
       })],
       catAxisMin: 0, catAxisMax: 2, valMin: 0, valMax: 2,
     }), RECT, 1);
-    expect(groupFallback.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(2);
+    expect(groupFallback.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(3);
   });
 
-  it('paints a compact diffuse-and-shade material in bubble-local coordinates', () => {
+  it('paints bounded diffuse, shade, and reflected-light material layers in bubble-local coordinates', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, baseModel({
       chartType: 'bubble', categories: ['1'],
@@ -10363,8 +10363,8 @@ describe('CH9 — bubble scale and numeric-X trendlines', () => {
     }), RECT, 1);
 
     const materials = rec.gradients.filter(gradient => gradient.kind === 'radial');
-    expect(materials).toHaveLength(2);
-    expect(materials.map(gradient => gradient.stops.length)).toEqual([3, 3]);
+    expect(materials).toHaveLength(3);
+    expect(materials.map(gradient => gradient.stops.length)).toEqual([4, 5, 6]);
     const bubble = rec.arcs.at(-1)!;
     const size = bubble.r * 2;
     const normalizedGradient = (gradient: (typeof materials)[number]) => {
@@ -10379,23 +10379,30 @@ describe('CH9 — bubble scale and numeric-X trendlines', () => {
       };
     };
     expect(normalizedGradient(materials[0])).toMatchObject({
-      x0: expect.closeTo(0.35, 2), y0: expect.closeTo(0.30, 2),
-      innerRadius: 0, x1: expect.closeTo(0.35, 2), y1: expect.closeTo(0.30, 2),
-      outerRadius: expect.closeTo(0.70, 2),
+      x0: expect.closeTo(0.42, 2), y0: expect.closeTo(0.33, 2),
+      innerRadius: 0, x1: expect.closeTo(0.42, 2), y1: expect.closeTo(0.33, 2),
+      outerRadius: expect.closeTo(0.55, 2),
     });
     expect(normalizedGradient(materials[1])).toMatchObject({
-      x0: expect.closeTo(0.35, 2), y0: expect.closeTo(0.30, 2),
-      innerRadius: 0, x1: expect.closeTo(0.35, 2), y1: expect.closeTo(0.30, 2),
-      outerRadius: expect.closeTo(0.85, 2),
+      x0: expect.closeTo(0.42, 2), y0: expect.closeTo(0.32, 2),
+      innerRadius: 0, x1: expect.closeTo(0.42, 2), y1: expect.closeTo(0.32, 2),
+      outerRadius: expect.closeTo(0.78, 2),
     });
-    expect(materials[0].stops.some(stop => stop.color === 'rgba(255,255,255,0.55)'))
+    expect(normalizedGradient(materials[2])).toMatchObject({
+      x0: expect.closeTo(0.30, 2), y0: expect.closeTo(0.05, 2),
+      innerRadius: 0, x1: expect.closeTo(0.30, 2), y1: expect.closeTo(0.05, 2),
+      outerRadius: expect.closeTo(1, 2),
+    });
+    expect(materials[0].stops.some(stop => stop.color === 'rgba(255,255,255,0.72)'))
       .toBe(true);
-    expect(materials[1].stops.some(stop => stop.color === 'rgba(0,0,0,0.55)'))
+    expect(materials[1].stops.some(stop => stop.color === 'rgba(0,0,0,0.62)'))
+      .toBe(true);
+    expect(materials[2].stops.some(stop => stop.color === 'rgba(255,255,255,0.28)'))
       .toBe(true);
     expect(materials.flatMap(material => material.stops).every(stop =>
       /^rgba\((?:255,255,255|0,0,0),/.test(stop.color)
     )).toBe(true);
-    expect(rec.compositeModes.filter(mode => mode === 'source-atop')).toHaveLength(2);
+    expect(rec.compositeModes.filter(mode => mode === 'source-atop')).toHaveLength(3);
   });
 
   it('keeps noFill and outline independent from the bubble3D material', () => {
@@ -10446,7 +10453,7 @@ describe('CH9 — bubble scale and numeric-X trendlines', () => {
     expect(rec.paintEvents.some(event =>
       event.kind === 'fill' && event.fillStyle === '#FFFFFF'
     )).toBe(true);
-    expect(rec.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(2);
+    expect(rec.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(3);
     expect(rec.strokeDetails.filter(stroke => stroke.strokeStyle === '#7F6000')).toHaveLength(2);
   });
 
@@ -10463,7 +10470,7 @@ describe('CH9 — bubble scale and numeric-X trendlines', () => {
     expect(rec.paintEvents.some(event =>
       event.kind === 'fill' && event.fillStyle === '#FFFFFF'
     )).toBe(true);
-    expect(rec.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(2);
+    expect(rec.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(3);
     expect(rec.strokeDetails.some(stroke => stroke.strokeStyle === '#000000')).toBe(true);
 
     const authoredNoLine = recordingCtx();
@@ -10489,7 +10496,7 @@ describe('CH9 — bubble scale and numeric-X trendlines', () => {
       catAxisMin: 0, catAxisMax: 2, valMin: 0, valMax: 2,
     }), RECT, 1);
 
-    expect(rec.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(4);
+    expect(rec.gradients.filter(gradient => gradient.kind === 'radial')).toHaveLength(6);
   });
 
   it('lists textual bubble x values as point legend entries', () => {
@@ -16865,6 +16872,16 @@ describe('CH13 — stock chart (high/low/close)', () => {
     expect(rec.rects.filter(rect => rect.fs === '#3F3F3F')).toHaveLength(3);
     expect(rec.arcs).toHaveLength(4); // three plotted High points + one legend marker
     expect(rec.texts.map(text => text.text)).toEqual(expect.arrayContaining(['High', 'Low', 'Close']));
+    const lastBar = rec.paintEvents.reduce((lastIndex, event, index) =>
+      event.kind === 'rect' && event.fillStyle === '#3F3F3F' ? index : lastIndex,
+      -1,
+    );
+    const markerFills = rec.paintEvents.flatMap((event, index) =>
+      event.kind === 'fill' && event.fillStyle === '#4472C4' ? [index] : []
+    );
+    expect(lastBar).toBeGreaterThanOrEqual(0);
+    expect(markerFills).toHaveLength(4);
+    expect(markerFills.every(index => index > lastBar)).toBe(true);
   });
 
   it('paints up/down bars over the high-low rule and owning line series', () => {
@@ -17810,6 +17827,66 @@ describe('surface contour charts', () => {
     expect(surfaceFills.length).toBeGreaterThan(3);
     const labels = rec.texts.map(text => text.text);
     expect(labels).toEqual(expect.arrayContaining(['X1', 'X2', 'X3', 'Y1', 'Y2', 'Y3', '0-20', '80-100']));
+  });
+
+  it('paints authored major and minor ticks on both ordinal Surface axes', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'surface',
+      categories: ['X1', 'X2', 'X3', 'X4', 'X5'],
+      valMin: 0,
+      valMax: 100,
+      valAxisHidden: true,
+      catAxisLineColor: 'AA0000',
+      catAxisLineHidden: false,
+      catAxisMajorTickMark: 'cross',
+      catAxisMinorTickMark: 'cross',
+      threeD: {
+        rotationX: 90,
+        rotationY: 0,
+        perspective: 0,
+        rightAngleAxes: false,
+        seriesAxis: {
+          hidden: false,
+          orientation: 'minMax',
+          majorTickMark: 'cross',
+          minorTickMark: 'cross',
+          lineColor: '0000AA',
+          lineHidden: false,
+        },
+      },
+      series: [
+        series({ name: 'Y1', values: [10, 20, 30, 20, 10] }),
+        series({ name: 'Y2', values: [20, 40, 60, 40, 20] }),
+        series({ name: 'Y3', values: [30, 60, 90, 60, 30] }),
+        series({ name: 'Y4', values: [20, 40, 60, 40, 20] }),
+        series({ name: 'Y5', values: [10, 20, 30, 20, 10] }),
+      ],
+    }), RECT, 1);
+
+    const categoryTicks = rec.segs.filter(segment =>
+      segment.ss === '#AA0000'
+      && Math.abs(segment.x1 - segment.x0) < 0.01
+      && Math.abs(segment.y1 - segment.y0) <= 6.01
+    );
+    expect(categoryTicks.filter(segment =>
+      Math.abs(Math.abs(segment.y1 - segment.y0) - 6) < 0.01
+    )).toHaveLength(5);
+    expect(categoryTicks.filter(segment =>
+      Math.abs(Math.abs(segment.y1 - segment.y0) - 4) < 0.01
+    )).toHaveLength(4);
+
+    const seriesTicks = rec.segs.filter(segment =>
+      segment.ss === '#0000AA'
+      && Math.abs(segment.y1 - segment.y0) < 0.01
+      && Math.abs(segment.x1 - segment.x0) <= 6.01
+    );
+    expect(seriesTicks.filter(segment =>
+      Math.abs(Math.abs(segment.x1 - segment.x0) - 6) < 0.01
+    )).toHaveLength(5);
+    expect(seriesTicks.filter(segment =>
+      Math.abs(Math.abs(segment.x1 - segment.x0) - 4) < 0.01
+    )).toHaveLength(4);
   });
 
   it('uses the shared automatic value-axis unit with one bounded surface material', () => {

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -7744,15 +7744,6 @@ function renderStockChart(
       ctx.stroke();
     }
   };
-  drawStockTick(openS, openIdx, 'left');
-  if (highS?.markerSymbol != null || (highS && hasVisiblePointMarkerOverride(highS))) {
-    drawStockTick(highS, highIdx, 'both');
-  }
-  if (lowS?.markerSymbol != null || (lowS && hasVisiblePointMarkerOverride(lowS))) {
-    drawStockTick(lowS, lowIdx, 'both');
-  }
-  drawStockTick(closeS, closeIdx, 'right');
-
   // Office accepts a line group after a stock group. Stock decorations retain
   // ownership of the stock slice; the later line group is a normal category
   // line overlay on its resolved value axis rather than becoming a fifth stock
@@ -7845,7 +7836,8 @@ function renderStockChart(
   // ── First/last-series up-down bars (§21.2.2.218/227). In DrawingML these
   // decorations follow the line series. Excel paints their opaque bodies over
   // both the high-low rule and the owning series lines, leaving plot geometry
-  // visible only outside each body.
+  // visible only outside each body. Explicit stock marker glyphs are replayed
+  // after the bodies below, so a marker at a bar endpoint remains fully visible.
   if (chart.stockUpDownBars && upDownStartS && upDownEndS) {
     const directStyle = chart.stockUpDownBarStyle ?? {
       gapWidthPercent: 150,
@@ -7868,6 +7860,18 @@ function renderStockChart(
       slotWidth, style, ptToPx, chart.stockAutomaticStyle ?? undefined, shapeRotationDeg,
     );
   }
+
+  // Marker/tick glyphs are the foreground annotation of a stock datum. Desktop
+  // Excel paints them after up/down-bar bodies; otherwise a circular High/Low
+  // marker intersecting the body is clipped to a semicircle.
+  drawStockTick(openS, openIdx, 'left');
+  if (highS?.markerSymbol != null || (highS && hasVisiblePointMarkerOverride(highS))) {
+    drawStockTick(highS, highIdx, 'both');
+  }
+  if (lowS?.markerSymbol != null || (lowS && hasVisiblePointMarkerOverride(lowS))) {
+    drawStockTick(lowS, lowIdx, 'both');
+  }
+  drawStockTick(closeS, closeIdx, 'right');
 
   // CT_LineSer error bars remain attached to their authored stock series.
   // Stock uses a category X axis, so only Y-direction bars have data-unit
@@ -9100,6 +9104,52 @@ function renderSurfaceChart(
   }
   ctx.restore();
 
+  const sceneCenter = projection.project(
+    front.x + front.w / 2,
+    front.y + front.h / 2,
+    0.5,
+  );
+  const drawSurfaceAxisTick = (
+    mode: string | null | undefined,
+    point: { x: number; y: number },
+    axisStart: { x: number; y: number },
+    axisEnd: { x: number; y: number },
+    color: string,
+    lineWidth: number,
+    lineHidden: boolean,
+    level: 'major' | 'minor',
+    dash?: string | null,
+  ): void => {
+    if (lineHidden || mode == null || mode === 'none') return;
+    const dx = axisEnd.x - axisStart.x;
+    const dy = axisEnd.y - axisStart.y;
+    const axisLength = Math.hypot(dx, dy);
+    if (!(axisLength > 1e-6)) return;
+    let normalX = -dy / axisLength;
+    let normalY = dx / axisLength;
+    const midpointX = (axisStart.x + axisEnd.x) / 2;
+    const midpointY = (axisStart.y + axisEnd.y) / 2;
+    if ((midpointX - sceneCenter.x) * normalX
+      + (midpointY - sceneCenter.y) * normalY < 0) {
+      normalX = -normalX;
+      normalY = -normalY;
+    }
+    const length = axisTickLengthPx(level, lineWidth, ptToPx);
+    const sideLength = mode === 'cross' ? length / 2 : length;
+    const outer = mode === 'out' || mode === 'cross' ? sideLength : 0;
+    const inner = mode === 'in' || mode === 'cross' ? sideLength : 0;
+    strokeAxisSegment(
+      ctx,
+      point.x + normalX * outer,
+      point.y + normalY * outer,
+      point.x - normalX * inner,
+      point.y - normalY * inner,
+      color,
+      lineWidth,
+      dash,
+    );
+  };
+
   const categoryAxisStart = projection.project(front.x, floorY, nearDepth);
   const categoryAxisEnd = projection.project(front.x + front.w, floorY, nearDepth);
   const surfaceCatLineWidth = chart.catAxisLineWidthEmu != null
@@ -9115,6 +9165,42 @@ function renderSurfaceChart(
     surfaceCatLineWidth,
     chart.catAxisLineDash,
   );
+  const categoryAxisColor = chart.catAxisLineColor
+    ? `#${chart.catAxisLineColor}` : '#000000';
+  const categoryAxisSuppressed = chart.catAxisHidden || chart.catAxisLineHidden === true;
+  const categoryTickSkip = Math.max(1, Math.floor(chart.catAxisTickMarkSkip ?? 1));
+  for (let column = 0; column < columnCount; column += categoryTickSkip) {
+    drawSurfaceAxisTick(
+      chart.catAxisMajorTickMark,
+      projection.project(toX(column), floorY, nearDepth),
+      categoryAxisStart,
+      categoryAxisEnd,
+      categoryAxisColor,
+      surfaceCatLineWidth,
+      categoryAxisSuppressed,
+      'major',
+      chart.catAxisLineDash,
+    );
+  }
+  if (chart.catAxisMinorTickMark != null && chart.catAxisMinorTickMark !== 'none') {
+    for (let column = 0; column < columnCount - 1; column++) {
+      const fraction = (
+        categoryPositionFraction(column, columnCount, categoryBetween, categoryReversed)
+        + categoryPositionFraction(column + 1, columnCount, categoryBetween, categoryReversed)
+      ) / 2;
+      drawSurfaceAxisTick(
+        chart.catAxisMinorTickMark,
+        projection.project(front.x + fraction * front.w, floorY, nearDepth),
+        categoryAxisStart,
+        categoryAxisEnd,
+        categoryAxisColor,
+        surfaceCatLineWidth,
+        categoryAxisSuppressed,
+        'minor',
+        chart.catAxisLineDash,
+      );
+    }
+  }
   ctx.font = chartFontCss(
     catFontPx,
     chartFontFamily(chart, chart.catAxisFontFace, 'minor'),
@@ -9155,6 +9241,37 @@ function renderSurfaceChart(
       seriesAxis?.lineColor ? `#${seriesAxis.lineColor}` : '#000000',
       seriesAxisWidth, seriesAxis?.lineDash,
     );
+    const seriesAxisColor = seriesAxis?.lineColor
+      ? `#${seriesAxis.lineColor}` : '#000000';
+    const seriesTickSkip = Math.max(1, Math.floor(seriesAxis?.tickMarkSkip ?? 1));
+    for (let row = 0; row < rowCount; row += seriesTickSkip) {
+      drawSurfaceAxisTick(
+        seriesAxis?.majorTickMark,
+        projection.project(seriesAxisX, floorY, toDepth(row)),
+        seriesStart,
+        seriesEnd,
+        seriesAxisColor,
+        seriesAxisWidth,
+        seriesAxis?.lineHidden === true,
+        'major',
+        seriesAxis?.lineDash,
+      );
+    }
+    if (seriesAxis?.minorTickMark != null && seriesAxis.minorTickMark !== 'none') {
+      for (let row = 0; row < rowCount - 1; row++) {
+        drawSurfaceAxisTick(
+          seriesAxis.minorTickMark,
+          projection.project(seriesAxisX, floorY, (toDepth(row) + toDepth(row + 1)) / 2),
+          seriesStart,
+          seriesEnd,
+          seriesAxisColor,
+          seriesAxisWidth,
+          seriesAxis.lineHidden === true,
+          'minor',
+          seriesAxis.lineDash,
+        );
+      }
+    }
     ctx.font = chartFontCss(
       seriesFontPx,
       chartFontFamily(chart, seriesAxis?.fontFace, 'minor'),
@@ -12877,15 +12994,18 @@ function renderScatterChart(
   drawAxisTitles(ctx, chart, x, y, w, h, px0, py0, pw, ph, legLeftW, legBottomH, catTitlePx, valTitlePx);
 }
 
-// One three-stop highlight and one three-stop edge shade. Keep the work count
-// aligned with the family-wide lighting rule so paint is bounded atomically.
-const BUBBLE_3D_MATERIAL_COMPONENTS = 6;
+// Three fixed gradients with 4 + 5 + 6 stops. Keep the work count aligned
+// with the complete material so a bubble is admitted or rejected atomically.
+const BUBBLE_3D_MATERIAL_COMPONENTS = 15;
 
-/** Paint a compact application-defined material for `bubble3D`: an off-centre
- * diffuse highlight plus an edge shade from the same upper-left light source.
- * This family-wide rule preserves the authored fill hue/alpha without fitting
- * reflected-light bands or stop positions to one Office output. The layers
- * remain in shape-local coordinates so host transforms rotate them together. */
+/** ECMA-376 §21.2.2.21 only enables `bubble3D`; it does not define a lighting
+ * material. Paint the bounded application-defined material observed in desktop
+ * Excel vector output. A single radial envelope cannot independently
+ * express the diffuse highlight, right/lower falloff, and narrow lower
+ * reflected-light band, so those three components are composited in order.
+ * The recipe is normalized to bubble-local coordinates and is therefore shared
+ * by every colour, size, and host transform rather than fitted per sample.
+ * `source-atop` preserves the authored fill alpha on every pass. */
 function paintBubble3DMaterial(
   ctx: CanvasRenderingContext2D,
   cx: number,
@@ -12902,25 +13022,47 @@ function paintBubble3DMaterial(
     ctx.fillRect(cx - sizePx / 2, cy - sizePx / 2, sizePx, sizePx);
   };
 
-  const lightX = cx - sizePx * 0.15;
-  const lightY = cy - sizePx * 0.20;
+  const diffuseX = cx - sizePx * 0.08;
+  const diffuseY = cy - sizePx * 0.17;
   const diffuse = ctx.createRadialGradient(
-    lightX, lightY, 0,
-    lightX, lightY, sizePx * 0.70,
+    diffuseX, diffuseY, 0,
+    diffuseX, diffuseY, sizePx * 0.55,
   );
-  diffuse.addColorStop(0, 'rgba(255,255,255,0.55)');
-  diffuse.addColorStop(0.32, 'rgba(255,255,255,0.18)');
+  diffuse.addColorStop(0, 'rgba(255,255,255,0.72)');
+  diffuse.addColorStop(0.14, 'rgba(255,255,255,0.48)');
+  diffuse.addColorStop(0.38, 'rgba(255,255,255,0.1)');
   diffuse.addColorStop(1, 'rgba(255,255,255,0)');
   paintLayer(diffuse);
 
+  const shadeX = cx - sizePx * 0.08;
+  const shadeY = cy - sizePx * 0.18;
   const shade = ctx.createRadialGradient(
-    lightX, lightY, 0,
-    lightX, lightY, sizePx * 0.85,
+    shadeX, shadeY, 0,
+    shadeX, shadeY, sizePx * 0.78,
   );
   shade.addColorStop(0, 'rgba(0,0,0,0)');
-  shade.addColorStop(0.58, 'rgba(0,0,0,0)');
-  shade.addColorStop(1, 'rgba(0,0,0,0.55)');
+  shade.addColorStop(0.3, 'rgba(0,0,0,0)');
+  shade.addColorStop(0.46, 'rgba(0,0,0,0.22)');
+  shade.addColorStop(0.66, 'rgba(0,0,0,0.48)');
+  shade.addColorStop(1, 'rgba(0,0,0,0.62)');
   paintLayer(shade);
+
+  // The annulus centre is above-left. Its narrow 0.8--0.95 radius band
+  // crosses the lower-left/lower-centre rim while staying clear of the dark
+  // lower-right shoulder, matching the material boundary observed in Excel.
+  const rimX = cx - sizePx * 0.2;
+  const rimY = cy - sizePx * 0.45;
+  const lowerRim = ctx.createRadialGradient(
+    rimX, rimY, 0,
+    rimX, rimY, sizePx,
+  );
+  lowerRim.addColorStop(0, 'rgba(255,255,255,0)');
+  lowerRim.addColorStop(0.76, 'rgba(255,255,255,0)');
+  lowerRim.addColorStop(0.82, 'rgba(255,255,255,0.05)');
+  lowerRim.addColorStop(0.87, 'rgba(255,255,255,0.12)');
+  lowerRim.addColorStop(0.95, 'rgba(255,255,255,0.28)');
+  lowerRim.addColorStop(1, 'rgba(255,255,255,0)');
+  paintLayer(lowerRim);
 
   // Recording contexts used by hosts/tests do not necessarily model a full
   // Canvas state stack, so restore the property explicitly as well.

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -1576,6 +1576,8 @@ export interface ChartThreeDSeriesAxis {
   tickLabelSkip?: number | null;
   tickMarkSkip?: number | null;
   majorTickMark: string;
+  /** `<c:serAx><c:minorTickMark>`; omission means no minor tick marks. */
+  minorTickMark?: string | null;
   fontColor?: string | null;
   fontSizeHpt?: number | null;
   fontBold?: boolean | null;

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -815,6 +815,8 @@ export interface ChartThreeDSeriesAxis {
     tickLabelSkip?: number | null;
     tickMarkSkip?: number | null;
     majorTickMark: string;
+    /** `<c:serAx><c:minorTickMark>`; omission means no minor tick marks. */
+    minorTickMark?: string | null;
     fontColor?: string | null;
     fontSizeHpt?: number | null;
     fontBold?: boolean | null;

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -1189,6 +1189,8 @@ pub struct ChartThreeDSeriesAxis {
     pub tick_mark_skip: Option<u32>,
     pub major_tick_mark: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minor_tick_mark: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_color: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_size_hpt: Option<i32>,
@@ -10638,6 +10640,7 @@ pub fn parse_chart_part_with_references_style_parts_and_images(
                 tick_label_skip: positive_u32("tickLblSkip"),
                 tick_mark_skip: positive_u32("tickMarkSkip"),
                 major_tick_mark: extract_axis_tick_mark_or_default(axis, "majorTickMark"),
+                minor_tick_mark: extract_axis_tick_mark(axis, "minorTickMark"),
                 font_color: extract_axis_tick_label_color(axis, color_resolver),
                 font_size_hpt: extract_axis_tick_label_size(axis),
                 font_bold: extract_axis_tick_label_bold(axis),
@@ -21074,7 +21077,7 @@ Subtitle</a:t></a:r></a:p>
                   <a:solidFill><a:srgbClr val="112233"/></a:solidFill><a:latin typeface="Arial"/>
                 </a:defRPr></a:pPr><a:r><a:t>Series Axis</a:t></a:r></a:p></c:rich></c:tx>
               </c:title>
-              <c:majorTickMark val="cross"/><c:tickLblPos val="low"/>
+              <c:majorTickMark val="cross"/><c:minorTickMark val="cross"/><c:tickLblPos val="low"/>
               <c:tickLblSkip val="2"/><c:tickMarkSkip val="3"/>
               <c:spPr><a:ln w="12700"><a:solidFill><a:srgbClr val="445566"/></a:solidFill></a:ln></c:spPr>
               <c:txPr><a:bodyPr/><a:p><a:pPr><a:defRPr sz="900" b="0">
@@ -21096,6 +21099,7 @@ Subtitle</a:t></a:r></a:p>
         assert_eq!(series_axis.tick_label_skip, Some(2));
         assert_eq!(series_axis.tick_mark_skip, Some(3));
         assert_eq!(series_axis.major_tick_mark, "cross");
+        assert_eq!(series_axis.minor_tick_mark.as_deref(), Some("cross"));
         assert_eq!(series_axis.font_color.as_deref(), Some("778899"));
         assert_eq!(series_axis.font_size_hpt, Some(900));
         assert_eq!(series_axis.line_color.as_deref(), Some("445566"));

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -803,6 +803,8 @@ export interface ChartThreeDSeriesAxis {
     tickLabelSkip?: number | null;
     tickMarkSkip?: number | null;
     majorTickMark: string;
+    /** `<c:serAx><c:minorTickMark>`; omission means no minor tick marks. */
+    minorTickMark?: string | null;
     fontColor?: string | null;
     fontSizeHpt?: number | null;
     fontBold?: boolean | null;

--- a/packages/pptx/src/renderer-chart-bubble3d.test.ts
+++ b/packages/pptx/src/renderer-chart-bubble3d.test.ts
@@ -44,7 +44,7 @@ function recordingCanvas() {
 }
 
 describe('PPTX rotated bubble3D chart', () => {
-  it('rotates the chart frame while keeping compact material layers in local coordinates', async () => {
+  it('rotates the chart frame while keeping the complete material in local coordinates', async () => {
     const chart = {
       chartType: 'bubble', categories: ['1'], showLegend: false,
       catAxisMin: 0, catAxisMax: 2, valMin: 0, valMax: 2,
@@ -64,9 +64,9 @@ describe('PPTX rotated bubble3D chart', () => {
     await renderSlide(rec.canvas, slide, 9_144_000, 6_858_000, { width: 960, dpr: 1 });
 
     expect(rec.rotations).toContain(Math.PI / 2);
-    expect(rec.radialGradients).toHaveLength(2);
-    expect(rec.radialGradients.map(gradient => gradient.stops.length)).toEqual([3, 3]);
-    expect(rec.compositeModes.filter(mode => mode === 'source-atop')).toHaveLength(2);
+    expect(rec.radialGradients).toHaveLength(3);
+    expect(rec.radialGradients.map(gradient => gradient.stops.length)).toEqual([4, 5, 6]);
+    expect(rec.compositeModes.filter(mode => mode === 'source-atop')).toHaveLength(3);
   });
 
   it('forwards the opt-in ChartEx module through the PPTX chart element boundary', async () => {

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -903,6 +903,8 @@ export interface ChartThreeDSeriesAxis {
     tickLabelSkip?: number | null;
     tickMarkSkip?: number | null;
     majorTickMark: string;
+    /** `<c:serAx><c:minorTickMark>`; omission means no minor tick marks. */
+    minorTickMark?: string | null;
     fontColor?: string | null;
     fontSizeHpt?: number | null;
     fontBold?: boolean | null;


### PR DESCRIPTION
## Summary

- restore the bounded three-layer Bubble3D material after the compact lighting rule removed the reflected-light band
- paint explicit stock marker glyphs after opaque up/down-bar bodies
- preserve `CT_SerAx/minorTickMark` and render authored major/minor ticks on projected Surface category and series axes
- keep the shared renderer change bounded: the production shared renderer chunk grows by about 2.14 kB raw / 0.56 kB gzip, while the XLSX host chunk is unchanged

## Basis

- ECMA-376 DrawingML chart schema: `CT_SerAx` includes `EG_AxShared`, which carries `majorTickMark` and `minorTickMark`
- desktop Office output: Bubble3D lighting is application-defined; stock marker glyphs are foreground annotations over up/down bars

## Verification

- `pnpm build:wasm`
- `vitest run packages/core/src/chart/renderer-correctness.test.ts packages/pptx/src/renderer-chart-bubble3d.test.ts` (933 passed)
- `cargo test -p ooxml-common chart::tests` (268 passed)
- `pnpm typecheck`
- `pnpm check:public-api:built`
- `pnpm build`
- local Office-reference Storybook comparisons for the affected chart families

`pnpm test` reached 8,076 passing tests. Two unrelated Skia effect-crop pixel-equality cases fail identically on the merge-base checkout.
