### PR TITLE
fix: harden numbering offsets and worker assets

### DIFF
--- a/packages/core/src/math/engine-runtime.ts
+++ b/packages/core/src/math/engine-runtime.ts
@@ -1,0 +1,62 @@
+import { type MathSvg, svgExtents } from './mathjax.js';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+interface Stix2Engine {
+  /** MathML string → standalone `<svg>…</svg>` (currentColor fill, viewBox in 1000-units/em). */
+  mathml2svg(mathml: string): string;
+}
+
+let enginePromise: Promise<Stix2Engine> | null = null;
+
+function loadScript(src: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error(`Failed to load math engine from ${src}`));
+    document.head.appendChild(script);
+  });
+}
+
+/** Module workers have no document and cannot use the classic-worker
+ * importScripts API. The prebuilt engine is a strict IIFE that is also valid as
+ * a side-effect-only ES module, so dynamic import evaluates it in the worker's
+ * own global realm and installs `globalThis.__ooxmlStix2`. */
+async function loadWorkerModule(src: string): Promise<void> {
+  await import(/* @vite-ignore */ src);
+}
+
+function ensureEngine(assetUrl: string): Promise<Stix2Engine> {
+  if (enginePromise) return enginePromise;
+  enginePromise = (async () => {
+    const existing = (globalThis as any).__ooxmlStix2 as Stix2Engine | undefined;
+    if (existing) return existing;
+    // The main realm resolves this URL before its descriptor crosses the worker
+    // boundary. Keeping that resolution out of this runtime prevents opaque
+    // worker assets from retaining import.meta solely for optional MathJax.
+    const resolvedAssetUrl = new URL(assetUrl).href;
+    if (typeof document === 'undefined') await loadWorkerModule(resolvedAssetUrl);
+    else await loadScript(resolvedAssetUrl);
+    const engine = (globalThis as any).__ooxmlStix2 as Stix2Engine | undefined;
+    if (!engine) throw new Error('Math engine failed to initialize');
+    return engine;
+  })();
+  return enginePromise;
+}
+
+/** Preload MathJax from an absolute URL resolved outside an opaque worker asset. */
+export async function loadMathJaxFromResolvedAsset(assetUrl: string): Promise<void> {
+  await ensureEngine(assetUrl);
+}
+
+/** Convert MathML using an absolute URL resolved outside an opaque worker asset. */
+export async function mathMLToSvgFromResolvedAsset(
+  mathml: string,
+  assetUrl: string,
+): Promise<MathSvg> {
+  const engine = await ensureEngine(assetUrl);
+  const svg = engine.mathml2svg(mathml);
+  return { svg, ...svgExtents(svg) };
+}

--- a/packages/core/src/math/engine.ts
+++ b/packages/core/src/math/engine.ts
@@ -17,8 +17,6 @@
 // The asset itself is self-contained: DOM-free internally, zero network, zero
 // cross-origin requests. It exposes `globalThis.__ooxmlStix2`.
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 // `?url` (not a bare `new URL(..., import.meta.url)`) so the same `wasmAssetUrl`
 // build plugin that keeps the WASM parsers out of the base64 data-URL trap emits
 // this ~3 MB engine as a real asset too. In Vite **library mode** a bare
@@ -32,14 +30,11 @@
 // option (the whole engine is already a swappable dependency), so no dedicated
 // `mathUrl`/asset-override option is warranted.
 import mathjaxAssetUrl from '../../assets/mathjax-stix2.js?url';
-import { type MathSvg, svgExtents } from './mathjax';
-
-interface Stix2Engine {
-  /** MathML string → standalone `<svg>…</svg>` (currentColor fill, viewBox in 1000-units/em). */
-  mathml2svg(mathml: string): string;
-}
-
-let enginePromise: Promise<Stix2Engine> | null = null;
+import type { MathSvg } from './mathjax.js';
+import {
+  loadMathJaxFromResolvedAsset,
+  mathMLToSvgFromResolvedAsset,
+} from './engine-runtime.js';
 
 export function resolveMathJaxAssetUrl(): string {
   // `?url` yields the asset href directly — an absolute URL at build time, the
@@ -53,56 +48,20 @@ function normalizedAssetUrl(assetUrl?: string): string {
   return assetUrl ? new URL(assetUrl, import.meta.url).href : resolveMathJaxAssetUrl();
 }
 
-function loadScript(src: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const s = document.createElement('script');
-    s.src = src;
-    s.async = true;
-    s.onload = () => resolve();
-    s.onerror = () => reject(new Error(`Failed to load math engine from ${src}`));
-    document.head.appendChild(s);
-  });
-}
-
-/** Module workers have no document and cannot use the classic-worker
- * importScripts API. The prebuilt engine is a strict IIFE that is also valid as
- * a side-effect-only ES module, so dynamic import evaluates it in the worker's
- * own global realm and installs `globalThis.__ooxmlStix2`. */
-async function loadWorkerModule(src: string): Promise<void> {
-  await import(/* @vite-ignore */ src);
-}
-
-function ensureEngine(assetUrl?: string): Promise<Stix2Engine> {
-  if (enginePromise) return enginePromise;
-  enginePromise = (async () => {
-    const existing = (globalThis as any).__ooxmlStix2 as Stix2Engine | undefined;
-    if (existing) return existing;
-    const resolvedAssetUrl = normalizedAssetUrl(assetUrl);
-    if (typeof document === 'undefined') await loadWorkerModule(resolvedAssetUrl);
-    else await loadScript(resolvedAssetUrl);
-    const engine = (globalThis as any).__ooxmlStix2 as Stix2Engine | undefined;
-    if (!engine) throw new Error('Math engine failed to initialize');
-    return engine;
-  })();
-  return enginePromise;
-}
-
 /** Preload the math engine. Call once before rendering equations. */
 export async function loadMathJax(): Promise<void> {
-  await ensureEngine();
+  await loadMathJaxFromResolvedAsset(resolveMathJaxAssetUrl());
 }
 
 /** Internal worker entry: use the asset URL resolved by the consumer bundler
  * in the main realm instead of resolving relative to an opaque worker asset. */
 export async function loadMathJaxFromAsset(assetUrl: string): Promise<void> {
-  await ensureEngine(assetUrl);
+  await loadMathJaxFromResolvedAsset(normalizedAssetUrl(assetUrl));
 }
 
 /** Convert a MathML string to a standalone SVG + its baseline-relative extents. */
 export async function mathMLToSvg(mathml: string): Promise<MathSvg> {
-  const engine = await ensureEngine();
-  const svg = engine.mathml2svg(mathml);
-  return { svg, ...svgExtents(svg) };
+  return mathMLToSvgFromResolvedAsset(mathml, resolveMathJaxAssetUrl());
 }
 
 /** Internal worker entry paired with {@link loadMathJaxFromAsset}. */
@@ -110,7 +69,5 @@ export async function mathMLToSvgFromAsset(
   mathml: string,
   assetUrl: string,
 ): Promise<MathSvg> {
-  const engine = await ensureEngine(assetUrl);
-  const svg = engine.mathml2svg(mathml);
-  return { svg, ...svgExtents(svg) };
+  return mathMLToSvgFromResolvedAsset(mathml, normalizedAssetUrl(assetUrl));
 }

--- a/packages/core/src/worker/renderer-module.ts
+++ b/packages/core/src/worker/renderer-module.ts
@@ -26,10 +26,10 @@ export async function loadWorkerRenderer<T>(descriptor: WorkerRendererDescriptor
 async function loadBuiltinRenderer(descriptor: WorkerRendererDescriptor): Promise<object> {
   switch (descriptor.builtin) {
     case 'math': {
-      const engine = await import('../math/engine.js');
+      const engine = await import('../math/engine-runtime.js');
       return Object.freeze({
-        loadMathJax: () => engine.loadMathJaxFromAsset(descriptor.engineAssetUrl),
-        mathMLToSvg: (mathml: string) => engine.mathMLToSvgFromAsset(
+        loadMathJax: () => engine.loadMathJaxFromResolvedAsset(descriptor.engineAssetUrl),
+        mathMLToSvg: (mathml: string) => engine.mathMLToSvgFromResolvedAsset(
           mathml,
           descriptor.engineAssetUrl,
         ),

--- a/packages/docx/src/layout/numbering-marker.test.ts
+++ b/packages/docx/src/layout/numbering-marker.test.ts
@@ -55,6 +55,35 @@ function textService(advancePt: number): TextLayoutService {
 }
 
 describe('resolveNumberingMarkerGeometry', () => {
+  function geometryWithSuffix(suff: 'nothing' | 'space', authoredFirstIndentPt: number) {
+    return resolveNumberingMarkerGeometry(
+      {
+        numId: 1,
+        level: 0,
+        format: 'decimal',
+        text: '1.',
+        indentLeft: 36,
+        tab: 36,
+        suff,
+        jc: 'left',
+      },
+      {
+        fontSizePt: 10,
+        fonts: { ascii: 'serif', eastAsia: 'serif' },
+        weight: 400,
+        style: 'normal',
+        complexScript: false,
+      },
+      {
+        authoredFirstIndentPt,
+        physicalIndentLeftPt: 36,
+        tabStops: [],
+        defaultTabPt: 36,
+      },
+      textService(10),
+    );
+  }
+
   function geometryAtCoincidentStop(alignment: 'left' | 'num') {
     return resolveNumberingMarkerGeometry(
       {
@@ -96,4 +125,24 @@ describe('resolveNumberingMarkerGeometry', () => {
   it('keeps ordinary coincident tabs strictly forward', () => {
     expect(geometryAtCoincidentStop('left').bodyOffsetPt).toBeCloseTo(24.55, 10);
   });
+
+  it.each([
+    ['nothing', -36],
+    ['space', -36],
+  ] as const)(
+    'keeps a %s suffix body at the paragraph start when its marker ends inside the hanging region',
+    (suffix, authoredFirstIndentPt) => {
+      expect(geometryWithSuffix(suffix, authoredFirstIndentPt).bodyOffsetPt).toBe(0);
+    },
+  );
+
+  it.each([
+    ['nothing', 2],
+    ['space', 12],
+  ] as const)(
+    'keeps a positive %s suffix advance beyond the paragraph start',
+    (suffix, expectedBodyOffsetPt) => {
+      expect(geometryWithSuffix(suffix, -8).bodyOffsetPt).toBe(expectedBodyOffsetPt);
+    },
+  );
 });

--- a/packages/docx/src/layout/numbering-marker.ts
+++ b/packages/docx/src/layout/numbering-marker.ts
@@ -187,6 +187,11 @@ export function resolveNumberingMarkerGeometry(
       bodyOffsetPt = stop ? stop.pos - input.physicalIndentLeftPt : markerEndPt;
     }
   }
+  // ECMA-376 §17.3.1.12 keeps paragraph content at the authored start indent.
+  // The §17.9.28 suffix advances that body only when the marker plus suffix
+  // crosses the start edge; a marker contained by its hanging region cannot
+  // pull the paragraph body backward into that region.
+  bodyOffsetPt = Math.max(0, bodyOffsetPt);
   return {
     bodyOffsetPt,
     markerText,

--- a/scripts/check-production-render-workers.mjs
+++ b/scripts/check-production-render-workers.mjs
@@ -31,6 +31,11 @@ for (const hostName of hosts) {
 
 for (const assetPath of workerAssets) {
   const source = readFileSync(assetPath, 'utf8');
+  if (/\bimport\.meta\b/.test(source)) {
+    throw new Error(
+      `${assetPath} contains import.meta; opaque worker assets must remain parseable as classic scripts`,
+    );
+  }
   const specifiers = [
     ...source.matchAll(/\bfrom\s*["']([^"']+)["']/g),
     ...source.matchAll(/\bimport\(\s*["']([^"']+)["']\s*\)/g),


### PR DESCRIPTION
## Summary

- clamp numbering body offsets at the authored paragraph start when `nothing` or `space` suffixes remain inside a hanging region
- split the MathJax loader into an `import.meta`-free runtime for render workers while retaining host-side asset resolution
- reject `import.meta` in emitted opaque render-worker assets

## Verification

- 12 focused MathJax, worker descriptor, and numbering test files (71 tests)
- DOCX layout boundary, compatibility evidence, public API, and package-build audit gates
- full repository typecheck
- production library build plus render-worker artifact checker (3 workers, zero inner `import.meta`)
- Next.js 14.2.35 optimized production build against the candidate package
- local comparison of a self-authored hanging-numbering DOCX with a Word-generated PDF; body and continuation lines remain at the authored start indent

Superseded by release PR #1369.