### PR TITLE
feat(docx): paint insertions (w:ins) with author-coloured underline

### DIFF
--- a/packages/docx/src/layout/paragraph.ts
+++ b/packages/docx/src/layout/paragraph.ts
@@ -73,6 +73,10 @@ import {
   type RetainedEmphasisClusterInk,
   type RetainedEmphasisMarkInput,
 } from './retained-typography.js';
+import {
+  wordTrackChangeAuthorColor,
+  wordTrackChangeDecoration,
+} from './track-changes.js';
 import type { RunTypographyAcquisitionInput } from './typography-input.js';
 import { resolveAnchorFrame, type AnchorReferenceFramesInput, type AnchorFrameResult } from './anchor-frame.js';
 import { paragraphGapPt } from './paragraph-spacing.js';
@@ -208,6 +212,13 @@ interface RetainedTextGeometryPlan {
     double: boolean;
     probe: RetainedInkMetric;
     doubleProbe?: RetainedInkMetric;
+  }>;
+  /** ECMA-376 §17.13.5 tracked-changes markup in the deterministic
+   * revision-author color, painted in addition to authored decorations. */
+  readonly revision?: Readonly<{
+    color: string;
+    underline?: Readonly<{ probe: RetainedInkMetric }>;
+    strike?: Readonly<{ probe: RetainedInkMetric }>;
   }>;
   readonly emphasis?: Readonly<{
     authored: string;
@@ -913,6 +924,7 @@ export function planLine(input: PlanLineInput): LineLayout {
             color: retainedColorString(style.color),
             ...(retainedGeometry.underline ? { underline: retainedGeometry.underline } : {}),
             ...(retainedGeometry.strike ? { strike: retainedGeometry.strike } : {}),
+            ...(retainedGeometry.revision ? { revision: retainedGeometry.revision } : {}),
           })
         : style.decorations;
       const emphasis = retainedGeometry?.emphasis ? {
@@ -1680,8 +1692,10 @@ function retainedGeometryPlan(
   sourceOffset: number,
   color: TextPlacement['color'],
 ): RetainedTextGeometryPlan | undefined {
+  const revisionDecoration = wordTrackChangeDecoration(segment.revision?.kind);
   if (!(segment.highlight || segment.underline || segment.strikethrough
-    || segment.doubleStrikethrough || segment.emphasisMark)) return undefined;
+    || segment.doubleStrikethrough || segment.emphasisMark
+    || revisionDecoration.underline || revisionDecoration.strike)) return undefined;
   const service = segment.textLayoutService;
   const request = segment.textShapeRequest;
   if (!service || !request) {
@@ -1721,6 +1735,18 @@ function retainedGeometryPlan(
     probe: glyphProbe('-'),
     ...(segment.doubleStrikethrough ? { doubleProbe: glyphProbe('=') } : {}),
   } : undefined;
+  // §17.13.5 — a visible revision (insertion / deletion) adds its own
+  // author-coloured decoration on top of any authored underline / strike,
+  // reusing the authored probes when they already shaped the same glyph.
+  const revision = revisionDecoration.underline || revisionDecoration.strike ? {
+    color: wordTrackChangeAuthorColor(segment.revision?.author),
+    ...(revisionDecoration.underline
+      ? { underline: { probe: underline?.probe ?? glyphProbe('_') } }
+      : {}),
+    ...(revisionDecoration.strike
+      ? { strike: { probe: strike?.probe ?? glyphProbe('-') } }
+      : {}),
+  } : undefined;
   const emphasis = segment.emphasisMark ? (() => {
     const glyph = emphasisGlyph(segment.emphasisMark);
     const markShape = shape(glyph);
@@ -1755,6 +1781,7 @@ function retainedGeometryPlan(
     base,
     ...(underline ? { underline } : {}),
     ...(strike ? { strike } : {}),
+    ...(revision ? { revision } : {}),
     ...(emphasis ? { emphasis } : {}),
   };
 }

--- a/packages/docx/src/layout/retained-typography.test.ts
+++ b/packages/docx/src/layout/retained-typography.test.ts
@@ -99,6 +99,41 @@ describe('retained typography geometry', () => {
     expect(structuredClone(underline)).toEqual(underline);
   });
 
+  it('adds an author-coloured revision underline for insertions and strike for deletions', () => {
+    const base = { ascentPt: 9, descentPt: 4 };
+    const inserted = retainedTextDecorations({
+      origin: { xPt: 5, yPt: 10 }, advancePt: 20,
+      base, color: '#000000',
+      revision: { color: '#C00000', underline: { probe: { ascentPt: 2, descentPt: 2 } } },
+    });
+    expect(inserted).toEqual([{
+      kind: 'underline', color: '#C00000', widthPt: 2, style: 'solid',
+      from: { xPt: 5, yPt: 15 }, to: { xPt: 25, yPt: 15 },
+    }]);
+    const deleted = retainedTextDecorations({
+      origin: { xPt: 5, yPt: 10 }, advancePt: 20,
+      base, color: '#000000',
+      revision: { color: '#0070C0', strike: { probe: { ascentPt: 2, descentPt: 2 } } },
+    });
+    expect(deleted).toEqual([{
+      kind: 'strikethrough', color: '#0070C0', widthPt: 2, style: 'solid',
+      from: { xPt: 5, yPt: 10 }, to: { xPt: 25, yPt: 10 },
+    }]);
+  });
+
+  it('stacks the author-coloured revision decoration on the authored underline', () => {
+    const decorations = retainedTextDecorations({
+      origin: { xPt: 5, yPt: 10 }, advancePt: 20,
+      base: { ascentPt: 9, descentPt: 4 }, color: '#000000',
+      underline: { color: '#112233', probe: { ascentPt: 2, descentPt: 2 } },
+      revision: { color: '#C00000', underline: { probe: { ascentPt: 2, descentPt: 2 } } },
+    });
+    expect(decorations.map((decoration) => [decoration.kind, decoration.color])).toEqual([
+      ['underline', '#112233'],
+      ['underline', '#C00000'],
+    ]);
+  });
+
   it('centers a shaped tab-leader sequence inside the authored tab interval', () => {
     expect(centeredLeaderGlyphOrigins({
       interval: { xPt: 10, yPt: 4, widthPt: 23, heightPt: 12 },

--- a/packages/docx/src/layout/retained-typography.ts
+++ b/packages/docx/src/layout/retained-typography.ts
@@ -135,15 +135,26 @@ export function retainedTextDecorations(input: Readonly<{
   color: string;
   underline?: Readonly<{ authoredStyle?: string; color: string; probe: RetainedInkMetric }>;
   strike?: Readonly<{ double: boolean; probe: RetainedInkMetric; doubleProbe?: RetainedInkMetric }>;
+  /** ECMA-376 §17.13.5 tracked-changes markup: an additional decoration in the
+   * deterministic revision-author color, layered AFTER any authored underline /
+   * strike so the author color stays visible. Insertions underline, deletions
+   * strike through; both reuse the same selected-face probes as the authored
+   * decorations. */
+  revision?: Readonly<{
+    color: string;
+    underline?: Readonly<{ probe: RetainedInkMetric }>;
+    strike?: Readonly<{ probe: RetainedInkMetric }>;
+  }>;
 }>): readonly TextDecorationLayout[] {
   const decorations: TextDecorationLayout[] = [];
   const rightPt = input.origin.xPt + input.advancePt;
+  const underlineCenterPt = (probe: RetainedInkMetric, strokeWidthPt: number): number => Math.max(
+    input.origin.yPt + (inkTop(probe) + inkBottom(probe)) / 2,
+    input.origin.yPt + inkBottom(input.base) + strokeWidthPt / 2,
+  );
   if (input.underline) {
     const strokeWidthPt = inkStrokeWidth(input.underline.probe);
-    const nativeCenterPt = input.origin.yPt
-      + (inkTop(input.underline.probe) + inkBottom(input.underline.probe)) / 2;
-    const clearCenterPt = input.origin.yPt + inkBottom(input.base) + strokeWidthPt / 2;
-    const centerPt = Math.max(nativeCenterPt, clearCenterPt);
+    const centerPt = underlineCenterPt(input.underline.probe, strokeWidthPt);
     const style = underlineStyle(input.underline.authoredStyle);
     const common = {
       kind: 'underline' as const,
@@ -189,6 +200,23 @@ export function retainedTextDecorations(input: Readonly<{
         from: { xPt: input.origin.xPt, yPt }, to: { xPt: rightPt, yPt },
       });
     }
+  }
+  if (input.revision?.underline) {
+    const strokeWidthPt = inkStrokeWidth(input.revision.underline.probe);
+    const centerPt = underlineCenterPt(input.revision.underline.probe, strokeWidthPt);
+    decorations.push({
+      kind: 'underline', color: input.revision.color, widthPt: strokeWidthPt, style: 'solid',
+      from: { xPt: input.origin.xPt, yPt: centerPt }, to: { xPt: rightPt, yPt: centerPt },
+    });
+  }
+  if (input.revision?.strike) {
+    const strokeWidthPt = inkStrokeWidth(input.revision.strike.probe);
+    const yPt = input.origin.yPt
+      + (inkTop(input.revision.strike.probe) + inkBottom(input.revision.strike.probe)) / 2;
+    decorations.push({
+      kind: 'strikethrough', color: input.revision.color, widthPt: strokeWidthPt, style: 'solid',
+      from: { xPt: input.origin.xPt, yPt }, to: { xPt: rightPt, yPt },
+    });
   }
   return decorations;
 }

--- a/packages/docx/src/layout/track-changes.test.ts
+++ b/packages/docx/src/layout/track-changes.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+  WORD_TRACK_CHANGE_AUTHOR_COLORS,
+  wordTrackChangeAuthorColor,
+  wordTrackChangeDecoration,
+} from './track-changes.js';
+
+describe('track-changes paint policy (ECMA-376 §17.13.5)', () => {
+  it('pins the eight track-change author colors independently of author indexing', () => {
+    expect(WORD_TRACK_CHANGE_AUTHOR_COLORS).toEqual([
+      '#C00000', '#0070C0', '#00B050', '#7030A0',
+      '#E97132', '#196B24', '#9E480E', '#525252',
+    ]);
+    expect(Object.isFrozen(WORD_TRACK_CHANGE_AUTHOR_COLORS)).toBe(true);
+  });
+
+  it('maps visible track-change kinds to their revision decorations', () => {
+    expect(wordTrackChangeDecoration('insertion')).toEqual({
+      underline: true,
+      strike: false,
+    });
+    expect(wordTrackChangeDecoration('deletion')).toEqual({
+      underline: false,
+      strike: true,
+    });
+    expect(wordTrackChangeDecoration(null)).toEqual({
+      underline: false,
+      strike: false,
+    });
+    expect(Object.isFrozen(wordTrackChangeDecoration('insertion'))).toBe(true);
+  });
+
+  it('assigns track-change author colors deterministically from the palette', () => {
+    expect(wordTrackChangeAuthorColor(undefined)).toBe(WORD_TRACK_CHANGE_AUTHOR_COLORS[0]);
+    expect(wordTrackChangeAuthorColor(null)).toBe(WORD_TRACK_CHANGE_AUTHOR_COLORS[0]);
+    expect(wordTrackChangeAuthorColor('')).toBe(WORD_TRACK_CHANGE_AUTHOR_COLORS[0]);
+    for (const author of ['Alice', 'Carol', 'Bob', 'Heidi']) {
+      expect(WORD_TRACK_CHANGE_AUTHOR_COLORS).toContain(wordTrackChangeAuthorColor(author));
+      expect(wordTrackChangeAuthorColor(author)).toBe(wordTrackChangeAuthorColor(author));
+    }
+    // Distinct authors hash to distinct palette slots where the eight slots allow.
+    expect(wordTrackChangeAuthorColor('Alice')).not.toBe(wordTrackChangeAuthorColor('Carol'));
+  });
+});

--- a/packages/docx/src/layout/track-changes.ts
+++ b/packages/docx/src/layout/track-changes.ts
@@ -1,0 +1,58 @@
+/** ECMA-376 §17.13.5 tracked-changes (`<w:ins>` / `<w:del>`) paint policy.
+ * Word's "All Markup" view underlines insertions and strikes through deletions
+ * in the author's color. The palette mirrors Word's fixed author-color set;
+ * the author→slot assignment is renderer-defined (Word's own assignment is
+ * per-installation, not document-authored), so this module pins a deterministic
+ * one. */
+
+export const WORD_TRACK_CHANGE_AUTHOR_COLORS = Object.freeze([
+  '#C00000',
+  '#0070C0',
+  '#00B050',
+  '#7030A0',
+  '#E97132',
+  '#196B24',
+  '#9E480E',
+  '#525252',
+] as const);
+
+const NO_TRACK_CHANGE_DECORATION = Object.freeze({
+  underline: false,
+  strike: false,
+});
+const INSERTION_TRACK_CHANGE_DECORATION = Object.freeze({
+  underline: true,
+  strike: false,
+});
+const DELETION_TRACK_CHANGE_DECORATION = Object.freeze({
+  underline: false,
+  strike: true,
+});
+
+export function wordTrackChangeDecoration(
+  kind: string | null | undefined,
+): Readonly<{ underline: boolean; strike: boolean }> {
+  if (kind === 'insertion') return INSERTION_TRACK_CHANGE_DECORATION;
+  if (kind === 'deletion') return DELETION_TRACK_CHANGE_DECORATION;
+  return NO_TRACK_CHANGE_DECORATION;
+}
+
+/** Deterministic author-index policy: a stable FNV-1a hash of the author name
+ * with a finalizer mix selects one of the eight palette slots, so a given
+ * author keeps the same color across runs, pages, sessions, and documents
+ * regardless of layout order. An absent or empty author takes slot 0. Once
+ * more than eight authors appear, slots repeat — the same fixed-size
+ * author-color behaviour Word itself exhibits. */
+export function wordTrackChangeAuthorColor(
+  author: string | null | undefined,
+): string {
+  if (!author) return WORD_TRACK_CHANGE_AUTHOR_COLORS[0];
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < author.length; index += 1) {
+    hash = Math.imul(hash ^ author.charCodeAt(index), 0x01000193);
+  }
+  hash = Math.imul(hash ^ (hash >>> 16), 0x45d9f3b);
+  hash = Math.imul(hash ^ (hash >>> 16), 0x45d9f3b);
+  hash ^= hash >>> 16;
+  return WORD_TRACK_CHANGE_AUTHOR_COLORS[(hash >>> 0) % WORD_TRACK_CHANGE_AUTHOR_COLORS.length];
+}

--- a/packages/docx/src/track-changes-render.test.ts
+++ b/packages/docx/src/track-changes-render.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import { wordTrackChangeAuthorColor } from './layout/track-changes.js';
+import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps } from './types';
+
+// Characterization of the docx track-changes decoration draw path
+// (ECMA-376 §17.13.5 `<w:ins>` / `<w:del>`): inserted runs gain an
+// author-coloured underline layered on any authored run decorations.
+// Deleted (`<w:del>`) and moved-away (`<w:moveFrom>`) runs are projected out
+// of the laid-out final state upstream (line-layout.ts), so the canvas shows
+// the accepted document; their review markup is consumer-owned via the parsed
+// revision metadata. The recording ctx mirrors the underline draw-path tests
+// so stroke geometry / colour can be asserted without a real canvas.
+
+interface StrokeOp { op: string; args: (number | string)[]; }
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; ops: StrokeOp[] } {
+  let font = '10px serif';
+  const ops: StrokeOp[] = [];
+  let strokeStyle = '#000';
+  let fillStyle = '#000';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get strokeStyle() { return strokeStyle; },
+    set strokeStyle(v: string) { strokeStyle = v; },
+    get fillStyle() { return fillStyle; },
+    set fillStyle(v: string) { fillStyle = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      const lowLine = s === '_';
+      return {
+        width: [...s].length * p * 0.5,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: lowLine ? 0 : p * 0.8,
+        actualBoundingBoxDescent: lowLine ? p * 0.05 : p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo(x: number, y: number) { ops.push({ op: 'moveTo', args: [x, y] }); },
+    lineTo(x: number, y: number) { ops.push({ op: 'lineTo', args: [x, y] }); },
+    stroke() { ops.push({ op: 'stroke', args: [strokeStyle] }); },
+    fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    setLineDash() {},
+    clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(t: string) { ops.push({ op: 'fillText', args: [String(t), fillStyle] }); },
+    strokeText() {},
+    lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, ops };
+}
+
+function para(run: Partial<DocParagraph['runs'][number]>): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [{
+      type: 'text', text: 'abc', bold: false, italic: false, underline: false,
+      strikethrough: false, fontSize: 40, color: null, fontFamily: 'Times New Roman',
+      fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+      ...run,
+    } as DocParagraph['runs'][number]],
+    defaultFontSize: 40, defaultFontFamily: 'Times New Roman', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function doc(body: BodyElement[]): DocxDocumentModel {
+  const section = {
+    pageWidth: 400, pageHeight: 600,
+    marginTop: 5, marginRight: 5, marginBottom: 5, marginLeft: 5,
+    headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+  } as SectionProps;
+  return {
+    section, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+async function render(...runs: Partial<DocParagraph['runs'][number]>[]) {
+  const { canvas, ops } = makeRecordingCanvas();
+  const body = runs.map((run) => para(run) as unknown as BodyElement);
+  await renderDocumentToCanvas(doc(body), canvas, 0, { dpr: 1, width: 400 });
+  return ops;
+}
+
+function strokeColors(ops: StrokeOp[]): string[] {
+  return ops
+    .filter((op) => op.op === 'stroke')
+    .map((op) => String(op.args[0]).toLowerCase());
+}
+
+describe('docx track-changes decorations (§17.13.5) draw path', () => {
+  it('underlines an inserted run in the deterministic author palette color', async () => {
+    const ops = await render({ revision: { kind: 'insertion', author: 'Alice' } });
+    expect(strokeColors(ops)).toContain(wordTrackChangeAuthorColor('Alice').toLowerCase());
+  });
+
+  it('projects deleted runs out of the final-state layout (no text, no decoration)', async () => {
+    // Upstream's accepted-final-state projection (line-layout.ts §17.13.5)
+    // drops `<w:del>` runs before segment building, so deleted text neither
+    // paints nor carries decorations; review UI reads the parsed metadata.
+    const ops = await render(
+      { text: 'kept' },
+      { text: 'deleted', revision: { kind: 'deletion', author: 'Alice' } },
+    );
+    const drawnText = ops
+      .filter((op) => op.op === 'fillText')
+      .map((op) => String(op.args[0]))
+      .join('');
+    expect(drawnText).toContain('kept');
+    expect(drawnText).not.toContain('deleted');
+    expect(strokeColors(ops)).toHaveLength(0);
+  });
+
+  it('draws no decoration for a run without a revision', async () => {
+    const ops = await render({});
+    expect(strokeColors(ops)).toHaveLength(0);
+  });
+
+  it('gives different authors different palette colors', async () => {
+    const ops = await render(
+      { revision: { kind: 'insertion', author: 'Alice' } },
+      { revision: { kind: 'insertion', author: 'Carol' } },
+    );
+    const colors = strokeColors(ops);
+    expect(colors).toContain(wordTrackChangeAuthorColor('Alice').toLowerCase());
+    expect(colors).toContain(wordTrackChangeAuthorColor('Carol').toLowerCase());
+    expect(wordTrackChangeAuthorColor('Alice')).not.toBe(wordTrackChangeAuthorColor('Carol'));
+  });
+
+  it('stacks the author-coloured revision underline on an authored underline', async () => {
+    const ops = await render({
+      underline: true, underlineStyle: 'dotted', underlineColor: '112233',
+      revision: { kind: 'insertion', author: 'Alice' },
+    });
+    const colors = strokeColors(ops);
+    expect(colors).toContain('#112233');
+    expect(colors).toContain(wordTrackChangeAuthorColor('Alice').toLowerCase());
+  });
+
+  it('keeps the run text color unchanged by the revision decoration color', async () => {
+    const ops = await render({ revision: { kind: 'insertion', author: 'Alice' } });
+    const textFills = ops
+      .filter((op) => op.op === 'fillText')
+      .map((op) => String(op.args[1]).toLowerCase());
+    expect(textFills.length).toBeGreaterThan(0);
+    expect(textFills).not.toContain(wordTrackChangeAuthorColor('Alice').toLowerCase());
+  });
+});


### PR DESCRIPTION
## Problem

The DOCX model carries per-run revision facts (ECMA-376 §17.13.5 `<w:ins>` / `<w:del>` — `DocxTextRun.revision`) end-to-end, but the paint pipeline never converts them into `TextDecorationLayout` entries. Tracked insertions render indistinguishable from accepted content, and both the README feature table and the `RunRevision` doc comment claim author-coloured inline markup that was never wired.

## What this does

Builds revision decorations where other run decorations are built, matching the insertion presentation of Word's **All Markup** view:

- **Insertions (`<w:ins>`)** gain an author-coloured underline.
- Revision decorations are appended **after** authored ones, so a run that is both underlined (§17.3.2.40 `<w:u>`) and inserted shows both rules, with the author color visible.
- Decoration style/thickness reuse the same selected-face probes as authored `<w:u>`; the run's own text color is untouched.

**Author color policy.** Word's author-color assignment is renderer-defined (per-installation, not document-authored), so this uses a deterministic FNV-1a hash of the author name into an eight-color palette (Word's author-color set) — stable across pages, sessions, and measure order. Absent/empty author takes slot 0. More than 8 distinct authors repeat slots, the same class of behavior as Word.

The palette, the kind→decoration mapping, and the author-color hash live in a new production module `layout/track-changes.ts` (the earlier test-only scaffolding in `paint-compatibility.ts` was removed in #1372; this is its first production consumer).

## Interaction with #1372 (accepted-final-state projection)

Since #1372, `<w:del>` / `<w:moveFrom>` runs produce no canvas segments at all — the canvas renders the accepted document, and revision metadata is reserved for consumer-owned review UIs. This PR builds on that decision:

- **Insertions** remain visible content and now get their author-coloured underline.
- **Deletions** stay projected out of the canvas (served to review UIs through the parsed revision metadata, §17.13.5).
- The deletion→strikethrough arm of `wordTrackChangeDecoration` / `retainedTextDecorations` is kept (symmetric with the policy mapping, unit-tested, reusable by a consumer review UI) but is unreachable in production while the projection stands — happy to trim it if you prefer.

## Tests

- New `layout/track-changes.test.ts` — palette pins, kind→decoration mapping, author-color determinism/membership/absent-author/distinct authors.
- `layout/retained-typography.test.ts` — insertion→underline in author color with exact geometry; authored underline + insertion yields both decorations.
- `track-changes-render.test.ts` (recording-canvas via `renderDocumentToCanvas`) — insertion strokes in author colors, no decoration without revision, per-author colors, stacking on authored underline, text fill untouched; deleted text neither paints nor carries decorations (projection pinned).

## Verification

- `npx vitest run packages/docx/src` — all green (incl. the #1372 conformance suite; requires a local `pnpm build:wasm` after the rebase since the parser changed).
- `tsc --build` clean; `ast-grep scan` clean.
- Headless renders (node session API + software canvas) of a synthetic tracked-changes document and a real-world document with tracked insertions/deletions: insertions show author-coloured underlines in the right places, deletions follow the accepted-final-state projection, body text otherwise unchanged.

Co-Authored-By: Kimi <noreply@moonshot.ai>