### PR TITLE
chore(release): 0.82.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ the corresponding minor release.
 
 ## Unreleased
 
+## 0.82.1 — 2026-08-26
+
+Compatible patch release improving Word and PowerPoint layout reliability,
+comment-margin scrolling, and the bundled VS Code viewing experience without
+changing the 0.82 public integration contract.
+
+- **Word table pagination:** defer a trailing partial row that has not emitted
+  content when a vertically merged row group outgrows the remaining page band,
+  preventing repeated admission of the same over-page fragment. (#1373)
+- **PowerPoint baseline text:** render non-zero DrawingML baseline runs at the
+  Office-observed glyph scale while retaining authored line geometry, avoiding
+  citation-only lines near a wrap boundary. (#1376)
+- **comment margins:** omit the inter-card gap after the final built-in comment
+  card so a bottom-aligned card does not create a small nested scroll range.
+- **VS Code extension:** enable the first-party ChartEx, 3-D chart, and offline
+  Region Map renderers for DOCX, XLSX, and PPTX webviews.
+- **site and integration guidance:** preserve WASM-backed viewer initialization
+  in the production site, bring framework examples to the current 0.82 line,
+  and document host-controlled light and dark XLSX viewer chrome.
+- **package declarations:** align the published Node entry's declaration build
+  aliases with its existing typecheck boundary so the ESM package emits the
+  complete Node declaration graph.
+- **compatibility:** no application or API migration is required from 0.82.0.
+
 ## 0.82.0 — 2026-08-26
 
 Minor release adding read-only review information across Word, Excel, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.82.0"
+version = "0.82.1"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.82.0",
+  "version": "0.82.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.82.0",
+  "version": "0.82.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.82.0",
+  "version": "0.82.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.82.0",
+  "version": "0.82.1",
   "description": "Internal workspace adapter for DOCX / XLSX / PPTX Markdown projection",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.82.0"
+version = "0.82.1"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.82.0",
+  "version": "0.82.1",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.82.0",
+  "version": "0.82.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity local viewer for Office files (.docx / .xlsx / .pptx), powered by Rust/WASM and Canvas. Optional MCP integration can share requested context with an AI agent.",
-  "version": "0.82.0",
+  "version": "0.82.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.82.0",
+  "version": "0.82.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.82.0",
+  "version": "0.82.1",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",

--- a/site/src/announcement-content.test.ts
+++ b/site/src/announcement-content.test.ts
@@ -83,7 +83,7 @@ describe('v0.81 ChartEx migration guide', () => {
 
 describe('stable documentation boundaries', () => {
   it('keeps the current bundle measurements on one stable page', () => {
-    expect(bundleSizePage).toContain('Current production assets in v0.82.0');
+    expect(bundleSizePage).toContain('Current production assets in v0.82.1');
     expect(bundleSizePage).toContain('DOCX static JavaScript');
     expect(bundleSizePage).toContain('XLSX static JavaScript');
     expect(bundleSizePage).toContain('PPTX static JavaScript');

--- a/site/src/framework-guides.test.ts
+++ b/site/src/framework-guides.test.ts
@@ -178,7 +178,7 @@ describe('framework integration guides', () => {
     expect(packageJson.stackblitz?.startCommand).toBe(false);
   });
 
-  it.each(exampleFrameworks)('uses the current library release in the %s example', (framework) => {
+  it.each(exampleFrameworks)('uses the current library minor line in the %s example', (framework) => {
     const rootPackage = JSON.parse(readFileSync(new URL('package.json', repositoryRoot), 'utf8')) as {
       version: string;
     };
@@ -186,7 +186,8 @@ describe('framework integration guides', () => {
       dependencies?: Record<string, string>;
     };
 
-    expect(packageJson.dependencies?.['@silurus/ooxml']).toBe(`^${rootPackage.version}`);
+    const [major, minor] = rootPackage.version.split('.');
+    expect(packageJson.dependencies?.['@silurus/ooxml']).toBe(`^${major}.${minor}.0`);
   });
 
   it.each(exampleFrameworks)(

--- a/site/src/pages/bundle-size.astro
+++ b/site/src/pages/bundle-size.astro
@@ -15,7 +15,7 @@ import SiteFooter from '../components/SiteFooter.astro';
       <div class="wrap">
         <p class="eyebrow">Current measurement</p>
         <h1>Bundle size.</h1>
-        <p>Current production assets in v0.82.0.</p>
+        <p>Current production assets in v0.82.1.</p>
       </div>
     </header>
 
@@ -52,7 +52,7 @@ import SiteFooter from '../components/SiteFooter.astro';
           </thead>
           <tbody>
             <tr><th>ChartEx</th><td>40.6 KiB</td><td>12.0 KiB</td></tr>
-            <tr><th>3-D charts</th><td>100.9 KiB</td><td>28.5 KiB</td></tr>
+            <tr><th>3-D charts</th><td>100.9 KiB</td><td>28.6 KiB</td></tr>
             <tr><th>Region Map</th><td>231.5 KiB</td><td>62.6 KiB</td></tr>
             <tr><th>Math adapter</th><td>1.3 KiB</td><td>0.7 KiB</td></tr>
           </tbody>

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -5,7 +5,8 @@
     "packages/core/src/**/*",
     "packages/pptx/src/**/*",
     "packages/xlsx/src/**/*",
-    "packages/docx/src/**/*"
+    "packages/docx/src/**/*",
+    "packages/node/typecheck/**/*"
   ],
   "compilerOptions": {
     "composite": false,
@@ -14,7 +15,13 @@
     "emitDeclarationOnly": true,
     "paths": {
       "@silurus/ooxml-core": ["./packages/core/src/index.ts"],
-      "@silurus/ooxml-core/*": ["./packages/core/src/*"]
+      "@silurus/ooxml-core/*": ["./packages/core/src/*"],
+      "@silurus/ooxml-pptx": ["./packages/pptx/src/types.ts"],
+      "@silurus/ooxml-pptx/internal/session": ["./packages/pptx/src/internal/session.ts"],
+      "@silurus/ooxml-docx": ["./packages/node/typecheck/docx-public-types.ts"],
+      "@silurus/ooxml-docx/internal/session": ["./packages/docx/src/internal/session.ts"],
+      "@silurus/ooxml-xlsx": ["./packages/xlsx/src/types.ts"],
+      "@silurus/ooxml-xlsx/internal/session": ["./packages/xlsx/src/internal/session.ts"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- prepare the compatible `0.82.1` patch release for the Word table-pagination, PowerPoint baseline-text, comment-margin, VS Code renderer, and production-site fixes merged after `0.82.0`
- bump every shipped package, update the changelog, and refresh the measured bundle-size version
- align the published Node entry's declaration build aliases with its existing typecheck boundary
- keep framework examples on the compatible `^0.82.0` minor line so the release does not invent npm integrity metadata for an unpublished patch

The README screenshots were regenerated and visually reviewed; all three were byte-identical to the checked-in images. The README, capability table, and public API reference remain current, with no public API change in this patch. Per maintainer direction, this PR does not add or modify an announcement.

## Adversarial and security review

- reviewed the complete `v0.82.0..HEAD` change set, including the workflow, VS Code webview wiring, site server configuration, and package manifests
- found and removed an invalid draft lockfile state that paired `0.82.1` with the published `0.82.0` tarball integrity
- no new third-party dependency, binary, workflow permission, credential path, dynamic evaluation, or external runtime request is introduced by the release diff
- `pnpm audit --prod --audit-level high`: no known vulnerabilities
- published format entries still exclude optional ChartEx, 3-D, and Region Map implementations unless explicitly imported

## Verification

- `cargo check -p ooxml-mcp-server`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages:ci`
- `pnpm build-storybook`
- focused release tests: 90 passed
- release-documentation tests: 44 passed
- production-site browser smoke: 4 passed
- private-corpus harness: 2 passed
- public API, viewer symmetry, optional-renderer, production-worker, no-inline-WASM, lint, and DOCX layout-boundary gates passed

The full local macOS suite completed 8,235 tests with two pre-existing Skia effect-crop pixel-oracle failures that reproduce only after the wider suite; the same file passes 6/6 in isolation. CI remains the merge gate for the clean Linux run.
