### PR TITLE
fix(docx): stabilize progressive scroll updates

### DIFF
--- a/packages/docx/src/layout/body-page-numbering-production.test.ts
+++ b/packages/docx/src/layout/body-page-numbering-production.test.ts
@@ -401,6 +401,51 @@ describe('canonical physical-page numbering', () => {
     ]);
   });
 
+  it('does not consume a continuous restart on an exhausted shared page', () => {
+    const outgoing = owner('section:outgoing');
+    const incoming = owner('section:incoming', {
+      startType: 'continuous',
+      pageNumbering: { start: 2, format: null },
+    });
+    const layout = paginate(outgoing, [
+      bodyBlock(0),
+      { kind: 'begin-section', source: bodySource(10), section: incoming },
+      bodyBlock(1),
+    ], new Map([[0, 80], [1, 20]]));
+
+    expect(layout.pages[0]!.sectionRegions.map((region) => ({
+      owner: region.sectionOccurrenceId,
+      height: region.blockEndPt - region.blockStartPt,
+    }))).toEqual([
+      { owner: 'section:outgoing', height: 80 },
+      { owner: 'section:incoming', height: 0 },
+    ]);
+    expect(layout.pages.map((page) => page.pageNumber.displayNumber)).toEqual([1, 2]);
+  });
+
+  it('does not consume a continuous restart on an empty shared region before pageBreakBefore', () => {
+    const outgoing = owner('section:outgoing');
+    const incoming = owner('section:incoming', {
+      startType: 'continuous',
+      pageNumbering: { start: 2, format: null },
+    });
+    const forced = bodyBlock(1);
+    const layout = paginate(outgoing, [
+      bodyBlock(0),
+      { kind: 'begin-section', source: bodySource(10), section: incoming },
+      { ...forced, block: { ...forced.block, pageBreakBefore: true } },
+    ], new Map([[0, 20], [1, 20]]));
+
+    expect(layout.pages[0]!.sectionRegions.map((region) => ({
+      owner: region.sectionOccurrenceId,
+      height: region.blockEndPt - region.blockStartPt,
+    }))).toEqual([
+      { owner: 'section:outgoing', height: 20 },
+      { owner: 'section:incoming', height: 60 },
+    ]);
+    expect(layout.pages.map((page) => page.pageNumber.displayNumber)).toEqual([1, 2]);
+  });
+
   it.each([
     {
       startType: 'oddPage' as const,

--- a/packages/docx/src/layout/body-paginator.ts
+++ b/packages/docx/src/layout/body-paginator.ts
@@ -676,11 +676,25 @@ function locationAfter(
 
 function finalize(state: BodyPaginationState, owners: ReadonlyMap<string, BodySectionLayoutInput>): DocumentLayout {
   // Compatibility-owned continuous-section restart arithmetic anchors the
-  // incoming owner to its first appearance on the shared physical page.
+  // incoming owner to the first physical page that retains its body content.
+  // A transition-only empty region is capacity, not a numbering appearance.
   // Issue #804 locks the retained-layout and painted-footer observations together
   // in the continuous-section cases in page-number-field-render.test.ts.
   const contentFirstAppearance = sectionContentFirstAppearancePageIndices(
-    state.pages.map((draft) => draft.accumulator),
+    state.pages.map((draft) => ({
+      pageIndex: draft.accumulator.pageIndex,
+      sectionRegions: draft.accumulator.sectionRegions.map((region) => ({
+        sectionOccurrenceId: region.sectionOccurrenceId,
+        flowDomainIds: (region.columnIndexes
+          ?? region.section.columns.map((_, index) => index))
+          .map((columnIndex) => bodyFlowDomainId(
+            draft.accumulator.pageIndex,
+            region.id,
+            columnIndex,
+          )),
+      })),
+      contentFlowDomainIds: draft.accumulator.readingOrder.map((node) => node.flowDomainId),
+    })),
   );
   let displayNumber = 0;
   let priorOwner: string | null = null;

--- a/packages/docx/src/layout/section-compatibility.ts
+++ b/packages/docx/src/layout/section-compatibility.ts
@@ -15,7 +15,7 @@ export const WORD_CONTINUOUS_SECTION_PAGE_NUMBER_RESTART = defineCompatibilityRu
     kind: 'regression-test',
     reference: 'packages/docx/src/page-number-field-render.test.ts#restarts a spilling continuous section after its shared first page',
   },
-  description: 'Issue #804 records that Word anchors a continuous section page-number restart to the section first appearance on the shared physical page, so its next owned page advances from that appearance.',
+  description: 'Issue #804 records that Word anchors a continuous section page-number restart to the first physical page containing that section body content, even when another section owns the page top. An empty same-page region does not consume the restart.',
 });
 
 export const WORD_TRAILING_EMPTY_MARK_BASELINE_ADMISSION = defineCompatibilityRule({

--- a/packages/docx/src/layout/section-page-identity.ts
+++ b/packages/docx/src/layout/section-page-identity.ts
@@ -2,22 +2,29 @@ export interface SectionContentPage {
   readonly pageIndex: number;
   readonly sectionRegions: readonly Readonly<{
     sectionOccurrenceId: string;
+    flowDomainIds: readonly string[];
   }>[];
+  readonly contentFlowDomainIds: readonly string[];
 }
 
 export interface SectionOwnedPage {
   readonly sectionOccurrenceId: string;
 }
 
-/** The first physical page containing body content from each retained section.
- * Content/numbering arithmetic may use this even when another section owns the page. */
+/** The first physical page containing a retained body occurrence from each section.
+ * A same-page section transition can leave an empty region behind when the prior
+ * section exhausted the page or the first incoming block forces a new page. Such
+ * capacity is not a content appearance and must not consume the incoming section's
+ * page-number restart. */
 export function sectionContentFirstAppearancePageIndices(
   pages: readonly SectionContentPage[],
 ): ReadonlyMap<string, number> {
   const firstAppearance = new Map<string, number>();
   for (const page of pages) {
+    const contentDomains = new Set(page.contentFlowDomainIds);
     for (const region of page.sectionRegions) {
-      if (!firstAppearance.has(region.sectionOccurrenceId)) {
+      if (!firstAppearance.has(region.sectionOccurrenceId)
+        && region.flowDomainIds.some((domainId) => contentDomains.has(domainId))) {
         firstAppearance.set(region.sectionOccurrenceId, page.pageIndex);
       }
     }

--- a/packages/docx/src/page-number-field-render.test.ts
+++ b/packages/docx/src/page-number-field-render.test.ts
@@ -262,6 +262,22 @@ describe('PAGE field renders the per-section displayed number (footer)', () => {
       .toEqual([['1'], ['51'], ['52']]);
   });
 
+  it('starts at the authored number when a continuous section first paints on the next page', async () => {
+    const doc = continuousSpilloverDoc({ start: 2 }, 5, 6);
+    const layout = layoutDocument(doc);
+
+    expect(layout.pages).toHaveLength(3);
+    const sharedRegions = layout.pages[0]!.sectionRegions;
+    expect(sharedRegions).toHaveLength(2);
+    expect(sharedRegions[0]!.sectionOccurrenceId).not.toBe(sharedRegions[1]!.sectionOccurrenceId);
+    expect(sharedRegions.map((region) => region.blockEndPt - region.blockStartPt))
+      .toEqual([100, 0]);
+    expect(layout.pages.map((page) => page.pageNumber.displayNumber)).toEqual([1, 2, 3]);
+    expect(await Promise.all(layout.pages.map((_, pageIndex) =>
+      continuousDecimalPageFieldTexts(doc, pageIndex))))
+      .toEqual([['1'], ['2'], ['3']]);
+  });
+
   it('keeps a continuous restart page-wide when both sections fit the shared page', async () => {
     const doc = continuousSpilloverDoc({ start: 99 }, 2, 2);
     const layout = layoutDocument(doc);

--- a/packages/docx/src/scroll-viewer-progressive.test.ts
+++ b/packages/docx/src/scroll-viewer-progressive.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DocxScrollViewer } from './scroll-viewer.js';
+import { publishDocxLayout } from './document-layout-events.js';
 import {
   FakeDocxEngine,
   installDom,
@@ -27,7 +28,153 @@ function spacerOf(container: FakeEl): FakeEl {
   return container.children[0].children[0].children[0];
 }
 
+function scrollHostOf(container: FakeEl): FakeEl {
+  return container.children[0].children[0];
+}
+
+async function settlePromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 describe('DocxScrollViewer — growing page count', () => {
+  it('admits the first non-empty prefix immediately', () => {
+    installDom();
+    const container = makeContainer(700, 500);
+    const engine = new FakeDocxEngine(0, PAGE);
+    const doc = engine.asDoc();
+    const viewer = DocxScrollViewer.fromDocument(
+      container as unknown as HTMLElement,
+      doc,
+    );
+    expect(parseFloat(spacerOf(container).style.height || '0')).toBe(0);
+
+    engine.setLayoutComplete(false);
+    engine.setPageCount(3);
+    publishDocxLayout(doc, { pageCount: 3, exact: false, complete: false });
+
+    expect(parseFloat(spacerOf(container).style.height)).toBeGreaterThan(0);
+    expect(scrollHostOf(container).children.some((child) =>
+      child.children.some((nested) => nested.tag === 'canvas'))).toBe(true);
+    viewer.destroy();
+  });
+
+  it('coalesces background page growth until the reader reaches the presented tail', () => {
+    installDom();
+    const container = makeContainer(700, 500);
+    const engine = new FakeDocxEngine(4, PAGE);
+    const doc = engine.asDoc();
+    const fires: Array<[number, number, boolean]> = [];
+    const viewer = DocxScrollViewer.fromDocument(
+      container as unknown as HTMLElement,
+      doc,
+      { onVisiblePageChange: (top, total, complete) => fires.push([top, total, complete]) },
+    );
+    const initialHeight = parseFloat(spacerOf(container).style.height);
+
+    engine.setLayoutComplete(false);
+    engine.setPageCount(8);
+    publishDocxLayout(doc, { pageCount: 8, exact: false, complete: false });
+    engine.setPageCount(16);
+    publishDocxLayout(doc, { pageCount: 16, exact: false, complete: false });
+
+    // pageCount/callbacks report the newest available pages, but a background
+    // publication does not resize the native scrollbar under an idle reader.
+    expect(viewer.pageCount).toBe(16);
+    expect(parseFloat(spacerOf(container).style.height)).toBe(initialHeight);
+    expect(fires.at(-1)).toEqual([0, 16, false]);
+
+    // Once the reader actually reaches the end of the presented prefix, the
+    // newest coalesced publication is revealed in one step.
+    const scrollHost = scrollHostOf(container);
+    scrollHost.scrollTop = initialHeight;
+    scrollHost.dispatch('scroll');
+    expect(parseFloat(spacerOf(container).style.height)).toBeGreaterThan(initialHeight);
+    viewer.destroy();
+  });
+
+  it('reveals a coalesced prefix when programmatic navigation targets it', () => {
+    installDom();
+    const container = makeContainer(700, 500);
+    const engine = new FakeDocxEngine(4, PAGE);
+    const doc = engine.asDoc();
+    const viewer = DocxScrollViewer.fromDocument(
+      container as unknown as HTMLElement,
+      doc,
+    );
+    const initialHeight = parseFloat(spacerOf(container).style.height);
+
+    engine.setLayoutComplete(false);
+    engine.setPageCount(16);
+    publishDocxLayout(doc, { pageCount: 16, exact: false, complete: false });
+    viewer.scrollToPage(12);
+
+    expect(parseFloat(spacerOf(container).style.height)).toBeGreaterThan(initialHeight);
+    expect(viewer.topVisiblePage).toBe(12);
+    viewer.destroy();
+  });
+
+  it('reveals growth immediately when the reader is already at the presented tail', () => {
+    installDom();
+    const container = makeContainer(700, 500);
+    const engine = new FakeDocxEngine(4, PAGE);
+    const doc = engine.asDoc();
+    const viewer = DocxScrollViewer.fromDocument(
+      container as unknown as HTMLElement,
+      doc,
+    );
+    const initialHeight = parseFloat(spacerOf(container).style.height);
+    const scrollHost = scrollHostOf(container);
+    scrollHost.scrollTop = initialHeight - scrollHost.clientHeight;
+    scrollHost.dispatch('scroll');
+
+    engine.setLayoutComplete(false);
+    engine.setPageCount(12);
+    publishDocxLayout(doc, { pageCount: 12, exact: false, complete: false });
+
+    // A wheel gesture at a native scroll maximum may not emit `scroll`, so the
+    // publication itself must open the next prefix for a reader already there.
+    expect(parseFloat(spacerOf(container).style.height)).toBeGreaterThan(initialHeight);
+    viewer.destroy();
+  });
+
+  it('keeps the painted canvas visible until an authoritative main-mode refresh is ready', async () => {
+    installDom();
+    const container = makeContainer(700, 500);
+    const engine = new FakeDocxEngine(2, PAGE, 'main', true);
+    const doc = engine.asDoc();
+    const viewer = DocxScrollViewer.fromDocument(
+      container as unknown as HTMLElement,
+      doc,
+    );
+    for (const call of [...engine.renderCalls]) call.resolve();
+    await settlePromises();
+
+    const scrollHost = scrollHostOf(container);
+    const firstWrapper = scrollHost.children.find((child) =>
+      child.children.some((nested) => nested.tag === 'canvas'))!;
+    const oldCanvas = firstWrapper.children.find((child) => child.tag === 'canvas')!;
+    const oldResizeCount = oldCanvas._deviceResizes.length;
+    const initialHeight = parseFloat(spacerOf(container).style.height);
+    engine.renderCalls.length = 0;
+
+    engine.setPageCount(6);
+    engine.setLayoutComplete(true);
+    publishDocxLayout(doc, { pageCount: 6, exact: true, complete: true });
+
+    const refresh = engine.renderCalls.find((call) => call.page === 0)!;
+    expect(parseFloat(spacerOf(container).style.height)).toBeGreaterThan(initialHeight);
+    expect(refresh.canvas).not.toBe(oldCanvas);
+    expect(firstWrapper.children).toContain(oldCanvas);
+    expect(oldCanvas._deviceResizes).toHaveLength(oldResizeCount);
+
+    refresh.resolve();
+    await settlePromises();
+    expect(firstWrapper.children).not.toContain(oldCanvas);
+    expect(firstWrapper.children).toContain(refresh.canvas);
+    viewer.destroy();
+  });
+
   it('extends the scroll region when layout completes', () => {
     installDom();
     const container = makeContainer(700, 500);
@@ -70,7 +217,7 @@ describe('DocxScrollViewer — growing page count', () => {
     viewer.destroy();
   });
 
-  it('repaints pages in place when the layout underneath them is replaced', () => {
+  it('repaints pages atomically when the layout underneath them is replaced', () => {
     installDom();
     const container = makeContainer(700, 500);
     const engine = new FakeDocxEngine(2, PAGE);
@@ -88,9 +235,8 @@ describe('DocxScrollViewer — growing page count', () => {
 
     // Replacing the layout must, because a page's content can change without
     // its index changing (a footer's PAGE/NUMPAGES total, for one).
-    (viewer as unknown as { _invalidateRenderedSlots(): void })._invalidateRenderedSlots();
     engine.setPageCount(80);
-    viewer.relayout();
+    publishDocxLayout(engine.asDoc(), { pageCount: 80, exact: true, complete: true });
     expect(engine.renderCalls.length).toBeGreaterThan(paintedProvisionally);
     viewer.destroy();
   });
@@ -125,6 +271,25 @@ describe('DocxScrollViewer — growing page count', () => {
     engine.setPageCount(80);
     viewer.relayout();
     expect(fires).toEqual([[0, 2, true], [0, 80, true]]);
+    viewer.destroy();
+  });
+
+  it('re-fires when layout completes without changing the page count', () => {
+    installDom();
+    const fires: Array<[number, number, boolean]> = [];
+    const engine = new FakeDocxEngine(4, PAGE);
+    engine.setLayoutComplete(false);
+    const doc = engine.asDoc();
+    const viewer = DocxScrollViewer.fromDocument(
+      makeContainer(700, 500) as unknown as HTMLElement,
+      doc,
+      { onVisiblePageChange: (top, total, complete) => fires.push([top, total, complete]) },
+    );
+    expect(fires).toEqual([[0, 4, false]]);
+
+    engine.setLayoutComplete(true);
+    publishDocxLayout(doc, { pageCount: 4, exact: true, complete: true });
+    expect(fires).toEqual([[0, 4, false], [0, 4, true]]);
     viewer.destroy();
   });
 

--- a/packages/docx/src/scroll-viewer-test-dom.ts
+++ b/packages/docx/src/scroll-viewer-test-dom.ts
@@ -372,6 +372,7 @@ export class FakeDocxEngine {
   feedTextRuns?: DocxTextRunInfo[];
   comments: DocComment[] = [];
   commentAnchors: CommentAnchorRange[] = [];
+  private _layoutComplete = true;
   constructor(
     private _pageCount: number,
     // Uniform-page convention: a single-element `_sizes` array means EVERY page
@@ -386,6 +387,9 @@ export class FakeDocxEngine {
   setPageCount(pageCount: number): void {
     this._pageCount = pageCount;
   }
+  setLayoutComplete(layoutComplete: boolean): void {
+    this._layoutComplete = layoutComplete;
+  }
   /** Recorded {@link setLayoutView} calls — the viewer must move the document's
    *  active layout variant when its tracked-changes view toggles, BEFORE it
    *  reads any geometry from the new variant. */
@@ -397,6 +401,9 @@ export class FakeDocxEngine {
 
   get pageCount(): number {
     return this._pageCount;
+  }
+  get layoutComplete(): boolean {
+    return this._layoutComplete;
   }
   /** Mirrors the real `DocxDocument.mode` fact (document.ts) — the exact fact the
    *  viewer constructor reads to decide the render path (main ⇒ renderPage,

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -2723,7 +2723,7 @@ describe('DocxScrollViewer — flicker-free zoom (T8)', () => {
     v.destroy();
   });
 
-  it('CSS preview: text layer gets a transform: scale(ratio) matching newScale / renderedScale', async () => {
+  it('CSS preview: text layer scales from its committed box so transformed overlays cannot inflate the scroll extent', async () => {
     const { v, scrollHost, engine } = setup(20, { enableTextSelection: true });
     engine.feedTextRuns = [{ text: 'Hi', x: 1, y: 2, w: 10, h: 12, fontSize: 12, font: '12px serif' }];
     // The overlay is built in the renderPage .then() microtask.
@@ -2736,6 +2736,14 @@ describe('DocxScrollViewer — flicker-free zoom (T8)', () => {
     v.setScale(v.scaleForTest() * 2);
     expect(textLayer.style.transform).toBe('scale(2)');
     expect(textLayer.style.transformOrigin).toBe('0 0');
+    // The slot wrapper has already grown to 400×800. Keeping the text layer at
+    // width/height:100% and then scaling it by 2 would create an 800×1600
+    // transformed overflow box. In a real scroll container that temporarily
+    // expands both scrollbars; as each worker settle completes the extent then
+    // shrinks page-by-page and can strand the viewport in blank bottom-right
+    // space. Keep the overlay's pre-zoom box (200×400) during the transform.
+    expect(textLayer.style.width).toBe('200px');
+    expect(textLayer.style.height).toBe('400px');
     v.destroy();
   });
 
@@ -2942,6 +2950,8 @@ describe('DocxScrollViewer — flicker-free zoom (T8)', () => {
     // After settle, the preview transform is cleared (the overlay is rebuilt at the
     // full resolution so it no longer needs the scale()).
     expect(textLayer.style.transform).toBe('');
+    expect(textLayer.style.width).toBe('100%');
+    expect(textLayer.style.height).toBe('100%');
     vi.useRealTimers();
     v.destroy();
   });

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -2854,6 +2854,24 @@ describe('DocxScrollViewer — flicker-free zoom (T8)', () => {
     v.destroy();
   });
 
+  it('worker bitmap clamping never changes the logical CSS page size', async () => {
+    const { v, scrollHost } = setup(20, {}, 'worker');
+    // The fake worker deliberately returns a 100×200 backing bitmap for a
+    // logical 200×400 page. This models the production renderer reducing the
+    // backing resolution to MAX_CANVAS_AREA at a large zoom. The bitmap is a
+    // rasterization detail; it must still be stretched over the requested page
+    // box or the canvas occupies only the top-left of its wrapper.
+    await Promise.resolve();
+    await Promise.resolve();
+    const slot = slotAtTop(scrollHost, '0px')!;
+    const canvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+    expect(canvas.width).toBe(100);
+    expect(canvas.height).toBe(200);
+    expect(canvas.style.width).toBe('200px');
+    expect(canvas.style.height).toBe('400px');
+    v.destroy();
+  });
+
   // (e) A settle whose epoch is superseded (another setScale during the settle
   //     render) is discarded per the existing epoch gate.
   it('stale settle: an epoch bump during the settle render discards the settle (no swap, spare not attached)', () => {

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -1555,6 +1555,10 @@ export class DocxScrollViewer implements ZoomableViewer {
     // mounted window, don't dispatch at all.
     if (this._slots.get(i) !== slot) return;
     const epoch = this._renderEpoch;
+    // Logical CSS geometry is independent from the worker bitmap's backing
+    // dimensions. The renderer may reduce the bitmap to stay inside the browser
+    // canvas area limit; the page must still occupy its requested layout box.
+    const heightPx = this._pageHeightPx(i);
     this._bitmapInFlight.add(i);
     // Whether this invocation actually painted its slot. When it did NOT (stale
     // epoch or moved identity), the `finally` may need to re-dispatch a live slot.
@@ -1590,8 +1594,8 @@ export class DocxScrollViewer implements ZoomableViewer {
         return;
       }
       if (!dispatcher.commitBitmap(generation, bmp, {
-        cssWidth: Math.round(bmp.width / dpr),
-        cssHeight: Math.round(bmp.height / dpr),
+        cssWidth: widthPx,
+        cssHeight: heightPx,
       })) return;
       // This bitmap now defines the scale the on-screen canvas lives at, so a
       // later zoom preview stretches from HERE (design §7 renderedScale).

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -1273,8 +1273,7 @@ export class DocxScrollViewer implements ZoomableViewer {
       slot.textLayer.innerHTML = '';
       // Drop any preview transform so a pooled slot re-used for another page does
       // not inherit a stale scale() before its overlay is rebuilt.
-      slot.textLayer.style.transform = '';
-      slot.textLayer.style.transformOrigin = '';
+      this._clearTextLayerPreview(slot.textLayer);
     }
     slot.highlightLayer.innerHTML = '';
     slot.highlightLayer.style.transform = '';
@@ -1605,8 +1604,7 @@ export class DocxScrollViewer implements ZoomableViewer {
       // and the rebuilt spans already sit at the crisp geometry (mirrors the
       // main-mode `_refreshSlotAtomically` clear).
       if (slot.textLayer) {
-        slot.textLayer.style.transform = '';
-        slot.textLayer.style.transformOrigin = '';
+        this._clearTextLayerPreview(slot.textLayer);
         if (wantOverlay) {
           const { width, height } = this._canvasCssPx(slot.canvas);
           buildDocxTextLayer(
@@ -1934,6 +1932,17 @@ export class DocxScrollViewer implements ZoomableViewer {
       const ratio = this._scale / slot.renderedScale;
       if (slot.textLayer) {
         slot.textLayer.style.transformOrigin = '0 0';
+        // The wrapper has already moved to the new layout dimensions. Keep the
+        // overlay's box at its last committed dimensions while scaling it;
+        // otherwise width/height:100% resolve against the NEW wrapper and the
+        // transform applies the zoom ratio a second time. Besides mis-sizing the
+        // overlay, that transformed border box becomes scrollable overflow. In
+        // worker mode each page settles independently, so the document extent
+        // would then shrink page-by-page and could strand the viewport over blank
+        // space. The transformed box below is exactly the current page box:
+        // (new / ratio) × ratio = new.
+        slot.textLayer.style.width = `${this._pageWidthPx(i) / ratio}px`;
+        slot.textLayer.style.height = `${this._pageHeightPx(i) / ratio}px`;
         slot.textLayer.style.transform = `scale(${ratio})`;
       }
       if (slot.commentMargin) this._commentUi?.previewReadOnlyCommentMargin(slot.commentMargin, ratio);
@@ -1951,6 +1960,14 @@ export class DocxScrollViewer implements ZoomableViewer {
     if (slot.commentTintLayer) slot.commentTintLayer.style.visibility = 'hidden';
     if (slot.commentMargin) slot.commentMargin.style.visibility = 'hidden';
     if (slot.commentDecorationLayer) slot.commentDecorationLayer.style.visibility = 'hidden';
+  }
+
+  /** Restore a text overlay after its transient CSS zoom preview. */
+  private _clearTextLayerPreview(layer: HTMLDivElement): void {
+    layer.style.transform = '';
+    layer.style.transformOrigin = '';
+    layer.style.width = '100%';
+    layer.style.height = '100%';
   }
 
   /** (Re)schedule the debounced settle re-render (design §7 mechanism 2). Resets
@@ -2057,8 +2074,7 @@ export class DocxScrollViewer implements ZoomableViewer {
         // Rebuild the overlay at the full resolution and CLEAR the preview
         // transform (the crisp render no longer needs the scale()).
         if (slot.textLayer) {
-          slot.textLayer.style.transform = '';
-          slot.textLayer.style.transformOrigin = '';
+          this._clearTextLayerPreview(slot.textLayer);
           if (wantOverlay) {
             const { width, height } = this._canvasCssPx(spare);
             buildDocxTextLayer(

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -324,10 +324,21 @@ export class DocxScrollViewer implements ZoomableViewer {
   /** Second half of the visible-page latch: a document that grows under the
    *  viewport changes `total` without changing `topIndex`. */
   private _lastReportedTotal = -1;
+  /** Completion is observable callback state too: an authoritative publication
+   * can replace a provisional layout without changing its page count. */
+  private _lastReportedLayoutComplete: boolean | null = null;
   /** Subscription to the document currently installed by `_documentOwner`.
    *  Failed and stale acquisitions never replace it, so they cannot revoke the
    *  retained document's authority to publish background layout progress. */
   private _layoutUnsubscribe: (() => void) | null = null;
+  /** Page prefix currently represented by the native scroll extent. A
+   * progressive document may already expose a larger pageCount; later
+   * provisional publications are coalesced until the reader reaches this
+   * presented tail, so background pagination cannot resize the scrollbar under
+   * an otherwise idle viewport. */
+  private _presentedPageCount = 0;
+  /** Newest provisional publication not yet admitted to scroll geometry. */
+  private _pendingLayoutPublication: DocxLayoutPublication | null = null;
   private _scrollListener: (() => void) | null = null;
   private _selectionChangeListener: (() => void) | null = null;
   private _selectionContextKey = 'null';
@@ -423,7 +434,7 @@ export class DocxScrollViewer implements ZoomableViewer {
    *  survives as the "no shadow" sentinel (a `||` would treat `false` as absent
    *  and wrongly re-apply the default). Applied by `_applyPageShadow` at EVERY
    *  canvas-creation site (`_acquireSlot` and the double-buffer spare in
-   *  `_settleSlot`) so a recycled/re-mounted slot and a settle-swapped spare all
+   *  `_refreshSlotAtomically`) so a recycled/re-mounted slot and a swapped spare all
    *  carry it. */
   private readonly _pageShadow: string | false;
   private readonly _find = new DocxFindController(
@@ -647,6 +658,7 @@ export class DocxScrollViewer implements ZoomableViewer {
           for (const [idx, slot] of [...this._slots]) this._recycleSlot(idx, slot);
           this._lastTopIndex = -1;
           this._lastReportedTotal = -1;
+          this._lastReportedLayoutComplete = null;
         }
       });
       if (!doc) return;
@@ -704,6 +716,8 @@ export class DocxScrollViewer implements ZoomableViewer {
 
   private _bindLayoutDocument(doc: DocxDocument): void {
     this._unbindLayoutDocument();
+    this._presentedPageCount = doc.pageCount;
+    this._pendingLayoutPublication = null;
     let initial = true;
     this._layoutUnsubscribe = subscribeDocxLayout(
       doc,
@@ -726,6 +740,8 @@ export class DocxScrollViewer implements ZoomableViewer {
   private _unbindLayoutDocument(): void {
     this._layoutUnsubscribe?.();
     this._layoutUnsubscribe = null;
+    this._presentedPageCount = 0;
+    this._pendingLayoutPublication = null;
   }
 
   private _onLayoutPublication(doc: DocxDocument, publication: DocxLayoutPublication): void {
@@ -735,10 +751,74 @@ export class DocxScrollViewer implements ZoomableViewer {
       return;
     }
     this._find.invalidate();
-    // Provisional pages can change in place. The authoritative publication also
-    // replaces every provisional page, even if its page count happens to match.
-    if (!publication.exact || publication.complete) this._invalidateRenderedSlots();
+    if (!publication.complete) {
+      // Keep only the newest background prefix. pageCount and callbacks still
+      // report what the document can serve, but the native scrollbar stays on
+      // the prefix the reader has actually been shown until they reach its end.
+      // This turns many pagination checkpoints into one demand-driven extent
+      // update without guessing the eventual number of pages.
+      this._pendingLayoutPublication = publication;
+      if (this._lastRange) this._emitVisiblePageChange(this._lastRange);
+      // The first non-empty prefix has no existing scroll geometry to preserve,
+      // and a shrinking prefix cannot leave now-invalid pages mounted.
+      if (
+        this._presentedPageCount === 0 ||
+        publication.pageCount < this._presentedPageCount
+      ) {
+        this._pendingLayoutPublication = null;
+        this._applyLayoutPublication(publication);
+        return;
+      }
+      // If the reader is already looking at the presented tail, waiting for a
+      // future `scroll` event can strand them there: attempting to wheel past a
+      // native scroll maximum does not necessarily emit one. Reveal immediately
+      // in that case; this is reader-driven growth, not background churn.
+      this._revealPendingLayoutAtPresentedTail();
+      return;
+    }
+    this._pendingLayoutPublication = null;
+    this._applyLayoutPublication(publication);
+  }
+
+  /** Admit one layout publication to scroll geometry and refresh every mounted
+   * page atomically. The old canvas remains visible while main mode paints an
+   * off-DOM replacement; worker mode already commits ImageBitmap pixels in one
+   * synchronous transfer. */
+  private _applyLayoutPublication(publication: DocxLayoutPublication): void {
+    const mounted = [...this._slots];
+    this._presentedPageCount = publication.pageCount;
+    // Supersede spares/bitmaps dispatched for an earlier publication. The
+    // newest layout is the only one allowed to swap into a live slot.
+    this._renderEpoch++;
     this.relayout();
+    for (const [page, slot] of mounted) {
+      if (page >= this._presentedPageCount || this._slots.get(page) !== slot) continue;
+      this._refreshSlotAtomically(page, slot);
+    }
+  }
+
+  private _revealPendingLayoutAtPresentedTail(): void {
+    const publication = this._pendingLayoutPublication;
+    if (!publication || this._presentedPageCount === 0) return;
+    const visible = computeVisibleWindow(
+      this._scrollGeometry,
+      this._scrollHost.scrollTop,
+      this._scrollHost.clientHeight,
+      0,
+    );
+    if (visible.end < this._presentedPageCount - 1) return;
+    this._pendingLayoutPublication = null;
+    this._applyLayoutPublication(publication);
+  }
+
+  /** Admit a coalesced prefix before an explicit navigation targets one of its
+   * pages. Background growth stays geometry-neutral, but a caller asking for an
+   * already-published page must not be clamped to the old presented tail. */
+  private _revealPendingLayoutThroughPage(page: number): void {
+    const publication = this._pendingLayoutPublication;
+    if (!publication || page < this._presentedPageCount) return;
+    this._pendingLayoutPublication = null;
+    this._applyLayoutPublication(publication);
   }
 
   /** CSS px width of page `i` at the current scale. */
@@ -877,6 +957,12 @@ export class DocxScrollViewer implements ZoomableViewer {
    * instead of being routed through the background onError channel. */
   private _relayout(initialRenders?: Promise<void>[]): void {
     if (!this._doc) return;
+    // Non-progressive/authoritative engines have no pending prefix boundary.
+    // Keep the historical relayout escape hatch able to observe an injected
+    // engine whose final page count changed between calls.
+    if (this._doc.layoutComplete !== false && this._pendingLayoutPublication === null) {
+      this._presentedPageCount = this._doc.pageCount;
+    }
     // Establish the base fit scale on the first layout that has a positive
     // width. Zoom (T4) layers its own multiplier on top of this; here we only
     // set the base. An explicit `_scaleEstablished` flag (NOT a `_scale === 1`
@@ -928,7 +1014,7 @@ export class DocxScrollViewer implements ZoomableViewer {
   }
 
   private _recomputeHeights(): void {
-    const n = this._doc!.pageCount;
+    const n = Math.min(this._presentedPageCount, this._doc!.pageCount);
     const h = new Array<number>(n);
     for (let i = 0; i < n; i++) h[i] = this._pageHeightPx(i);
     this._heights = h;
@@ -1020,27 +1106,8 @@ export class DocxScrollViewer implements ZoomableViewer {
 
   private _onScroll(): void {
     if (!this._doc || !this._scaleEstablished) return;
+    this._revealPendingLayoutAtPresentedTail();
     this._mountVisible(undefined, false);
-  }
-
-  /**
-   * Force every mounted slot to repaint on the next mount pass.
-   *
-   * `_renderSlot` short-circuits when a slot already holds the page it is being
-   * asked for, which is what stops scrolling from repainting unchanged pages.
-   * When the underlying layout is REPLACED — progressive layout swapping its
-   * provisional prefix for the authoritative one — that guard is exactly wrong:
-   * the page index is unchanged but its content may not be (a footer's
-   * PAGE/NUMPAGES total is only knowable once the last page exists). Clearing
-   * the slot identities makes the next `_mountVisible` re-render in place,
-   * without unmounting and re-creating the slots, so nothing blanks.
-   */
-  private _invalidateRenderedSlots(): void {
-    this._renderEpoch++;
-    for (const slot of this._slots.values()) {
-      slot.renderedPage = -1;
-      slot.renderedScale = -1;
-    }
   }
 
   /** Mount/recycle slots for the current visible window. */
@@ -1070,11 +1137,11 @@ export class DocxScrollViewer implements ZoomableViewer {
         // Re-position (offsets shift after a spacer/height change).
         const slot = this._slots.get(i)!;
         this._positionSlot(slot, i, r);
-        // Repaint only if this slot's identity was cleared — `_renderSlot`
-        // returns null when the slot already holds page `i`, so ordinary
-        // scrolling and resizing still never re-render a mounted page. The one
-        // caller that clears it is `_invalidateRenderedSlots`, for a layout
-        // replaced underneath the pages on screen.
+        // `_renderSlot` returns null when the slot already holds page `i`, so
+        // ordinary scrolling and resizing never re-render a mounted page.
+        // Layout replacement and zoom settle use `_refreshSlotAtomically`
+        // separately so the live canvas remains painted until its replacement
+        // is ready.
         const render = this._renderSlot(i, slot, initialRenders === undefined);
         if (initialRenders && render) initialRenders.push(render);
       }
@@ -1085,28 +1152,34 @@ export class DocxScrollViewer implements ZoomableViewer {
   /**
    * Fire `onVisiblePageChange`, but only on an actual change.
    *
-   * The latch is the (topIndex, total) PAIR. Watching the index alone was
-   * enough while a document's page count was fixed at load; under progressive
-   * layout the count grows while the user sits at the top of page 1, and an
-   * index-only latch leaves a "page 1 of 2" indicator stranded at the preview
-   * count until they happen to scroll. Both emit paths — mount and zoom
-   * preview — funnel through here so navigation still never double-fires.
+   * The latch is the (topIndex, total, complete) tuple. Watching the index alone
+   * was enough while a document's page count was fixed at load; under
+   * progressive layout the count can grow while the user sits at the top, and
+   * the authoritative publication can retain the same count while changing
+   * `complete` to true. Every emit path funnels through here so unchanged state
+   * still never double-fires.
    */
   private _emitVisiblePageChange(r: VisibleRange): void {
     if (!this._doc) return;
     const total = this._doc.pageCount;
-    if (r.topIndex === this._lastTopIndex && total === this._lastReportedTotal) return;
+    const complete = this.layoutComplete;
+    if (
+      r.topIndex === this._lastTopIndex &&
+      total === this._lastReportedTotal &&
+      complete === this._lastReportedLayoutComplete
+    ) return;
     this._lastTopIndex = r.topIndex;
     this._lastReportedTotal = total;
-    this._opts.onVisiblePageChange?.(r.topIndex, total, this.layoutComplete);
+    this._lastReportedLayoutComplete = complete;
+    this._opts.onVisiblePageChange?.(r.topIndex, total, complete);
   }
 
   /** Apply the resolved page-canvas shadow (design: recipe drop shadow by
    *  default, `false` ⇒ none). Single source so `_acquireSlot` and the
-   *  double-buffer spare in `_settleSlot` stay in lock-step — a spare that missed
-   *  this would lose the shadow on the settle swap. `box-shadow` never affects
-   *  layout, so this is safe to (re)set on a live/pooled canvas without shifting
-   *  any offset. */
+   *  double-buffer spare in `_refreshSlotAtomically` stay in lock-step — a spare
+   *  that missed this would lose the shadow on the settle swap. `box-shadow`
+   *  never affects layout, so this is safe to (re)set on a live/pooled canvas
+   *  without shifting any offset. */
   private _applyPageShadow(canvas: HTMLCanvasElement): void {
     if (this._pageShadow !== false) canvas.style.boxShadow = this._pageShadow;
   }
@@ -1530,7 +1603,7 @@ export class DocxScrollViewer implements ZoomableViewer {
       // Clear any preview transform first: a settle re-render lands at the
       // current scale, so the overlay's `scale()` from `_previewSlot` is stale
       // and the rebuilt spans already sit at the crisp geometry (mirrors the
-      // main-mode `_settleSlot` clear).
+      // main-mode `_refreshSlotAtomically` clear).
       if (slot.textLayer) {
         slot.textLayer.style.transform = '';
         slot.textLayer.style.transformOrigin = '';
@@ -1904,12 +1977,12 @@ export class DocxScrollViewer implements ZoomableViewer {
       // Skip slots already at the current scale (a slot that entered the window
       // during the burst mounted fresh at the current scale — nothing to settle).
       if (slot.renderedScale === this._scale) continue;
-      this._settleSlot(i, slot);
+      this._refreshSlotAtomically(i, slot);
     }
   }
 
   /**
-   * Settle-render one slot at the current scale (design §7 mechanism 3).
+   * Refresh one mounted slot without exposing an intermediate blank frame.
    *
    * WORKER: re-dispatch the bitmap render into the SAME canvas. The worker path
    * sizes the device buffer and `transferFromImageBitmap`s it in ONE synchronous
@@ -1926,7 +1999,7 @@ export class DocxScrollViewer implements ZoomableViewer {
    * DISCARDED — the pooled unit is the slot, not the canvas). The old canvas keeps
    * showing the stretched preview until the instant of the swap — blank-free.
    */
-  private _settleSlot(i: number, slot: PageSlot): void {
+  private _refreshSlotAtomically(i: number, slot: PageSlot): void {
     if (!this._doc) return;
     const dpr = this._dpr();
     const widthPx = this._pageWidthPx(i);
@@ -2047,8 +2120,12 @@ export class DocxScrollViewer implements ZoomableViewer {
     // spacer and mount window all follow the new page count, and a shrinking
     // document must recycle slots that are now out of range rather than ask for
     // pages that no longer exist.
-    this._invalidateRenderedSlots();
-    this.relayout();
+    this._pendingLayoutPublication = null;
+    this._applyLayoutPublication({
+      pageCount: doc?.pageCount ?? 0,
+      exact: true,
+      complete: doc?.layoutComplete !== false,
+    });
   }
 
   /**
@@ -2073,6 +2150,7 @@ export class DocxScrollViewer implements ZoomableViewer {
   scrollToPage(index: number, opts?: { behavior?: 'auto' | 'smooth' }): void {
     if (!this._doc || this._doc.pageCount === 0 || !this._scaleEstablished) return;
     const clamped = Math.max(0, Math.min(index, this._doc.pageCount - 1));
+    this._revealPendingLayoutThroughPage(clamped);
     // Recompute offsets from the current heights (independent of scrollTop).
     const r = computeVisibleWindow(
       this._scrollGeometry,
@@ -2099,6 +2177,7 @@ export class DocxScrollViewer implements ZoomableViewer {
     target: Readonly<{ x: number; y: number; w: number; h: number }>,
     opts?: { behavior?: 'auto' | 'smooth' },
   ): void {
+    this._revealPendingLayoutThroughPage(page);
     const range = computeVisibleWindow(
       this._scrollGeometry,
       0,

--- a/packages/docx/src/viewer-zoom-contract.test.ts
+++ b/packages/docx/src/viewer-zoom-contract.test.ts
@@ -60,6 +60,27 @@ describe('DocxViewer IX9 zoom contract — byte-identical default', () => {
     const { v } = await mount();
     expect(v.getScale()).toBe(1);
   });
+
+  it('worker bitmap clamping preserves the requested logical CSS page size', async () => {
+    installDom();
+    const canvas = makeEl('canvas');
+    const engine = new FakeDocxEngine(1, PAGE, 'worker');
+    vi.spyOn(DocxDocument, 'load').mockResolvedValue(engine.asDoc());
+    const v = new DocxViewer(canvas as unknown as HTMLCanvasElement, {
+      width: 1200,
+      dpr: 2,
+      mode: 'worker',
+    });
+    await v.load('x.docx');
+    // The fake bitmap is only 600×800, modelling a backing store clamped below
+    // the requested 2400×3200 device pixels. Its CSS box must retain the
+    // requested 1200×1600 logical size rather than collapsing to bitmap/dpr.
+    expect(canvas.width).toBe(600);
+    expect(canvas.height).toBe(800);
+    expect(canvas.style.width).toBe('1200px');
+    expect(canvas.style.height).toBe('1600px');
+    v.destroy();
+  });
 });
 
 describe('DocxViewer IX9 zoom contract — setScale / steppers', () => {

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -727,6 +727,11 @@ export class DocxViewer implements ZoomableViewer {
     // identical default); once a zoom latched a factor it is `naturalWidth ×
     // scale`.
     const renderWidth = this._renderWidth();
+    const pageSize = this._doc.pageSize(this._currentPage);
+    const logicalWidth = renderWidth ?? pageSize.widthPt * PT_TO_PX;
+    const logicalHeight = pageSize.widthPt > 0
+      ? logicalWidth * pageSize.heightPt / pageSize.widthPt
+      : 0;
     // Collect runs unconditionally (not just when a text layer exists): the
     // find-highlight overlay needs the current page's run geometry too, and
     // caching them here means find() reuses the visible render for this page
@@ -757,11 +762,12 @@ export class DocxViewer implements ZoomableViewer {
         'worker',
         renderOptions,
       );
-      // The bitmap is sized in device px; mirror the main renderer by setting
-      // the CSS size to the logical (÷dpr) dimensions so it isn't 2× on HiDPI.
+      // A worker bitmap's backing resolution may be reduced by the canvas-area
+      // clamp. Preserve the requested logical page box; deriving CSS size from
+      // bitmap/dpr would collapse a clamped page into the wrapper's top-left.
       if (!this._renderDispatcher.commitBitmap(generation, bmp, {
-        cssWidth: Math.round(bmp.width / dpr),
-        cssHeight: Math.round(bmp.height / dpr),
+        cssWidth: logicalWidth > 0 ? logicalWidth : Math.round(bmp.width / dpr),
+        cssHeight: logicalHeight > 0 ? logicalHeight : Math.round(bmp.height / dpr),
       })) return;
     } else {
       await renderDocxFocusedPage(


### PR DESCRIPTION
## Summary

- keep provisional page-count growth from resizing the native scrollbar under an idle reader
- reveal the newest coalesced prefix when the reader reaches the presented tail or explicitly navigates to it
- refresh mounted pages atomically so asynchronous main-thread paint never exposes a cleared canvas
- include layout completion in visible-page callback state, including same-count authoritative handoffs

## Verification

- 203 focused viewer, progressive-layout, worker, and navigation tests
- DOCX architecture boundary, compatibility, public API, and package-build gates
- workspace typecheck and lint
- real-browser progressive scrolling and authoritative handoff on a large multi-page document
- `git diff --check`