### PR TITLE
fix(docx): trim snap-grid underline overflow

### DIFF
--- a/packages/docx/src/layout/paragraph.ts
+++ b/packages/docx/src/layout/paragraph.ts
@@ -172,6 +172,9 @@ export type MeasuredTextPlanSegment = Readonly<
   Omit<TextPlacement, 'origin' | 'bounds' | 'advancePt' | 'paintOps'> & {
     measuredWidthPt: number;
     basePaintOps: readonly import('./types.js').TextPaintOp[];
+    /** Physical advance from the segment origin through the final glyph. Word
+     * retains later grid slack for layout but excludes it from a terminal underline. */
+    decorationTerminalAdvancePt?: number;
     /** False when this segment continues the preceding shaped grapheme. */
     breakBefore?: boolean;
     /** WordprocessingML bidi classification facts consumed by the shared UAX#9 seam. */
@@ -617,6 +620,27 @@ function mergedContinuousDecoration(
   };
 }
 
+function trimTerminalUnderline(
+  decoration: TextDecorationLayout,
+  trimPt: number,
+): TextDecorationLayout {
+  const retainedTrimPt = Math.min(
+    trimPt,
+    Math.max(0, decoration.to.xPt - decoration.from.xPt),
+  );
+  const from = decoration.from;
+  const to = { ...decoration.to, xPt: decoration.to.xPt - retainedTrimPt };
+  const { path: _discardedPath, ...withoutPath } = decoration;
+  return {
+    ...withoutPath,
+    from,
+    to,
+    ...(decoration.style === 'wavy'
+      ? { path: retainedWavePath(from, to, decoration.widthPt) }
+      : {}),
+  };
+}
+
 /** Adjacent underlined source runs form one visual rule. Use a common
  * clearance below every glyph in the contiguous span; acquiring each run in
  * isolation instead creates stepped solid rules and restarts dash/wave phase
@@ -779,6 +803,7 @@ export function planLine(input: PlanLineInput): LineLayout {
     : Math.max(0, input.paragraphXPt + input.decimalAutoTabPt - drawnWidthPt - lineStartPt);
   let xPt = lineStartPt + alignmentOffsetPt;
   const placements: ParagraphPlacement[] = [];
+  const terminalDecorationTrims = new Map<number, number>();
   for (const segmentIndex of visual.order) {
     const segment = segments[segmentIndex];
     if (!segment) continue;
@@ -851,6 +876,7 @@ export function planLine(input: PlanLineInput): LineLayout {
         rtl: _rtl,
         digitsAsAN: _digitsAsAN,
         fixedPitch: _fixedPitch,
+        decorationTerminalAdvancePt,
         textLayoutService: _textLayoutService,
         textShapeRequest: _textShapeRequest,
         retainedGeometry,
@@ -943,10 +969,36 @@ export function planLine(input: PlanLineInput): LineLayout {
           },
         } : {}),
       };
+      const terminalDecorationTrimPt = decorationTerminalAdvancePt === undefined
+        ? 0
+        : Math.max(
+            0,
+            widthPt + ownedTrailingSlackPt - decorationTerminalAdvancePt,
+          );
+      // The physical end of a bidi line is not the logical run tail. Keep this
+      // Office-observed compatibility rule scoped to horizontal LTR text.
+      if (direction === 'ltr' && terminalDecorationTrimPt > 0) {
+        terminalDecorationTrims.set(placements.length, terminalDecorationTrimPt);
+      }
       placements.push(placed);
     }
     xPt += widthPt;
     if (stretch?.trailingGap) xPt += perGapPt;
+  }
+  for (const [placementIndex, trimPt] of terminalDecorationTrims) {
+    const placement = placements[placementIndex];
+    if (placement?.kind !== 'text' || !placement.decorations) continue;
+    const next = placements[placementIndex + 1];
+    const decorations = placement.decorations.map((decoration) => {
+      if (decoration.kind !== 'underline') return decoration;
+      const continues = (next?.kind === 'text' || next?.kind === 'tab')
+        && next.decorations?.some((candidate) =>
+          sameContinuousDecoration(decoration, candidate));
+      return continues
+        ? decoration
+        : trimTerminalUnderline(decoration, trimPt);
+    });
+    placements[placementIndex] = { ...placement, decorations };
   }
   for (let start = 0; start < placements.length;) {
     const first = placements[start];
@@ -1784,10 +1836,12 @@ function textPlanSegment(
     };
   });
   const snapLeadingPadPt = segment.snapGridLeadingPadPx ?? 0;
+  let decorationTerminalAdvancePt = segment.measuredWidth
+    - (segment.snapGridTrailingPadPx ?? 0);
   if (segment.snapGridClass === 'eastAsia' && segment.snapGridCellPitchPx) {
     const cellPitchPt = segment.snapGridCellPitchPx;
     let precedingCells = 0;
-    clusters = clusters.map((cluster) => {
+    clusters = clusters.map((cluster, index) => {
       const text = segment.text.slice(
         cluster.range.start - sourceOffset,
         cluster.range.end - sourceOffset,
@@ -1797,6 +1851,11 @@ function textPlanSegment(
         cellPitchPt,
       );
       const allocatedAdvancePt = cells * cellPitchPt;
+      if (index === clusters.length - 1) {
+        decorationTerminalAdvancePt = precedingCells * cellPitchPt
+          + (allocatedAdvancePt - cluster.advancePt) / 2
+          + cluster.advancePt;
+      }
       const placed = {
         ...cluster,
         offset: {
@@ -1958,6 +2017,16 @@ function textPlanSegment(
             yPt: operation.offset.yPt,
           },
         }));
+  const retainedDecorationTerminalAdvancePt =
+    characterGrid?.type === 'snapToChars'
+    && segment.underline
+    && !segment.verticalRun
+    && basePaintOps.length === 1
+    && segment.selectedFaceInkBounds
+      ? basePaintOps[0]!.offset.xPt
+        + (basePaintOps[0]!.glyphOffsetPt?.xPt ?? 0)
+        + segment.selectedFaceInkBounds.xMaxPt * (basePaintOps[0]!.scaleX ?? 1)
+      : decorationTerminalAdvancePt;
   return {
     ...style,
     kind: 'text', measuredWidthPt: segment.measuredWidth,
@@ -1995,6 +2064,9 @@ function textPlanSegment(
     rtl: segment.rtl,
     digitsAsAN: segment.digitsAsAN,
     fixedPitch: segment.fitTextRegionIndex !== undefined || segment.snapGridClass !== undefined,
+    ...(characterGrid?.type === 'snapToChars' && segment.underline
+      ? { decorationTerminalAdvancePt: retainedDecorationTerminalAdvancePt }
+      : {}),
     ...(retainedGeometry ? { retainedGeometry } : {}),
     ...(segment.textLayoutService ? { textLayoutService: segment.textLayoutService } : {}),
     ...(segment.textShapeRequest ? { textShapeRequest: segment.textShapeRequest } : {}),

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -346,6 +346,20 @@ export interface LayoutTextSeg extends LayoutSegSource {
   seaBreaks?: readonly number[];
 }
 
+/** Shaping and line allocation are derived from the current text slice. A
+ * segment split for wrapping must not retain geometry from the parent slice;
+ * measurement and addToLine recompute these facts from the new text. */
+const RESET_SLICED_TEXT_MEASUREMENT = {
+  shapedClusters: undefined,
+  selectedFaceInkBounds: undefined,
+  selectedFaceFontBox: undefined,
+  snapGridClass: undefined,
+  snapGridNaturalWidthPx: undefined,
+  snapGridLeadingPadPx: undefined,
+  snapGridTrailingPadPx: undefined,
+  snapGridCellPitchPx: undefined,
+} as const;
+
 /** ECMA-376 §17.3.3.12 defines `hpsRaise` as the “distance [...] between the
  * phonetic guide base text and the phonetic guide text.” The absent case needs
  * selected-face ink and is therefore resolved by retainedRubyAscentReservePx. */
@@ -4816,6 +4830,7 @@ export function layoutLines(
     const hangingText = follower.text.slice(0, hangingCount);
     const hangingSegment: LayoutTextSeg = {
       ...follower,
+      ...RESET_SLICED_TEXT_MEASUREMENT,
       text: hangingText,
       measuredWidth: 0,
       punctuationCompressions: slicedPunctuationCompressions(follower, 0, 1),
@@ -4833,6 +4848,7 @@ export function layoutLines(
     if (remainder.length > 0) {
       queue.unshift({
         ...follower,
+        ...RESET_SLICED_TEXT_MEASUREMENT,
         text: remainder,
         measuredWidth: 0,
         joinPrev: undefined,
@@ -5204,6 +5220,7 @@ export function layoutLines(
     ) {
       const visibleSegment: LayoutTextSeg = {
         ...s,
+        ...RESET_SLICED_TEXT_MEASUREMENT,
         text: visibleBeforeParagraphFinalTail,
         paragraphFinalIdeographicSpaceTail: undefined,
         paragraphFinalIdeographicSpaceLocalCount: undefined,
@@ -5218,6 +5235,7 @@ export function layoutLines(
       };
       const trailingSegment: LayoutTextSeg = {
         ...s,
+        ...RESET_SLICED_TEXT_MEASUREMENT,
         text: s.text.slice(visibleBeforeParagraphFinalTail.length),
         paragraphFinalIdeographicSpaceLocalCount,
         joinPrev: undefined,
@@ -5609,6 +5627,7 @@ export function layoutLines(
         const pw = strNaturalAdvance(s, prefix);
         const headSeg: LayoutTextSeg = {
           ...s,
+          ...RESET_SLICED_TEXT_MEASUREMENT,
           text: prefix,
           measuredWidth: pw,
           punctuationCompressions: slicedPunctuationCompressions(s, 0, prefix.length),
@@ -5618,6 +5637,7 @@ export function layoutLines(
         if (tail) {
           queue.unshift({
             ...s,
+            ...RESET_SLICED_TEXT_MEASUREMENT,
             text: tail,
             punctuationCompressions: slicedPunctuationCompressions(
               s,
@@ -5653,6 +5673,7 @@ export function layoutLines(
             const tailText = chars.slice(chars.length - k).join('');
             retracted = {
               ...lastText,
+              ...RESET_SLICED_TEXT_MEASUREMENT,
               text: tailText,
               punctuationCompressions: slicedPunctuationCompressions(
                 lastText,
@@ -5670,6 +5691,7 @@ export function layoutLines(
               currentWidth -= lastText.measuredWidth - headW;
               currentLine[currentLine.length - 1] = {
                 ...lastText,
+                ...RESET_SLICED_TEXT_MEASUREMENT,
                 text: headText,
                 measuredWidth: headW,
                 punctuationCompressions: slicedPunctuationCompressions(
@@ -5710,6 +5732,7 @@ export function layoutLines(
           const fw = strNaturalAdvance(s, firstChar);
           const headSeg: LayoutTextSeg = {
             ...s,
+            ...RESET_SLICED_TEXT_MEASUREMENT,
             text: firstChar,
             measuredWidth: fw,
             punctuationCompressions: slicedPunctuationCompressions(s, 0, firstChar.length),
@@ -5719,6 +5742,7 @@ export function layoutLines(
           if (tail) {
             queue.unshift({
               ...s,
+              ...RESET_SLICED_TEXT_MEASUREMENT,
               text: tail,
               punctuationCompressions: slicedPunctuationCompressions(
                 s,
@@ -5763,6 +5787,7 @@ export function layoutLines(
         const pw = strNaturalAdvance(s, prefix);
         addToLine({
           ...s,
+          ...RESET_SLICED_TEXT_MEASUREMENT,
           text: prefix,
           measuredWidth: pw,
           punctuationCompressions: slicedPunctuationCompressions(s, 0, prefix.length),
@@ -5771,6 +5796,7 @@ export function layoutLines(
         if (tail) {
           queue.unshift({
             ...s,
+            ...RESET_SLICED_TEXT_MEASUREMENT,
             text: tail,
             punctuationCompressions: slicedPunctuationCompressions(
               s,
@@ -5803,6 +5829,7 @@ export function layoutLines(
             const tailText = chars.slice(chars.length - k).join('');
             retracted = {
               ...lastText,
+              ...RESET_SLICED_TEXT_MEASUREMENT,
               text: tailText,
               punctuationCompressions: slicedPunctuationCompressions(
                 lastText,
@@ -5821,6 +5848,7 @@ export function layoutLines(
               currentWidth -= lastText.measuredWidth - headW;
               currentLine[currentLine.length - 1] = {
                 ...lastText,
+                ...RESET_SLICED_TEXT_MEASUREMENT,
                 text: headText,
                 measuredWidth: headW,
                 punctuationCompressions: slicedPunctuationCompressions(
@@ -5851,6 +5879,7 @@ export function layoutLines(
         const pw = strNaturalAdvance(s, prefix);
         addToLine({
           ...s,
+          ...RESET_SLICED_TEXT_MEASUREMENT,
           text: prefix,
           measuredWidth: pw,
           punctuationCompressions: slicedPunctuationCompressions(s, 0, prefix.length),
@@ -5859,6 +5888,7 @@ export function layoutLines(
         if (tail) {
           queue.unshift({
             ...s,
+            ...RESET_SLICED_TEXT_MEASUREMENT,
             text: tail,
             punctuationCompressions: slicedPunctuationCompressions(
               s,
@@ -5913,12 +5943,14 @@ export function layoutLines(
         const pw = strNaturalAdvance(s, prefix);
         addToLine({
           ...s,
+          ...RESET_SLICED_TEXT_MEASUREMENT,
           text: prefix,
           measuredWidth: pw,
           punctuationCompressions: slicedPunctuationCompressions(s, 0, prefix.length),
         }, pw, h, asc, desc);
         queue.unshift({
           ...s,
+          ...RESET_SLICED_TEXT_MEASUREMENT,
           text: s.text.slice(split),
           punctuationCompressions: slicedPunctuationCompressions(
             s,

--- a/packages/docx/src/snap-to-chars-underline.test.ts
+++ b/packages/docx/src/snap-to-chars-underline.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxDocumentModel,
+  SectionProps,
+} from './types.js';
+
+interface StrokeLine {
+  readonly x1: number;
+  readonly y1: number;
+  readonly x2: number;
+  readonly y2: number;
+}
+
+interface FilledText {
+  readonly text: string;
+  readonly x: number;
+  readonly y: number;
+}
+
+function recordingCanvas(): Readonly<{
+  canvas: HTMLCanvasElement;
+  strokes: StrokeLine[];
+  texts: FilledText[];
+}> {
+  let font = '10px serif';
+  const fontPx = () => Number(/([\d.]+)px/u.exec(font)?.[1] ?? 10);
+  const strokes: StrokeLine[] = [];
+  const texts: FilledText[] = [];
+  let path: Array<Readonly<{ x: number; y: number }>> = [];
+  const context = {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    letterSpacing: '0px',
+    fontKerning: 'auto',
+    measureText(text: string) {
+      const width = [...text].length * fontPx();
+      return {
+        width,
+        actualBoundingBoxLeft: 0,
+        actualBoundingBoxRight: width,
+        actualBoundingBoxAscent: fontPx() * 0.8,
+        actualBoundingBoxDescent: fontPx() * 0.2,
+        fontBoundingBoxAscent: fontPx() * 0.8,
+        fontBoundingBoxDescent: fontPx() * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() { path = []; }, closePath() {},
+    moveTo(x: number, y: number) { path.push({ x, y }); },
+    lineTo(x: number, y: number) { path.push({ x, y }); },
+    stroke() {
+      for (let index = 1; index < path.length; index += 1) {
+        strokes.push({
+          x1: path[index - 1]!.x,
+          y1: path[index - 1]!.y,
+          x2: path[index]!.x,
+          y2: path[index]!.y,
+        });
+      }
+    },
+    fill() {}, fillRect() {}, strokeRect() {}, clip() {}, rect() {},
+    scale() {}, translate() {}, rotate() {}, setLineDash() {}, drawImage() {},
+    clearRect() {}, arc() {}, quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    fillText(text: string, x: number, y: number) { texts.push({ text, x, y }); },
+    strokeText() {},
+    fillStyle: '#000000', strokeStyle: '#000000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+    direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1,
+    lineCap: 'butt' as CanvasLineCap,
+    lineJoin: 'miter' as CanvasLineJoin,
+  };
+  return {
+    canvas: {
+      width: 0,
+      height: 0,
+      style: {} as CSSStyleDeclaration,
+      getContext: () => context,
+    } as unknown as HTMLCanvasElement,
+    strokes,
+    texts,
+  };
+}
+
+function document(text = 'あいう'): DocxDocumentModel {
+  const paragraph: DocParagraph = {
+    type: 'paragraph',
+    alignment: 'left',
+    indentLeft: 0,
+    indentRight: 0,
+    indentFirst: 0,
+    spaceBefore: 0,
+    spaceAfter: 0,
+    lineSpacing: null,
+    numbering: null,
+    tabStops: [],
+    widowControl: false,
+    defaultFontSize: 10,
+    defaultFontFamily: 'Test Mincho',
+    runs: [{
+      type: 'text',
+      text,
+      bold: false,
+      italic: false,
+      underline: true,
+      strikethrough: false,
+      fontSize: 10,
+      color: null,
+      fontFamily: 'Test Mincho',
+      fontFamilyEastAsia: 'Test Mincho',
+      isLink: false,
+      background: null,
+      vertAlign: null,
+      hyperlink: null,
+    }],
+  } as DocParagraph;
+  return {
+    section: {
+      pageWidth: 40,
+      pageHeight: 100,
+      marginTop: 0,
+      marginRight: 0,
+      marginBottom: 0,
+      marginLeft: 0,
+      headerDistance: 0,
+      footerDistance: 0,
+      titlePage: false,
+      evenAndOddHeaders: false,
+      docGridType: 'snapToChars',
+      docGridLinePitch: 20,
+      // The default 10pt font plus 10pt character spacing produces a 20pt cell.
+      docGridCharSpace: 40960,
+    } as SectionProps,
+    body: [paragraph as BodyElement],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Test Mincho': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+describe('snapToChars underline geometry', () => {
+  it('ends a soft-wrapped underline at the final glyph instead of the unused cell edge', async () => {
+    const { canvas, strokes, texts } = recordingCanvas();
+    await renderDocumentToCanvas(document(), canvas, 0, { dpr: 1, width: 40 });
+
+    const horizontal = strokes.filter((line) => Math.abs(line.y1 - line.y2) < 1e-6);
+    expect(texts.map(({ text, x }) => ({ text, x }))).toEqual([
+      { text: 'あ', x: 5 },
+      { text: 'い', x: 25 },
+      { text: 'う', x: 5 },
+    ]);
+    expect(horizontal).toHaveLength(2);
+    // Word retains the leading half-cell but ends the underline at the final
+    // glyph instead of extending it through the trailing half-cell.
+    expect(horizontal[0]!.x1).toBeCloseTo(0, 6);
+    expect(horizontal[0]!.x2).toBeCloseTo(35, 6);
+    expect(horizontal[1]!.x1).toBeCloseTo(0, 6);
+    expect(horizontal[1]!.x2).toBeCloseTo(15, 6);
+  });
+
+  it('keeps one continuous rule across script segments before trimming the terminal cell', async () => {
+    const { canvas, strokes, texts } = recordingCanvas();
+    await renderDocumentToCanvas(document('Aあ'), canvas, 0, { dpr: 1, width: 40 });
+
+    expect(texts.map(({ text, x }) => ({ text, x }))).toEqual([
+      { text: 'A', x: 5 },
+      { text: 'あ', x: 25 },
+    ]);
+    const horizontal = strokes.filter((line) => Math.abs(line.y1 - line.y2) < 1e-6);
+    expect(horizontal).toHaveLength(1);
+    expect(horizontal[0]!.x1).toBeCloseTo(0, 6);
+    expect(horizontal[0]!.x2).toBeCloseTo(35, 6);
+  });
+});


### PR DESCRIPTION
## Summary

- recompute shaping and character-grid allocation after wrapped text segments are sliced
- end LTR `snapToChars` underlines at the retained terminal glyph extent while preserving grid advance
- cover wrapped and mixed-script character-grid underlines

## Basis

ECMA-376 §17.6.5 defines the character-grid allocation. Desktop Word output shows that unused trailing grid-cell space participates in layout but is not painted as part of the terminal underline. The implementation derives the trim from retained shaping geometry; it does not use document- or font-specific constants.

## Verification

- `./node_modules/.bin/vitest run packages/docx/src` (304 files, 3085 tests)
- `./node_modules/.bin/tsc --build packages/docx/tsconfig.json --pretty false`
- `git diff --check`
- local-only visual comparison against desktop Word PDF output
