### PR TITLE
fix(xlsx): hide default viewport focus ring

### DIFF
--- a/packages/xlsx/src/sheet-viewer.test.ts
+++ b/packages/xlsx/src/sheet-viewer.test.ts
@@ -1121,7 +1121,7 @@ describe('XlsxSheetViewer canvas mount', () => {
       '[data-xlsx-viewport-input]:focus{outline:none}',
     );
     expect(viewerStyle?.textContent).toContain(
-      '[data-xlsx-viewport-input]:focus-visible{outline:2px solid var(--ooxml-xlsx-focus-ring,#2563eb);outline-offset:-2px}',
+      '[data-xlsx-viewport-input]:focus-visible{outline:2px solid var(--ooxml-xlsx-focus-ring,transparent);outline-offset:-2px}',
     );
     expect(openerDocument.head.querySelector('style[data-xlsx-viewer-styles]')).toBeNull();
     const viewportInput = mounted.find((element) => element.hasAttribute('data-xlsx-viewport-input')) as FakeEl;

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -154,10 +154,10 @@ const VIEWER_STYLE_ATTR = 'data-xlsx-viewer-styles';
 const VIEWER_STYLE_CSS =
   `.xlsx-tab-strip::-webkit-scrollbar{display:none}` +
   // The viewport remains focusable so copy shortcuts belong to the active
-  // Viewer. Pointer focus stays quiet, while keyboard focus remains visible at
-  // the viewport boundary and distinct from the selected-cell border.
+  // Viewer. Focus stays quiet by default; consumers can opt into a keyboard
+  // focus ring without conflating it with the selected-cell border.
   `[data-xlsx-viewport-input]:focus{outline:none}` +
-  `[data-xlsx-viewport-input]:focus-visible{outline:2px solid var(--ooxml-xlsx-focus-ring,#2563eb);outline-offset:-2px}` +
+  `[data-xlsx-viewport-input]:focus-visible{outline:2px solid var(--ooxml-xlsx-focus-ring,transparent);outline-offset:-2px}` +
   `.xlsx-tab-nav{background:transparent;transition:background 0.1s;}` +
   `.xlsx-tab-nav:hover{background:color-mix(in srgb,var(--ooxml-xlsx-chrome-text,#444) 8%,transparent);}` +
   // Excel-status-bar zoom slider: a thin uniform gray track (no colored

--- a/site/src/components/XlsxChromeThemeGuide.astro
+++ b/site/src/components/XlsxChromeThemeGuide.astro
@@ -38,7 +38,7 @@ const properties = [
   ['--ooxml-xlsx-chrome-selection-background', 'Strong row or column header selection.'],
   ['--ooxml-xlsx-chrome-accent', 'Selected-header border accent.'],
   ['--ooxml-xlsx-chrome-scrollbar-color', 'Native scrollbar thumb and track; use the CSS scrollbar-color syntax.'],
-  ['--ooxml-xlsx-focus-ring', 'Keyboard focus outline around the worksheet viewport.'],
+  ['--ooxml-xlsx-focus-ring', 'Optional keyboard focus outline around the worksheet viewport; transparent when unset.'],
 ] as const;
 ---
 


### PR DESCRIPTION
## Summary
- make the XlsxViewer viewport focus ring transparent by default
- preserve explicit focus-ring customization through the existing CSS variable
- update the stylesheet contract test and theme documentation

## Verification
- `./node_modules/.bin/vitest run packages/xlsx/src` (91 files, 835 tests)
- `./node_modules/.bin/vitest run site/src/xlsx-chrome-theme-docs.test.ts`
- `./node_modules/.bin/tsc --build packages/xlsx/tsconfig.json --pretty false`
- `git diff --check`

The root workspace typecheck remains blocked by stale generated PPTX WASM types that do not expose `PptxArchive.extract_font`; the scoped XLSX typecheck passes.