### PR TITLE
fix(comments): remove trailing margin scroll range

### DIFF
--- a/packages/core/src/internal/read-only-comment-margin.ts
+++ b/packages/core/src/internal/read-only-comment-margin.ts
@@ -166,6 +166,9 @@ const READ_ONLY_COMMENT_STYLES = `
   box-sizing: border-box;
   transform-origin: 0 0;
 }
+:where([data-ooxml-comment-ui="margin"] > [data-ooxml-comment-item]:last-child > .ooxml-comment-card) {
+  margin-bottom: 0;
+}
 `;
 
 export function ensureReadOnlyCommentStyles(owner: Document): void {

--- a/tests/site-dist/playwright.config.ts
+++ b/tests/site-dist/playwright.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     baseURL: `http://127.0.0.1:${port}`,
     channel: 'chrome',
     viewport: { width: 1440, height: 1000 },
+    deviceScaleFactor: 2,
   },
   webServer: {
     command: `./node_modules/.bin/astro preview --host 127.0.0.1 --port ${port}`,

--- a/tests/site-dist/viewer-pages.spec.ts
+++ b/tests/site-dist/viewer-pages.spec.ts
@@ -13,3 +13,25 @@ for (const format of ['docx', 'xlsx', 'pptx'] as const) {
     expect(pageErrors).toEqual([]);
   });
 }
+
+test('PPTX single-comment margin has no trailing scroll range', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto('/pptx/?all');
+  await expect(page.locator('[data-built-in-comment-status]')).toBeHidden({ timeout: 60_000 });
+
+  const margin = page.locator('[data-ooxml-comment-ui="margin"]')
+    .filter({ has: page.locator('.ooxml-comment-card') })
+    .first();
+  await expect(margin.locator('.ooxml-comment-card')).toHaveCount(1);
+
+  const before = await margin.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+    scrollTop: element.scrollTop,
+  }));
+  expect(before.scrollHeight).toBe(before.clientHeight);
+
+  await margin.locator('.ooxml-comment-card').hover();
+  await page.mouse.wheel(0, 100);
+  await expect.poll(() => margin.evaluate((element) => element.scrollTop)).toBe(0);
+});


### PR DESCRIPTION
## Summary
- remove the inter-card gap after the final built-in comment card
- preserve the existing nested scroll only when the card list actually exceeds the page
- add a high-DPI production-site regression for the PPTX single-comment demo

## Root cause
The card layout correctly clamped the final card itself to the page, but the CSS inter-card bottom margin remained after that final card. The margin container therefore gained a small excess scroll range even with one comment.

## Verification
- 262 focused core, DOCX, and PPTX tests
- production-site runtime smoke: DOCX, XLSX, PPTX initialization plus the PPTX no-trailing-scroll assertion (4/4)
- manual 1280×720 high-DPI browser check: comment margin clientHeight and scrollHeight both 481px