### PR TITLE
fix(docx): trim trailing first-fragment partial rows in table pagination

### DIFF
--- a/packages/docx/src/layout/table-pagination.test.ts
+++ b/packages/docx/src/layout/table-pagination.test.ts
@@ -10,6 +10,7 @@ import type {
   AcquiredParagraphLayoutInput,
   LayoutServices,
   ParagraphLayout,
+  TableCellLayoutInput,
   TableEdgeInputs,
   TableLayoutInput,
   TableRowLayoutInput,
@@ -1147,6 +1148,72 @@ describe('retained table pagination', () => {
     expect(first.fragment?.rows[0]?.cells[0]?.contentRanges).toEqual([
       { kind: 'paragraph', blockIndex: 0, lineStart: 0, lineEnd: 1 },
     ]);
+  });
+
+  it('trims a trailing partial row when a vMerge owner deficit relocates into the truncated span', () => {
+    const cell = (
+      logicalRowIndex: number,
+      columnStart: number,
+      verticalMerge: 'none' | 'restart' | 'continue',
+      layout: ParagraphLayout | null,
+    ): TableCellLayoutInput => ({
+      id: `cell-${logicalRowIndex}-${columnStart}`,
+      source: { story: 'body', storyInstance: 'body', path: [0, logicalRowIndex, columnStart] },
+      columnStart, columnSpan: 1,
+      verticalMerge,
+      margins: { topPt: 0, rightPt: 0, bottomPt: 0, leftPt: 0 },
+      vAlign: 'top' as const, borders: noBorders,
+      blocks: layout ? [{ layout, sourceBlockIndex: 0 }] : [],
+    });
+    const twoColumnRow = (
+      logicalRowIndex: number,
+      first: ReturnType<typeof cell>,
+      second: ParagraphLayout,
+    ): TableRowLayoutInput => ({
+      id: `row-${logicalRowIndex}`,
+      source: { story: 'body', storyInstance: 'body', path: [0, logicalRowIndex] },
+      logicalRowIndex,
+      cantSplit: false,
+      heightPt: null,
+      heightRule: 'auto',
+      cellSpacingPt: 0,
+      exceptionBorders: null,
+      alignment: 'left', indentPt: 0,
+      repeatedHeader: false,
+      cells: [first, cell(logicalRowIndex, 1, 'none', second)],
+    });
+    // A split plain row's tail completes on this page, after which the vMerge
+    // group is admitted by retained track heights. Materializing the
+    // fragment-truncated span relocates the owner deficit into the trailing
+    // partial row, so the fragment outgrows the page even though every
+    // admission fit; pagination must trim back to a whole-row boundary
+    // instead of returning an over-page fragment that cannot advance.
+    const source = acquisition([
+      twoColumnRow(0, cell(0, 0, 'none', paragraph('split-row', [40, 40, 40, 40])), paragraph('r0-side', [40])),
+      twoColumnRow(1, cell(1, 0, 'restart', paragraph('merged-owner', [30, 30, 30, 30, 30])), paragraph('r1-side', [40])),
+      twoColumnRow(2, cell(2, 0, 'continue', null), paragraph('r2-side', [40])),
+      twoColumnRow(3, cell(3, 0, 'continue', null), paragraph('r3-side', [30, 30, 30, 30])),
+    ]);
+    const tailCursor = Object.freeze({
+      rowIndex: 0,
+      rowFragmentIndex: 1,
+      cells: Object.freeze([
+        Object.freeze({ blockIndex: 0, paragraphLineStart: 2, nestedCursor: null, nestedFragmentIndex: 0 }),
+        Object.freeze({ blockIndex: 1, paragraphLineStart: 0, nestedCursor: null, nestedFragmentIndex: 0 }),
+      ]),
+    });
+
+    const first = take(source, 200, tailCursor, { freshPageHeightPt: 200 });
+
+    expect(first.requiresFreshPage).toBe(false);
+    expect(first.fragment?.advancePt).toBeLessThanOrEqual(200);
+    expect(first.fragment?.rows.map((item) => [item.logicalRowIndex, item.fragmentIndex])).toEqual([[0, 1]]);
+    expect(first.nextCursor).toMatchObject({ rowIndex: 1, rowFragmentIndex: 0 });
+
+    const rest = take(source, 200, first.nextCursor!, { freshPageHeightPt: 200 });
+    expect(rest.requiresFreshPage).toBe(false);
+    expect(rest.fragment?.rows.map((item) => item.logicalRowIndex)).toEqual([1, 2, 3]);
+    expect(rest.nextCursor).toBeNull();
   });
 
   it('reacquires only page-dependent blocks with stable source indices per occurrence', () => {

--- a/packages/docx/src/layout/table-pagination.ts
+++ b/packages/docx/src/layout/table-pagination.ts
@@ -1293,10 +1293,15 @@ export function takeTableFragment(
   while (fragment.advancePt > context.availableHeightPt + EPSILON_PT) {
     const last = selected.at(-1);
     const sourceCount = selected.filter((row) => row.ownership === 'source').length;
-    const wholeSourceRow = last?.ownership === 'source'
-      && last.fragmentIndex === 0
-      && last.ranges.every((ranges) => ranges.every((range) => range.kind === 'whole'));
-    if (!wholeSourceRow || sourceCount <= 1) break;
+    // Only a first-fragment source row is a legal trim boundary. Materializing
+    // a fragment-truncated vMerge span relocates the owner's deficit into the
+    // span's last row (table.ts resolveRowHeights), which can grow a trailing
+    // partial row past the budget its lines were selected against. Such a row
+    // has emitted nothing yet, so deferring it whole loses no content; a later
+    // fragment (fragmentIndex > 0) or a non-source row would.
+    const trimmableSourceRow = last?.ownership === 'source'
+      && last.fragmentIndex === 0;
+    if (!trimmableSourceRow || sourceCount <= 1) break;
     selected.pop();
     nextCursor = Object.freeze({
       rowIndex: last.logicalRowIndex,


### PR DESCRIPTION
## Problem

Paginating certain DOCX documents containing long multi-page tables with vertically merged cells (`w:vMerge` row spans) fails with:

```
Error: Table footnote admission did not converge
```

thrown from the retry loop in `body-paginator.ts` — even for documents that contain **no footnotes at all**. The whole document fails to render.

Affected document class: a table whose rows are admitted across a page boundary after a completed partial (split) row, where a trailing row is admitted as a *partial* row against the leftover height budget, and that row participates in a `vMerge` span that gets truncated by the fragment boundary.

## Root cause

In `takeTableFragment` (`packages/docx/src/layout/table-pagination.ts`):

1. After a split row completes, subsequent rows are admitted by retained track height; the last admitted row may be a **partial** row selected against the remaining budget.
2. `materializeFragment` re-runs `layoutTable` on the selected rows. When a fragment truncates a `vMerge` span, `resolveRowHeights` (`table.ts`) relocates the span owner's height deficit into the fragment's **last span row** — so the trailing partial row can grow well past the budget its line selection was made against (observed: fragment materializes to ~769pt against a ~728pt fresh page).
3. The over-admission trim loop only popped trailing rows whose ranges were **all `whole`**, so it stopped immediately at the trailing partial row. The fresh-page rescue requires `available < freshPage`, which does not hold on an already-fresh page. The function therefore returned an over-page fragment with `requiresFreshPage` unset.
4. The body paginator can never admit such a fragment: its footnote-admission retry loop re-requests the identical fragment (`reservePt` is 0 with no footnotes, so the requested extent never changes), the fingerprint repeats, and the convergence guard throws.

## Fix

Per ECMA-376 §17.4.6 a table row may split across pages, but a row group whose merged-cell content cannot physically fit the remaining band must move to the next page. A trailing partial row that is still in its **first** fragment (`fragmentIndex === 0`) has emitted nothing on earlier pages, so deferring it whole is a legal trim boundary: no content is lost or duplicated and the cursor never moves backward.

The trim condition changes from "trailing all-whole source row" to "trailing first-fragment source row":

```ts
const trimmableSourceRow = last?.ownership === 'source'
  && last.fragmentIndex === 0;
if (!trimmableSourceRow || sourceCount <= 1) break;
```

After popping the partial row, the loop keeps trimming whole rows until the fragment fits; the deferred row group re-paginates from the next page. The existing `fragmentIndex === 0` and `sourceCount <= 1` guards keep protecting already-emitted content and forward progress, so the `'Table pagination cannot advance from a fresh page'` invariant is preserved, and the paginator's convergence guard remains as a safety net.

## Tests

- New unit test in `packages/docx/src/layout/table-pagination.test.ts` (`retained table pagination > trims a trailing partial row when a vMerge owner deficit relocates into the truncated span`) builds a minimal 4-row table (plain split row + 3-row `vMerge` span) that reproduces the exact mechanism: admitted 230pt into a 200pt fresh page with an unpoppable trailing partial row. It fails before the fix (`expected 230 to be <= 200`) and passes after; a second `take` then paginates the remainder to completion.
- Full `packages/docx/src` vitest suite: **3104 tests passed**.
- `tsc --build`: clean.
- Verified end-to-end by paginating a real-world multi-page document whose 48-row vertically merged table previously triggered the non-convergence throw; it now paginates to completion.