### PR TITLE
fix(pptx): keep overflowing text selectable

### DIFF
--- a/packages/pptx/src/text-layer.test.ts
+++ b/packages/pptx/src/text-layer.test.ts
@@ -91,7 +91,6 @@ describe('buildPptxTextLayer (extracted from PptxViewer._buildTextLayer)', () =>
     expect(shapeDiv.style.top).toBe(`${(20 / 540) * 100}%`);
     expect(shapeDiv.style.width).toBe(`${(200 / 960) * 100}%`);
     expect(shapeDiv.style.height).toBe(`${(80 / 540) * 100}%`);
-    expect(shapeDiv.style.overflow).toBe('hidden');
     expect(shapeDiv.children.map((c) => c.textContent)).toEqual(['A', 'B']);
     // Span uses the shipped `font` shorthand + line-height + letter-spacing reset.
     // Its position inside the shape div is a PERCENTAGE of the shape's own
@@ -104,6 +103,25 @@ describe('buildPptxTextLayer (extracted from PptxViewer._buildTextLayer)', () =>
     expect(spanA.style['line-height']).toBe('12px');
     expect(spanA.style['letter-spacing']).toBe('0');
     expect(spanA.style.color).toBe('transparent');
+  });
+
+  it('keeps text selectable when a rendered line overflows its shape frame', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    buildPptxTextLayer(
+      layer as unknown as HTMLDivElement,
+      [run({ text: 'OVERFLOW', inShapeY: 40, h: 20, shapeH: 50 })],
+      960,
+      540,
+    );
+
+    const shapeDiv = layer.children[0];
+    const span = shapeDiv.children[0];
+    expect(Number.parseFloat(span.style.top) + (20 / 50) * 100).toBeGreaterThan(100);
+    // Canvas deliberately paints DrawingML text beyond the shape rectangle.
+    // The matching transparent DOM run must not be clipped at that rectangle;
+    // the outer slide text layer remains responsible for slide-edge clipping.
+    expect(shapeDiv.style.overflow).toBe('visible');
   });
 
   it('splits runs of different shapes into separate group divs', () => {

--- a/packages/pptx/src/text-layer.ts
+++ b/packages/pptx/src/text-layer.ts
@@ -77,7 +77,10 @@ export function buildPptxTextLayer(
         `position:absolute;` +
         `left:${overlayPercent(run.shapeX, cssWidth)};top:${overlayPercent(run.shapeY, cssHeight)};` +
         `width:${overlayPercent(run.shapeW, cssWidth)};height:${overlayPercent(run.shapeH, cssHeight)};` +
-        `pointer-events:all;overflow:hidden;`;
+        // DrawingML text may paint beyond its shape rectangle when the body does
+        // not autofit. Match the canvas renderer by keeping those runs selectable;
+        // the outer slide text layer still clips anything past the slide edge.
+        `pointer-events:all;overflow:visible;`;
       if (totalRot !== 0) {
         div.style.transformOrigin = 'center center';
         div.style.transform = `rotate(${totalRot}deg)`;


### PR DESCRIPTION
## Summary

- let transparent PPTX text runs remain selectable when no-autofit text paints beyond its shape rectangle
- retain clipping at the outer slide boundary
- add a focused regression test for an overflowing line

## Verification

- `node_modules/.bin/vitest run packages/pptx/src/text-layer.test.ts packages/pptx/src/text-layer-hyperlink.test.ts packages/pptx/src/enable-hyperlinks-option.test.ts packages/pptx/src/viewer-selection-context.test.ts packages/pptx/src/scroll-viewer-selection-context.test.ts packages/core/src/internal/canvas-viewer-mechanics.test.ts`
- `node_modules/.pnpm/typescript@7.0.2/node_modules/typescript/bin/tsc --build --pretty false`
- `git diff --check`
- checked the public PPTX demo in Storybook