### PR TITLE
fix(site): preserve viewers across browser back

### DIFF
--- a/site/src/bfcache-lifecycle.test.ts
+++ b/site/src/bfcache-lifecycle.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const read = (path: string): string => readFileSync(new URL(path, import.meta.url), 'utf8');
+
+const viewerSources = [
+  './components/BuiltInCommentViewer.astro',
+  './components/CommentListNavigationDemo.astro',
+  './components/LiveShowcase.astro',
+  './components/ReviewDemo.astro',
+  './lib/demo-snippets.ts',
+  './lib/demos.ts',
+  './pages/selection-context.astro',
+  './pages/try.astro',
+] as const;
+
+describe('official-site viewer BFCache lifecycle', () => {
+  for (const path of viewerSources) {
+    it(`does not destroy persisted viewers in ${path}`, () => {
+      const source = read(path);
+      const pagehideListeners = source.match(/addEventListener\('pagehide'/g) ?? [];
+      const persistedGuards = source.match(/if \(event\.persisted\) return;/g) ?? [];
+      expect(pagehideListeners.length).toBeGreaterThan(0);
+      expect(persistedGuards).toHaveLength(pagehideListeners.length);
+    });
+  }
+});

--- a/site/src/components/BuiltInCommentViewer.astro
+++ b/site/src/components/BuiltInCommentViewer.astro
@@ -155,7 +155,13 @@ const demoId = `built-in-comment-${formats.join('-')}`;
     }));
     const initial = root.dataset.initialFormat as DemoFormat | undefined;
     void show(initial ?? 'docx');
-    window.addEventListener('pagehide', destroy, { once: true });
+    window.addEventListener('pagehide', (event) => {
+      // BFCache restores the existing DOM without rerunning this module. Keep
+      // the Viewer alive while the page is frozen so browser Back can resume
+      // the rendered document instead of restoring an emptied host.
+      if (event.persisted) return;
+      destroy();
+    });
     document.addEventListener('astro:before-swap', destroy, { once: true });
   }
 </script>

--- a/site/src/components/CommentListNavigationDemo.astro
+++ b/site/src/components/CommentListNavigationDemo.astro
@@ -303,7 +303,10 @@ const demoId = 'comment-list-navigation';
     }));
 
     void show((root.dataset.initialFormat as DemoFormat | undefined) ?? 'docx');
-    window.addEventListener('pagehide', destroy, { once: true });
+    window.addEventListener('pagehide', (event) => {
+      if (event.persisted) return;
+      destroy();
+    });
     document.addEventListener('astro:before-swap', destroy, { once: true });
   }
 </script>

--- a/site/src/components/ReviewDemo.astro
+++ b/site/src/components/ReviewDemo.astro
@@ -90,7 +90,10 @@ const { showCode = true } = Astro.props;
     controllers.push(mountReviewDemo(root, url));
   }
   const destroy = () => controllers.forEach((controller) => controller.destroy());
-  window.addEventListener('pagehide', destroy, { once: true });
+  window.addEventListener('pagehide', (event) => {
+    if (event.persisted) return;
+    destroy();
+  });
   document.addEventListener('astro:before-swap', destroy, { once: true });
 </script>
 

--- a/site/src/lib/demo-snippets.ts
+++ b/site/src/lib/demo-snippets.ts
@@ -84,10 +84,11 @@ for (let i = 0; i < ${c.engineVariable}.${c.count}; i++) {
   await ${c.engineVariable}.${c.render}(thumb, i, { width: 200 });
 }
 
-window.addEventListener('pagehide', () => {
+window.addEventListener('pagehide', (event) => {
+  if (event.persisted) return;
   viewer.destroy();
   ${c.engineVariable}.destroy(); // borrowed engines remain caller-owned
-}, { once: true });`,
+});`,
   };
 }
 
@@ -111,22 +112,24 @@ async function openSheetInWindow(sheetIndex: number): Promise<void> {
 
   const viewer = XlsxSheetViewer.fromWorkbook(canvas, workbook);
   viewers.set(popup, viewer);
-  popup.addEventListener('pagehide', () => {
+  popup.addEventListener('pagehide', (event) => {
+    if (event.persisted) return;
     viewer.destroy();
     viewers.delete(popup);
-  }, { once: true });
+  });
 
   await viewer.goToSheet(sheetIndex);
 }
 
 // Example: openSheetInWindow(1) from a sheet button's click handler.
-window.addEventListener('pagehide', () => {
+window.addEventListener('pagehide', (event) => {
+  if (event.persisted) return;
   viewers.forEach((viewer, popup) => {
     viewer.destroy();
     popup.close();
   });
   workbook.destroy();
-}, { once: true });`;
+});`;
 
 export const xlsxSheetSnippet = `import { XlsxViewer } from '@silurus/ooxml/xlsx';
 

--- a/site/src/lib/demos.ts
+++ b/site/src/lib/demos.ts
@@ -254,14 +254,15 @@ function mountSheetWindows(el: HTMLElement, url: string): void {
           open.textContent = 'Rendering…';
           open.disabled = true;
 
-          popup.addEventListener('pagehide', () => {
+          popup.addEventListener('pagehide', (event) => {
+            if (event.persisted) return;
             themeObserver.disconnect();
             viewer.destroy();
             if (sessions.get(index) === session) sessions.delete(index);
             open.textContent = 'Open in window \u2197\uFE0E';
             open.disabled = false;
             closeAll.disabled = sessions.size === 0;
-          }, { once: true });
+          });
 
           viewer.goToSheet(index)
             .then(() => {
@@ -302,7 +303,8 @@ function mountSheetWindows(el: HTMLElement, url: string): void {
 
       st.remove();
       launcher.append(summary, popupError, list);
-      window.addEventListener('pagehide', () => {
+      window.addEventListener('pagehide', (event) => {
+        if (event.persisted) return;
         sessions.forEach(({ popup, viewer, themeObserver }) => {
           themeObserver.disconnect();
           viewer.destroy();
@@ -310,7 +312,7 @@ function mountSheetWindows(el: HTMLElement, url: string): void {
         });
         sessions.clear();
         workbook.destroy();
-      }, { once: true });
+      });
     })
     .catch((error) => { st.textContent = err(error); });
 }
@@ -433,10 +435,11 @@ function mountMasterDetail(el: HTMLElement, format: Format, url: string): void {
       const viewer = makeBorrowedViewer(doc, detailCanvas, 960);
       const detailViewerWrapper = detailCanvas.parentElement as HTMLDivElement;
       detailViewerWrapper.hidden = true;
-      window.addEventListener('pagehide', () => {
+      window.addEventListener('pagehide', (event) => {
+        if (event.persisted) return;
         viewer.destroy();
         doc.engine.destroy();
-      }, { once: true });
+      });
       await viewer.go(0);
       detailCanvas.hidden = false;
       detailViewerWrapper.hidden = false;

--- a/site/src/pages/selection-context.astro
+++ b/site/src/pages/selection-context.astro
@@ -414,11 +414,12 @@ const contextMenuSnippet = `const viewer = new XlsxViewer(container, {
 
     void showFormat('xlsx');
 
-    window.addEventListener('pagehide', () => {
+    window.addEventListener('pagehide', (event) => {
+      if (event.persisted) return;
       loadGeneration++;
       destroyViewer?.();
       destroyViewer = null;
-    }, { once: true });
+    });
   }
 </script>
 

--- a/site/src/pages/try.astro
+++ b/site/src/pages/try.astro
@@ -142,7 +142,10 @@ import BrandIcon from '../components/BrandIcon.astro';
       if (f) void handle(f);
     });
     reset.addEventListener('click', () => { input.value = ''; input.click(); });
-    window.addEventListener('pagehide', disposeRenderedFile, { once: true });
+    window.addEventListener('pagehide', (event) => {
+      if (event.persisted) return;
+      disposeRenderedFile();
+    });
   </script>
 </Base>
 

--- a/site/src/review-ui-docs.test.ts
+++ b/site/src/review-ui-docs.test.ts
@@ -94,6 +94,13 @@ describe('Office comment UI integration guide', () => {
     expect(builtIn).not.toContain('min-height: 640px');
   });
 
+  it('keeps the built-in viewer alive while the page is stored in the back-forward cache', () => {
+    const builtIn = read('./components/BuiltInCommentViewer.astro');
+    expect(builtIn).toContain("window.addEventListener('pagehide', (event) => {");
+    expect(builtIn).toContain('if (event.persisted) return;');
+    expect(builtIn).not.toContain("window.addEventListener('pagehide', destroy, { once: true });");
+  });
+
   it('maps concepts to public APIs and distinguishes transcript from anchored UI', () => {
     const example = read('./examples/review-margin/index.ts');
     for (const api of ['doc.comments', 'getCommentThreads(pageIndex', 'workbook.getComments(sheetIndex)', 'getElementBoundsByIds']) {

--- a/tests/site-dist/viewer-pages.spec.ts
+++ b/tests/site-dist/viewer-pages.spec.ts
@@ -1,4 +1,13 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+
+const docxSample = fileURLToPath(
+  new URL('../../packages/docx/public/demo/sample-1.docx', import.meta.url),
+);
+
+const dispatchPersistedPagehide = (page: Page) => page.evaluate(() => {
+  window.dispatchEvent(new PageTransitionEvent('pagehide', { persisted: true }));
+});
 
 for (const format of ['docx', 'xlsx', 'pptx'] as const) {
   test(`${format.toUpperCase()} live and comment demos initialize`, async ({ page }) => {
@@ -13,6 +22,55 @@ for (const format of ['docx', 'xlsx', 'pptx'] as const) {
     expect(pageErrors).toEqual([]);
   });
 }
+
+test('DOCX comment demo survives browser back', async ({ page }) => {
+  await page.goto('/docx/?all');
+  const status = page.locator('[data-built-in-comment-status]');
+  const viewer = page.locator('[data-built-in-comment-viewer]');
+  await expect(status).toBeHidden({ timeout: 60_000 });
+  await expect(viewer.locator('canvas').first()).toBeVisible();
+
+  // Headless Chrome does not reliably retain localhost pages in BFCache, so
+  // exercise the persisted pagehide branch explicitly before browser Back.
+  await dispatchPersistedPagehide(page);
+  await expect(viewer.locator('canvas').first()).toBeVisible();
+
+  await page.goto('/');
+  await page.goBack();
+
+  await expect(page).toHaveURL(/\/docx\/?\?all$/);
+  await expect(status).toBeHidden({ timeout: 60_000 });
+  await expect(viewer.locator('canvas').first()).toBeVisible();
+});
+
+test('other live viewer screens survive persisted pagehide', async ({ page }) => {
+  await page.goto('/review-ui/');
+  await expect(page.locator('[data-built-in-comment-status]')).toBeHidden({ timeout: 60_000 });
+  await expect(page.locator('[data-comment-list-loading]')).toBeHidden({ timeout: 60_000 });
+  const builtInCanvas = page.locator('[data-built-in-comment-viewer] canvas').first();
+  const listCanvas = page.locator('[data-comment-list-viewer] canvas').first();
+  const listItem = page.locator('[data-comment-list-items] button').first();
+  await expect(builtInCanvas).toBeVisible();
+  await expect(listCanvas).toBeVisible();
+  await expect(listItem).toBeVisible();
+  await dispatchPersistedPagehide(page);
+  await expect(builtInCanvas).toBeVisible();
+  await expect(listCanvas).toBeVisible();
+  await expect(listItem).toBeVisible();
+
+  await page.goto('/selection-context/');
+  const selectionCanvas = page.locator('[data-selection-context-demo] canvas').first();
+  await expect(selectionCanvas).toBeVisible({ timeout: 60_000 });
+  await dispatchPersistedPagehide(page);
+  await expect(selectionCanvas).toBeVisible();
+
+  await page.goto('/try/');
+  await page.locator('#file').setInputFiles(docxSample);
+  const tryCanvas = page.locator('#stage canvas').first();
+  await expect(tryCanvas).toBeVisible({ timeout: 60_000 });
+  await dispatchPersistedPagehide(page);
+  await expect(tryCanvas).toBeVisible();
+});
 
 test('PPTX single-comment margin has no trailing scroll range', async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 720 });


### PR DESCRIPTION
## Summary

- retain official-site viewers and owned models when a page enters the back-forward cache
- cover built-in comments, application-owned review UI, Selection Context, Try Yours, MasterDetail, and XLSX window demos
- keep cleanup for non-persisted exits and align the public lifecycle snippets
- add a cross-site lifecycle audit and production Chrome regressions

## Verification

- 180 site tests passed
- 6 production-site Chrome tests passed
- production site build passed
- git diff --check passed