### PR TITLE
chore: integrate v0.80.3 maintenance release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ semantic versioning. While the major version is zero, minor releases may contain
 explicitly documented breaking changes; patch releases remain compatible with
 the corresponding minor release.
 
+## 0.80.3 — 2026-08-25
+
+Patch release improving Word list resilience and production worker compatibility
+without changing the 0.80 public integration contract.
+
+- **Word numbering resilience:** keep list bodies at the authored paragraph
+  start when `nothing` or `space` suffixes remain inside a hanging-indent region,
+  avoiding a non-negative layout invariant failure. (#1366)
+- **production worker compatibility:** resolve the optional MathJax asset in the
+  main realm so emitted render-worker assets contain no inner `import.meta`,
+  including when rebundled by Next.js 14 and webpack. (#1367)
+- **compatibility:** no application or API migration is required from 0.80.2.
+
 ## 0.80.2 — 2026-08-18
 
 Compatible patch release improving Office document fidelity and navigation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.80.2"
+version = "0.80.3"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.80.2",
+  "version": "0.80.3",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.80.2",
+  "version": "0.80.3",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/src/math/engine-runtime.ts
+++ b/packages/core/src/math/engine-runtime.ts
@@ -1,0 +1,62 @@
+import { type MathSvg, svgExtents } from './mathjax.js';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+interface Stix2Engine {
+  /** MathML string → standalone `<svg>…</svg>` (currentColor fill, viewBox in 1000-units/em). */
+  mathml2svg(mathml: string): string;
+}
+
+let enginePromise: Promise<Stix2Engine> | null = null;
+
+function loadScript(src: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error(`Failed to load math engine from ${src}`));
+    document.head.appendChild(script);
+  });
+}
+
+/** Module workers have no document and cannot use the classic-worker
+ * importScripts API. The prebuilt engine is a strict IIFE that is also valid as
+ * a side-effect-only ES module, so dynamic import evaluates it in the worker's
+ * own global realm and installs `globalThis.__ooxmlStix2`. */
+async function loadWorkerModule(src: string): Promise<void> {
+  await import(/* @vite-ignore */ src);
+}
+
+function ensureEngine(assetUrl: string): Promise<Stix2Engine> {
+  if (enginePromise) return enginePromise;
+  enginePromise = (async () => {
+    const existing = (globalThis as any).__ooxmlStix2 as Stix2Engine | undefined;
+    if (existing) return existing;
+    // The main realm resolves this URL before its descriptor crosses the worker
+    // boundary. Keeping that resolution out of this runtime prevents opaque
+    // worker assets from retaining import.meta solely for optional MathJax.
+    const resolvedAssetUrl = new URL(assetUrl).href;
+    if (typeof document === 'undefined') await loadWorkerModule(resolvedAssetUrl);
+    else await loadScript(resolvedAssetUrl);
+    const engine = (globalThis as any).__ooxmlStix2 as Stix2Engine | undefined;
+    if (!engine) throw new Error('Math engine failed to initialize');
+    return engine;
+  })();
+  return enginePromise;
+}
+
+/** Preload MathJax from an absolute URL resolved outside an opaque worker asset. */
+export async function loadMathJaxFromResolvedAsset(assetUrl: string): Promise<void> {
+  await ensureEngine(assetUrl);
+}
+
+/** Convert MathML using an absolute URL resolved outside an opaque worker asset. */
+export async function mathMLToSvgFromResolvedAsset(
+  mathml: string,
+  assetUrl: string,
+): Promise<MathSvg> {
+  const engine = await ensureEngine(assetUrl);
+  const svg = engine.mathml2svg(mathml);
+  return { svg, ...svgExtents(svg) };
+}

--- a/packages/core/src/math/engine.ts
+++ b/packages/core/src/math/engine.ts
@@ -17,8 +17,6 @@
 // The asset itself is self-contained: DOM-free internally, zero network, zero
 // cross-origin requests. It exposes `globalThis.__ooxmlStix2`.
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 // `?url` (not a bare `new URL(..., import.meta.url)`) so the same `wasmAssetUrl`
 // build plugin that keeps the WASM parsers out of the base64 data-URL trap emits
 // this ~3 MB engine as a real asset too. In Vite **library mode** a bare
@@ -32,14 +30,11 @@
 // option (the whole engine is already a swappable dependency), so no dedicated
 // `mathUrl`/asset-override option is warranted.
 import mathjaxAssetUrl from '../../assets/mathjax-stix2.js?url';
-import { type MathSvg, svgExtents } from './mathjax';
-
-interface Stix2Engine {
-  /** MathML string → standalone `<svg>…</svg>` (currentColor fill, viewBox in 1000-units/em). */
-  mathml2svg(mathml: string): string;
-}
-
-let enginePromise: Promise<Stix2Engine> | null = null;
+import type { MathSvg } from './mathjax.js';
+import {
+  loadMathJaxFromResolvedAsset,
+  mathMLToSvgFromResolvedAsset,
+} from './engine-runtime.js';
 
 export function resolveMathJaxAssetUrl(): string {
   // `?url` yields the asset href directly — an absolute URL at build time, the
@@ -53,56 +48,20 @@ function normalizedAssetUrl(assetUrl?: string): string {
   return assetUrl ? new URL(assetUrl, import.meta.url).href : resolveMathJaxAssetUrl();
 }
 
-function loadScript(src: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const s = document.createElement('script');
-    s.src = src;
-    s.async = true;
-    s.onload = () => resolve();
-    s.onerror = () => reject(new Error(`Failed to load math engine from ${src}`));
-    document.head.appendChild(s);
-  });
-}
-
-/** Module workers have no document and cannot use the classic-worker
- * importScripts API. The prebuilt engine is a strict IIFE that is also valid as
- * a side-effect-only ES module, so dynamic import evaluates it in the worker's
- * own global realm and installs `globalThis.__ooxmlStix2`. */
-async function loadWorkerModule(src: string): Promise<void> {
-  await import(/* @vite-ignore */ src);
-}
-
-function ensureEngine(assetUrl?: string): Promise<Stix2Engine> {
-  if (enginePromise) return enginePromise;
-  enginePromise = (async () => {
-    const existing = (globalThis as any).__ooxmlStix2 as Stix2Engine | undefined;
-    if (existing) return existing;
-    const resolvedAssetUrl = normalizedAssetUrl(assetUrl);
-    if (typeof document === 'undefined') await loadWorkerModule(resolvedAssetUrl);
-    else await loadScript(resolvedAssetUrl);
-    const engine = (globalThis as any).__ooxmlStix2 as Stix2Engine | undefined;
-    if (!engine) throw new Error('Math engine failed to initialize');
-    return engine;
-  })();
-  return enginePromise;
-}
-
 /** Preload the math engine. Call once before rendering equations. */
 export async function loadMathJax(): Promise<void> {
-  await ensureEngine();
+  await loadMathJaxFromResolvedAsset(resolveMathJaxAssetUrl());
 }
 
 /** Internal worker entry: use the asset URL resolved by the consumer bundler
  * in the main realm instead of resolving relative to an opaque worker asset. */
 export async function loadMathJaxFromAsset(assetUrl: string): Promise<void> {
-  await ensureEngine(assetUrl);
+  await loadMathJaxFromResolvedAsset(normalizedAssetUrl(assetUrl));
 }
 
 /** Convert a MathML string to a standalone SVG + its baseline-relative extents. */
 export async function mathMLToSvg(mathml: string): Promise<MathSvg> {
-  const engine = await ensureEngine();
-  const svg = engine.mathml2svg(mathml);
-  return { svg, ...svgExtents(svg) };
+  return mathMLToSvgFromResolvedAsset(mathml, resolveMathJaxAssetUrl());
 }
 
 /** Internal worker entry paired with {@link loadMathJaxFromAsset}. */
@@ -110,7 +69,5 @@ export async function mathMLToSvgFromAsset(
   mathml: string,
   assetUrl: string,
 ): Promise<MathSvg> {
-  const engine = await ensureEngine(assetUrl);
-  const svg = engine.mathml2svg(mathml);
-  return { svg, ...svgExtents(svg) };
+  return mathMLToSvgFromResolvedAsset(mathml, normalizedAssetUrl(assetUrl));
 }

--- a/packages/core/src/worker/renderer-module.ts
+++ b/packages/core/src/worker/renderer-module.ts
@@ -24,10 +24,10 @@ export async function loadWorkerRenderer<T>(descriptor: WorkerRendererDescriptor
 async function loadBuiltinRenderer(descriptor: WorkerRendererDescriptor): Promise<object> {
   switch (descriptor.builtin) {
     case 'math': {
-      const engine = await import('../math/engine.js');
+      const engine = await import('../math/engine-runtime.js');
       return Object.freeze({
-        loadMathJax: () => engine.loadMathJaxFromAsset(descriptor.engineAssetUrl),
-        mathMLToSvg: (mathml: string) => engine.mathMLToSvgFromAsset(
+        loadMathJax: () => engine.loadMathJaxFromResolvedAsset(descriptor.engineAssetUrl),
+        mathMLToSvg: (mathml: string) => engine.mathMLToSvgFromResolvedAsset(
           mathml,
           descriptor.engineAssetUrl,
         ),

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.80.2",
+  "version": "0.80.3",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/src/layout/numbering-marker.test.ts
+++ b/packages/docx/src/layout/numbering-marker.test.ts
@@ -55,6 +55,35 @@ function textService(advancePt: number): TextLayoutService {
 }
 
 describe('resolveNumberingMarkerGeometry', () => {
+  function geometryWithSuffix(suff: 'nothing' | 'space', authoredFirstIndentPt: number) {
+    return resolveNumberingMarkerGeometry(
+      {
+        numId: 1,
+        level: 0,
+        format: 'decimal',
+        text: '1.',
+        indentLeft: 36,
+        tab: 36,
+        suff,
+        jc: 'left',
+      },
+      {
+        fontSizePt: 10,
+        fonts: { ascii: 'serif', eastAsia: 'serif' },
+        weight: 400,
+        style: 'normal',
+        complexScript: false,
+      },
+      {
+        authoredFirstIndentPt,
+        physicalIndentLeftPt: 36,
+        tabStops: [],
+        defaultTabPt: 36,
+      },
+      textService(10),
+    );
+  }
+
   function geometryAtCoincidentStop(alignment: 'left' | 'num') {
     return resolveNumberingMarkerGeometry(
       {
@@ -96,4 +125,24 @@ describe('resolveNumberingMarkerGeometry', () => {
   it('keeps ordinary coincident tabs strictly forward', () => {
     expect(geometryAtCoincidentStop('left').bodyOffsetPt).toBeCloseTo(24.55, 10);
   });
+
+  it.each([
+    ['nothing', -36],
+    ['space', -36],
+  ] as const)(
+    'keeps a %s suffix body at the paragraph start when its marker ends inside the hanging region',
+    (suffix, authoredFirstIndentPt) => {
+      expect(geometryWithSuffix(suffix, authoredFirstIndentPt).bodyOffsetPt).toBe(0);
+    },
+  );
+
+  it.each([
+    ['nothing', 2],
+    ['space', 12],
+  ] as const)(
+    'keeps a positive %s suffix advance beyond the paragraph start',
+    (suffix, expectedBodyOffsetPt) => {
+      expect(geometryWithSuffix(suffix, -8).bodyOffsetPt).toBe(expectedBodyOffsetPt);
+    },
+  );
 });

--- a/packages/docx/src/layout/numbering-marker.ts
+++ b/packages/docx/src/layout/numbering-marker.ts
@@ -187,6 +187,11 @@ export function resolveNumberingMarkerGeometry(
       bodyOffsetPt = stop ? stop.pos - input.physicalIndentLeftPt : markerEndPt;
     }
   }
+  // ECMA-376 §17.3.1.12 keeps paragraph content at the authored start indent.
+  // The §17.9.28 suffix advances that body only when the marker plus suffix
+  // crosses the start edge; a marker contained by its hanging region cannot
+  // pull the paragraph body backward into that region.
+  bodyOffsetPt = Math.max(0, bodyOffsetPt);
   return {
     bodyOffsetPt,
     markerText,

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.80.2",
+  "version": "0.80.3",
   "description": "Internal workspace adapter for DOCX / XLSX / PPTX Markdown projection",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.80.2"
+version = "0.80.3"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.80.2",
+  "version": "0.80.3",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.80.2",
+  "version": "0.80.3",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity local viewer for Office files (.docx / .xlsx / .pptx), powered by Rust/WASM and Canvas. Optional MCP integration can share requested context with an AI agent.",
-  "version": "0.80.2",
+  "version": "0.80.3",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.80.2",
+  "version": "0.80.3",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/scripts/check-production-render-workers.mjs
+++ b/scripts/check-production-render-workers.mjs
@@ -31,6 +31,11 @@ for (const hostName of hosts) {
 
 for (const assetPath of workerAssets) {
   const source = readFileSync(assetPath, 'utf8');
+  if (/\bimport\.meta\b/.test(source)) {
+    throw new Error(
+      `${assetPath} contains import.meta; opaque worker assets must remain parseable as classic scripts`,
+    );
+  }
   const specifiers = [
     ...source.matchAll(/\bfrom\s*["']([^"']+)["']/g),
     ...source.matchAll(/\bimport\(\s*["']([^"']+)["']\s*\)/g),

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.80.2",
+  "version": "0.80.3",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",


### PR DESCRIPTION
## Summary

Merge the v0.80.3 maintenance release back into main before preparing the next minor release.

This preserves the released maintenance history and brings main forward to the published patch version, including:

- DOCX hanging-numbering body-offset correction
- production worker assets that avoid worker-side `import.meta`
- the v0.80.3 changelog and package versions

## Verification

- focused DOCX numbering-marker tests
- `pnpm typecheck`
- `pnpm build:wasm`
- `pnpm build`
- `pnpm check:production-render-workers`