### PR TITLE
docs(site): clarify ChartEx migration heading

### DIFF
--- a/site/src/lib/announcements.ts
+++ b/site/src/lib/announcements.ts
@@ -61,7 +61,7 @@ export const announcements: readonly Announcement[] = [
         ],
       },
       {
-        title: 'Why the boundary changed',
+        title: 'The new module boundary',
         modules: ['@silurus/ooxml/chart-ex', '@silurus/ooxml-core'],
         rationale: 'Classic charts are the broadly useful default; Microsoft ChartEx is a newer extension used by a smaller set of chart families.',
         paragraphs: [


### PR DESCRIPTION
## Summary

- rename the ChartEx migration section to avoid repeating the fixed "Why" metadata label
- keep the migration guidance and module boundary rationale unchanged

## Verification

- `pnpm exec vitest run site/src/lib/announcements.test.ts site/src/announcement-content.test.ts`
- `pnpm --dir site build:ci`
