### PR TITLE
fix(site): preserve viewer module initialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,12 @@ jobs:
       - name: Smoke tests
         run: pnpm smoke
 
+      - name: Build public site
+        run: pnpm --filter @silurus/ooxml-site build
+
+      - name: Public site runtime smoke
+        run: pnpm test:site-runtime
+
       - name: Published render-worker smoke
         run: |
           # This job validates runtime assets, not declarations. Declaration

--- a/examples/frameworks/pnpm-lock.yaml
+++ b/examples/frameworks/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
   react:
     dependencies:
       '@silurus/ooxml':
-        specifier: ^0.75.3
-        version: 0.75.3
+        specifier: ^0.82.0
+        version: 0.82.0
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -39,8 +39,8 @@ importers:
   solid:
     dependencies:
       '@silurus/ooxml':
-        specifier: ^0.75.3
-        version: 0.75.3
+        specifier: ^0.82.0
+        version: 0.82.0
       solid-js:
         specifier: ^1.9.14
         version: 1.9.14
@@ -58,8 +58,8 @@ importers:
   svelte:
     dependencies:
       '@silurus/ooxml':
-        specifier: ^0.75.3
-        version: 0.75.3
+        specifier: ^0.82.0
+        version: 0.82.0
       svelte:
         specifier: ^5.56.8
         version: 5.56.8
@@ -80,8 +80,8 @@ importers:
   vue:
     dependencies:
       '@silurus/ooxml':
-        specifier: ^0.75.3
-        version: 0.75.3
+        specifier: ^0.82.0
+        version: 0.82.0
       vue:
         specifier: ^3.5.40
         version: 3.5.40(typescript@6.0.3)
@@ -294,8 +294,8 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@silurus/ooxml@0.75.3':
-    resolution: {integrity: sha512-GuN71jKDv7uSu6Qn4lfsCNAy/K302k0eo5pYm7w9IPGXsFbmujHzni3BZpQ9TU3GP/dByYMwK8vRkr+DXqBZ9w==}
+  '@silurus/ooxml@0.82.0':
+    resolution: {integrity: sha512-9+drDf1gLDmgy1Dc/iy3mMrc8ZCVO5M/oTPwvHnUarNOenN4ATV30/mrS0Ug+2mWAiKl34LBjyICjhmtTmEBWA==}
 
   '@sveltejs/acorn-typescript@1.0.11':
     resolution: {integrity: sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==}
@@ -1012,7 +1012,7 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@silurus/ooxml@0.75.3': {}
+  '@silurus/ooxml@0.82.0': {}
 
   '@sveltejs/acorn-typescript@1.0.11(acorn@8.18.0)':
     dependencies:

--- a/examples/frameworks/pnpm-workspace.yaml
+++ b/examples/frameworks/pnpm-workspace.yaml
@@ -8,4 +8,4 @@ allowBuilds:
   esbuild: false
 
 minimumReleaseAgeExclude:
-  - '@silurus/ooxml@0.75.3'
+  - '@silurus/ooxml@0.82.0'

--- a/examples/frameworks/react/package.json
+++ b/examples/frameworks/react/package.json
@@ -11,7 +11,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@silurus/ooxml": "^0.75.3",
+    "@silurus/ooxml": "^0.82.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   },

--- a/examples/frameworks/solid/package.json
+++ b/examples/frameworks/solid/package.json
@@ -11,7 +11,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@silurus/ooxml": "^0.75.3",
+    "@silurus/ooxml": "^0.82.0",
     "solid-js": "^1.9.14"
   },
   "devDependencies": {

--- a/examples/frameworks/svelte/package.json
+++ b/examples/frameworks/svelte/package.json
@@ -11,7 +11,7 @@
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {
-    "@silurus/ooxml": "^0.75.3",
+    "@silurus/ooxml": "^0.82.0",
     "svelte": "^5.56.8"
   },
   "devDependencies": {

--- a/examples/frameworks/vue/package.json
+++ b/examples/frameworks/vue/package.json
@@ -11,7 +11,7 @@
     "check": "vue-tsc --noEmit"
   },
   "dependencies": {
-    "@silurus/ooxml": "^0.75.3",
+    "@silurus/ooxml": "^0.82.0",
     "vue": "^3.5.40"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "vrt:fidelity": "pnpm -r --workspace-concurrency=1 vrt:fidelity",
     "vrt:worker": "pnpm --workspace-concurrency=1 --filter @silurus/ooxml-pptx --filter @silurus/ooxml-docx --filter @silurus/ooxml-xlsx vrt:worker",
     "smoke": "playwright test --config tests/smoke/playwright.config.ts layouts",
+    "test:site-runtime": "playwright test --config tests/site-dist/playwright.config.ts",
     "test": "vitest run && node --test tests/visual/private-corpus.test.mjs",
     "check:no-inline-wasm": "node scripts/check-no-inline-wasm.mjs dist",
     "check:production-render-workers": "node scripts/check-production-render-workers.mjs dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,9 +288,6 @@ importers:
       astro:
         specifier: ^6.4.8
         version: 6.4.8(@azure/identity@4.13.1)(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)
-      vite-plugin-top-level-await:
-        specifier: ^1.6.0
-        version: 1.6.0(rollup@4.60.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7))
       vite-plugin-wasm:
         specifier: ^3.6.0
         version: 3.6.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7))

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,6 +1,5 @@
 import { defineConfig } from 'astro/config';
 import wasm from 'vite-plugin-wasm';
-import topLevelAwait from 'vite-plugin-top-level-await';
 import { fileURLToPath } from 'node:url';
 
 const pkgSrc = (p) => fileURLToPath(new URL(`../packages/${p}/src/index.ts`, import.meta.url));
@@ -13,10 +12,15 @@ export default defineConfig({
   base: SITE_BASE,
   trailingSlash: 'ignore',
   vite: {
-    plugins: [wasm(), topLevelAwait()],
+    // Keep native module evaluation ordering for the WASM-backed Viewer
+    // graph. Transforming top-level await into exported `__tla` promises can
+    // leave Astro's separately emitted page scripts using Viewer exports before
+    // their chunks have initialized.
+    build: { target: 'esnext' },
+    plugins: [wasm()],
     worker: {
       format: 'es',
-      plugins: () => [wasm(), topLevelAwait()],
+      plugins: () => [wasm()],
     },
     resolve: {
       // Pull the workspace packages from source so Vite processes their

--- a/site/package.json
+++ b/site/package.json
@@ -22,7 +22,6 @@
   },
   "devDependencies": {
     "astro": "^6.4.8",
-    "vite-plugin-top-level-await": "^1.6.0",
     "vite-plugin-wasm": "^3.6.0"
   }
 }

--- a/site/src/client-module-init.test.ts
+++ b/site/src/client-module-init.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const config = readFileSync(new URL('../astro.config.mjs', import.meta.url), 'utf8');
+
+describe('official-site client module initialization', () => {
+  it('preserves native top-level await ordering for WASM-backed viewers', () => {
+    expect(config).toContain("build: { target: 'esnext' }");
+    expect(config).not.toContain("from 'vite-plugin-top-level-await'");
+    expect(config).not.toContain('topLevelAwait()');
+  });
+});

--- a/site/src/framework-guides.test.ts
+++ b/site/src/framework-guides.test.ts
@@ -178,6 +178,17 @@ describe('framework integration guides', () => {
     expect(packageJson.stackblitz?.startCommand).toBe(false);
   });
 
+  it.each(exampleFrameworks)('uses the current library release in the %s example', (framework) => {
+    const rootPackage = JSON.parse(readFileSync(new URL('package.json', repositoryRoot), 'utf8')) as {
+      version: string;
+    };
+    const packageJson = JSON.parse(exampleSource(`${framework}/package.json`)) as {
+      dependencies?: Record<string, string>;
+    };
+
+    expect(packageJson.dependencies?.['@silurus/ooxml']).toBe(`^${rootPackage.version}`);
+  });
+
   it.each(exampleFrameworks)(
     'keeps the %s viewer surface transparent and owns the desk background in CSS',
     (framework) => {

--- a/tests/site-dist/playwright.config.ts
+++ b/tests/site-dist/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+
+const port = Number(process.env.SITE_DIST_PORT ?? 4322);
+const siteRoot = fileURLToPath(new URL('../../site', import.meta.url));
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: 'viewer-pages.spec.ts',
+  reporter: [['list']],
+  use: {
+    baseURL: `http://127.0.0.1:${port}`,
+    channel: 'chrome',
+    viewport: { width: 1440, height: 1000 },
+  },
+  webServer: {
+    command: `./node_modules/.bin/astro preview --host 127.0.0.1 --port ${port}`,
+    cwd: siteRoot,
+    url: `http://127.0.0.1:${port}`,
+    reuseExistingServer: false,
+    timeout: 30_000,
+  },
+});

--- a/tests/site-dist/viewer-pages.spec.ts
+++ b/tests/site-dist/viewer-pages.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test';
+
+for (const format of ['docx', 'xlsx', 'pptx'] as const) {
+  test(`${format.toUpperCase()} live and comment demos initialize`, async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+
+    await page.goto(`/${format}/?all`);
+
+    await expect(page.locator('[data-built-in-comment-status]')).toBeHidden({ timeout: 60_000 });
+    await expect(page.locator('canvas').first()).toBeVisible();
+    await expect(page.locator('body')).not.toContainText(/not a constructor|Failed:/i);
+    expect(pageErrors).toEqual([]);
+  });
+}


### PR DESCRIPTION
## Summary
- keep native top-level-await ordering for the official site's WASM-backed viewer graph
- add a production-site runtime smoke for the DOCX, XLSX, and PPTX demo pages
- update the React, Vue, Svelte, and Solid examples from 0.75.3 to 0.82.0

## Root cause
The top-level-await transform rewrote Viewer chunks to expose asynchronous initialization through generated promises, but Astro's separately emitted page scripts did not await those promises before constructing the exported Viewer classes. The static site built successfully while all three format demos failed at runtime.

## Verification
- 33 focused site tests
- full Astro production build (32 pages)
- production-site Playwright smoke (DOCX, XLSX, PPTX: 3/3)
- React, Vue, Svelte, and Solid type checks and production builds
- manual browser checks of the format pages, review UI, selection context, Try yours, and home page