### PR TITLE
chore(release): 0.83.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ the corresponding minor release.
 
 ## Unreleased
 
+## 0.83.0 — 2026-08-28
+
+Minor release making large Word documents and PowerPoint presentations useful
+sooner, while improving Word review output and PowerPoint font fidelity.
+
+- **progressive Word and PowerPoint viewing:** add opt-in `progressiveLayout`
+  to the single-canvas Viewers, virtualized ScrollViewers, and document engines
+  in main and worker modes. Opening pages or slides can render while the rest of
+  the file is prepared, with a shared completion lifecycle and
+  `waitUntilLayoutComplete()` for operations that require the final layout.
+- **stable progressive interaction:** preserve the user's scroll position and
+  visible content while Word pagination grows, keep the final PowerPoint slide
+  count and scroll extent stable from first paint, and show loading states for
+  slides that are not ready yet.
+- **Word layout performance:** eliminate repeated acquisition and serialization
+  work in large documents, especially for tables spanning many pages, without
+  introducing a second or approximate pagination path.
+- **Word tracked changes:** add an opt-in `showTrackedChanges` markup view with
+  author-coloured underlines, strikethroughs, and margin change bars. The
+  accepted final state remains the default.
+- **PowerPoint fidelity and interaction:** use presentation-embedded fonts in
+  both rendering modes and keep overflowing slide text selectable outside its
+  authored shape bounds.
+- **Word correctness and viewer stability:** prevent empty continuous-section
+  transitions from skipping an authored page number, keep the visible page
+  anchored when zoom settles, and preserve a page's logical size when worker
+  bitmap resolution is constrained. Long web addresses now wrap within the
+  page instead of leaving unnatural gaps or being clipped at the edge.
+- **site and viewer polish:** preserve live viewers across browser back/forward
+  navigation, use worker-progressive DOCX and PPTX viewers in Try Yours, and
+  keep equations and other enabled optional renderers available there; also
+  avoid showing a default focus outline around the XLSX canvas.
+- **compatibility:** no existing option is removed or renamed, and progressive
+  layout and tracked-change markup remain opt-in. No source migration is
+  required. Presentations that contain embedded fonts now use them
+  automatically, improving fidelity for those files.
+
 ## 0.82.1 — 2026-08-26
 
 Compatible patch release improving Word and PowerPoint layout reliability,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.82.1"
+version = "0.83.0"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/README.md
+++ b/README.md
@@ -484,8 +484,8 @@ mean pages available so far, not the final total. The page callbacks fire again
 when that count grows, even if the visible page does not change. Await
 `waitUntilLayoutComplete()` before printing, exporting, or snapshotting a final count.
 In-document `NUMPAGES` fields are repainted with their authoritative value after
-pagination converges. See the [progressive layout guide](https://ooxml-viewer.com/docx#progressive-layout)
-and [DOCX API reference](https://ooxml-viewer.com/api/docx).
+pagination converges. See the [progressive layout guide](https://ooxml.silurus.dev/docx#progressive-layout)
+and [DOCX API reference](https://ooxml.silurus.dev/api/docx).
 
 ### Progressive PPTX layout
 
@@ -512,8 +512,8 @@ Unlike DOCX pagination, a PPTX bootstrap already provides the final slide list
 and uniform dimensions. `slideCount` and the ScrollViewer's scroll extent are
 therefore stable from first paint; `availableSlideCount` grows as the paintable
 opening prefix is prepared. Scrolling ahead shows a loading state without
-changing the scrollbar length. See the [PPTX progressive layout guide](https://ooxml-viewer.com/pptx#progressive-layout)
-and [PPTX API reference](https://ooxml-viewer.com/api/pptx).
+changing the scrollbar length. See the [PPTX progressive layout guide](https://ooxml.silurus.dev/pptx#progressive-layout)
+and [PPTX API reference](https://ooxml.silurus.dev/api/pptx).
 
 For presentations, `enableMediaPlayback: true` makes embedded audio and video
 interactive inside the real viewport plus `mediaOverscan` slides. Other mounted
@@ -522,8 +522,10 @@ animation loops.
 
 Both viewers also expose `relayout()` (force a re-fit when the container resizes
 in a way a `ResizeObserver` cannot see — e.g. a late web-font load),
-`onVisiblePageChange` / `onVisibleSlideChange` (fires when the top-most visible
-page/slide, or the page count, changes), and `onError` (async per-page render failures are routed
+`onVisiblePageChange` (fires when the top-most visible page, provisional DOCX
+page count, or completion state changes), `onVisibleSlideChange` (fires when the
+top-most visible slide or PPTX completion state changes; its slide count is
+final from first paint), and `onError` (async per-page render failures are routed
 here instead of crashing the scroll loop). The parse/render knobs from the
 headless engines (`mode`, `useGoogleFonts`, `resourceLimits`, the deprecated
 `maxZipEntryBytes` alias, `math`, `dpr`) are accepted too.

--- a/examples/frameworks/pnpm-lock.yaml
+++ b/examples/frameworks/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
   react:
     dependencies:
       '@silurus/ooxml':
-        specifier: ^0.82.0
-        version: 0.82.0
+        specifier: ^0.83.0
+        version: 0.83.0
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -39,8 +39,8 @@ importers:
   solid:
     dependencies:
       '@silurus/ooxml':
-        specifier: ^0.82.0
-        version: 0.82.0
+        specifier: ^0.83.0
+        version: 0.83.0
       solid-js:
         specifier: ^1.9.14
         version: 1.9.14
@@ -58,8 +58,8 @@ importers:
   svelte:
     dependencies:
       '@silurus/ooxml':
-        specifier: ^0.82.0
-        version: 0.82.0
+        specifier: ^0.83.0
+        version: 0.83.0
       svelte:
         specifier: ^5.56.8
         version: 5.56.8
@@ -80,8 +80,8 @@ importers:
   vue:
     dependencies:
       '@silurus/ooxml':
-        specifier: ^0.82.0
-        version: 0.82.0
+        specifier: ^0.83.0
+        version: 0.83.0
       vue:
         specifier: ^3.5.40
         version: 3.5.40(typescript@6.0.3)
@@ -294,8 +294,8 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@silurus/ooxml@0.82.0':
-    resolution: {integrity: sha512-9+drDf1gLDmgy1Dc/iy3mMrc8ZCVO5M/oTPwvHnUarNOenN4ATV30/mrS0Ug+2mWAiKl34LBjyICjhmtTmEBWA==}
+  '@silurus/ooxml@0.83.0':
+    resolution: {integrity: sha512-ovYCUQHRfZbWNQ1FRlKht19wk98GRiAWaM2Kkl5A3YjCs+tNquL78KdCoa09VG97HD19fv0DuqzHo8LdVYua6A==}
 
   '@sveltejs/acorn-typescript@1.0.11':
     resolution: {integrity: sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==}
@@ -1012,7 +1012,7 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@silurus/ooxml@0.82.0': {}
+  '@silurus/ooxml@0.83.0': {}
 
   '@sveltejs/acorn-typescript@1.0.11(acorn@8.18.0)':
     dependencies:

--- a/examples/frameworks/pnpm-workspace.yaml
+++ b/examples/frameworks/pnpm-workspace.yaml
@@ -8,4 +8,4 @@ allowBuilds:
   esbuild: false
 
 minimumReleaseAgeExclude:
-  - '@silurus/ooxml@0.82.0'
+  - '@silurus/ooxml@0.83.0'

--- a/examples/frameworks/react/package.json
+++ b/examples/frameworks/react/package.json
@@ -11,7 +11,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@silurus/ooxml": "^0.82.0",
+    "@silurus/ooxml": "^0.83.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   },

--- a/examples/frameworks/solid/package.json
+++ b/examples/frameworks/solid/package.json
@@ -11,7 +11,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@silurus/ooxml": "^0.82.0",
+    "@silurus/ooxml": "^0.83.0",
     "solid-js": "^1.9.14"
   },
   "devDependencies": {

--- a/examples/frameworks/svelte/package.json
+++ b/examples/frameworks/svelte/package.json
@@ -11,7 +11,7 @@
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {
-    "@silurus/ooxml": "^0.82.0",
+    "@silurus/ooxml": "^0.83.0",
     "svelte": "^5.56.8"
   },
   "devDependencies": {

--- a/examples/frameworks/vue/package.json
+++ b/examples/frameworks/vue/package.json
@@ -11,7 +11,7 @@
     "check": "vue-tsc --noEmit"
   },
   "dependencies": {
-    "@silurus/ooxml": "^0.82.0",
+    "@silurus/ooxml": "^0.83.0",
     "vue": "^3.5.40"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.82.1",
+  "version": "0.83.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.82.1",
+  "version": "0.83.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",
@@ -34,6 +34,8 @@
     "./internal/dom-geometry": "./src/internal/dom-geometry.ts",
     "./internal/in-process-pull-transport": "./src/internal/in-process-pull-transport.ts",
     "./internal/owned-session": "./src/internal/owned-session.ts",
+    "./internal/progressive-layout-lifecycle": "./src/internal/progressive-layout-lifecycle.ts",
+    "./internal/progressive-layout-observers": "./src/internal/progressive-layout-observers.ts",
     "./internal/resource-measurement": "./src/internal/resource-measurement.ts",
     "./internal/region-map-renderer": "./src/chart/region-map-renderer.ts",
     "./internal/read-only-comment-margin": "./src/internal/read-only-comment-margin.ts",

--- a/packages/core/src/internal/canvas-viewer-mechanics.test.ts
+++ b/packages/core/src/internal/canvas-viewer-mechanics.test.ts
@@ -251,6 +251,51 @@ describe('CanvasViewerErrorRouter', () => {
     expect(onError).toHaveBeenCalledOnce();
     expect(onError.mock.calls[0][0]).toEqual(new Error('failure'));
   });
+
+  it('delivers one Error identity once and respects an explicit callback owner', () => {
+    const onError = vi.fn();
+    const router = new CanvasViewerErrorRouter('TestViewer', onError);
+    const repeated = new Error('repeated');
+    router.report(repeated);
+    router.report(repeated);
+
+    const explicitlyHandled = new Error('handled elsewhere');
+    router.markHandled(explicitlyHandled);
+    router.report(explicitlyHandled);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(repeated);
+  });
+
+  it('keeps a terminal failure on the active Promise channel', async () => {
+    const onError = vi.fn();
+    const router = new CanvasViewerErrorRouter('TestViewer', onError);
+    const failure = new Error('layout failed');
+    let reject!: (error: Error) => void;
+    const pending = new Promise<void>((_resolve, rejectPromise) => { reject = rejectPromise; });
+    const awaited = router.ownBackgroundLifecycle(() => pending);
+
+    router.reportBackground(failure);
+    reject(failure);
+
+    await expect(awaited).rejects.toBe(failure);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('does not hide an unrelated background failure while a Promise is pending', async () => {
+    const onError = vi.fn();
+    const router = new CanvasViewerErrorRouter('TestViewer', onError);
+    let resolve!: () => void;
+    const pending = new Promise<void>((resolvePromise) => { resolve = resolvePromise; });
+    const awaited = router.ownAwaitable(() => pending);
+    const unrelated = new Error('unrelated render failure');
+
+    router.reportBackground(unrelated);
+    expect(onError).toHaveBeenCalledWith(unrelated);
+
+    resolve();
+    await awaited;
+  });
 });
 
 class Resource {

--- a/packages/core/src/internal/canvas-viewer-mechanics.ts
+++ b/packages/core/src/internal/canvas-viewer-mechanics.ts
@@ -526,6 +526,11 @@ export class StaticCanvasRenderDispatcher {
 /** Shared render-error delivery, with a permanent close gate for teardown. */
 export class CanvasViewerErrorRouter {
   private closed = false;
+  private readonly handled = new WeakSet<Error>();
+  /** Awaiters for the same background lifecycle reported by reportBackground.
+   * This is deliberately narrower than all Viewer promises: an unrelated find
+   * or render operation must never suppress a terminal layout notification. */
+  private backgroundLifecycleOwners = 0;
 
   constructor(
     private readonly viewerName: string,
@@ -535,8 +540,53 @@ export class CanvasViewerErrorRouter {
   report(error: unknown): void {
     if (this.closed) return;
     const normalized = error instanceof Error ? error : new Error(String(error));
+    if (this.handled.has(normalized)) return;
+    this.handled.add(normalized);
     if (this.onError) this.onError(normalized);
     else console.error(`[ooxml] ${this.viewerName} render failed:`, normalized);
+  }
+
+  /** Claim an Error for another explicit callback so derived render rejections
+   * cannot deliver the same terminal failure again through onError. */
+  markHandled(error: unknown): void {
+    if (this.closed || !(error instanceof Error)) return;
+    this.handled.add(error);
+  }
+
+  /** Keep a terminal background failure on the Promise channel while an
+   * explicit awaitable Viewer operation is waiting for that same lifecycle.
+   * Mark the exact Error identity before rethrowing; unrelated background
+   * failures must never be hidden merely because another Promise is pending. */
+  async ownAwaitable<T>(operation: () => Promise<T>): Promise<T> {
+    try {
+      return await operation();
+    } catch (error) {
+      this.markHandled(error);
+      throw error;
+    }
+  }
+
+  /** Claim the background lifecycle while an explicit public Promise waits for
+   * it. Publication and Promise rejection can cross any number of async jobs;
+   * synchronous ownership makes their single-channel contract deterministic. */
+  async ownBackgroundLifecycle<T>(operation: () => Promise<T>): Promise<T> {
+    this.backgroundLifecycleOwners++;
+    try {
+      return await this.ownAwaitable(operation);
+    } finally {
+      this.backgroundLifecycleOwners--;
+    }
+  }
+
+  /** Route an unowned background failure, or claim it for an explicit callback
+   * owner or an explicit Promise awaiting this same lifecycle. */
+  reportBackground(error: unknown, explicitCallbackOwner = false): void {
+    const normalized = error instanceof Error ? error : new Error(String(error));
+    if (explicitCallbackOwner || this.backgroundLifecycleOwners > 0) {
+      this.markHandled(normalized);
+      return;
+    }
+    this.report(normalized);
   }
 
   close(): void {

--- a/packages/core/src/internal/progressive-layout-lifecycle.test.ts
+++ b/packages/core/src/internal/progressive-layout-lifecycle.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { ProgressiveLayoutLifecycle } from './progressive-layout-lifecycle.js';
+
+describe('ProgressiveLayoutLifecycle', () => {
+  it('distinguishes successful completion from terminal failure', () => {
+    const lifecycle = new ProgressiveLayoutLifecycle();
+    expect({ complete: lifecycle.complete, settled: lifecycle.settled }).toEqual({
+      complete: true,
+      settled: true,
+    });
+
+    lifecycle.begin();
+    expect({ complete: lifecycle.complete, settled: lifecycle.settled }).toEqual({
+      complete: false,
+      settled: false,
+    });
+
+    const error = lifecycle.fail('background layout failed');
+    expect(error).toBeInstanceOf(Error);
+    expect({ complete: lifecycle.complete, settled: lifecycle.settled }).toEqual({
+      complete: false,
+      settled: true,
+    });
+    expect(() => lifecycle.throwIfFailed()).toThrow('background layout failed');
+
+    lifecycle.begin();
+    lifecycle.succeed();
+    expect({ complete: lifecycle.complete, settled: lifecycle.settled }).toEqual({
+      complete: true,
+      settled: true,
+    });
+    expect(() => lifecycle.throwIfFailed()).not.toThrow();
+  });
+});

--- a/packages/core/src/internal/progressive-layout-lifecycle.ts
+++ b/packages/core/src/internal/progressive-layout-lifecycle.ts
@@ -1,0 +1,39 @@
+/** Internal success/failure state shared by progressive document engines. */
+type ProgressiveLayoutState =
+  | { readonly status: 'complete' }
+  | { readonly status: 'pending' }
+  | { readonly status: 'failed'; readonly error: Error };
+
+/**
+ * Keeps "all content is ready" separate from "background work has stopped".
+ * A failed progressive load is settled, but it is never complete.
+ */
+export class ProgressiveLayoutLifecycle {
+  private state: ProgressiveLayoutState = Object.freeze({ status: 'complete' });
+
+  get complete(): boolean {
+    return this.state.status === 'complete';
+  }
+
+  get settled(): boolean {
+    return this.state.status !== 'pending';
+  }
+
+  begin(): void {
+    this.state = Object.freeze({ status: 'pending' });
+  }
+
+  succeed(): void {
+    this.state = Object.freeze({ status: 'complete' });
+  }
+
+  fail(cause: unknown): Error {
+    const error = cause instanceof Error ? cause : new Error(String(cause));
+    this.state = Object.freeze({ status: 'failed', error });
+    return error;
+  }
+
+  throwIfFailed(): void {
+    if (this.state.status === 'failed') throw this.state.error;
+  }
+}

--- a/packages/core/src/internal/progressive-layout-observers.test.ts
+++ b/packages/core/src/internal/progressive-layout-observers.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ProgressiveLayoutObserverNotifier } from './progressive-layout-observers.js';
+
+describe('ProgressiveLayoutObserverNotifier', () => {
+  it('isolates a throwing observer and reports it only once', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const callback = vi.fn((_progress: { committedUnits: number }) => {
+      throw new Error('observer failed');
+    });
+    const notifier = new ProgressiveLayoutObserverNotifier();
+
+    expect(() => notifier.notify('onLayoutProgress', callback, { committedUnits: 1 })).not.toThrow();
+    notifier.notify('onLayoutProgress', callback, { committedUnits: 2 });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    consoleError.mockRestore();
+  });
+
+  it('contains asynchronous observer rejection', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const callback = vi.fn(async () => { throw new Error('async observer failed'); });
+    const notifier = new ProgressiveLayoutObserverNotifier();
+
+    notifier.notify('onLayoutComplete', callback);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    consoleError.mockRestore();
+  });
+
+  it('isolates registrations when one function serves multiple observer slots', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const callback = vi.fn((progress?: { committedUnits: number }) => {
+      if (progress) throw new Error('progress observer failed');
+    });
+    const notifier = new ProgressiveLayoutObserverNotifier();
+
+    notifier.notify('onLayoutProgress', callback, { committedUnits: 1 });
+    notifier.notify('onLayoutProgress', callback, { committedUnits: 2 });
+    notifier.notify('onLayoutComplete', callback);
+
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback).toHaveBeenLastCalledWith();
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    consoleError.mockRestore();
+  });
+});

--- a/packages/core/src/internal/progressive-layout-observers.ts
+++ b/packages/core/src/internal/progressive-layout-observers.ts
@@ -1,0 +1,32 @@
+/** Isolates application observer failures from the authoritative layout result. */
+export class ProgressiveLayoutObserverNotifier {
+  /** One callback may intentionally serve more than one lifecycle slot. A
+   * failure disables only that registration, not the same function registered
+   * under another observer name. */
+  private readonly failed = new WeakMap<Function, Set<string>>();
+
+  notify<Args extends readonly unknown[]>(
+    name: string,
+    callback: ((...args: Args) => unknown) | undefined,
+    ...args: Args
+  ): void {
+    if (!callback || this.failed.get(callback)?.has(name)) return;
+    try {
+      const result = callback(...args);
+      if (result && typeof (result as PromiseLike<unknown>).then === 'function') {
+        Promise.resolve(result).catch((error) => this.reportOnce(name, callback, error));
+      }
+    } catch (error) {
+      this.reportOnce(name, callback, error);
+    }
+  }
+
+  private reportOnce(name: string, callback: Function, cause: unknown): void {
+    const registrations = this.failed.get(callback) ?? new Set<string>();
+    if (registrations.has(name)) return;
+    registrations.add(name);
+    if (!this.failed.has(callback)) this.failed.set(callback, registrations);
+    const error = cause instanceof Error ? cause : new Error(String(cause));
+    console.error(`[ooxml] ${name} callback failed and was disabled:`, error);
+  }
+}

--- a/packages/core/src/types/load-options.ts
+++ b/packages/core/src/types/load-options.ts
@@ -149,13 +149,16 @@ export interface LoadOptions {
    */
   onResourceMetrics?: (metrics: OoxmlResourceMetrics) => void;
   /**
-   * Reject the parse request if the parser worker does not answer within this
-   * many milliseconds. Opt-in safety net for a wedged or crashed worker that
-   * would otherwise leave `load()` pending forever. **Default: unlimited** —
-   * parsing a large document with heavy embedded media can legitimately take
-   * tens of seconds, so no timeout is imposed unless you set one. A worker that
-   * throws or fails to load already rejects immediately regardless of this
-   * value; this bound only covers the "silent, never-responds" case.
+   * Opt-in worker liveness limit in milliseconds. For an ordinary load it is
+   * the response deadline for the parse request. When progressive DOCX/PPTX
+   * preparation runs in `mode: 'worker'`, it becomes a silence interval that is restarted by each layout
+   * progress or partial publication, so a busy worker is not timed out merely
+   * because the complete document takes longer. Silence before the first
+   * publication rejects `load()`; silence after `load()` has resolved leaves
+   * `layoutComplete` false and makes `waitUntilLayoutComplete()` reject (and is
+   * also delivered to the layout-completion/error callback when configured).
+   * **Default: unlimited.** A worker that throws or fails to load rejects
+   * immediately regardless of this value.
    */
   workerTimeoutMs?: number;
   /**

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -2030,7 +2030,6 @@ export interface SectionProps {
     lineNumbering?: LineNumbering | null;
     vAlign?: string | null;
 }
-export function setDocumentLayoutValidation(next: boolean): void;
 export type ShapeFill = {
     fillType: 'solid';
     color: string;

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.82.1",
+  "version": "0.83.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -6471,6 +6471,7 @@ fn parse_run_inner(
                         text,
                         no_break_before: false,
                         no_break_after: false,
+                        no_break_hyphen_offsets: Vec::new(),
                         bold,
                         italic,
                         underline,
@@ -6526,7 +6527,13 @@ fn parse_run_inner(
                                 && !preserve_next_comment_boundary
                                 && text_runs_mergeable(prev, &this) =>
                         {
+                            let base_utf16 = prev.text.encode_utf16().count();
                             prev.text.push_str(&this.text);
+                            prev.no_break_hyphen_offsets.extend(
+                                this.no_break_hyphen_offsets
+                                    .iter()
+                                    .map(|offset| base_utf16 + offset),
+                            );
                             // The protected pair is now internal to this text
                             // token; do not extend it to the token's later end.
                             prev.no_break_after = false;
@@ -6566,6 +6573,7 @@ fn parse_run_inner(
                         text: c.to_string(),
                         no_break_before: false,
                         no_break_after: false,
+                        no_break_hyphen_offsets: Vec::new(),
                         bold,
                         italic,
                         underline,
@@ -6628,6 +6636,7 @@ fn parse_run_inner(
                     text: "\t".to_string(),
                     no_break_before: false,
                     no_break_after: false,
+                    no_break_hyphen_offsets: Vec::new(),
                     bold,
                     italic,
                     underline,
@@ -6733,6 +6742,7 @@ fn parse_run_inner(
                     // boundary for every formatting/revision/comment reason.
                     no_break_before: true,
                     no_break_after: true,
+                    no_break_hyphen_offsets: vec![1],
                     bold,
                     italic,
                     underline,
@@ -6786,7 +6796,13 @@ fn parse_run_inner(
                     Some(DocRun::Text(prev))
                         if !preserve_next_comment_boundary && text_runs_mergeable(prev, &this) =>
                     {
+                        let base_utf16 = prev.text.encode_utf16().count();
                         prev.text.push_str(&this.text);
+                        prev.no_break_hyphen_offsets.extend(
+                            this.no_break_hyphen_offsets
+                                .iter()
+                                .map(|offset| base_utf16 + offset),
+                        );
                         prev.no_break_after = true;
                     }
                     _ => runs.push(DocRun::Text(Box::new(this))),
@@ -6958,6 +6974,7 @@ fn parse_run_inner(
                     text: id_str.clone(),
                     no_break_before: false,
                     no_break_after: false,
+                    no_break_hyphen_offsets: Vec::new(),
                     bold,
                     italic,
                     underline,
@@ -15152,6 +15169,14 @@ mod tests {
         // run's own font rather than risking tofu.
         assert!(joined.contains('\u{002D}'));
         assert!(!joined.contains('\u{2011}'));
+        let text = runs
+            .iter()
+            .find_map(|run| match run {
+                DocRun::Text(text) => Some(text.as_ref()),
+                _ => None,
+            })
+            .expect("text run");
+        assert_eq!(text.no_break_hyphen_offsets, vec![4]);
     }
 
     // §17.3.3.29 <w:softHyphen> — zero width and no glyph when not a break point.
@@ -15267,6 +15292,22 @@ mod tests {
             "the two noBreakHyphen run boundaries must merge into the single \
              surrounding text run, not remain separate breakable segments"
         );
+        let text = runs
+            .iter()
+            .find_map(|run| match run {
+                DocRun::Text(text) => Some(text.as_ref()),
+                _ => None,
+            })
+            .expect("merged text run");
+        assert_eq!(
+            text.no_break_hyphen_offsets,
+            text.text
+                .encode_utf16()
+                .enumerate()
+                .filter_map(|(index, unit)| (unit == b'-' as u16).then_some(index + 1))
+                .collect::<Vec<_>>(),
+            "both authored noBreakHyphen positions survive model coalescing",
+        );
     }
 
     // Negative case: a noBreakHyphen must NOT absorb into a neighbour that
@@ -15285,16 +15326,24 @@ mod tests {
             &base,
             &StyleMap::parse(""),
         );
-        let texts: Vec<(&str, bool, bool)> = runs
+        let texts: Vec<(&str, bool, bool, &[usize])> = runs
             .iter()
             .filter_map(|r| match r {
-                DocRun::Text(t) => Some((t.text.as_str(), t.bold, t.no_break_before)),
+                DocRun::Text(t) => Some((
+                    t.text.as_str(),
+                    t.bold,
+                    t.no_break_before,
+                    t.no_break_hyphen_offsets.as_slice(),
+                )),
                 _ => None,
             })
             .collect();
         assert_eq!(
             texts,
-            vec![("999", true, false), ("-99", false, true)],
+            vec![
+                ("999", true, false, &[][..]),
+                ("-99", false, true, &[1][..])
+            ],
             "a formatting difference must block the merge — the bold \"999\" \
              and the non-bold \"-99\" stay separate runs without becoming a \
              line-break opportunity"

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -2265,6 +2265,15 @@ pub struct TextRun {
     /// run's addressable identity.
     #[serde(rename = "__noBreakAfter", skip_serializing_if = "std::ops::Not::not")]
     pub no_break_after: bool,
+    /// UTF-16 offsets immediately after authored `<w:noBreakHyphen/>` glyphs.
+    /// The glyph is serialized as U+002D for font compatibility, so layout
+    /// needs this parser-private provenance to distinguish it from an ordinary
+    /// hyphen-minus when considering compatibility break opportunities.
+    #[serde(
+        rename = "__noBreakHyphenOffsets",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub no_break_hyphen_offsets: Vec<usize>,
     pub bold: bool,
     pub italic: bool,
     pub underline: bool,

--- a/packages/docx/src/comments.ts
+++ b/packages/docx/src/comments.ts
@@ -3,6 +3,7 @@ import { sourceKey } from './layout/source-key.js';
 import type { SourceRef } from './layout/types.js';
 import { decimalReviewIdKey } from './review-id.js';
 import type { DocComment, DocxCommentMark, DocxStorySource, DocxTextRunInfo } from './types.js';
+import type { ReviewAnchorProjectionOptions } from './review-projection.js';
 
 export interface CommentAnchorRange {
   readonly commentId: string;
@@ -330,9 +331,33 @@ export function collectLayoutSourceCommentRangesIfPresent(
   comments: readonly Readonly<{ id: string }>[] | undefined,
   source: LayoutSourceStore,
   renderedRunIndex: RenderedRunIndex = new Map(),
+  options: ReviewAnchorProjectionOptions = {},
 ): CommentAnchorRange[] {
   if ((comments?.length ?? 0) === 0) return [];
-  return collectLayoutSourceCommentRanges(comments ?? [], source, renderedRunIndex);
+  const ranges = collectLayoutSourceCommentRanges(comments ?? [], source, renderedRunIndex);
+  const completed = options.completedSourceKeys;
+  if (completed === undefined) return ranges;
+  return ranges.filter((range) => {
+    const sourceIndices = renderedRunIndex.get(sourceKey(range.source)) ?? new Set<number>();
+    const hasCoveredRun = range.startRunIndex < range.endRunIndex
+      ? [...sourceIndices].some((index) =>
+          index >= range.startRunIndex && index < range.endRunIndex)
+      : sourceIndices.has(
+          range.reference.affinity === 'following'
+            ? range.startRunIndex
+            : range.startRunIndex - 1,
+        );
+    const referenceIndices = renderedRunIndex.get(sourceKey(range.reference.source));
+    const hasReferenceRun = referenceIndices?.has(
+      range.reference.affinity === 'following'
+        ? range.reference.runIndex
+        : range.reference.runIndex - 1,
+    ) === true;
+    return hasCoveredRun
+      || hasReferenceRun
+      || completed.has(sourceKey(range.source))
+      || completed.has(sourceKey(range.reference.source));
+  });
 }
 
 function sameStorySource(

--- a/packages/docx/src/document-worker-progressive.test.ts
+++ b/packages/docx/src/document-worker-progressive.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import { BoundedRawPartCache } from '@silurus/ooxml-core/internal/bounded-raw-part-cache';
+import { ProgressiveLayoutLifecycle } from '@silurus/ooxml-core/internal/progressive-layout-lifecycle';
+import { ProgressiveLayoutObserverNotifier } from '@silurus/ooxml-core/internal/progressive-layout-observers';
 import { WorkerBridge, type WorkerLike } from '@silurus/ooxml-core';
 import { DocxDocument } from './document';
 import { attachDocumentLayoutRuntime, documentLayoutRuntimeOf } from './layout/runtime-state.js';
+import { subscribeDocxLayout } from './document-layout-events.js';
 import type {
   DocumentLayoutPartial,
   DocumentMeta,
@@ -31,6 +34,8 @@ function partial(pageCount: number, over: Partial<DocumentLayoutPartial> = {}): 
     pageCount,
     pageSizes: Array.from({ length: pageCount }, () => ({ ...PAGE })),
     bookmarkPages: [['intro', 0]],
+    commentAnchorRanges: [],
+    revisionAnchorRanges: [],
     exact: false,
     ...over,
   };
@@ -81,7 +86,8 @@ function progressiveDocument(opts: {
     _document: null,
     _source: null,
     _meta: null,
-    _layoutComplete: true,
+    _layoutLifecycle: new ProgressiveLayoutLifecycle(),
+    _layoutObservers: new ProgressiveLayoutObserverNotifier(),
     _layoutViewGeneration: 0,
     // Field initializers the real constructor runs; destroy() reads them.
     _rawParts: new BoundedRawPartCache({ maxEntries: 4, maxBytes: 1024 }),
@@ -123,6 +129,7 @@ function progressiveDocument(opts: {
       return { promise, resolve, reject };
     })(),
     published: false,
+    settled: false,
   };
 
   const parsed = (document as unknown as {
@@ -196,8 +203,7 @@ describe('worker-mode progressive load', () => {
     // Review data established by the first publication survives later ones,
     // which deliberately do not re-send it.
     expect(harness.document.comments).toHaveLength(1);
-    // Anchor projections are whole-document joins; the worker omits them from a
-    // prefix rather than ship truncated ones.
+    // Prefix projections are authoritative for the pages already published.
     expect(harness.document.commentAnchorRanges()).toEqual([]);
     // Identity-stable, so a per-frame consumer caching on identity does not
     // rebuild every draw.
@@ -259,6 +265,27 @@ describe('worker-mode progressive load', () => {
     expect(progress).toEqual([{ committedUnits: 17 }]);
   });
 
+  it('keeps observer exceptions out of the authoritative layout result', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const harness = progressiveDocument({
+      onProgress: () => { throw new Error('progress observer failed'); },
+      onPartial: () => { throw new Error('partial observer failed'); },
+      onComplete: () => { throw new Error('complete observer failed'); },
+    });
+
+    harness.push({ type: 'layoutPartial', forId: 11, partial: partial(2, { review: REVIEW }) });
+    await harness.parsed;
+    harness.push({ type: 'layoutProgress', forId: 11, committedPages: 3 });
+    harness.push({ type: 'layoutPartial', forId: 11, partial: partial(4) });
+    harness.settle({ type: 'parsedMeta', id: 11, meta: fullMeta(5) });
+
+    await expect(harness.document.waitUntilLayoutComplete()).resolves.toBeUndefined();
+    expect(harness.document.layoutComplete).toBe(true);
+    expect(harness.document.pageCount).toBe(5);
+    expect(consoleError).toHaveBeenCalledTimes(3);
+    consoleError.mockRestore();
+  });
+
   it('rejects load() when the worker fails before publishing anything', async () => {
     let completed = 0;
     const harness = progressiveDocument({ onComplete: () => { completed += 1; } });
@@ -281,6 +308,7 @@ describe('worker-mode progressive load', () => {
 
     await expect(harness.document.waitUntilLayoutComplete()).rejects.toThrow('background layout failed');
     expect(errors).toHaveLength(1);
+    expect(harness.document.layoutComplete).toBe(false);
     // The provisional pages stay usable; only the completion is lost.
     expect(harness.document.pageCount).toBe(2);
   });
@@ -320,6 +348,46 @@ describe('worker-mode progressive load', () => {
         'worker layout produced no progress for 1000ms',
       );
       expect(harness.terminated()).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps a post-publication silence failure as the single terminal result', async () => {
+    vi.useFakeTimers();
+    try {
+      const completions: unknown[] = [];
+      const publications: unknown[] = [];
+      const harness = progressiveDocument({
+        timeoutMs: 1_000,
+        onComplete: (error) => completions.push(error),
+      });
+      const unsubscribe = subscribeDocxLayout(
+        harness.document,
+        () => ({ pageCount: harness.document.pageCount, exact: false, complete: false }),
+        (publication) => {
+          if (publication.error) publications.push(publication.error);
+        },
+        () => {},
+      );
+      harness.push({
+        type: 'layoutPartial',
+        forId: 11,
+        partial: partial(2, { review: REVIEW }),
+      });
+      await harness.parsed;
+
+      vi.advanceTimersByTime(1_001);
+      expect(harness.terminated()).toBe(true);
+      const silenceError = completions[0];
+      expect(silenceError).toBeInstanceOf(Error);
+      harness.fail(new Error('Worker terminated'));
+      await Promise.resolve();
+
+      await expect(harness.document.waitUntilLayoutComplete()).rejects.toBe(silenceError);
+      expect(completions).toEqual([silenceError]);
+      expect(publications).toEqual([silenceError]);
+      unsubscribe();
     } finally {
       vi.useRealTimers();
     }
@@ -487,7 +555,8 @@ describe('worker layout-view metadata switch', () => {
       _document: null,
       _source: null,
       _meta: null,
-      _layoutComplete: true,
+      _layoutLifecycle: new ProgressiveLayoutLifecycle(),
+      _layoutObservers: new ProgressiveLayoutObserverNotifier(),
       _layoutViewGeneration: 0,
       _parseRequestId: null,
       _bridge: {

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -35,6 +35,8 @@ import {
   type WorkerRendererDescriptors,
 } from '@silurus/ooxml-core/worker';
 import { BoundedRawPartCache } from '@silurus/ooxml-core/internal/bounded-raw-part-cache';
+import { ProgressiveLayoutLifecycle } from '@silurus/ooxml-core/internal/progressive-layout-lifecycle';
+import { ProgressiveLayoutObserverNotifier } from '@silurus/ooxml-core/internal/progressive-layout-observers';
 import type { DocxDocumentModel, RenderPageOptions, WorkerRequest, WorkerResponse, DocComment, DocNote, DocRevision } from './types';
 import { renderLayoutSourceToCanvas, documentHasMath, prepareMathRuns, type DocxTextRunInfo } from './renderer';
 import { createLayoutServices } from './layout-runtime.js';
@@ -61,7 +63,10 @@ import type {
 } from './worker-protocol';
 import { retainRenderWorkerDocumentLayout } from './render-worker-layout.js';
 import { textRunsForSelectedPage } from './text-run-projection.js';
-import { textRunSourceIndexForDocument } from './layout/text-index.js';
+import {
+  reviewProjectionIndexForDocument,
+  type ReviewProjectionIndex,
+} from './layout/text-index.js';
 import {
   hitTestSelectedDocxElementContext,
   type DocxElementContextOptions,
@@ -86,6 +91,7 @@ import { layoutDocumentInputAsync } from './layout/document.js';
 import { layoutDocumentProgressively } from './layout/progressive.js';
 import { PaginationAbortError } from './layout/pagination-scheduler.js';
 import { normalizeLayoutOptions, type LayoutOptions } from './layout/options.js';
+import type { LayoutVariantStore } from './layout/variant-store.js';
 import { publishDocxLayout } from './document-layout-events.js';
 
 /** Options for {@link DocxDocument.load}. Extends the shared load-options type
@@ -115,9 +121,10 @@ export interface LoadOptions extends CoreLoadOptions {
    *
    * Layout is unchanged — this only spreads it over event-loop turns — so the
    * document that eventually loads is byte-identical either way. What changes is
-   * that the thread doing the work (the main thread in `mode: 'main'`, the
-   * render worker in `mode: 'worker'`) stays responsive while a large document
-   * paginates. `load()` still resolves only once layout is complete.
+   * that the main thread stays responsive while a large document paginates.
+   * In `mode: 'worker'`, pagination is already off the UI thread; this option
+   * has no additional effect unless progressive layout is enabled. `load()`
+   * still resolves only once layout is complete.
    *
    * Off by default: for small documents the slicing is pure overhead, and
    * existing callers should not silently change scheduling behaviour.
@@ -133,7 +140,10 @@ export interface LoadOptions extends CoreLoadOptions {
    * progress reporting, not a page count.
    *
    * Implies {@link sliceLayout} in main mode, since a blocking layout cannot
-   * deliver progress the UI could act on.
+   * deliver progress the UI could act on. Worker mode reports this callback
+   * when {@link progressiveLayout} is enabled; an ordinary worker load does not
+   * publish intermediate pagination progress. Observer failures are reported
+   * and isolated from the layout result.
    */
   onLayoutProgress?: (progress: Readonly<ProgressiveLayoutProgress>) => void;
   /**
@@ -169,7 +179,8 @@ export interface LoadOptions extends CoreLoadOptions {
   /**
    * Called once the full layout has replaced the provisional one, or with the
    * failure if background layout threw. Only fires when
-   * {@link progressiveLayout} actually deferred work.
+   * {@link progressiveLayout} actually deferred work. Observer failures are
+   * reported and isolated from the layout result.
    */
   onLayoutComplete?: (error?: unknown) => void;
   /**
@@ -179,7 +190,8 @@ export interface LoadOptions extends CoreLoadOptions {
    * `availableUnits` is the pages available so far. `totalUnits` is omitted
    * because pagination does not know the final page count yet. `exact` is
    * currently always false because a later convergence pass can still replace
-   * those pages.
+   * those pages. Observer failures are reported and isolated from the layout
+   * result.
    */
   onLayoutPartial?: (progress: Readonly<ProgressiveLayoutPartial>) => void;
   /**
@@ -244,6 +256,9 @@ interface WorkerProgressiveLoad {
    *  `load()` waits on. */
   readonly firstPublication: Deferred<void>;
   published: boolean;
+  /** Exactly one of authoritative success, parse failure, watchdog failure, or
+   * teardown may terminate this worker progressive session. */
+  settled: boolean;
 }
 
 interface Deferred<T> {
@@ -300,13 +315,12 @@ export class DocxDocument {
   /** One immutable review snapshot backs both the public detached records and
    * lazy anchor projections. It is captured once per load in both render modes. */
   private _review: ReviewSnapshot = EMPTY_REVIEW_SNAPSHOT;
-  /** Progressive layout only: false while the authoritative layout is still
-   *  being built in the background. Always true for an ordinary load. */
-  private _layoutComplete = true;
-  /** Settles when background layout finishes; never rejects (the failure is
-   *  retained in `_layoutError` and re-thrown by `waitUntilLayoutComplete`). */
+  /** Separates successful completion from terminal background failure. */
+  private readonly _layoutLifecycle = new ProgressiveLayoutLifecycle();
+  private readonly _layoutObservers = new ProgressiveLayoutObserverNotifier();
+  /** Settles when background layout finishes; never rejects (the lifecycle
+   *  retains a failure and `waitUntilLayoutComplete` re-throws it). */
   private _layoutCompletion: Promise<void> | null = null;
-  private _layoutError: unknown = undefined;
   /** Cancels background layout when the document is destroyed or replaced. */
   private _layoutAbort: AbortController | null = null;
   /** Lazily-built `bookmarkName → 0-based page index` map for internal hyperlink
@@ -321,8 +335,8 @@ export class DocxDocument {
   /** Lazily-computed §17.13.5 revision source ranges (main mode; worker mode
    * reads them from metadata). */
   private _revisionAnchorRanges: readonly RevisionAnchorRange[] | null = null;
-  /** Shared lightweight index for comment and revision anchor projections. */
-  private _reviewTextRunSourceIndex: ReadonlyMap<string, ReadonlySet<number>> | null = null;
+  /** Shared one-pass index for comment and revision anchor projections. */
+  private _reviewProjectionIndex: ReviewProjectionIndex | null = null;
   /** Correlation id of the in-flight worker `parse`. Progressive pushes name it
    *  in `forId`; ids are monotonic and never reused, so a push carrying any
    *  other id belongs to a parse this document has already moved past. */
@@ -489,6 +503,7 @@ export class DocxDocument {
               abort: new AbortController(),
               firstPublication: deferred<void>(),
               published: false,
+              settled: false,
             }
           : undefined,
       );
@@ -552,6 +567,7 @@ export class DocxDocument {
         preparedMath = await prepareMathRuns(doc._document, opts.math);
       }
       if (doc._mode === 'main' && doc._document && doc._source) {
+        const layoutDocument = doc;
         const runtime = documentLayoutRuntimeOf(doc);
         runtime.services = createLayoutServices(doc._source, {
           localMetrics: localMetrics?.metrics,
@@ -586,7 +602,9 @@ export class DocxDocument {
         if (!layoutOptions) throw new Error('Active layout view was not recorded at load');
         const scheduler = {
           onProgress: opts.onLayoutProgress
-            ? (committedPages: number) => opts.onLayoutProgress?.({ committedUnits: committedPages })
+            ? (committedPages: number) => layoutDocument._layoutObservers.notify(
+              'onLayoutProgress', opts.onLayoutProgress, { committedUnits: committedPages },
+            )
             : undefined,
         };
         if (deferrable && opts.progressiveLayout) {
@@ -610,7 +628,8 @@ export class DocxDocument {
               onPreview: (preview) => {
                 if (!ownsPublication) return;
                 const first = publishedLayout === null;
-                const retainedPreview = store.replaceIfCurrent(
+                const retainedPreview = progressiveDocument._replaceMainLayoutPublication(
+                  store,
                   layoutOptions,
                   publishedLayout,
                   preview.layout,
@@ -623,7 +642,6 @@ export class DocxDocument {
                   return;
                 }
                 publishedLayout = retainedPreview;
-                progressiveDocument._bookmarkPages = null;
                 if (!first) {
                   // This background session still owns its store entry, but a
                   // runtime view switch may have selected a different entry.
@@ -636,12 +654,12 @@ export class DocxDocument {
                     exact: preview.exact,
                     complete: false,
                   });
-                  opts.onLayoutPartial?.({
+                  progressiveDocument._layoutObservers.notify('onLayoutPartial', opts.onLayoutPartial, {
                     availableUnits: preview.layout.pages.length,
                     exact: preview.exact,
                   });
                 } else {
-                  progressiveDocument._layoutComplete = false;
+                  progressiveDocument._layoutLifecycle.begin();
                   publishDocxLayout(progressiveDocument, {
                     pageCount: preview.layout.pages.length,
                     exact: preview.exact,
@@ -655,16 +673,15 @@ export class DocxDocument {
             // Replace only the exact prefix this drain last published. A newer
             // synchronous rebuild of the same variant owns the key otherwise.
             if (ownsPublication) {
-              const authoritative = store.replaceIfCurrent(
+              const authoritative = progressiveDocument._replaceMainLayoutPublication(
+                store,
                 layoutOptions,
                 publishedLayout,
                 layout,
               );
               if (authoritative === null) ownsPublication = false;
             }
-            // The prefix's bookmark map described a 2-page document.
-            progressiveDocument._bookmarkPages = null;
-            progressiveDocument._layoutComplete = true;
+            progressiveDocument._layoutLifecycle.succeed();
             publishDocxLayout(progressiveDocument, {
               // A runtime view switch can complete before this original
               // session. Publish the geometry the document actually exposes,
@@ -673,7 +690,11 @@ export class DocxDocument {
               exact: true,
               complete: true,
             });
-            opts.onLayoutComplete?.();
+            if (publishedLayout !== null) {
+              progressiveDocument._layoutObservers.notify(
+                'onLayoutComplete', opts.onLayoutComplete,
+              );
+            }
             // Nothing was published: there was nothing to show early, so
             // load() resolves here, on the layout that would have been built
             // anyway. Resolving an already-resolved deferred is a no-op.
@@ -694,18 +715,19 @@ export class DocxDocument {
             // not that layout failed. Settle quietly: there is nobody left to
             // tell, and `waitUntilLayoutComplete` must not reject for it.
             if (error instanceof PaginationAbortError) {
-              progressiveDocument._layoutComplete = true;
+              progressiveDocument._layoutLifecycle.succeed();
               return;
             }
-            progressiveDocument._layoutError = error;
-            progressiveDocument._layoutComplete = true;
+            const layoutError = progressiveDocument._layoutLifecycle.fail(error);
             publishDocxLayout(progressiveDocument, {
               pageCount: progressiveDocument.pageCount,
               exact: false,
-              complete: true,
-              error,
+              complete: false,
+              error: layoutError,
             });
-            opts.onLayoutComplete?.(error);
+            progressiveDocument._layoutObservers.notify(
+              'onLayoutComplete', opts.onLayoutComplete, layoutError,
+            );
           });
           await firstPublication.promise;
         } else if (deferrable && (opts.sliceLayout || opts.onLayoutProgress)) {
@@ -821,8 +843,11 @@ export class DocxDocument {
     // the watchdog is asking about.
     this._rearmParseWatchdog();
     const progressive = this._progressive;
+    if (progressive?.settled) return;
     if (res.type === 'layoutProgress') {
-      progressive?.onProgress?.({ committedUnits: res.committedPages });
+      this._layoutObservers.notify(
+        'onLayoutProgress', progressive?.onProgress, { committedUnits: res.committedPages },
+      );
       return;
     }
     if (res.type !== 'layoutPartial' || !progressive) return;
@@ -839,7 +864,7 @@ export class DocxDocument {
         exact: res.partial.exact,
         complete: false,
       });
-      progressive.onPartial?.({
+      this._layoutObservers.notify('onLayoutPartial', progressive.onPartial, {
         availableUnits: res.partial.pageCount,
         exact: res.partial.exact,
       });
@@ -849,7 +874,7 @@ export class DocxDocument {
     // `onLayoutPartial`: the caller is about to see these pages as the loaded
     // document, not as an extension of one — same rule main mode follows.
     progressive.published = true;
-    this._layoutComplete = false;
+    this._layoutLifecycle.begin();
     publishDocxLayout(this, {
       pageCount: res.partial.pageCount,
       exact: res.partial.exact,
@@ -878,9 +903,8 @@ export class DocxDocument {
       comments: review?.comments ?? [],
       footnotes: review?.footnotes ?? [],
       endnotes: review?.endnotes ?? [],
-      // The two anchor projections are whole-document joins; only the
-      // authoritative `parsedMeta` carries them. Absent is a shape
-      // `DocumentMeta` already documents as supported.
+      commentAnchorRanges: partial.commentAnchorRanges,
+      revisionAnchorRanges: partial.revisionAnchorRanges,
     };
     if (partial.review) {
       this._review = snapshotReviewData(partial.review.comments, partial.review.revisions);
@@ -892,6 +916,7 @@ export class DocxDocument {
   private _onAuthoritativeMeta(meta: DocumentMeta): void {
     this._clearParseWatchdog();
     const progressive = this._progressive;
+    if (progressive?.settled) return;
     if (!progressive || this._isLayoutViewActive(progressive.layoutOptions) || !this._meta) {
       this._meta = meta;
     } else {
@@ -911,7 +936,8 @@ export class DocxDocument {
     this._invalidateLayoutDerivedCaches();
     this._review = snapshotReviewData(meta.comments, meta.revisions);
     if (!progressive) return;
-    this._layoutComplete = true;
+    progressive.settled = true;
+    this._layoutLifecycle.succeed();
     publishDocxLayout(this, {
       pageCount: this.pageCount,
       exact: true,
@@ -920,7 +946,9 @@ export class DocxDocument {
     // A load whose worker published nothing resolves here instead — there was
     // never anything to show early, so `load()` waited for the real document.
     progressive.firstPublication.resolve();
-    if (progressive.published) progressive.onComplete?.();
+    if (progressive.published) {
+      this._layoutObservers.notify('onLayoutComplete', progressive.onComplete);
+    }
   }
 
   /** Bookmark pages and the review anchor projections are derived from the
@@ -929,7 +957,25 @@ export class DocxDocument {
     this._bookmarkPages = null;
     this._commentAnchorRanges = null;
     this._revisionAnchorRanges = null;
-    this._reviewTextRunSourceIndex = null;
+    this._reviewProjectionIndex = null;
+  }
+
+  /** Atomically advance one main-thread layout publication and invalidate only
+   * the derived projections that belong to the layout the document currently
+   * exposes. An inactive progressive variant may continue draining in the
+   * background, but it must neither stale nor evict the active variant's
+   * bookmark/review caches. */
+  private _replaceMainLayoutPublication(
+    store: LayoutVariantStore,
+    options: LayoutOptions,
+    expected: DeepReadonly<DocumentLayout> | null,
+    next: DeepReadonly<DocumentLayout>,
+  ): DeepReadonly<DocumentLayout> | null {
+    const retained = store.replaceIfCurrent(options, expected, next);
+    if (retained !== null && this._isLayoutViewActive(options)) {
+      this._invalidateLayoutDerivedCaches();
+    }
+    return retained;
   }
 
   /** Whether synchronous geometry and paint currently select this normalized
@@ -960,21 +1006,32 @@ export class DocxDocument {
     const error = new Error(
       `worker layout produced no progress for ${silenceMs}ms`,
     );
-    if (progressive && !progressive.published) {
-      // load() has not resolved yet, so this can still be its rejection.
-      progressive.firstPublication.reject(error);
-    } else if (progressive) {
-      this._layoutError = error;
-      this._layoutComplete = true;
-      publishDocxLayout(this, {
-        pageCount: this.pageCount,
-        exact: false,
-        complete: true,
-        error,
-      });
-      progressive.onComplete?.(error);
-    }
+    if (progressive) this._failWorkerProgressive(progressive, error);
     this._bridge.terminate();
+  }
+
+  /** Single terminal failure authority for worker progressive layout. The
+   * watchdog terminates the worker after calling this method; the resulting
+   * bridge rejection is therefore a duplicate and is ignored by `settled`. */
+  private _failWorkerProgressive(
+    progressive: WorkerProgressiveLoad,
+    cause: unknown,
+  ): void {
+    if (progressive.settled) return;
+    progressive.settled = true;
+    this._clearParseWatchdog();
+    if (!progressive.published) {
+      progressive.firstPublication.reject(cause);
+      return;
+    }
+    const layoutError = this._layoutLifecycle.fail(cause);
+    publishDocxLayout(this, {
+      pageCount: this.pageCount,
+      exact: false,
+      complete: false,
+      error: layoutError,
+    });
+    this._layoutObservers.notify('onLayoutComplete', progressive.onComplete, layoutError);
   }
 
   /** The variant fields the worker `parse` carries, derived from the SAME
@@ -1054,6 +1111,7 @@ export class DocxDocument {
           // main mode exactly as the ordinary parse does; load()'s main-mode
           // block then lays it out — progressively — on this thread.
           this._clearParseWatchdog();
+          progressive.settled = true;
           this._progressive = null;
           this._layoutAbort = null;
           const adapted = await materializeDocumentPullAdapterSession(
@@ -1079,28 +1137,17 @@ export class DocxDocument {
       (error: unknown) => {
         this._parseRequestId = null;
         this._clearParseWatchdog();
+        if (progressive.settled) return;
         // Destroyed or replaced mid-layout: the worker was terminated on
         // purpose, there is nobody left to tell, and waitUntilLayoutComplete() must
         // not reject for it. Exactly how main mode treats PaginationAbortError.
         if (progressive.abort.signal.aborted) {
-          this._layoutComplete = true;
+          progressive.settled = true;
+          this._layoutLifecycle.succeed();
           progressive.firstPublication.resolve();
           return;
         }
-        if (!progressive.published) {
-          // load() has not resolved yet, so this is still its rejection.
-          progressive.firstPublication.reject(error);
-          return;
-        }
-        this._layoutError = error;
-        this._layoutComplete = true;
-        publishDocxLayout(this, {
-          pageCount: this.pageCount,
-          exact: false,
-          complete: true,
-          error,
-        });
-        progressive.onComplete?.(error);
+        this._failWorkerProgressive(progressive, error);
       },
     );
     this._rearmParseWatchdog();
@@ -1130,7 +1177,7 @@ export class DocxDocument {
     this._bookmarkPages = null;
     this._commentAnchorRanges = null;
     this._revisionAnchorRanges = null;
-    this._reviewTextRunSourceIndex = null;
+    this._reviewProjectionIndex = null;
     this._rawParts.clear();
     // Release the embedded fonts this document added to the shared FontFaceSet
     // (main mode). Refcounted in core: a font also used by another open document
@@ -1246,13 +1293,14 @@ export class DocxDocument {
   /**
    * Whether every page has been laid out.
    *
-   * Only ever false under `progressiveLayout`, between `load()` resolving on the
-   * document's opening pages and the full layout replacing them. While false,
-   * {@link pageCount} reports the pages available so far, not the document's
-   * total.
+   * True only after the authoritative layout succeeds. Under
+   * `progressiveLayout`, it is false between `load()` resolving on the opening
+   * pages and successful completion, and remains false after a background
+   * failure. While false, {@link pageCount} is not an authoritative total;
+   * {@link waitUntilLayoutComplete} distinguishes pending work from failure.
    */
   get layoutComplete(): boolean {
-    return this._layoutComplete;
+    return this._layoutLifecycle.complete;
   }
 
   /**
@@ -1265,7 +1313,7 @@ export class DocxDocument {
    */
   async waitUntilLayoutComplete(): Promise<void> {
     if (this._layoutCompletion) await this._layoutCompletion;
-    if (this._layoutError !== undefined) throw this._layoutError;
+    this._layoutLifecycle.throwIfFailed();
   }
 
   /** The render mode this engine was loaded with ('main' | 'worker'). A fact for
@@ -1302,8 +1350,9 @@ export class DocxDocument {
   }
 
   /** ECMA-376 §17.13.5 body-story revision events in document order. Available
-   * in both main and worker modes; rendering always projects the accepted final
-   * state. Consumers may use these detached records in their own review UI. */
+   * in both main and worker modes. Rendering uses the accepted final state by
+   * default; `showTrackedChanges` opts into the markup projection. Consumers may
+   * use these detached records in their own review UI. */
   get revisions(): readonly Readonly<DocRevision>[] {
     return this._reviewSnapshot().revisions;
   }
@@ -1315,11 +1364,15 @@ export class DocxDocument {
    * `DocxTextRunInfo.source`, covering body, headers, footers, notes, and text
    * boxes. Join it to rendered geometry with `sourceRunIndex`. Mode-agnostic:
    * main mode resolves lazily from the retained source; worker mode returns the
-   * same projection in metadata. Returns `[]` when no anchors exist.
+   * same projection in metadata. During progressive loading it covers the
+   * currently available page prefix; await {@link waitUntilLayoutComplete}
+   * before treating an empty or partial result as whole-document authority.
    */
   commentAnchorRanges(): readonly CommentAnchorRange[] {
     if (this._meta) return this._meta.commentAnchorRanges ?? NO_COMMENT_ANCHOR_RANGES;
     if (!this._document || !this._source) return [];
+    const comments = this._reviewSnapshot().comments;
+    if (comments.length === 0) return NO_COMMENT_ANCHOR_RANGES;
     const runtime = documentLayoutRuntimeOf(this);
     const services = runtime.services;
     if (!services) throw new Error('Document layout services are not initialized');
@@ -1331,11 +1384,17 @@ export class DocxDocument {
     if (!store) throw new Error('Document layout variant store is not initialized');
     const active = runtime.activeLayoutOptions;
     const layout = active ? store.layoutFor(active) : store.defaultLayout;
-    this._reviewTextRunSourceIndex ??= textRunSourceIndexForDocument(layout);
+    this._reviewProjectionIndex ??= reviewProjectionIndexForDocument(layout);
+    const projectionOptions = (this._layoutLifecycle?.complete ?? true)
+      ? undefined
+      : {
+          completedSourceKeys: this._reviewProjectionIndex.completedSourceKeys,
+        };
     this._commentAnchorRanges ??= collectLayoutSourceCommentRangesIfPresent(
-      this._reviewSnapshot().comments,
+      comments,
       this._source,
-      this._reviewTextRunSourceIndex,
+      this._reviewProjectionIndex.renderedRunIndex,
+      projectionOptions,
     );
     return this._commentAnchorRanges;
   }
@@ -1344,10 +1403,14 @@ export class DocxDocument {
    * intervals. Join them to `collectPageRuns()` with
    * `resolveRevisionAnchorRuns()`. Deletions and move sources use the nearest
    * deterministic final-state text position because accepted rendering gives
-   * their own content no geometry. Mode-agnostic. */
+   * their own content no geometry. Mode-agnostic. During progressive loading
+   * this projects the available prefix; await {@link waitUntilLayoutComplete}
+   * before a whole-document review scan. */
   revisionAnchorRanges(): readonly RevisionAnchorRange[] {
     if (this._meta) return this._meta.revisionAnchorRanges ?? NO_REVISION_ANCHOR_RANGES;
     if (!this._document || !this._source) return [];
+    const revisions = this._reviewSnapshot().revisions;
+    if (revisions.length === 0) return NO_REVISION_ANCHOR_RANGES;
     const runtime = documentLayoutRuntimeOf(this);
     const services = runtime.services;
     if (!services) throw new Error('Document layout services are not initialized');
@@ -1356,11 +1419,17 @@ export class DocxDocument {
     if (!store) throw new Error('Document layout variant store is not initialized');
     const active = runtime.activeLayoutOptions;
     const layout = active ? store.layoutFor(active) : store.defaultLayout;
-    this._reviewTextRunSourceIndex ??= textRunSourceIndexForDocument(layout);
+    this._reviewProjectionIndex ??= reviewProjectionIndexForDocument(layout);
+    const projectionOptions = (this._layoutLifecycle?.complete ?? true)
+      ? undefined
+      : {
+          completedSourceKeys: this._reviewProjectionIndex.completedSourceKeys,
+        };
     this._revisionAnchorRanges ??= collectLayoutSourceRevisionRangesIfPresent(
-      this._reviewSnapshot().revisions,
+      revisions,
       this._source,
-      this._reviewTextRunSourceIndex,
+      this._reviewProjectionIndex.renderedRunIndex,
+      projectionOptions,
     );
     return this._revisionAnchorRanges;
   }
@@ -1487,7 +1556,9 @@ export class DocxDocument {
    * `onHyperlinkClick` default (or an integrator) turns the anchor into a page
    * and calls {@link DocxViewer.goToPage} (or scrolls the scroll viewer to it).
    * Works in BOTH `main` and `worker` mode (the map rides along in the worker
-   * meta, built from the same paginated pages as `pageSizes`).
+   * meta, built from the same paginated pages as `pageSizes`). During
+   * progressive loading, `undefined` means only "not in the available prefix";
+   * await {@link waitUntilLayoutComplete} before concluding it is absent.
    */
   getBookmarkPage(bookmarkName: string): number | undefined {
     return this._getBookmarkPages()?.get(bookmarkName);

--- a/packages/docx/src/external-link-line-break.test.ts
+++ b/packages/docx/src/external-link-line-break.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { graphemeClusterOffsets } from '@silurus/ooxml-core';
+import { wordExternalLinkSyntaxBreakOffsets } from './layout/line-compatibility.js';
+import { layoutLines, type LayoutTextSeg } from './line-layout.js';
+
+const breaks = (text: string, protectedOffsets: readonly number[] = []) =>
+  wordExternalLinkSyntaxBreakOffsets(
+    text,
+    new Set(graphemeClusterOffsets(text)),
+    new Set(protectedOffsets),
+  );
+
+describe('Word-observed external-link syntax breaks', () => {
+  it('keeps a hyphenated authority intact and exposes path/query separators', () => {
+    const text = 'https://hyphen-host.example/path/long-name.pdf?part=one&part=two';
+    const authorityHyphen = text.indexOf('-') + 1;
+    const pathSlash = text.indexOf('/', text.indexOf('/path') + 1) + 1;
+    const pathHyphen = text.indexOf('-', text.indexOf('/path')) + 1;
+    expect(breaks(text)).not.toContain(authorityHyphen);
+    expect(breaks(text)).toEqual(expect.arrayContaining([
+      pathSlash,
+      pathHyphen,
+      text.indexOf('?') + 1,
+      text.indexOf('&') + 1,
+    ]));
+  });
+
+  it('does not split a separator from its combining mark', () => {
+    const text = 'https://example.test/path/a-\u0301combined/next-part';
+    const clusteredHyphen = text.indexOf('-') + 1;
+    expect(breaks(text)).not.toContain(clusteredHyphen);
+    expect(breaks(text)).toContain(text.lastIndexOf('-') + 1);
+  });
+
+  it('excludes an authored noBreakHyphen while retaining other URL breaks', () => {
+    const text = 'https://example.test/path/no-break/ordinary-break';
+    const protectedHyphen = text.indexOf('-') + 1;
+    const ordinaryHyphen = text.lastIndexOf('-') + 1;
+    expect(breaks(text, [protectedHyphen])).not.toContain(protectedHyphen);
+    expect(breaks(text, [protectedHyphen])).toContain(ordinaryHyphen);
+  });
+
+  it('checks every candidate when negative spacing makes prefix widths non-monotone', () => {
+    const text = 'https://example.test/path/i-i-W-W-document.pdf';
+    const offsets = breaks(text);
+    const ctx = {
+      font: '10px serif',
+      letterSpacing: '0px',
+      fontKerning: 'none',
+      measureText(value: string) {
+        const width = [...value].reduce(
+          (sum, char) => sum + (char === 'i' ? 2 : char === 'W' ? 20 : 8),
+          0,
+        );
+        return {
+          width,
+          fontBoundingBoxAscent: 8,
+          fontBoundingBoxDescent: 2,
+          actualBoundingBoxAscent: 8,
+          actualBoundingBoxDescent: 2,
+        } as TextMetrics;
+      },
+    } as unknown as CanvasRenderingContext2D;
+    const segment: LayoutTextSeg = {
+      text,
+      bold: false,
+      italic: false,
+      underline: true,
+      strikethrough: false,
+      fontSize: 10,
+      color: null,
+      fontFamily: 'serif',
+      vertAlign: null,
+      measuredWidth: 0,
+      charSpacing: -5,
+      hyperlink: { kind: 'external', url: text },
+      externalLinkBreakOffsets: offsets,
+      src: { segIndex: 0, charOffset: 0 },
+    };
+
+    const lines = layoutLines(ctx, [segment], 94, 0, 1);
+    const pieces = lines.flatMap((line) => line.segments)
+      .filter((item): item is LayoutTextSeg => 'text' in item);
+    expect(pieces.map((piece) => piece.text).join('')).toBe(text);
+    expect(pieces.length).toBeGreaterThan(1);
+    expect(offsets).toContain(pieces[0]!.text.length);
+  });
+});

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -16,12 +16,6 @@ export type {
   ViewerCommentThreadContext,
 } from '@silurus/ooxml-core';
 export { buildDocxTextLayer } from './text-layer';
-// The path-precise plain-data pre-pass is a development-time diagnostic: on
-// under a test runner, off in production, where its duplicate graph walk costs
-// real layout time. Fatal checks (non-finite geometry, layout invariants) run
-// unconditionally either way. Exposed so an embedder can re-enable the precise
-// error paths while diagnosing a layout defect against a production build.
-export { setDocumentLayoutValidation } from './layout/validation-policy';
 export {
   readDocxTextSelectionContext,
   type DocxSelectionContext,

--- a/packages/docx/src/layout-lines-zoom-invariant.test.ts
+++ b/packages/docx/src/layout-lines-zoom-invariant.test.ts
@@ -269,6 +269,29 @@ describe('zoom-invariant line breaking (Phase 4-1 B2 Stage 2)', () => {
     expect(at1.length).toBeGreaterThan(3);
   });
 
+  it('reuses the retained external-link partition at every paint zoom', async () => {
+    const url = [
+      'https://example.test/path/a-long-document-name.pdf',
+      'more/path/with-separators-and-query.pdf?part=one&part=two',
+      'final/path/another-long-document-name.pdf',
+    ].join('/');
+    const paragraph = para(url);
+    Object.assign(paragraph.runs[0]!, {
+      isLink: true,
+      underline: true,
+      hyperlink: url,
+    });
+    const model = doc([paragraph as unknown as BodyElement]);
+    const { layout, services } = canonical(model);
+    expect(layout.pages.length).toBeGreaterThan(1);
+
+    const at1 = await partitionAtWidth(model, layout, services, 200);
+    const at05 = await partitionAtWidth(model, layout, services, 100);
+    expect(at05).toEqual(at1);
+    expect(at1.join('')).toBe(url);
+    expect(at1.length).toBeGreaterThan(3);
+  });
+
   it('CJK per-glyph wrap: same partition at scale 1 and scale 0.5', async () => {
     const text = 'あ'.repeat(240);
     const model = doc([para(text) as unknown as BodyElement]);
@@ -420,13 +443,19 @@ describe('zoom-invariant line breaking (Phase 4-1 B2 Stage 2)', () => {
     const text = Array.from({ length: 200 }, (_, i) => `w${i % 10}`).join(' ');
 
     // Same real content width (180pt) at two scales: scale-1 box 180, scale-0.75
-    // box 135, first-indent 0. A linear font would give the SAME line count; the
+    // box 135, first-indent 0. A linear font would give the SAME partitions; the
     // sub-linear font does not.
     const a = layoutLines(makeMeasureStubCtx(), [seg(text)], 180, 0, 1);
     const b = layoutLines(makeMeasureStubCtx(), [seg(text)], 135, 0, 0.75);
     expect(a.length).toBeGreaterThan(1);
-    // The partitions differ — different line count under the non-linear advance.
-    expect(b.length).not.toBe(a.length);
+    const partitions = (lines: typeof a) => lines.map((line) => line.segments
+      .filter((segment): segment is Extract<LayoutSeg, { text: string }> => 'text' in segment)
+      .map((segment) => segment.text)
+      .join(''));
+    // The exact partitions differ under the non-linear advance. They may happen
+    // to produce the same total line count after emergency wrapping consumes a
+    // preceding line remainder, so compare the retained line content directly.
+    expect(partitions(b)).not.toEqual(partitions(a));
   });
 
   it('an ANCHORED image in the paragraph adds no inline advance at any scale', async () => {

--- a/packages/docx/src/layout/line-compatibility.ts
+++ b/packages/docx/src/layout/line-compatibility.ts
@@ -615,8 +615,53 @@ export const WORD_OVERLONG_TOKEN_EMERGENCY_BREAK = defineCompatibilityRule({
     kind: 'regression-test',
     reference: 'packages/docx/src/run-inline-formatting.test.ts#breaks a no-space token wider than the line at the character level',
   },
-  description: 'Emergency-break a non-CJK token that is wider than an empty line at grapheme-safe character boundaries so it remains inside the content band.',
+  description: 'Emergency-break an overlong token at grapheme-safe character boundaries on an empty line so the complete token remains inside the content band.',
 });
+
+export const WORD_EXTERNAL_LINK_SYNTAX_BREAKS = defineCompatibilityRule({
+  id: 'word-external-link-syntax-breaks',
+  evidence: {
+    kind: 'office-observation',
+    syntheticFixtureId: 'external-link-syntax-formatting-seam-matrix',
+    application: 'Microsoft Word',
+    version: '16.111.1',
+    platform: 'macOS 26.5.2',
+  },
+  description: 'Treat readable separators in the path and query of displayed external URLs as line-break opportunities, while keeping the scheme and authority intact and preserving authored no-break hyphens and grapheme clusters.',
+});
+
+/** Compatibility projection governed by {@link WORD_EXTERNAL_LINK_SYNTAX_BREAKS}.
+ * `graphemeBoundaries` and `authoredNoBreakOffsets` are UTF-16 offsets in the
+ * complete displayed link token, not in an individual formatting run. */
+export function wordExternalLinkSyntaxBreakOffsets(
+  text: string,
+  graphemeBoundaries: ReadonlySet<number>,
+  authoredNoBreakOffsets: ReadonlySet<number>,
+): readonly number[] {
+  const scheme = /^[A-Za-z][A-Za-z0-9+.-]*:\/\//u.exec(text);
+  if (!scheme) return [];
+  const authorityStart = scheme[0].length;
+  const authorityEndCandidate = text.slice(authorityStart).search(/[/?#]/u);
+  const authorityEnd = authorityEndCandidate < 0
+    ? text.length
+    : authorityStart + authorityEndCandidate;
+  const offsets: number[] = [];
+  for (let index = authorityEnd; index < text.length; index += 1) {
+    const character = text[index]!;
+    const offset = index + 1;
+    const readable =
+      (character === '/' && index > authorityEnd)
+      || character === '-'
+      || character === '?'
+      || character === '&';
+    if (
+      readable
+      && graphemeBoundaries.has(offset)
+      && !authoredNoBreakOffsets.has(offset)
+    ) offsets.push(offset);
+  }
+  return offsets;
+}
 
 export const WORD_RUN_VERTICAL_ALIGN_BASELINE_SHIFT = defineCompatibilityRule({
   id: 'word-run-vertical-align-baseline-shift',

--- a/packages/docx/src/layout/text-index.ts
+++ b/packages/docx/src/layout/text-index.ts
@@ -67,6 +67,7 @@ export type ElementGeometry = DrawingGeometry | InlineResourceGeometry;
 interface ProjectionContext {
   readonly collectTextRuns: boolean;
   readonly collectTextRunSources: boolean;
+  readonly collectCompletedParagraphSources: boolean;
   readonly collectDrawings: boolean;
   readonly drawingEntries: ReadonlyMap<string, PagePaintDrawingEntry>;
   readonly rootPointToPage: ReadonlyMap<string, Matrix2DData>;
@@ -76,6 +77,7 @@ interface ProjectionContext {
   readonly emittedDrawings: Set<string>;
   readonly runs: TextRunGeometry[];
   readonly sourceRuns: Map<string, Set<number>>;
+  readonly completedParagraphSources: Set<string>;
   readonly drawings: DrawingGeometry[];
   readonly inlineResources: InlineResourceGeometry[];
   drawingSourceOrder: number;
@@ -286,6 +288,12 @@ function visitParagraph(
   context: ProjectionContext,
 ): void {
   const paragraphProjection = withClip(projection, paragraph.clipBounds);
+  if (
+    context.collectCompletedParagraphSources
+    && paragraph.continuation?.continuesOnNext !== true
+  ) {
+    context.completedParagraphSources.add(sourceKey(paragraph.source));
+  }
   if (context.collectTextRuns || context.collectTextRunSources) {
     for (const line of paragraph.lines) {
       for (const placement of line.placements) {
@@ -455,6 +463,7 @@ function pageGeometryIndex(
   options: Readonly<{
     collectTextRuns: boolean;
     collectTextRunSources: boolean;
+    collectCompletedParagraphSources?: boolean;
     collectDrawings: boolean;
   }>,
 ): ProjectionContext {
@@ -476,6 +485,7 @@ function pageGeometryIndex(
   }
   const context: ProjectionContext = {
     ...options,
+    collectCompletedParagraphSources: options.collectCompletedParagraphSources === true,
     drawingEntries,
     rootPointToPage,
     rootPaintOrder,
@@ -484,6 +494,7 @@ function pageGeometryIndex(
     emittedDrawings: new Set(),
     runs: [],
     sourceRuns: new Map(),
+    completedParagraphSources: new Set(),
     drawings: [],
     inlineResources: [],
     drawingSourceOrder: 0,
@@ -533,6 +544,56 @@ export function textRunSourceIndexForDocument(
       if (!result.has(key)) result.set(key, indices);
       for (const index of pageIndices) indices.add(index);
     }
+  }
+  return result;
+}
+
+export interface ReviewProjectionIndex {
+  readonly renderedRunIndex: ReadonlyMap<string, ReadonlySet<number>>;
+  readonly completedSourceKeys: ReadonlySet<string>;
+}
+
+/** Build every index needed by comment/revision projection in one canonical
+ * geometry traversal. Progressive publications call this only when review data
+ * exists; combining the indexes avoids walking the growing prefix twice. */
+export function reviewProjectionIndexForDocument(
+  layout: DocumentLayout,
+): ReviewProjectionIndex {
+  const renderedRunIndex = new Map<string, Set<number>>();
+  const completedSourceKeys = new Set<string>();
+  for (let pageIndex = 0; pageIndex < layout.pages.length; pageIndex += 1) {
+    const page = pageGeometryIndex(layout, pageIndex, {
+      collectTextRuns: false,
+      collectTextRunSources: true,
+      collectCompletedParagraphSources: true,
+      collectDrawings: false,
+    });
+    for (const [key, pageIndices] of page.sourceRuns) {
+      const indices = renderedRunIndex.get(key) ?? new Set<number>();
+      if (!renderedRunIndex.has(key)) renderedRunIndex.set(key, indices);
+      for (const index of pageIndices) indices.add(index);
+    }
+    for (const key of page.completedParagraphSources) completedSourceKeys.add(key);
+  }
+  return Object.freeze({ renderedRunIndex, completedSourceKeys });
+}
+
+/** Canonical paragraph sources that have an occurrence in the supplied layout.
+ * Unlike the rendered-run index this includes empty and final-state-hidden
+ * paragraphs, so a provisional review projection can distinguish content that
+ * is already paginated from content that belongs to a future prefix. */
+export function completedParagraphSourceKeysForDocument(
+  layout: DocumentLayout,
+): ReadonlySet<string> {
+  const result = new Set<string>();
+  for (let pageIndex = 0; pageIndex < layout.pages.length; pageIndex += 1) {
+    const pageSources = pageGeometryIndex(layout, pageIndex, {
+      collectTextRuns: false,
+      collectTextRunSources: false,
+      collectCompletedParagraphSources: true,
+      collectDrawings: false,
+    }).completedParagraphSources;
+    for (const key of pageSources) result.add(key);
   }
   return result;
 }

--- a/packages/docx/src/layout/text.ts
+++ b/packages/docx/src/layout/text.ts
@@ -129,6 +129,11 @@ export function shapeRunToDocRun(
 /** Plain parser-boundary snapshot used by retained line acquisition. Private
  * parser extensions are copied into named immutable fields exactly once. */
 type ParagraphTextFacts = Readonly<{
+  /** Parser-projected CT_R boundary constraint around an authored
+   * `<w:noBreakHyphen/>`. These names are layout facts, not parser wire keys. */
+  noBreakBefore?: boolean;
+  noBreakAfter?: boolean;
+  noBreakRanges?: readonly Readonly<{ start: number; end: number }>[];
   fontFamilyHighAnsi?: string | null;
   fontFamilyEastAsia?: string | null;
   fontHint?: 'default' | 'eastAsia' | 'cs';

--- a/packages/docx/src/layout/validation-policy.ts
+++ b/packages/docx/src/layout/validation-policy.ts
@@ -25,8 +25,9 @@
  *
  * - ON by default under a test runner, so every suite (and therefore CI) keeps
  *   the path-precise reports.
- * - OFF otherwise; an embedder diagnosing a layout defect against a production
- *   build can re-enable it via the exported `setDocumentLayoutValidation`.
+ * - OFF otherwise. Internal tests and benchmarks can change the policy
+ *   explicitly when they need to compare validated and production-equivalent
+ *   execution.
  *
  * Freezing is NOT part of this policy and always runs: retained-layout
  * immutability is load-bearing (the identity WeakSets here and in
@@ -54,10 +55,9 @@ export function documentLayoutValidationEnabled(): boolean {
 /**
  * Turn the retained-layout contract checks on or off for this realm.
  *
- * Exposed as an explicit switch rather than an implicit `NODE_ENV` sniff inside
- * the layout code so an embedder can opt into full validation in production
- * while diagnosing a layout defect. `DocxDocument.load({ debug: true })` calls
- * this for the same reason.
+ * This is an internal test and benchmark control, not a public runtime option.
+ * Keeping the mutable policy inside the layout module avoids exposing realm-wide
+ * process state as part of the document API.
  */
 export function setDocumentLayoutValidation(next: boolean): void {
   enabled = next;

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -272,9 +272,9 @@ export interface LayoutTextSeg extends LayoutSegSource {
   /** Parser-independent UTF-16 ranges occupied by authored
    * `<w:noBreakHyphen/>` glyphs. Neither edge is a legal line boundary. */
   noBreakRanges?: readonly Readonly<{ start: number; end: number }>[];
-  /** Word-observed external-URL syntax breaks, as segment-local UTF-16 offsets. */
+  /** Registered external-URL syntax breaks, as segment-local UTF-16 offsets. */
   externalLinkBreakOffsets?: readonly number[];
-  /** This segment starts after a Word-observed external-URL syntax break. */
+  /** This segment starts after a registered external-URL syntax break. */
   externalLinkBreakBefore?: true;
   /** ECMA-376 §17.3.2.34 `<w:snapToGrid>` — false opts this run out of the
    *  section character grid without changing paragraph line-grid policy. */
@@ -3669,9 +3669,9 @@ export function buildSegments(
     }
   }
 
-  // Word treats path/query separators in a displayed external URL as ordinary
-  // line opportunities. Analyse the complete semantic link across formatting
-  // seams first, then project the opportunities onto the existing segments.
+  // Project the registered `word-external-link-syntax-breaks` opportunities
+  // across the complete semantic link and all formatting seams first, then
+  // distribute them onto the existing segments.
   // Segments stay intact unless a real overflow selects one of those offsets,
   // preserving contextual shaping, decoration geometry, and paint identity on
   // lines that do not wrap.

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -107,6 +107,7 @@ import {
   wordIdeographicSpaceLineEndAllowanceCount,
   wordUniformRunPositionPaintPt,
   wordUseFeLayoutParagraphMarkGridAdvancePx,
+  wordExternalLinkSyntaxBreakOffsets,
 } from './layout/line-compatibility.js';
 import { wordNeutralAttachesToActiveScript } from './layout/script-compatibility.js';
 
@@ -206,6 +207,9 @@ export interface LayoutTextSeg extends LayoutSegSource {
    *  not start a new line before a glued segment; it retracts the whole glued
    *  group instead, so a small-caps word never splits across lines. */
   joinPrev?: boolean;
+  /** Non-negotiable CT_R/noBreakHyphen seam. Unlike kinsoku/UAX glue, this
+   * remains atomic even when either side otherwise exposes CJK/SEA breaks. */
+  hardJoinPrev?: true;
   doubleStrikethrough?: boolean;
   highlight?: string | null;
   /** ECMA-376 §17.3.2.12 `<w:em w:val>` — emphasis (boten / 圏点) mark stamped on
@@ -260,10 +264,18 @@ export interface LayoutTextSeg extends LayoutSegSource {
   textBoxVertical?: boolean;
   /** IX1 — the resolved hyperlink target of the originating run (ECMA-376
    *  §17.16.22 external `r:id` URL / §17.16.23 internal `w:anchor` bookmark),
-   *  computed once per run in `buildSegments`. Carried purely so the text-layer
-   *  overlay can build a clickable region; it does NOT affect measurement, line
-   *  breaking, or the drawn glyphs. Absent for a non-link run. */
+   *  computed once per run in `buildSegments`. The text-layer consumes it for
+   *  the clickable region; line layout also uses external-link syntax as a
+   *  preferred break opportunity for otherwise unbreakable URL text. Absent
+   *  for a non-link run. */
   hyperlink?: HyperlinkTarget;
+  /** Parser-independent UTF-16 ranges occupied by authored
+   * `<w:noBreakHyphen/>` glyphs. Neither edge is a legal line boundary. */
+  noBreakRanges?: readonly Readonly<{ start: number; end: number }>[];
+  /** Word-observed external-URL syntax breaks, as segment-local UTF-16 offsets. */
+  externalLinkBreakOffsets?: readonly number[];
+  /** This segment starts after a Word-observed external-URL syntax break. */
+  externalLinkBreakBefore?: true;
   /** ECMA-376 §17.3.2.34 `<w:snapToGrid>` — false opts this run out of the
    *  section character grid without changing paragraph line-grid policy. */
   snapToCharacterGrid?: boolean;
@@ -1202,6 +1214,76 @@ export function slicedPunctuationCompressions(
       end: compression.end - start,
       adjustmentPt: compression.adjustmentPt,
     }));
+  return sliced && sliced.length > 0 ? Object.freeze(sliced) : undefined;
+}
+
+function slicedNoBreakRanges(
+  seg: LayoutTextSeg,
+  start: number,
+  end: number,
+): LayoutTextSeg['noBreakRanges'] {
+  const sliced = seg.noBreakRanges
+    ?.filter((range) => range.start >= start && range.end <= end)
+    .map((range) => Object.freeze({
+      start: range.start - start,
+      end: range.end - start,
+    }));
+  return sliced && sliced.length > 0 ? Object.freeze(sliced) : undefined;
+}
+
+function protectedNoBreakOffsets(seg: LayoutTextSeg): ReadonlySet<number> {
+  return new Set(seg.noBreakRanges?.flatMap((range) => [range.start, range.end]) ?? []);
+}
+
+function legalTextSplitAtOrBefore(
+  seg: LayoutTextSeg,
+  proposed: number,
+  minimum = 0,
+): number {
+  const protectedOffsets = protectedNoBreakOffsets(seg);
+  return [0, ...graphemeClusterOffsets(seg.text), seg.text.length]
+    .filter((offset, index, all) => all.indexOf(offset) === index)
+    .filter((offset) => offset >= minimum && offset <= proposed && !protectedOffsets.has(offset))
+    .at(-1) ?? 0;
+}
+
+/** Smallest prefix that consumes a hard source seam. It includes the complete
+ * authored noBreakHyphen range plus the first following grapheme when both
+ * range edges live in this segment. */
+function hardJoinPrefixEnd(seg: LayoutTextSeg): number | undefined {
+  if (seg.hardJoinPrev !== true || seg.text.length === 0) return undefined;
+  const protectedOffsets = protectedNoBreakOffsets(seg);
+  const firstLegal = [
+    ...graphemeClusterOffsets(seg.text),
+    seg.text.length,
+  ].find((offset) => offset > 0 && !protectedOffsets.has(offset));
+  return firstLegal ?? seg.text.length;
+}
+
+/** Single authority for metadata whose UTF-16 coordinates are relative to a
+ * text segment. Every retained split path must use this projection. */
+function slicedTextMetadata(
+  seg: LayoutTextSeg,
+  start: number,
+  end: number,
+): Pick<LayoutTextSeg,
+  'punctuationCompressions' | 'noBreakRanges' | 'externalLinkBreakOffsets'
+> {
+  return {
+    punctuationCompressions: slicedPunctuationCompressions(seg, start, end),
+    noBreakRanges: slicedNoBreakRanges(seg, start, end),
+    externalLinkBreakOffsets: slicedExternalLinkBreakOffsets(seg, start, end),
+  };
+}
+
+function slicedExternalLinkBreakOffsets(
+  seg: LayoutTextSeg,
+  start: number,
+  end: number,
+): readonly number[] | undefined {
+  const sliced = seg.externalLinkBreakOffsets
+    ?.filter((offset) => offset > start && offset < end)
+    .map((offset) => offset - start);
   return sliced && sliced.length > 0 ? Object.freeze(sliced) : undefined;
 }
 
@@ -3132,11 +3214,14 @@ export function buildSegments(
         smallCaps: reduced,
         joinPrev: (
           (firstSeg && (
-            (r as DocxTextRun & { __noBreakBefore?: boolean }).__noBreakBefore === true
+            r.noBreakBefore === true
             || joinPreviousRun
           ))
           || gluePending
           || authoritativeSpan?.breakBefore === false
+        ) ? true : undefined,
+        hardJoinPrev: (
+          firstSeg && (r.noBreakBefore === true || joinPreviousRun)
         ) ? true : undefined,
         doubleStrikethrough: base.doubleStrikethrough ?? false,
         highlight: base.highlight ?? null,
@@ -3164,7 +3249,8 @@ export function buildSegments(
         textBoxLineFloor: (r as DocxTextRun & { textBoxLineFloor?: boolean }).textBoxLineFloor,
         textBoxVertical: (r as DocxTextRun & { textBoxVertical?: boolean }).textBoxVertical,
         // IX1 — resolved hyperlink target of the originating run, for the
-        // text-layer clickable overlay. Does not affect layout or drawing.
+        // text-layer clickable overlay and URL-aware line-break opportunities.
+        // It does not change glyph measurement or drawing.
         hyperlink,
         snapToCharacterGrid: effectiveSnapToGrid !== false,
         // WD4 — run character metrics (§17.3.2.35 spacing / §17.3.2.43 w /
@@ -3314,7 +3400,7 @@ export function buildSegments(
     }
     const joinFromPreviousNoBreakHyphen = joinNextVisibleText;
     joinNextVisibleText = run.type === 'text'
-      && (run as DocxTextRun & { __noBreakAfter?: boolean }).__noBreakAfter === true;
+      && (run as ParagraphTextBearingRun).noBreakAfter === true;
     const emittedStart = segs.length;
     if (run.type === 'text') {
       const t = run as unknown as DocxTextRun & { type: 'text' };
@@ -3542,6 +3628,130 @@ export function buildSegments(
     }
   }
 
+  // Project acquisition-owned no-break ranges through the display case
+  // transform and onto the single-font layout segments produced above.
+  for (const [runIndex, run] of runs.entries()) {
+    if (run.type !== 'text') continue;
+    const textRun = run as Extract<ParagraphTextBearingRun, { type: 'text' }>;
+    const sourceRanges = textRun.noBreakRanges;
+    if (!sourceRanges || sourceRanges.length === 0) continue;
+    const displayedRanges = sourceRanges.map((range) => {
+      const transformOffset = (offset: number) => {
+        const prefix = textRun.text.slice(0, offset);
+        return textRun.allCaps || textRun.smallCaps ? prefix.toUpperCase().length : prefix.length;
+      };
+      return { start: transformOffset(range.start), end: transformOffset(range.end) };
+    });
+    let displayedCursor = 0;
+    for (const candidate of segs) {
+      if (candidate.sourceRunIndex !== runIndex) continue;
+      if (!('text' in candidate)) {
+        if ('isTab' in candidate) displayedCursor += 1;
+        continue;
+      }
+      const segmentEnd = displayedCursor + candidate.text.length;
+      if (
+        displayedCursor > 0
+        && displayedRanges.some((range) =>
+          range.start === displayedCursor || range.end === displayedCursor)
+      ) {
+        candidate.joinPrev = true;
+        candidate.hardJoinPrev = true;
+      }
+      const local = displayedRanges
+        .filter((range) => range.start >= displayedCursor && range.end <= segmentEnd)
+        .map((range) => Object.freeze({
+          start: range.start - displayedCursor,
+          end: range.end - displayedCursor,
+        }));
+      if (local.length > 0) candidate.noBreakRanges = Object.freeze(local);
+      displayedCursor = segmentEnd;
+    }
+  }
+
+  // Word treats path/query separators in a displayed external URL as ordinary
+  // line opportunities. Analyse the complete semantic link across formatting
+  // seams first, then project the opportunities onto the existing segments.
+  // Segments stay intact unless a real overflow selects one of those offsets,
+  // preserving contextual shaping, decoration geometry, and paint identity on
+  // lines that do not wrap.
+  for (let groupStart = 0; groupStart < segs.length;) {
+    const first = segs[groupStart];
+    if (!('text' in first) || first.hyperlink?.kind !== 'external') {
+      groupStart += 1;
+      continue;
+    }
+    const target = first.hyperlink.url;
+    let groupEnd = groupStart;
+    const group: LayoutTextSeg[] = [];
+    while (groupEnd < segs.length) {
+      const candidate = segs[groupEnd];
+      if (
+        !('text' in candidate)
+        || candidate.hyperlink?.kind !== 'external'
+        || candidate.hyperlink.url !== target
+      ) break;
+      group.push(candidate);
+      groupEnd += 1;
+    }
+    const groupText = group.map((segment) => segment.text).join('');
+    const protectedOffsets = new Set<number>();
+    let cursor = 0;
+    for (const segment of group) {
+      for (const range of segment.noBreakRanges ?? []) {
+        const offsets = [range.start, range.end];
+        for (const offset of offsets) {
+          protectedOffsets.add(cursor + offset);
+        }
+      }
+      cursor += segment.text.length;
+    }
+    const legalOffsets = new Set<number>();
+    for (const match of groupText.matchAll(/\S+/gu)) {
+      const token = match[0];
+      const tokenStart = match.index;
+      const graphemeBoundaries = new Set(
+        graphemeClusterOffsets(token).map((offset) => tokenStart + offset),
+      );
+      const tokenProtected = new Set(
+        [...protectedOffsets]
+          .filter((offset) => offset > tokenStart && offset <= tokenStart + token.length)
+          .map((offset) => offset - tokenStart),
+      );
+      const tokenGraphemes = new Set(
+        [...graphemeBoundaries].map((offset) => offset - tokenStart),
+      );
+      for (const offset of wordExternalLinkSyntaxBreakOffsets(
+        token,
+        tokenGraphemes,
+        tokenProtected,
+      )) legalOffsets.add(tokenStart + offset);
+    }
+    if (legalOffsets.size === 0) {
+      groupStart = groupEnd;
+      continue;
+    }
+    cursor = 0;
+    for (let index = 0; index < group.length; index += 1) {
+      const segment = group[index]!;
+      const segmentStart = cursor;
+      const segmentEnd = segmentStart + segment.text.length;
+      const localBreaks = [...legalOffsets]
+        .filter((offset) => offset > segmentStart && offset < segmentEnd)
+        .map((offset) => offset - segmentStart)
+        .sort((a, b) => a - b);
+      if (localBreaks.length > 0) {
+        segment.externalLinkBreakOffsets = Object.freeze(localBreaks);
+      }
+      if (index > 0 && legalOffsets.has(segmentStart)) {
+        segment.joinPrev = undefined;
+        segment.externalLinkBreakBefore = true;
+      }
+      cursor = segmentEnd;
+    }
+    groupStart = groupEnd;
+  }
+
   if (environment.balanceSingleByteDoubleByteWidth) {
     // ECMA-376 §17.15.3.3 normatively requests a 1:2 SBCS/DBCS width balance,
     // but does not define how a proportional inter-word separator becomes a
@@ -3691,7 +3901,12 @@ export function buildSegments(
   // false means unsupported/deferred, never "break allowed".
   for (let i = 1; i < segs.length; i++) {
     const cur = segs[i];
-    if (!('text' in cur) || cur.joinPrev || cur.text.length === 0) continue;
+    if (
+      !('text' in cur)
+      || cur.joinPrev
+      || cur.externalLinkBreakBefore
+      || cur.text.length === 0
+    ) continue;
     const prev = segs[i - 1];
     if (!('text' in prev) || prev.text.length === 0) continue;
 
@@ -4531,7 +4746,9 @@ export function layoutLines(
     // layout kinsoku set (§17.15.1.58–.60) drops positions that would orphan a
     // forbidden char at a line head/tail, replacing the CJK path's retract.
     if ('text' in seg && containsSeaScript(seg.text)) {
-      seg.seaBreaks = seaMixedBreakOffsets(seg.text, { cjk: true, kinsoku });
+      const protectedOffsets = protectedNoBreakOffsets(seg);
+      seg.seaBreaks = seaMixedBreakOffsets(seg.text, { cjk: true, kinsoku })
+        .filter((offset) => !protectedOffsets.has(offset));
     }
     return seg;
   });
@@ -4554,11 +4771,12 @@ export function layoutLines(
                 text,
                 measuredWidth: 0,
                 src: { ...startBoundary },
-                punctuationCompressions: slicedPunctuationCompressions(
-                  first,
-                  startBoundary.charOffset,
-                  first.text.length,
-                ),
+                // A retained resume boundary has already consumed the source
+                // seam. Carrying either marker would invent new ownership at
+                // the start of this suffix.
+                joinPrev: undefined,
+                hardJoinPrev: undefined,
+                ...slicedTextMetadata(first, startBoundary.charOffset, first.text.length),
                 // Rebase the SEA break offsets onto the resumed (sliced) text so
                 // a paginated Thai paragraph still breaks at word boundaries.
                 seaBreaks: rebaseSeaBreaks(first.seaBreaks, startBoundary.charOffset),
@@ -4904,7 +5122,7 @@ export function layoutLines(
       ...RESET_SLICED_TEXT_MEASUREMENT,
       text: hangingText,
       measuredWidth: 0,
-      punctuationCompressions: slicedPunctuationCompressions(follower, 0, 1),
+      ...slicedTextMetadata(follower, 0, hangingText.length),
     };
     const followerBox = textSegmentBox(hangingSegment);
     hangingSegment.measuredWidth = followerBox.width;
@@ -4923,11 +5141,8 @@ export function layoutLines(
         text: remainder,
         measuredWidth: 0,
         joinPrev: undefined,
-        punctuationCompressions: slicedPunctuationCompressions(
-          follower,
-          hangingText.length,
-          follower.text.length,
-        ),
+        hardJoinPrev: undefined,
+        ...slicedTextMetadata(follower, hangingText.length, follower.text.length),
         src: follower.src
           ? {
               segIndex: follower.src.segIndex,
@@ -5021,6 +5236,225 @@ export function layoutLines(
       ? (wrapCtx?.paragraphMarkLineStartWidth ?? minLineStartWidth())
       : minLineStartWidth(),
   );
+
+  /**
+   * Return the widest grapheme-safe UTF-16 prefix that fits an emergency
+   * break band. This is the single authority used whether the overlong token
+   * starts on an empty line or consumes the useful remainder of the current
+   * line. Keeping both cases here prevents measurement and retained paint
+   * partitions from drifting apart.
+   */
+  const emergencyTextSplit = (
+    segment: LayoutTextSeg,
+    available: number,
+    forceAtLeastOne = true,
+  ): number => {
+    const protectedOffsets = protectedNoBreakOffsets(segment);
+    const graphemeOffsets = [
+      0,
+      ...graphemeClusterOffsets(segment.text),
+      segment.text.length,
+    ].filter((offset, index, all) => all.indexOf(offset) === index);
+    let split = 0;
+    if (available > 0) {
+      const monotoneAllocation = charSpacingDeltaPx(segment, scale) >= 0
+        && snapToCharsClass(segment, characterGrid) !== 'latin';
+      if (monotoneAllocation) {
+        setMeasureFont(buildFont(
+          segment.bold,
+          segment.italic,
+          effectiveFontPx(segment),
+          segment.fontFamily,
+          fontFamilyClasses,
+          segment.fontRoute,
+        ));
+        const prevKern = setSegKerning(segment);
+        try {
+          const fitted = fitCJKPrefix(
+            ctx,
+            segment.text,
+            available,
+            segmentCharacterGridDeltaPx(segment, characterGrid, scale),
+            charScaleFactor(segment),
+            charSpacingDeltaPx(segment, scale),
+            segment.verticalRun === true,
+            verticalGlyphMeasurement,
+            (prefix) => strAdvance(segment, prefix),
+          ).length;
+          split = graphemeOffsets
+            .filter((offset) => offset <= fitted && !protectedOffsets.has(offset))
+            .at(-1) ?? 0;
+        } finally {
+          restoreKerning(prevKern);
+        }
+      } else {
+        // Signed spacing and a Latin snap block can make prefix advances
+        // non-monotone. Evaluate every legal retained candidate against the
+        // exact prospective line block rather than binary-searching a
+        // standalone approximation.
+        for (const offset of graphemeOffsets) {
+          if (offset <= 0 || protectedOffsets.has(offset)) continue;
+          const natural = strNaturalAdvance(segment, segment.text.slice(0, offset));
+          if (prospectiveSnapAdvance(segment, natural) <= available + 1e-9) split = offset;
+        }
+      }
+    }
+    if (split <= 0 && forceAtLeastOne) {
+      split = graphemeOffsets.find((offset) => offset > 0 && !protectedOffsets.has(offset))
+        ?? segment.text.length;
+    }
+    // Preserve the existing JLReq/Word line-end hanging rule after switching
+    // the emergency splitter from code-point indexes to UTF-16 grapheme offsets.
+    while (segment.text.startsWith('\u3000', split)) split += 1;
+    return split;
+  };
+
+  /** Select the last semantic URL candidate that fits the prospective band.
+   * Every candidate is evaluated independently: signed character spacing can
+   * make prefix advances non-monotone, and snapToChars must include the current
+   * line's active script block rather than treating the prefix in isolation. */
+  const externalLinkSyntaxSplit = (
+    segment: LayoutTextSeg,
+    available: number,
+  ): number => {
+    if (!(available > 0) || !segment.externalLinkBreakOffsets?.length) return 0;
+    let selected = 0;
+    for (const offset of segment.externalLinkBreakOffsets) {
+      if (offset <= 0 || offset >= segment.text.length) continue;
+      const naturalAdvance = strNaturalAdvance(segment, segment.text.slice(0, offset));
+      const prospectiveAdvance = prospectiveSnapAdvance(segment, naturalAdvance);
+      if (prospectiveAdvance <= available + 1e-9) selected = offset;
+    }
+    return selected;
+  };
+
+  const queueEmergencyTail = (segment: LayoutTextSeg, split: number): void => {
+    queue.unshift({
+      ...segment,
+      ...RESET_SLICED_TEXT_MEASUREMENT,
+      text: segment.text.slice(split),
+      ...slicedTextMetadata(segment, split, segment.text.length),
+      seaBreaks: rebaseSeaBreaks(segment.seaBreaks, split),
+      measuredWidth: 0,
+      // The emergency split itself is now the legal line boundary. A source-
+      // boundary glue marker protects only the first retained prefix; carrying
+      // it onto the tail would make the next line overflow again.
+      joinPrev: undefined,
+      hardJoinPrev: undefined,
+      src: {
+        segIndex: segment.src!.segIndex,
+        charOffset: segment.src!.charOffset + split,
+      },
+    });
+  };
+
+  type CrossRunKinsokuRetraction =
+    | { readonly kind: 'none' }
+    | { readonly kind: 'blocked' }
+    | { readonly kind: 'retracted'; readonly tail: LayoutTextSeg };
+
+  /**
+   * Move a legal suffix of the current line ahead of a segment whose first
+   * glyph is forbidden at line start. This is the single cross-run 追い出し
+   * authority for both the CJK and SEA overflow paths.
+   *
+   * A source seam marked by `hardJoinPrev` is indivisible: moving the complete
+   * following segment would strand its owner on the previous line. Likewise,
+   * a split at either edge of an authored no-break range is not legal. When
+   * either constraint blocks retraction, the caller must keep the forbidden
+   * leader on the current line instead of weakening the authored constraint.
+   */
+  const retractCurrentLineForLeadingKinsoku = (
+    next: LayoutTextSeg,
+  ): CrossRunKinsokuRetraction => {
+    const firstCp = next.text.codePointAt(0);
+    const lastSeg = currentLine[currentLine.length - 1];
+    if (
+      firstCp === undefined
+      || !kinsoku.lineStartForbidden.has(firstCp)
+      || lastSeg === undefined
+      || !('text' in lastSeg)
+    ) {
+      return { kind: 'none' };
+    }
+
+    const lastText = lastSeg as LayoutTextSeg;
+    const chars = [...lastText.text];
+    const minKeep = currentLine.length > 1 ? 0 : 1;
+    const retractCount = crossRunKinsokuRetract(chars, kinsoku, minKeep);
+    if (retractCount <= 0) return { kind: 'none' };
+
+    const headText = chars.slice(0, chars.length - retractCount).join('');
+    const split = headText.length;
+    // Moving the whole segment would cut the hard source seam immediately
+    // before it. A protected no-break edge is equally indivisible.
+    if (
+      (split === 0 && lastText.hardJoinPrev === true)
+      || protectedNoBreakOffsets(lastText).has(split)
+    ) {
+      return { kind: 'blocked' };
+    }
+
+    const tailText = lastText.text.slice(split);
+    const tail: LayoutTextSeg = {
+      ...lastText,
+      ...RESET_SLICED_TEXT_MEASUREMENT,
+      text: tailText,
+      ...slicedTextMetadata(lastText, split, lastText.text.length),
+      measuredWidth: strAdvance(lastText, tailText, true),
+      // The retraction creates a real line boundary. The old source seam was
+      // either retained in `headText` or was soft; it must not be projected
+      // onto this newly-created suffix.
+      joinPrev: undefined,
+      hardJoinPrev: undefined,
+      src: {
+        segIndex: lastText.src!.segIndex,
+        charOffset: lastText.src!.charOffset + split,
+      },
+      seaBreaks: rebaseSeaBreaks(lastText.seaBreaks, split),
+    };
+
+    if (headText) {
+      const headW = strAdvance(lastText, headText);
+      currentWidth -= lastText.measuredWidth - headW;
+      currentLine[currentLine.length - 1] = {
+        ...lastText,
+        ...RESET_SLICED_TEXT_MEASUREMENT,
+        text: headText,
+        measuredWidth: headW,
+        ...slicedTextMetadata(lastText, 0, split),
+      };
+    } else {
+      currentWidth -= lastText.measuredWidth;
+      currentLine.pop();
+    }
+    return { kind: 'retracted', tail };
+  };
+
+  /** Keep one otherwise-forbidden line-start grapheme with the current line.
+   * This is the only legal fallback when cross-run retraction would split an
+   * authored hard/no-break group. Reprocessing the tail repeats the rule for a
+   * sequence of forbidden leaders while guaranteeing grapheme-safe progress. */
+  const keepLeadingKinsokuWithCurrentLine = (
+    segment: LayoutTextSeg,
+    h: number,
+    asc: number,
+    desc: number,
+  ): boolean => {
+    const firstEnd = graphemeClusterOffsets(segment.text)[0] ?? segment.text.length;
+    if (firstEnd <= 0) return false;
+    const prefix = segment.text.slice(0, firstEnd);
+    const prefixWidth = strNaturalAdvance(segment, prefix);
+    addToLine({
+      ...segment,
+      ...RESET_SLICED_TEXT_MEASUREMENT,
+      text: prefix,
+      measuredWidth: prefixWidth,
+      ...slicedTextMetadata(segment, 0, firstEnd),
+    }, prefixWidth, h, asc, desc);
+    if (firstEnd < segment.text.length) queueEmergencyTail(segment, firstEnd);
+    return true;
+  };
 
   while (queue.length > 0) {
     const seg = queue.shift()!;
@@ -5298,11 +5732,7 @@ export function layoutLines(
         paragraphFinalIdeographicSpaceCount: undefined,
         paragraphFinalIdeographicSpaceTailStart: undefined,
         measuredWidth: 0,
-        punctuationCompressions: slicedPunctuationCompressions(
-          s,
-          0,
-          visibleBeforeParagraphFinalTail.length,
-        ),
+        ...slicedTextMetadata(s, 0, visibleBeforeParagraphFinalTail.length),
       };
       const trailingSegment: LayoutTextSeg = {
         ...s,
@@ -5310,13 +5740,10 @@ export function layoutLines(
         text: s.text.slice(visibleBeforeParagraphFinalTail.length),
         paragraphFinalIdeographicSpaceLocalCount,
         joinPrev: undefined,
+        hardJoinPrev: undefined,
         paragraphFinalIdeographicSpaceTailStart: true,
         measuredWidth: 0,
-        punctuationCompressions: slicedPunctuationCompressions(
-          s,
-          visibleBeforeParagraphFinalTail.length,
-          s.text.length,
-        ),
+        ...slicedTextMetadata(s, visibleBeforeParagraphFinalTail.length, s.text.length),
         src: s.src
           ? {
               segIndex: s.src.segIndex,
@@ -5460,10 +5887,16 @@ export function layoutLines(
       !s.joinPrev &&
       currentLine.length > 0 &&
       (queue[0] as LayoutTextSeg | undefined)?.joinPrev &&
-      !hasCJKBreakOpportunity(s.text) &&
+      (
+        (queue[0] as LayoutTextSeg | undefined)?.hardJoinPrev === true
+        || !hasCJKBreakOpportunity(s.text)
+      ) &&
       // A SEA (Thai/Lao/Khmer) lead with usable word breaks is NOT atomic — the
       // run splits at a dictionary boundary (issue #797), mirroring the CJK gate.
-      !(s.seaBreaks && s.seaBreaks.length > 0)
+      (
+        (queue[0] as LayoutTextSeg | undefined)?.hardJoinPrev === true
+        || !(s.seaBreaks && s.seaBreaks.length > 0)
+      )
     ) {
       let groupW = w;
       let groupTrail = trailingSpaceW;
@@ -5482,6 +5915,31 @@ export function layoutLines(
       };
       for (; groupEnd < queue.length && (queue[groupEnd] as LayoutTextSeg).joinPrev; groupEnd++) {
         const f = queue[groupEnd] as LayoutTextSeg;
+        const hardPrefixEnd = hardJoinPrefixEnd(f);
+        if (hardPrefixEnd !== undefined) {
+          const prefix = f.text.slice(0, hardPrefixEnd);
+          const prefixWidth = strAdvance(f, prefix);
+          groupW += prefixWidth;
+          advanceGroupBias(f, prefix);
+          noteMeasurementRoute(groupMeasurementRoutes, f, prefix);
+          groupTrail = prefix.endsWith(' ')
+            ? prefixWidth - strAdvance(f, prefix.replace(/ +$/, ''))
+            : 0;
+          // A whole hard member can lead into another hard member. Otherwise
+          // the first legal boundary after the seam ends the atomic prefix.
+          if (hardPrefixEnd < f.text.length) break;
+          continue;
+        }
+        const firstExternalBreak = f.externalLinkBreakOffsets?.[0];
+        if (firstExternalBreak !== undefined) {
+          const prefix = f.text.slice(0, firstExternalBreak);
+          const prefixWidth = strAdvance(f, prefix);
+          groupW += prefixWidth;
+          advanceGroupBias(f, prefix);
+          noteMeasurementRoute(groupMeasurementRoutes, f, prefix);
+          groupTrail = 0;
+          break;
+        }
         // A CJK-BREAKABLE follower (e.g. "Roman" + "、あるいは…用いる。") is NOT
         // atomic: only its LEADING run of line-start-forbidden chars would orphan
         // at a line head (UAX#14 LB13 / §17.3.1.16); the rest splits at an
@@ -5630,7 +6088,11 @@ export function layoutLines(
       s.measuredWidth = w;
       addToLine(s, w, h, asc, desc, trailingSpaceW);
       appendQueuedIdeographicSpaceSegment(s);
-    } else if (hasCJKBreakOpportunity(s.text) && s.seaBreaks === undefined) {
+    } else if (
+      hasCJKBreakOpportunity(s.text)
+      && s.seaBreaks === undefined
+      && s.hardJoinPrev !== true
+    ) {
       // CJK overflow: split at the maximum prefix that fits, re-queue the tail.
       // A segment that ALSO contains SEA (a mixed CJK+SEA `<w:cs/>` run) is routed
       // to the SEA branch below instead — its `seaBreaks` already merges the CJK
@@ -5640,8 +6102,6 @@ export function layoutLines(
       //  separate: it sums per-char advances, whereas this path uses substring
       //  binary-search + the cross-run 追い出し below. Don't naively unify them.)
       const available = availW() - currentWidth;
-      setMeasureFont(buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses, s.fontRoute));
-      const prevKern = setSegKerning(s);
       let rawPrefix = '';
       const maximumIdeographicSpaceHang = paragraphFinalIdeographicSpaceTail
         ? wordIdeographicSpaceLineEndAllowanceCount(
@@ -5649,21 +6109,31 @@ export function layoutLines(
             s.paragraphFinalIdeographicSpaceCount ?? 0,
           )
         : Number.POSITIVE_INFINITY;
-      try {
-        rawPrefix = available > 0 ? fitCJKPrefix(
-          ctx,
-          s.text,
-          available,
-          segmentCharacterGridDeltaPx(s, characterGrid, scale),
-          charScaleFactor(s),
-          charSpacingDeltaPx(s, scale),
-          s.verticalRun === true,
-          verticalGlyphMeasurement,
-          (prefix) => strAdvance(s, prefix),
-          maximumIdeographicSpaceHang,
-        ) : '';
-      } finally {
-        restoreKerning(prevKern);
+      if (available > 0) {
+        const nonMonotoneAllocation = charSpacingDeltaPx(s, scale) < 0
+          || snapToCharsClass(s, characterGrid) === 'latin';
+        if (nonMonotoneAllocation) {
+          rawPrefix = s.text.slice(0, emergencyTextSplit(s, available, false));
+        } else {
+          setMeasureFont(buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses, s.fontRoute));
+          const prevKern = setSegKerning(s);
+          try {
+            rawPrefix = fitCJKPrefix(
+              ctx,
+              s.text,
+              available,
+              segmentCharacterGridDeltaPx(s, characterGrid, scale),
+              charScaleFactor(s),
+              charSpacingDeltaPx(s, scale),
+              s.verticalRun === true,
+              verticalGlyphMeasurement,
+              (prefix) => strAdvance(s, prefix),
+              maximumIdeographicSpaceHang,
+            );
+          } finally {
+            restoreKerning(prevKern);
+          }
+        }
       }
       // Apply kinsoku to the break position: retract leftwards so the tail
       // never begins with a 行頭禁則 char and the head never ends with a
@@ -5685,14 +6155,16 @@ export function layoutLines(
         && wordIsOverflowPunctuation(allChars[rawSplit], s.eastAsiaLanguage)
           ? rawSplit + 1
           : null;
-      const split = extendThroughTrailingIdeographicSpaces(
+      const proposedSplit = extendThroughTrailingIdeographicSpaces(
         allChars,
         hangingSplit ?? kinsokuAdjustedSplit(allChars, rawSplit, kinsoku, minSplit),
         paragraphFinalIdeographicSpaceTail && maximumIdeographicSpaceHang === 0
           ? 0
           : maximumIdeographicSpaceHang,
       );
-      const prefix = allChars.slice(0, split).join('');
+      const proposedPrefix = allChars.slice(0, proposedSplit).join('').length;
+      const protectedSplit = legalTextSplitAtOrBefore(s, proposedPrefix, minSplit > 0 ? 1 : 0);
+      const prefix = s.text.slice(0, protectedSplit);
       if (prefix.length > 0) {
         // Grid advance for the head piece — the same model as the line box / draw.
         const pw = strNaturalAdvance(s, prefix);
@@ -5701,7 +6173,7 @@ export function layoutLines(
           ...RESET_SLICED_TEXT_MEASUREMENT,
           text: prefix,
           measuredWidth: pw,
-          punctuationCompressions: slicedPunctuationCompressions(s, 0, prefix.length),
+          ...slicedTextMetadata(s, 0, prefix.length),
         };
         addToLine(headSeg, pw, h, asc, desc);
         const tail = s.text.slice(prefix.length);
@@ -5710,11 +6182,7 @@ export function layoutLines(
             ...s,
             ...RESET_SLICED_TEXT_MEASUREMENT,
             text: tail,
-            punctuationCompressions: slicedPunctuationCompressions(
-              s,
-              prefix.length,
-              s.text.length,
-            ),
+            ...slicedTextMetadata(s, prefix.length, s.text.length),
             measuredWidth: 0,
             src: {
               segIndex: s.src!.segIndex,
@@ -5731,58 +6199,14 @@ export function layoutLines(
         // text segment down so they lead the next line ahead of `s` — cross-run
         // 追い出し (§17.3.1.16). See crossRunKinsokuRetract for the bounded,
         // re-validating, whitespace-guarded retraction count.
-        let retracted: LayoutTextSeg | null = null;
-        const sFirstCp = s.text.codePointAt(0);
-        const lastSeg = currentLine[currentLine.length - 1];
-        if (sFirstCp !== undefined && kinsoku.lineStartForbidden.has(sFirstCp) && 'text' in lastSeg) {
-          const lastText = lastSeg as LayoutTextSeg;
-          const chars = [...lastText.text];
-          const minKeep = currentLine.length > 1 ? 0 : 1;
-          const k = crossRunKinsokuRetract(chars, kinsoku, minKeep);
-          if (k > 0) {
-            const headText = chars.slice(0, chars.length - k).join('');
-            const tailText = chars.slice(chars.length - k).join('');
-            retracted = {
-              ...lastText,
-              ...RESET_SLICED_TEXT_MEASUREMENT,
-              text: tailText,
-              punctuationCompressions: slicedPunctuationCompressions(
-                lastText,
-                headText.length,
-                lastText.text.length,
-              ),
-              measuredWidth: strAdvance(lastText, tailText, true),
-              src: {
-                segIndex: lastText.src!.segIndex,
-                charOffset: lastText.src!.charOffset + headText.length,
-              },
-            };
-            if (headText) {
-              const headW = strAdvance(lastText, headText);
-              currentWidth -= lastText.measuredWidth - headW;
-              currentLine[currentLine.length - 1] = {
-                ...lastText,
-                ...RESET_SLICED_TEXT_MEASUREMENT,
-                text: headText,
-                measuredWidth: headW,
-                punctuationCompressions: slicedPunctuationCompressions(
-                  lastText,
-                  0,
-                  headText.length,
-                ),
-              };
-            } else {
-              // Whole last segment moves down. Line metrics (ascent/descent) are
-              // not recomputed; the retracted graphemes share the line's font in
-              // practice, so the flushed box height is unaffected.
-              currentWidth -= lastText.measuredWidth;
-              currentLine.pop();
-            }
-          }
+        const retraction = retractCurrentLineForLeadingKinsoku(s);
+        if (retraction.kind === 'blocked') {
+          keepLeadingKinsokuWithCurrentLine(s, h, asc, desc);
+          continue;
         }
-        flush(undefined, false, retracted?.src ?? s.src);
+        flush(undefined, false, retraction.kind === 'retracted' ? retraction.tail.src : s.src);
         queue.unshift(s);
-        if (retracted) queue.unshift(retracted);
+        if (retraction.kind === 'retracted') queue.unshift(retraction.tail);
       } else {
         // Empty line and not even one char fits — force-fit one char to guarantee progress
         const forcedChars = [...s.text];
@@ -5798,7 +6222,10 @@ export function layoutLines(
                 : Number.POSITIVE_INFINITY,
             )
           : 0;
-        const firstChar = forcedChars.slice(0, forcedSplit).join('');
+        const forcedUtf16 = forcedChars.slice(0, forcedSplit).join('').length;
+        const legalForcedUtf16 = legalTextSplitAtOrBefore(s, forcedUtf16)
+          || emergencyTextSplit(s, availW(), true);
+        const firstChar = s.text.slice(0, legalForcedUtf16);
         if (firstChar) {
           const fw = strNaturalAdvance(s, firstChar);
           const headSeg: LayoutTextSeg = {
@@ -5806,7 +6233,7 @@ export function layoutLines(
             ...RESET_SLICED_TEXT_MEASUREMENT,
             text: firstChar,
             measuredWidth: fw,
-            punctuationCompressions: slicedPunctuationCompressions(s, 0, firstChar.length),
+            ...slicedTextMetadata(s, 0, firstChar.length),
           };
           addToLine(headSeg, fw, h, asc, desc);
           const tail = s.text.slice(firstChar.length);
@@ -5815,11 +6242,7 @@ export function layoutLines(
               ...s,
               ...RESET_SLICED_TEXT_MEASUREMENT,
               text: tail,
-              punctuationCompressions: slicedPunctuationCompressions(
-                s,
-                firstChar.length,
-                s.text.length,
-              ),
+              ...slicedTextMetadata(s, firstChar.length, s.text.length),
               measuredWidth: 0,
               src: {
                 segIndex: s.src!.segIndex,
@@ -5831,7 +6254,7 @@ export function layoutLines(
           }
         }
       }
-    } else if (s.seaBreaks !== undefined) {
+    } else if (s.seaBreaks !== undefined && s.hardJoinPrev !== true) {
       // No-inter-word-space line wrap: Thai/Lao/Khmer dictionary words (#797) or
       // Myanmar/Tibetan grapheme clusters (#961). This ONE segment is a whole run;
       // break it only at a member of `s.seaBreaks` — the UNION (#960) of the
@@ -5851,7 +6274,9 @@ export function layoutLines(
       // Grapheme-fill runs (Myanmar/Tibetan) have DENSE offsets (one per cluster),
       // so use the monotone binary-search fit — a per-line full scan would be O(n²)
       // down a long run. Dictionary runs keep the negative-spacing-safe full scan.
-      const monotone = isGraphemeFillText(s.text);
+      const monotone = isGraphemeFillText(s.text)
+        && charSpacingDeltaPx(s, scale) >= 0
+        && snapToCharsClass(s, characterGrid) !== 'latin';
       const split = fitSeaWordPrefix(s.text, s.seaBreaks, 0, available, measureSub, monotone);
       if (split > 0) {
         const prefix = s.text.slice(0, split);
@@ -5861,7 +6286,7 @@ export function layoutLines(
           ...RESET_SLICED_TEXT_MEASUREMENT,
           text: prefix,
           measuredWidth: pw,
-          punctuationCompressions: slicedPunctuationCompressions(s, 0, prefix.length),
+          ...slicedTextMetadata(s, 0, prefix.length),
         }, pw, h, asc, desc);
         const tail = s.text.slice(split);
         if (tail) {
@@ -5869,11 +6294,7 @@ export function layoutLines(
             ...s,
             ...RESET_SLICED_TEXT_MEASUREMENT,
             text: tail,
-            punctuationCompressions: slicedPunctuationCompressions(
-              s,
-              split,
-              s.text.length,
-            ),
+            ...slicedTextMetadata(s, split, s.text.length),
             measuredWidth: 0,
             src: { segIndex: s.src!.segIndex, charOffset: s.src!.charOffset + split },
             seaBreaks: rebaseSeaBreaks(s.seaBreaks, split),
@@ -5887,56 +6308,14 @@ export function layoutLines(
         // segment-initial char), pull trailing graphemes of the current line's
         // last text segment down so they lead ahead of `s` — the same cross-run
         // 追い出し (§17.3.1.16) the CJK branch does.
-        let retracted: LayoutTextSeg | null = null;
-        const sFirstCp = s.text.codePointAt(0);
-        const lastSeg = currentLine[currentLine.length - 1];
-        if (sFirstCp !== undefined && kinsoku.lineStartForbidden.has(sFirstCp) && 'text' in lastSeg) {
-          const lastText = lastSeg as LayoutTextSeg;
-          const chars = [...lastText.text];
-          const minKeep = currentLine.length > 1 ? 0 : 1;
-          const k = crossRunKinsokuRetract(chars, kinsoku, minKeep);
-          if (k > 0) {
-            const headText = chars.slice(0, chars.length - k).join('');
-            const tailText = chars.slice(chars.length - k).join('');
-            retracted = {
-              ...lastText,
-              ...RESET_SLICED_TEXT_MEASUREMENT,
-              text: tailText,
-              punctuationCompressions: slicedPunctuationCompressions(
-                lastText,
-                headText.length,
-                lastText.text.length,
-              ),
-              measuredWidth: strAdvance(lastText, tailText, true),
-              src: {
-                segIndex: lastText.src!.segIndex,
-                charOffset: lastText.src!.charOffset + headText.length,
-              },
-              seaBreaks: rebaseSeaBreaks(lastText.seaBreaks, headText.length),
-            };
-            if (headText) {
-              const headW = strAdvance(lastText, headText);
-              currentWidth -= lastText.measuredWidth - headW;
-              currentLine[currentLine.length - 1] = {
-                ...lastText,
-                ...RESET_SLICED_TEXT_MEASUREMENT,
-                text: headText,
-                measuredWidth: headW,
-                punctuationCompressions: slicedPunctuationCompressions(
-                  lastText,
-                  0,
-                  headText.length,
-                ),
-              };
-            } else {
-              currentWidth -= lastText.measuredWidth;
-              currentLine.pop();
-            }
-          }
+        const retraction = retractCurrentLineForLeadingKinsoku(s);
+        if (retraction.kind === 'blocked') {
+          keepLeadingKinsokuWithCurrentLine(s, h, asc, desc);
+          continue;
         }
-        flush(undefined, false, retracted?.src ?? s.src);
+        flush(undefined, false, retraction.kind === 'retracted' ? retraction.tail.src : s.src);
         queue.unshift(s);
-        if (retracted) queue.unshift(retracted);
+        if (retraction.kind === 'retracted') queue.unshift(retraction.tail);
       } else {
         // Empty line and the first dictionary word is wider than the whole
         // column: emergency GRAPHEME-safe split (a code-point split would tear a
@@ -5946,6 +6325,8 @@ export function layoutLines(
         const graphemes = graphemeClusterOffsets(firstWord);
         let gsplit = fitSeaWordPrefix(firstWord, graphemes, 0, available, measureSub, monotone);
         if (gsplit <= 0) gsplit = graphemes.length > 0 ? graphemes[0] : firstWord.length;
+        gsplit = legalTextSplitAtOrBefore(s, gsplit)
+          || emergencyTextSplit(s, available, true);
         const prefix = s.text.slice(0, gsplit);
         const pw = strNaturalAdvance(s, prefix);
         addToLine({
@@ -5953,7 +6334,7 @@ export function layoutLines(
           ...RESET_SLICED_TEXT_MEASUREMENT,
           text: prefix,
           measuredWidth: pw,
-          punctuationCompressions: slicedPunctuationCompressions(s, 0, prefix.length),
+          ...slicedTextMetadata(s, 0, prefix.length),
         }, pw, h, asc, desc);
         const tail = s.text.slice(gsplit);
         if (tail) {
@@ -5961,11 +6342,7 @@ export function layoutLines(
             ...s,
             ...RESET_SLICED_TEXT_MEASUREMENT,
             text: tail,
-            punctuationCompressions: slicedPunctuationCompressions(
-              s,
-              gsplit,
-              s.text.length,
-            ),
+            ...slicedTextMetadata(s, gsplit, s.text.length),
             measuredWidth: 0,
             src: { segIndex: s.src!.segIndex, charOffset: s.src!.charOffset + gsplit },
             seaBreaks: rebaseSeaBreaks(s.seaBreaks, gsplit),
@@ -5977,33 +6354,7 @@ export function layoutLines(
       // than a full line, fit the widest character prefix (at least one
       // character), draw it, and re-queue the remainder. Segments are already
       // space-delimited, so this cannot bypass an ordinary space opportunity.
-      const available = availW();
-      setMeasureFont(buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses, s.fontRoute));
-      const prevKern = setSegKerning(s);
-      let fittedUtf16 = 0;
-      try {
-        fittedUtf16 = available > 0
-          ? fitCJKPrefix(
-              ctx,
-              s.text,
-              available,
-              segmentCharacterGridDeltaPx(s, characterGrid, scale),
-              charScaleFactor(s),
-              charSpacingDeltaPx(s, scale),
-              s.verticalRun === true,
-              verticalGlyphMeasurement,
-              (prefix) => strAdvance(s, prefix),
-            ).length
-          : 0;
-      } finally {
-        restoreKerning(prevKern);
-      }
-      const graphemeOffsets = [0, ...graphemeClusterOffsets(s.text), s.text.length];
-      let split = graphemeOffsets.filter((offset) => offset <= fittedUtf16).at(-1) ?? 0;
-      if (split <= 0) split = graphemeOffsets[1] ?? s.text.length;
-      // Preserve the existing JLReq/Word line-end hanging rule after switching
-      // the emergency splitter from code-point indexes to UTF-16 grapheme offsets.
-      while (s.text.startsWith('\u3000', split)) split += 1;
+      const split = externalLinkSyntaxSplit(s, availW()) || emergencyTextSplit(s, availW());
       if (split >= s.text.length) {
         // The visible glyphs actually fit (only a trailing space pushed it over the
         // fit test) — place the word whole.
@@ -6017,26 +6368,49 @@ export function layoutLines(
           ...RESET_SLICED_TEXT_MEASUREMENT,
           text: prefix,
           measuredWidth: pw,
-          punctuationCompressions: slicedPunctuationCompressions(s, 0, prefix.length),
+          ...slicedTextMetadata(s, 0, prefix.length),
         }, pw, h, asc, desc);
-        queue.unshift({
-          ...s,
-          ...RESET_SLICED_TEXT_MEASUREMENT,
-          text: s.text.slice(split),
-          punctuationCompressions: slicedPunctuationCompressions(
-            s,
-            split,
-            s.text.length,
-          ),
-          measuredWidth: 0,
-          src: {
-            segIndex: s.src!.segIndex,
-            charOffset: s.src!.charOffset + prefix.length,
-          },
-        });
+        queueEmergencyTail(s, split);
       }
     } else {
+      const semanticSplit = externalLinkSyntaxSplit(
+        s,
+        availW() + shrinkBudget - currentWidth,
+      );
+      if (semanticSplit > 0 && semanticSplit < s.text.length) {
+        const prefix = s.text.slice(0, semanticSplit);
+        const pw = strNaturalAdvance(s, prefix);
+        addToLine({
+          ...s,
+          ...RESET_SLICED_TEXT_MEASUREMENT,
+          text: prefix,
+          measuredWidth: pw,
+          ...slicedTextMetadata(s, 0, prefix.length),
+        }, pw, h, asc, desc);
+        queueEmergencyTail(s, semanticSplit);
+        continue;
+      }
       if (s.joinPrev) {
+        // LB14 and the other UAX glue rules prohibit a line boundary at this
+        // source seam. If the complete glued group is wider than the fresh
+        // line, split this member at the widest legal grapheme boundary that
+        // fits the actual remaining band. This bases the decision on the group
+        // advance, not on the follower's standalone width.
+        const remaining = availW() - currentWidth;
+        const split = emergencyTextSplit(s, remaining, true);
+        if ((remaining > 0 || s.hardJoinPrev === true) && split > 0 && split < s.text.length) {
+          const prefix = s.text.slice(0, split);
+          const pw = strNaturalAdvance(s, prefix);
+          addToLine({
+            ...s,
+            ...RESET_SLICED_TEXT_MEASUREMENT,
+            text: prefix,
+            measuredWidth: pw,
+            ...slicedTextMetadata(s, 0, prefix.length),
+          }, pw, h, asc, desc);
+          queueEmergencyTail(s, split);
+          continue;
+        }
         // A scalar span that continues the preceding grapheme (or another
         // explicitly glued piece) may overflow a pathological narrow line, but
         // it must never become a new line head and tear the cluster.

--- a/packages/docx/src/parser-model-acquisition-projections.test.ts
+++ b/packages/docx/src/parser-model-acquisition-projections.test.ts
@@ -146,4 +146,27 @@ describe('parser-to-body-acquisition projection capability', () => {
       .paragraphAcquisitionInput(clonedParagraph, bodySource()).runs)
       .toEqual(acquired.runs);
   });
+
+  it('projects noBreakHyphen wire provenance into immutable parser-independent ranges', () => {
+    const inputParagraph = paragraph();
+    Object.assign(inputParagraph.runs[0]!, {
+      text: 'a-b',
+      __noBreakBefore: true,
+      __noBreakAfter: true,
+      __noBreakHyphenOffsets: [2],
+    });
+
+    const acquired = paragraphAcquisitionInput(inputParagraph, bodySource());
+    expect(acquired.runs[0]).toMatchObject({
+      text: 'a-b',
+      noBreakBefore: true,
+      noBreakAfter: true,
+      noBreakRanges: [{ start: 1, end: 2 }],
+    });
+    expect(acquired.runs[0]).not.toHaveProperty('__noBreakBefore');
+    expect(acquired.runs[0]).not.toHaveProperty('__noBreakAfter');
+    expect(acquired.runs[0]).not.toHaveProperty('__noBreakHyphenOffsets');
+    expect(Object.isFrozen((acquired.runs[0] as { noBreakRanges: readonly object[] }).noBreakRanges[0]))
+      .toBe(true);
+  });
 });

--- a/packages/docx/src/parser-model.ts
+++ b/packages/docx/src/parser-model.ts
@@ -128,6 +128,13 @@ export interface InternalRunSlotMetadata {
   langEastAsia?: string;
 }
 
+interface InternalNoBreakHyphenWire {
+  readonly __noBreakBefore?: boolean;
+  readonly __noBreakAfter?: boolean;
+  /** UTF-16 offsets immediately after the injected U+002D glyph. */
+  readonly __noBreakHyphenOffsets?: readonly number[];
+}
+
 /** Effective parser-owned run facts used by non-content glyphs such as list
  * markers and paragraph marks. Kept off the stable public document model. */
 export interface InternalRunFontFacts extends InternalRunSlotMetadata {
@@ -1528,10 +1535,23 @@ export function paragraphAcquisitionInput(
       const runTypographyInput = runTypographyAcquisitionInput(originalTextRun);
       const {
         __typographyAcquisition: _privateRunTypography,
+        __noBreakBefore: noBreakBefore,
+        __noBreakAfter: noBreakAfter,
+        __noBreakHyphenOffsets: noBreakHyphenOffsets,
         ...publicRun
-      } = run as typeof run & { __typographyAcquisition?: InternalRunTypographyWire };
+      } = run as typeof run & InternalNoBreakHyphenWire & {
+        __typographyAcquisition?: InternalRunTypographyWire;
+      };
+      const noBreakRanges = run.type === 'text'
+        ? noBreakHyphenOffsets
+          ?.filter((end) => Number.isInteger(end) && end > 0 && end <= run.text.length)
+          .map((end) => Object.freeze({ start: end - 1, end }))
+        : undefined;
       return Object.freeze({
         ...structuredClone(publicRun),
+        ...(noBreakBefore === true ? { noBreakBefore: true } : {}),
+        ...(noBreakAfter === true ? { noBreakAfter: true } : {}),
+        ...(noBreakRanges?.length ? { noBreakRanges: Object.freeze(noBreakRanges) } : {}),
         ...(runTypographyInput === undefined ? {} : { typographyInput: runTypographyInput }),
       }) as ParagraphAcquisitionRun;
     }

--- a/packages/docx/src/progressive-load.test.ts
+++ b/packages/docx/src/progressive-load.test.ts
@@ -13,7 +13,10 @@ import { layoutFingerprint } from './layout/invariants.js';
 import { normalizeLayoutOptions } from './layout/options.js';
 import { layoutDocumentProgressively } from './layout/progressive.js';
 import { setDocumentLayoutValidation } from './layout/validation-policy.js';
-import type { DocumentLayout } from './layout/types.js';
+import type { DeepReadonly, DocumentLayout } from './layout/types.js';
+import type { LayoutVariantStore } from './layout/variant-store.js';
+import { DocxDocument } from './document.js';
+import type { DocParagraph } from './types.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // The document-level contract for progressive layout, exercised through the
@@ -50,6 +53,22 @@ afterAll(() => {
 });
 
 describe('progressive layout handover', () => {
+  it('does not publish a progressive lifecycle for a small one-page document', async () => {
+    const { source, services } = retain('plain', 4);
+    const layoutOptions = normalizeLayoutOptions(undefined, DEFAULT_CURRENT_DATE_MS);
+    let publications = 0;
+
+    const layout = await layoutDocumentProgressively(
+      source.bodyLayoutInput,
+      services,
+      layoutOptions,
+      { onPreview: () => { publications += 1; } },
+    );
+
+    expect(layout.pages).toHaveLength(1);
+    expect(publications).toBe(0);
+  });
+
   it('serves provisional pages, then the authoritative layout', async () => {
     const { source, services, retained } = retain('plain', 300);
     const store = retained.layoutVariants;
@@ -86,6 +105,108 @@ describe('progressive layout handover', () => {
     expect(layoutFingerprint(store.defaultLayout as DocumentLayout))
       .toBe(layoutFingerprint(blocking));
   }, 300_000);
+
+  it('refreshes bookmark and review projections as the active main-mode prefix advances', () => {
+    const model = syntheticDocxModel('plain', { paragraphs: 300 });
+    const laterParagraph = model.body[280] as DocParagraph;
+    laterParagraph.bookmarks = ['later-bookmark'];
+    laterParagraph.commentMarks = [
+      { id: '42', kind: 'rangeStart', runIndex: 0 },
+      { id: '42', kind: 'rangeEnd', runIndex: 1 },
+      { id: '42', kind: 'reference', runIndex: 1 },
+    ];
+    laterParagraph.runs[0]!.revision = { kind: 'deletion', id: '84' };
+    model.comments = [{ id: '42', text: 'later comment' }];
+    model.revisions = [{ kind: 'deletion', id: '84', text: 'later revision' }];
+
+    const source = layoutSourceStore(model);
+    const services = createLayoutServices(source);
+    const retained = retainRenderWorkerDocumentLayout(
+      source,
+      services,
+      DEFAULT_CURRENT_DATE_MS,
+    );
+    const store = retained.layoutVariants;
+    const layoutOptions = normalizeLayoutOptions(undefined, DEFAULT_CURRENT_DATE_MS);
+    const full = paginateBody(source.bodyLayoutInput, services, layoutOptions);
+    expect(full.pages.length).toBeGreaterThan(1);
+    const prefix = { ...full, pages: full.pages.slice(0, 1) } as DocumentLayout;
+
+    const document = Object.create(DocxDocument.prototype) as DocxDocument;
+    const lifecycle = { complete: false };
+    Object.assign(document, {
+      _document: model,
+      _source: source,
+      _meta: null,
+      _review: { comments: model.comments, revisions: model.revisions },
+      _bookmarkPages: null,
+      _commentAnchorRanges: null,
+      _revisionAnchorRanges: null,
+      _reviewProjectionIndex: null,
+      _layoutLifecycle: lifecycle,
+    });
+    attachDocumentLayoutRuntime(document, DEFAULT_CURRENT_DATE_MS);
+    const runtime = documentLayoutRuntimeOf(document);
+    runtime.services = services;
+    runtime.activeLayoutOptions = layoutOptions;
+
+    type MainPublicationHarness = {
+      _replaceMainLayoutPublication(
+        variantStore: LayoutVariantStore,
+        options: typeof layoutOptions,
+        expected: DeepReadonly<DocumentLayout> | null,
+        next: DeepReadonly<DocumentLayout>,
+      ): DeepReadonly<DocumentLayout> | null;
+    };
+    const publications = document as unknown as MainPublicationHarness;
+    const retainedPrefix = publications._replaceMainLayoutPublication(
+      store,
+      layoutOptions,
+      null,
+      prefix,
+    );
+    expect(retainedPrefix).not.toBeNull();
+
+    // Cache the first publication exactly as a viewer does while it is visible.
+    expect(document.getBookmarkPage('later-bookmark')).toBeUndefined();
+    expect(document.commentAnchorRanges()).toEqual([]);
+    expect(document.revisionAnchorRanges()).toEqual([]);
+
+    expect(publications._replaceMainLayoutPublication(
+      store,
+      layoutOptions,
+      retainedPrefix,
+      full,
+    )).not.toBeNull();
+    lifecycle.complete = true;
+    expect(document.getBookmarkPage('later-bookmark')).toBeGreaterThan(0);
+    const [commentRange] = document.commentAnchorRanges();
+    expect(commentRange?.commentId).toBe('42');
+    expect(commentRange?.geometryFallback).toEqual(expect.any(Object));
+    const [revisionRange] = document.revisionAnchorRanges();
+    expect(revisionRange?.revisionIndex).toBe(0);
+    expect(revisionRange?.geometryFallback).toEqual(expect.any(Object));
+  }, 300_000);
+
+  it('returns identity-stable empty review projections without touching layout services', () => {
+    const document = Object.create(DocxDocument.prototype) as DocxDocument;
+    Object.assign(document, {
+      _document: {},
+      _source: {},
+      _meta: null,
+      _review: { comments: [], revisions: [] },
+      _commentAnchorRanges: null,
+      _revisionAnchorRanges: null,
+      _reviewProjectionIndex: null,
+    });
+
+    const comments = document.commentAnchorRanges();
+    const revisions = document.revisionAnchorRanges();
+    expect(document.commentAnchorRanges()).toBe(comments);
+    expect(document.revisionAnchorRanges()).toBe(revisions);
+    expect(comments).toEqual([]);
+    expect(revisions).toEqual([]);
+  });
 
   it('keeps geometry stable across the handover for the pages already shown', async () => {
     // The provisional pages a user has already seen must not move when the real

--- a/packages/docx/src/ptab-run-elements.test.ts
+++ b/packages/docx/src/ptab-run-elements.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import type { KinsokuRules } from '@silurus/ooxml-core';
 import { renderDocumentToCanvas } from './renderer.js';
 import {
   splitTextForLayout,
@@ -227,8 +228,8 @@ describe('noBreakHyphen (§17.3.3.18) and softHyphen (§17.3.3.29)', () => {
   });
 
   it('keeps a comment-boundary noBreakHyphen run joined without coalescing model runs', () => {
-    const hyphenRun = textRun('-cd') as DocRun & { __noBreakBefore?: boolean };
-    hyphenRun.__noBreakBefore = true;
+    const hyphenRun = textRun('-cd') as DocRun & { noBreakBefore?: boolean };
+    hyphenRun.noBreakBefore = true;
     const segs = buildSegments(
       [textRun('lead '), textRun('ab'), hyphenRun],
       {} as LineLayoutEnvironment,
@@ -250,14 +251,14 @@ describe('noBreakHyphen (§17.3.3.18) and softHyphen (§17.3.3.29)', () => {
   });
 
   it('keeps the following CT_R joined when noBreakHyphen ends its own run', () => {
-    const mergedLeft = textRun('ab-') as DocRun & { __noBreakAfter?: boolean };
-    mergedLeft.__noBreakAfter = true;
+    const mergedLeft = textRun('ab-') as DocRun & { noBreakAfter?: boolean };
+    mergedLeft.noBreakAfter = true;
     const separateHyphen = textRun('-') as DocRun & {
-      __noBreakBefore?: boolean;
-      __noBreakAfter?: boolean;
+      noBreakBefore?: boolean;
+      noBreakAfter?: boolean;
     };
-    separateHyphen.__noBreakBefore = true;
-    separateHyphen.__noBreakAfter = true;
+    separateHyphen.noBreakBefore = true;
+    separateHyphen.noBreakAfter = true;
     const formattedFollower = { ...textRun('cd'), bold: true } as DocRun;
 
     expect(buildSegments(
@@ -290,6 +291,160 @@ describe('noBreakHyphen (§17.3.3.18) and softHyphen (§17.3.3.29)', () => {
     const lines = layoutLines(ctx, segs, 70, 0, 1);
     expect(lines.map((line) => line.segments.map((seg) => (seg as LayoutTextSeg).text)))
       .toEqual([['lead '], ['ab', '-', 'cd']]);
+  });
+
+  it.each([
+    ['CJK', '漢-字語'],
+    ['mixed CJK and SEA', '漢-字ไทย'],
+  ])('protects both edges of noBreakHyphen through %s split paths', (_name, text) => {
+    const run = textRun(text) as DocRun & {
+      noBreakRanges?: readonly Readonly<{ start: number; end: number }>[];
+    };
+    run.noBreakRanges = [{ start: 1, end: 2 }];
+    const segs = buildSegments([run], {} as LineLayoutEnvironment);
+    const { canvas } = makeRecordingCanvas();
+    const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+    const lines = layoutLines(ctx, segs, 20, 0, 1);
+    const lineTexts = lines.map((line) => line.segments
+      .map((segment) => (segment as LayoutTextSeg).text)
+      .join(''));
+
+    expect(lineTexts.join('')).toBe(text);
+    expect(lineTexts[0]).toBe('漢-字');
+    expect(lineTexts.every((line) => !line.endsWith('漢') && !line.startsWith('-'))).toBe(true);
+    expect(lineTexts.every((line) => !line.endsWith('-') && !line.startsWith('字'))).toBe(true);
+  });
+
+  it.each([
+    ['CJK', '字語'],
+    ['mixed CJK and SEA', '字ไทย'],
+  ])('moves a cross-formatting noBreakHyphen %s group to a fresh line', (_name, followerText) => {
+    const hyphen = textRun('-') as DocRun & {
+      noBreakBefore?: boolean;
+      noBreakAfter?: boolean;
+      noBreakRanges?: readonly Readonly<{ start: number; end: number }>[];
+    };
+    hyphen.noBreakBefore = true;
+    hyphen.noBreakAfter = true;
+    hyphen.noBreakRanges = [{ start: 0, end: 1 }];
+    const follower = { ...textRun(followerText), bold: true } as DocRun;
+    const segs = buildSegments(
+      [textRun('lead '), textRun('ab'), hyphen, follower],
+      {} as LineLayoutEnvironment,
+    );
+    const { canvas } = makeRecordingCanvas();
+    const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+    const lines = layoutLines(ctx, segs, 70, 0, 1);
+    const texts = lines.map((line) => line.segments
+      .map((segment) => (segment as LayoutTextSeg).text)
+      .join(''));
+
+    expect(texts[0]).toBe('lead ');
+    expect(texts.slice(1).join('')).toBe(`ab-${followerText}`);
+    expect(texts.some((line) => line.endsWith('ab') || line.startsWith('-'))).toBe(false);
+    expect(texts.some((line) => line.endsWith('-') || line.startsWith('字'))).toBe(false);
+  });
+
+  it.each([
+    ['CJK', 'A漢', undefined],
+    ['SEA', 'Aไทยไทย', [1, 4, 'Aไทยไทย'.length]],
+  ] as const)(
+    'keeps custom-kinsoku %s leaders with a cross-run noBreakHyphen group',
+    (_name, followingText, seaBreaks) => {
+      const segment = (
+        text: string,
+        extra: Partial<LayoutTextSeg> = {},
+      ): LayoutTextSeg => ({
+        text,
+        bold: false,
+        italic: false,
+        underline: false,
+        strikethrough: false,
+        fontSize: 10,
+        color: null,
+        fontFamily: 'Times New Roman',
+        vertAlign: null,
+        measuredWidth: 0,
+        ...extra,
+      });
+      const customKinsoku: KinsokuRules = {
+        enabled: true,
+        lineStartForbidden: new Set(['A'.codePointAt(0)!]),
+        lineEndForbidden: new Set(),
+      };
+      const segs = [
+        segment('lead'),
+        segment('ab'),
+        segment('-', {
+          joinPrev: true,
+          hardJoinPrev: true,
+          noBreakRanges: [{ start: 0, end: 1 }],
+        }),
+        segment('字', { joinPrev: true, hardJoinPrev: true }),
+        segment(followingText, { seaBreaks }),
+      ];
+      const { canvas } = makeRecordingCanvas();
+      const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+      const lines = layoutLines(
+        ctx,
+        segs,
+        40,
+        0,
+        1,
+        [],
+        undefined,
+        {},
+        0,
+        customKinsoku,
+      );
+      const texts = lines.map((line) => line.segments
+        .map((item) => (item as LayoutTextSeg).text)
+        .join(''));
+
+      expect(texts.join('')).toBe(`leadab-字${followingText}`);
+      expect(texts).toContain('ab-字A');
+      expect(texts.some((line) => line.endsWith('ab') || line.startsWith('-'))).toBe(false);
+      expect(texts.some((line) => line.endsWith('-') || line.startsWith('字'))).toBe(false);
+      expect(texts.some((line) => line.startsWith('A'))).toBe(false);
+      if (_name === 'SEA') {
+        // Removing the custom-kinsoku leader must rebase the dictionary offsets
+        // from [1, 4, 7] to [3, 6]. Pin the actual reprocessed tail partitions,
+        // not only concatenated text, so a stale/intra-grapheme offset is visible.
+        expect(texts).toEqual(['lead', 'ab-字A', 'ไทย', 'ไทย']);
+      }
+    },
+  );
+
+  it('clears a consumed hard seam when pagination resumes inside its segment', () => {
+    const segment: LayoutTextSeg = {
+      text: '字語',
+      bold: false,
+      italic: false,
+      underline: false,
+      strikethrough: false,
+      fontSize: 10,
+      color: null,
+      fontFamily: 'Times New Roman',
+      vertAlign: null,
+      measuredWidth: 0,
+      joinPrev: true,
+      hardJoinPrev: true,
+      src: { segIndex: 0, charOffset: 0 },
+    };
+    const { canvas } = makeRecordingCanvas();
+    const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+    const lines = layoutLines(
+      ctx, [segment], 20, 0, 1,
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined,
+      { segIndex: 0, charOffset: 1 },
+    );
+    const resumed = lines.flatMap((line) => line.segments)
+      .find((item): item is LayoutTextSeg => 'text' in item);
+
+    expect(resumed?.text).toBe('語');
+    expect(resumed?.joinPrev).toBeUndefined();
+    expect(resumed?.hardJoinPrev).toBeUndefined();
   });
 
   // §17.3.3.29: a soft hyphen "shall have zero width" and "shall not change

--- a/packages/docx/src/render-worker-layout-parity.test.ts
+++ b/packages/docx/src/render-worker-layout-parity.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { BodyElement, DocxDocumentModel, SectionProps } from './types.js';
+import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps } from './types.js';
 import {
   attachDocumentLayoutVariants,
   selectDocumentLayoutPage,
@@ -19,7 +19,10 @@ import { createLayoutServices } from './layout-runtime.js';
 import { layoutDocument } from './document-layout.js';
 import { DocxDocument } from './document.js';
 import { retainRenderWorkerDocumentLayout } from './render-worker-layout.js';
-import { renderWorkerLayoutMeta } from './render-worker-metadata.js';
+import {
+  projectRenderWorkerLayoutMeta,
+  renderWorkerLayoutMeta,
+} from './render-worker-metadata.js';
 import { stableFingerprint } from './layout/fingerprint.js';
 import { buildBookmarkPageMap } from './bookmark-nav.js';
 import { textRunsForSelectedPage } from './text-run-projection.js';
@@ -181,6 +184,69 @@ function metadataForDefaultLayout(
 }
 
 describe('render worker canonical layout parity', () => {
+  it('does not traverse page geometry when a publication has no review data', () => {
+    const layout = {
+      pages: [{
+        pageIndex: 0,
+        geometry: { widthPt: 612, heightPt: 792 },
+        bookmarkStarts: [],
+      }],
+      diagnostics: [],
+    } as unknown as DocumentLayout;
+    const meta = projectRenderWorkerLayoutMeta(
+      layout,
+      {} as ReturnType<typeof layoutSourceStore>,
+      { comments: [], revisions: [] },
+      { provisional: true },
+    );
+    expect(meta.commentAnchorRanges).toEqual([]);
+    expect(meta.revisionAnchorRanges).toEqual([]);
+  });
+
+  it('withholds future review anchors inside a split paragraph until its final fragment', () => {
+    const model = syntheticDocxModel('plain', { paragraphs: 1 });
+    const paragraph = model.body[0] as Extract<BodyElement, { type: 'paragraph' }>;
+    const baseRun = paragraph.runs[0] as Extract<DocParagraph['runs'][number], { type: 'text' }>;
+    paragraph.runs = [
+      { ...baseRun, text: 'opening '.repeat(4_000) },
+      {
+        ...baseRun,
+        text: 'future review anchor',
+        revision: { kind: 'deletion', id: '84' },
+      },
+    ];
+    paragraph.commentMarks = [
+      { id: '42', kind: 'rangeStart', runIndex: 1 },
+      { id: '42', kind: 'rangeEnd', runIndex: 2 },
+      { id: '42', kind: 'reference', runIndex: 2 },
+    ];
+    model.comments = [{ id: '42', text: 'future comment' }];
+    model.revisions = [{ kind: 'deletion', id: '84', text: 'future revision' }];
+    const source = layoutSourceStore(model);
+    const layoutServices = createLayoutServices(source, { measureContext: measureContext() });
+    const full = layoutDocument(model, layoutServices, { currentDateMs: 0 });
+    expect(full.pages.length).toBeGreaterThan(1);
+    const prefix = { ...full, pages: full.pages.slice(0, 1) } as DocumentLayout;
+    const review = { comments: model.comments, revisions: model.revisions };
+
+    const provisional = projectRenderWorkerLayoutMeta(
+      prefix,
+      source,
+      review,
+      { provisional: true },
+    );
+    expect(provisional.commentAnchorRanges).toEqual([]);
+    expect(provisional.revisionAnchorRanges).toEqual([]);
+
+    const authoritative = projectRenderWorkerLayoutMeta(full, source, review);
+    expect(authoritative.commentAnchorRanges).toEqual([
+      expect.objectContaining({ commentId: '42' }),
+    ]);
+    expect(authoritative.revisionAnchorRanges).toEqual([
+      expect.objectContaining({ revisionIndex: 0, geometryFallback: expect.any(Object) }),
+    ]);
+  });
+
   it('projects page metadata from the runtime-selected tracked-changes variant', () => {
     const model = syntheticDocxModel('tracked', { paragraphs: 120 });
     const source = layoutSourceStore(model);
@@ -593,6 +659,8 @@ describe('render worker canonical layout parity', () => {
         pageCount: 2,
         pageSizes: [{ widthPt: 595, heightPt: 842 }, { widthPt: 595, heightPt: 842 }],
         bookmarkPages: [],
+        commentAnchorRanges: [],
+        revisionAnchorRanges: [],
         exact: false,
         review: { revisions: [], comments: [], footnotes: [], endnotes: [] },
       },
@@ -631,7 +699,8 @@ describe('render worker canonical layout parity', () => {
     ]);
     expect(Object.keys(layoutPartial).sort()).toEqual(['forId', 'partial', 'type']);
     expect(Object.keys(layoutPartial.partial).sort()).toEqual([
-      'bookmarkPages', 'exact', 'pageCount', 'pageSizes', 'review',
+      'bookmarkPages', 'commentAnchorRanges', 'exact', 'pageCount', 'pageSizes',
+      'review', 'revisionAnchorRanges',
     ]);
     expect(Object.keys(layoutProgress).sort()).toEqual(['committedPages', 'forId', 'type']);
     // The push arms must not be correlatable, or they would settle the parse.

--- a/packages/docx/src/render-worker-metadata.ts
+++ b/packages/docx/src/render-worker-metadata.ts
@@ -2,7 +2,9 @@ import { buildBookmarkPageMap } from './bookmark-nav.js';
 import { collectLayoutSourceCommentRangesIfPresent } from './comments.js';
 import { normalizeLayoutOptions } from './layout/options.js';
 import { layoutSourceStoreOf } from './layout/runtime-state.js';
-import { textRunSourceIndexForDocument } from './layout/text-index.js';
+import {
+  reviewProjectionIndexForDocument,
+} from './layout/text-index.js';
 import { collectLayoutSourceRevisionRangesIfPresent } from './revisions.js';
 import type { RetainedRenderWorkerDocumentLayout } from './render-worker-layout.js';
 import type { LayoutSourceStore } from './layout/layout-source-store.js';
@@ -18,8 +20,16 @@ export function projectRenderWorkerLayoutMeta(
   layout: DeepReadonly<DocumentLayout>,
   source: LayoutSourceStore,
   review: RenderWorkerReviewIndexInput,
+  options: Readonly<{ provisional?: boolean }> = {},
 ): DocumentLayoutMeta {
-  const renderedRunIndex = textRunSourceIndexForDocument(layout);
+  const hasComments = review.comments.length > 0;
+  const hasRevisions = review.revisions.length > 0;
+  const reviewIndex = hasComments || hasRevisions
+    ? reviewProjectionIndexForDocument(layout)
+    : undefined;
+  const reviewProjection = options.provisional && reviewIndex
+    ? { completedSourceKeys: reviewIndex.completedSourceKeys }
+    : undefined;
   return {
     pageCount: layout.pages.length,
     pageSizes: layout.pages.map((page) => ({
@@ -27,16 +37,22 @@ export function projectRenderWorkerLayoutMeta(
       heightPt: page.geometry.heightPt,
     })),
     bookmarkPages: [...buildBookmarkPageMap(layout)],
-    commentAnchorRanges: collectLayoutSourceCommentRangesIfPresent(
-      review.comments,
-      source,
-      renderedRunIndex,
-    ),
-    revisionAnchorRanges: collectLayoutSourceRevisionRangesIfPresent(
-      review.revisions,
-      source,
-      renderedRunIndex,
-    ),
+    commentAnchorRanges: hasComments
+      ? collectLayoutSourceCommentRangesIfPresent(
+          review.comments,
+          source,
+          reviewIndex!.renderedRunIndex,
+          reviewProjection,
+        )
+      : [],
+    revisionAnchorRanges: hasRevisions
+      ? collectLayoutSourceRevisionRangesIfPresent(
+          review.revisions,
+          source,
+          reviewIndex!.renderedRunIndex,
+          reviewProjection,
+        )
+      : [],
   };
 }
 

--- a/packages/docx/src/render-worker-progressive.ts
+++ b/packages/docx/src/render-worker-progressive.ts
@@ -38,13 +38,16 @@
  * reads would be worse than not previewing at all: the whole progressive pass
  * would be discarded AND a second full layout built.
  */
-import { buildBookmarkPageMap } from './bookmark-nav.js';
 import { layoutDocumentProgressively } from './layout/progressive.js';
 import type { DeepReadonly, DocumentLayout } from './layout/types.js';
 import type { LayoutOptions } from './layout/options.js';
 import type { LayoutSourceStore } from './layout/layout-source-store.js';
 import type { RetainedRenderWorkerDocumentLayout } from './render-worker-layout.js';
 import type { DocumentLayoutPartial } from './worker-protocol.js';
+import {
+  projectRenderWorkerLayoutMeta,
+  type RenderWorkerReviewIndexInput,
+} from './render-worker-metadata.js';
 
 /** One provisional publication: the geometry a host needs to grow its page
  *  count, its `pageSize` answers and its scroll extent. Structurally the wire's
@@ -70,14 +73,11 @@ export interface RenderWorkerLayoutPublisher {
 function publicationOf(
   layout: DocumentLayout | DeepReadonly<DocumentLayout>,
   exact: boolean,
+  source: LayoutSourceStore,
+  review: RenderWorkerReviewIndexInput,
 ): RenderWorkerLayoutPublication {
   return {
-    pageCount: layout.pages.length,
-    pageSizes: layout.pages.map((page) => ({
-      widthPt: page.geometry.widthPt,
-      heightPt: page.geometry.heightPt,
-    })),
-    bookmarkPages: [...buildBookmarkPageMap(layout)],
+    ...projectRenderWorkerLayoutMeta(layout, source, review, { provisional: true }),
     exact,
   };
 }
@@ -105,6 +105,7 @@ export async function paginateRenderWorkerDocumentProgressively(
   publisher: RenderWorkerLayoutPublisher,
   layoutOptions: LayoutOptions,
   signal?: AbortSignal,
+  review: RenderWorkerReviewIndexInput = { comments: [], revisions: [] },
 ): Promise<void> {
   const store = doc.layoutVariants;
   let publishedLayout: DeepReadonly<DocumentLayout> | null = null;
@@ -129,7 +130,7 @@ export async function paginateRenderWorkerDocumentProgressively(
           return;
         }
         publishedLayout = retainedPreview;
-        publisher.publish(publicationOf(preview.layout, preview.exact));
+        publisher.publish(publicationOf(preview.layout, preview.exact, source, review));
       },
     },
   );

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -318,7 +318,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerWireRequest>) => {
             lastProgressMs = now;
             post({ type: 'layoutProgress', forId: id, committedPages });
           },
-        }, layoutOptions, abort.signal);
+        }, layoutOptions, abort.signal, reviewIndexInput);
         if (layoutAbort === abort) layoutAbort = null;
       }
       // Usually a cache hit: the progressive drive above primed this exact

--- a/packages/docx/src/review-projection.ts
+++ b/packages/docx/src/review-projection.ts
@@ -1,0 +1,7 @@
+/** Scope for projecting review anchors from a retained layout. */
+export interface ReviewAnchorProjectionOptions {
+  /** When present, provisional projection may use fallback geometry only for
+   * paragraphs whose final fragment is already in the published prefix.
+   * Omit for authoritative projection. */
+  readonly completedSourceKeys?: ReadonlySet<string>;
+}

--- a/packages/docx/src/revisions.ts
+++ b/packages/docx/src/revisions.ts
@@ -3,6 +3,7 @@ import { sourceKey } from './layout/source-key.js';
 import type { SourceRef } from './layout/types.js';
 import { decimalReviewIdKey } from './review-id.js';
 import type { DocRevision, DocxStorySource, DocxTextRunInfo } from './types.js';
+import type { ReviewAnchorProjectionOptions } from './review-projection.js';
 
 export interface RevisionAnchorRange {
   /** Index into `DocxDocument.revisions`, preserving authored document order. */
@@ -208,9 +209,18 @@ export function collectLayoutSourceRevisionRangesIfPresent(
   revisions: readonly Readonly<DocRevision>[] | undefined,
   source: LayoutSourceStore,
   renderedRunIndex: RenderedRunIndex = new Map(),
+  options: ReviewAnchorProjectionOptions = {},
 ): RevisionAnchorRange[] {
   if ((revisions?.length ?? 0) === 0) return [];
-  return collectLayoutSourceRevisionRanges(revisions ?? [], source, renderedRunIndex);
+  const ranges = collectLayoutSourceRevisionRanges(revisions ?? [], source, renderedRunIndex);
+  const completed = options.completedSourceKeys;
+  if (completed === undefined) return ranges;
+  return ranges.filter((range) => {
+    const indices = renderedRunIndex.get(sourceKey(range.source));
+    const hasCoveredRun = indices !== undefined && [...indices].some((index) =>
+      index >= range.startRunIndex && index < range.endRunIndex);
+    return hasCoveredRun || completed.has(sourceKey(range.source));
+  });
 }
 
 /** Join one revision range to projected final-state text. Insertions and move

--- a/packages/docx/src/run-inline-formatting.test.ts
+++ b/packages/docx/src/run-inline-formatting.test.ts
@@ -143,6 +143,7 @@ function paraDoc(
   runs: DocxTextRun[],
   paraExtra: Partial<DocParagraph> = {},
   pageWidth = 400,
+  sectionExtra: Partial<SectionProps> = {},
 ): DocxDocumentModel {
   const p: DocParagraph = {
     alignment: 'left',
@@ -159,6 +160,7 @@ function paraDoc(
       pageWidth, pageHeight: 400,
       marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
       headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+      ...sectionExtra,
     } as SectionProps,
     body: [{ type: 'paragraph', ...p } as BodyElement],
     headers: { default: null, first: null, even: null },
@@ -173,9 +175,10 @@ async function render(
   runs: DocxTextRun[],
   paraExtra: Partial<DocParagraph> = {},
   pageWidth = 400,
+  sectionExtra: Partial<SectionProps> = {},
 ) {
   const { canvas, events } = makeRecordingCanvas();
-  await renderDocumentToCanvas(paraDoc(runs, paraExtra, pageWidth), canvas, 0, {
+  await renderDocumentToCanvas(paraDoc(runs, paraExtra, pageWidth, sectionExtra), canvas, 0, {
     dpr: 1,
     width: pageWidth, // scale = 1 (px per pt) so geometry is in pt-equivalent px
   });
@@ -345,6 +348,168 @@ describe('run border spans justification slack (§17.3.2.4 + §17.18.44 both)', 
 });
 
 describe('over-long word overflow-wrap (long URLs in a narrow column)', () => {
+  it('keeps an unwrapped hyperlink as one contextual draw', async () => {
+    const url = 'https://example.com/path/a-short-name.pdf';
+    const events = await render([
+      textRun(url, { isLink: true, hyperlink: url }),
+    ], {}, 800);
+    const pieces = events
+      .filter((event): event is Extract<DrawEvent, { kind: 'fillText' }> => event.kind === 'fillText');
+    expect(pieces.map((event) => event.text)).toEqual([url]);
+  });
+
+  it('recognizes URL syntax across a formatting seam in the scheme and authority', async () => {
+    const url = 'https://example.com/path/a-very-long-document-name.pdf';
+    const events = await render([
+      textRun('lead '),
+      textRun('https', { isLink: true, hyperlink: url }),
+      textRun('://example.com/path/a-very-long-document-name.pdf', {
+        isLink: true,
+        hyperlink: url,
+        bold: true,
+      }),
+    ], {}, 480);
+    const pieces = events
+      .filter((event): event is Extract<DrawEvent, { kind: 'fillText' }> => event.kind === 'fillText')
+      .filter((event) => event.text !== 'lead ');
+    expect(pieces.map((event) => event.text).join('')).toBe(url);
+    expect(pieces[0]?.x).toBeCloseTo(80);
+    expect(pieces.map((event) => event.text).join('')).toContain('example.com');
+  });
+
+  it('uses a URL path boundary in the current line remainder', async () => {
+    const url = 'https://example.com/path/a-very-long-document-name.pdf';
+    const events = await render([
+      textRun('lead '),
+      textRun(url, { isLink: true, hyperlink: url }),
+    ], {}, 480);
+    const texts = events.filter((event) => event.kind === 'fillText');
+    const urlPieces = texts.filter((event) => event.text !== 'lead ');
+
+    expect(urlPieces.map((event) => event.text).join('')).toBe(url);
+    // The 80px "lead " leaves exactly 400px: enough for the first complete
+    // path segment. Use that readable boundary instead of leaving a
+    // conspicuous remainder or splitting arbitrarily inside a host.
+    expect(urlPieces[0]?.x).toBeCloseTo(80);
+    expect(urlPieces[0]?.text).toBe('https://example.com/path/');
+    for (const piece of urlPieces) {
+      expect(piece.x + [...piece.text].length * 16).toBeLessThanOrEqual(480 + 1e-6);
+    }
+  });
+
+  it('keeps opening punctuation with a grapheme-safe prefix instead of overflowing the hyperlink', async () => {
+    const url = 'https://example.com/a-very-long-document-name.pdf';
+    const events = await render([
+      textRun('('),
+      textRun(url, { isLink: true, hyperlink: url }),
+      textRun(')'),
+    ], {}, 368);
+    const texts = events.filter((event) => event.kind === 'fillText');
+    const urlPieces = texts.filter((event) => event.text !== '(' && event.text !== ')');
+
+    expect(urlPieces.map((event) => event.text).join('')).toBe(url);
+    // UAX #14 LB14 keeps the first URL character with "(". That protected
+    // seam must not turn the complete hyperlink run into one over-wide draw.
+    expect(urlPieces[0]?.x).toBeCloseTo(16);
+    expect(urlPieces[0]?.text).toBe('https://example.com/a-');
+    expect(urlPieces.length).toBeGreaterThan(1);
+    for (const piece of urlPieces) {
+      expect(piece.x + [...piece.text].length * 16).toBeLessThanOrEqual(368 + 1e-6);
+    }
+  });
+
+  it('splits the real glued group when the hyperlink alone exactly fills the line', async () => {
+    const url = 'https://example.com/a-very-long-document-name.pdf';
+    const events = await render([
+      textRun('('),
+      textRun(url, { isLink: true, hyperlink: url }),
+    ], {}, 352);
+    const pieces = events
+      .filter((event): event is Extract<DrawEvent, { kind: 'fillText' }> => event.kind === 'fillText')
+      .filter((event) => event.text !== '(');
+    expect(pieces.map((event) => event.text).join('')).toBe(url);
+    expect(pieces[0]?.x).toBeCloseTo(16);
+    expect(pieces[0]!.x + [...pieces[0]!.text].length * 16).toBeLessThanOrEqual(352);
+  });
+
+  it('moves a hyperlink when no readable URL boundary fits the current remainder', async () => {
+    const url = 'https://example.com/a-very-long-document-name.pdf';
+    const events = await render([
+      textRun('prefix '),
+      textRun(url, { isLink: true, hyperlink: url }),
+    ], {}, 320);
+    const texts = events.filter((event) => event.kind === 'fillText');
+    const urlPieces = texts.filter((event) => event.text !== 'prefix ');
+
+    expect(urlPieces.map((event) => event.text).join('')).toBe(url);
+    expect(urlPieces[0]?.x).toBeCloseTo(0);
+  });
+
+  it('does not use the current remainder for an ordinary overlong token', async () => {
+    const word = 'abcdefghijklmnopqrstuvwxyz0123456789';
+    const events = await render([
+      textRun('lead '),
+      textRun(word),
+    ], {}, 160);
+    const texts = events.filter((event) => event.kind === 'fillText');
+    const wordPieces = texts.filter((event) => event.text !== 'lead ');
+
+    expect(wordPieces.map((event) => event.text).join('')).toBe(word);
+    expect(wordPieces[0]?.x).toBeCloseTo(0);
+  });
+
+  it('moves an overlong hyperlink when the current remainder cannot hold one grapheme', async () => {
+    const url = 'https://example.com/a-very-long-document-name.pdf';
+    const events = await render([
+      textRun('12345678 '), // 144px, leaving only 8px in the 152px band
+      textRun(url, { isLink: true, hyperlink: url }),
+    ], {}, 152);
+    const texts = events.filter((event) => event.kind === 'fillText');
+    const urlPieces = texts.filter((event) => event.text !== '12345678 ');
+
+    expect(urlPieces.map((event) => event.text).join('')).toBe(url);
+    expect(urlPieces[0]?.x).toBeCloseTo(0);
+    for (const piece of urlPieces) {
+      expect(piece.x + [...piece.text].length * 16).toBeLessThanOrEqual(152 + 1e-6);
+    }
+  });
+
+  it('evaluates every URL boundary with negative character spacing', async () => {
+    const url = 'https://example.com/path/a-long-document-name.pdf';
+    const events = await render([
+      textRun('lead '),
+      textRun(url, { isLink: true, hyperlink: url, charSpacing: -2 }),
+    ], {}, 350);
+    const pieces = events
+      .filter((event): event is Extract<DrawEvent, { kind: 'fillText' }> => event.kind === 'fillText')
+      .filter((event) => event.text !== 'lead ');
+    expect(pieces.map((event) => event.text).join('')).toBe(url);
+    expect(pieces.length).toBeGreaterThan(1);
+    expect(pieces.every((piece) => piece.text.length > 0)).toBe(true);
+  });
+
+  it('evaluates URL boundaries against the active snapToChars Latin block', async () => {
+    const url = 'https://example.com/path/a-long-document-name.pdf';
+    const events = await render([
+      textRun('lead'),
+      textRun(url, { isLink: true, hyperlink: url }),
+    ], {}, 220, {
+      docGridType: 'snapToChars',
+      docGridLinePitch: 20,
+      docGridCharSpace: 4096,
+    });
+    const pieces = events
+      .filter((event): event is Extract<DrawEvent, { kind: 'fillText' }> => event.kind === 'fillText')
+      .filter((event) => event.text !== 'lead');
+
+    expect(pieces.map((event) => event.text).join('')).toBe(url);
+    expect(pieces.length).toBeGreaterThan(1);
+    // The leading "lead" run and this prefix share one Latin snap block.
+    // Evaluating the prefix as a standalone block would admit a different
+    // number of glyphs at the cell-rounding boundary.
+    expect(pieces[0]?.text).toBe('https://e');
+  });
+
   it('breaks a no-space token wider than the line at the character level', async () => {
     // pageWidth 400, margins 0, 16px/char ⇒ 25 chars per line. A 40-char URL with
     // no break opportunity must wrap (ECMA-376 prescribes no algorithm; Word

--- a/packages/docx/src/scroll-viewer-internal-nav.test.ts
+++ b/packages/docx/src/scroll-viewer-internal-nav.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { DocxScrollViewer } from './scroll-viewer.js';
+import { publishDocxLayout } from './document-layout-events.js';
 import { installDom, makeContainer, makeBorrowedDocxScrollViewer, FakeDocxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
 import type { DocxTextRunInfo } from './renderer';
 import type { HyperlinkTarget } from '@silurus/ooxml-core';
@@ -101,6 +102,25 @@ describe('DocxScrollViewer — internal-anchor click default (IX-nav)', () => {
     clickLink();
     expect(engine.bookmarkCalls).toContain('DoesNotExist'); // it TRIED to resolve
     expect(scrollHost.scrollTop).toBe(before); // ...but did not move
+    v.destroy();
+  });
+
+  it('waits for the authoritative bookmark projection during progressive layout', async () => {
+    const target: HyperlinkTarget = { kind: 'internal', ref: 'Later' };
+    const { engine, v, scrollHost, clickLink } = await setup(1, target);
+    const doc = engine.asDoc();
+    engine.setLayoutComplete(false);
+    const before = scrollHost.scrollTop;
+
+    clickLink();
+    expect(engine.bookmarkCalls).not.toContain('Later');
+
+    engine.bookmarkPages.set('Later', 2);
+    engine.setPageCount(3);
+    engine.setLayoutComplete(true);
+    publishDocxLayout(doc, { pageCount: 3, exact: true, complete: true });
+    await vi.waitFor(() => expect(engine.bookmarkCalls).toContain('Later'));
+    expect(scrollHost.scrollTop).toBeGreaterThan(before);
     v.destroy();
   });
 

--- a/packages/docx/src/scroll-viewer-progressive.test.ts
+++ b/packages/docx/src/scroll-viewer-progressive.test.ts
@@ -393,4 +393,27 @@ describe('DocxScrollViewer — growing page count', () => {
     expect(canvases.length).toBeLessThan(10);
     viewer.destroy();
   });
+
+  it('does not start a deferred full-document find after clearFind()', async () => {
+    installDom();
+    const engine = new FakeDocxEngine(1, PAGE);
+    engine.setLayoutComplete(false);
+    const doc = engine.asDoc();
+    const viewer = DocxScrollViewer.fromDocument(
+      makeContainer(700, 500) as unknown as HTMLElement,
+      doc,
+    ) as DocxScrollViewer;
+    const findController = (viewer as unknown as { _find: { find: unknown } })._find;
+    const findSpy = vi.spyOn(findController as { find: (query: string) => Promise<unknown[]> }, 'find');
+
+    const pending = viewer.findText('later');
+    viewer.clearFind();
+    engine.setPageCount(3);
+    engine.setLayoutComplete(true);
+    publishDocxLayout(doc, { pageCount: 3, exact: true, complete: true });
+
+    await expect(pending).resolves.toEqual([]);
+    expect(findSpy).not.toHaveBeenCalled();
+    viewer.destroy();
+  });
 });

--- a/packages/docx/src/scroll-viewer-test-dom.ts
+++ b/packages/docx/src/scroll-viewer-test-dom.ts
@@ -373,6 +373,9 @@ export class FakeDocxEngine {
   comments: DocComment[] = [];
   commentAnchors: CommentAnchorRange[] = [];
   private _layoutComplete = true;
+  private _layoutCompletion: Promise<void> = Promise.resolve();
+  private _resolveLayoutCompletion: (() => void) | null = null;
+  private _layoutFailure: unknown = undefined;
   constructor(
     private _pageCount: number,
     // Uniform-page convention: a single-element `_sizes` array means EVERY page
@@ -388,7 +391,24 @@ export class FakeDocxEngine {
     this._pageCount = pageCount;
   }
   setLayoutComplete(layoutComplete: boolean): void {
+    if (!layoutComplete && this._layoutComplete) {
+      this._layoutCompletion = new Promise<void>((resolve) => {
+        this._resolveLayoutCompletion = resolve;
+      });
+    }
     this._layoutComplete = layoutComplete;
+    this._layoutFailure = undefined;
+    if (layoutComplete) {
+      this._resolveLayoutCompletion?.();
+      this._resolveLayoutCompletion = null;
+    }
+  }
+  setLayoutFailure(error: unknown): void {
+    this._layoutComplete = false;
+    this._layoutFailure = error;
+    this._resolveLayoutCompletion?.();
+    this._resolveLayoutCompletion = null;
+    this._layoutCompletion = Promise.resolve();
   }
   /** Recorded {@link setLayoutView} calls — the viewer must move the document's
    *  active layout variant when its tracked-changes view toggles, BEFORE it
@@ -404,6 +424,11 @@ export class FakeDocxEngine {
   }
   get layoutComplete(): boolean {
     return this._layoutComplete;
+  }
+  waitUntilLayoutComplete(): Promise<void> {
+    return this._layoutCompletion.then(() => {
+      if (this._layoutFailure !== undefined) throw this._layoutFailure;
+    });
   }
   /** Mirrors the real `DocxDocument.mode` fact (document.ts) — the exact fact the
    *  viewer constructor reads to decide the render path (main ⇒ renderPage,

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { DocxScrollViewer } from './scroll-viewer.js';
 import { DocxDocument } from './document.js';
+import { publishDocxLayout } from './document-layout-events.js';
 import { installDom, makeContainer, makeEl, makeBorrowedDocxScrollViewer, FakeDocxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
 import * as docxIndex from './index.js';
 import type { DocxElementContext } from './selection-context.js';
@@ -162,6 +163,166 @@ describe('DocxScrollViewer — skeleton (T1)', () => {
 });
 
 describe('DocxScrollViewer — opt-in comment cards', () => {
+  it.each(['main', 'worker'] as const)(
+    'shows opening-page comments immediately in progressive %s mode',
+    async (mode) => {
+      installDom();
+      const engine = new FakeDocxEngine(3, [{ widthPt: 612, heightPt: 792 }], mode);
+      const source = { story: 'body', storyInstance: 'body', path: [0] } as const;
+      engine.setLayoutComplete(false);
+      engine.comments = [{ id: 'opening', author: 'Ada', text: 'Opening review' }];
+      engine.commentAnchors = [{
+        commentId: 'opening', source, startRunIndex: 0, endRunIndex: 1,
+        reference: { source, runIndex: 1, affinity: 'preceding' },
+      }] as CommentAnchorRange[];
+      engine.feedTextRuns = [{
+        text: 'opening', source, sourceRunIndex: 0,
+        x: 20, y: 20, w: 80, h: 14, fontSize: 12, font: '12px sans-serif',
+      }];
+      const viewer = DocxScrollViewer.fromDocument(
+        makeContainer() as unknown as HTMLElement,
+        engine.asDoc(),
+        { comments: true, overscan: 0 },
+      ) as DocxScrollViewer;
+      const slots = (viewer as unknown as {
+        _slots: Map<number, { commentTintLayer: FakeEl | null; commentMargin: FakeEl | null }>;
+      })._slots;
+
+      expect([...slots.values()].every((slot) =>
+        slot.commentTintLayer !== null && slot.commentMargin !== null)).toBe(true);
+      viewer.destroy();
+    },
+  );
+
+  it('keeps authored page screen position stable when a left review rail appears', () => {
+    installDom();
+    const engine = new FakeDocxEngine(3, [{ widthPt: 612, heightPt: 792 }], 'worker');
+    const source = { story: 'body', storyInstance: 'body', path: [2] } as const;
+    engine.setLayoutComplete(false);
+    engine.comments = [{ id: 'later-left', author: 'Ada', text: 'Later review' }];
+    engine.commentAnchors = [];
+    const doc = engine.asDoc();
+    const container = makeContainer();
+    const viewer = DocxScrollViewer.fromDocument(
+      container as unknown as HTMLElement,
+      doc,
+      { comments: { side: 'left' }, overscan: 0 },
+    ) as DocxScrollViewer;
+    const state = viewer as unknown as {
+      _reviewOriginPx: number;
+      _slots: Map<number, { wrapper: FakeEl }>;
+    };
+    const scrollHost = container.children[0]!.children[0]!;
+    const spacer = scrollHost.children[0]!;
+    let browserScrollLeft = 0;
+    Object.defineProperty(scrollHost, 'scrollLeft', {
+      configurable: true,
+      get: () => browserScrollLeft,
+      set: (value: number) => {
+        const max = Math.max(0, parseFloat(spacer.style.width) - scrollHost.clientWidth);
+        browserScrollLeft = Math.min(max, Math.max(0, value));
+      },
+    });
+    const openingLeft = state._slots.get(0)!.wrapper.style.left;
+    const authoredLeft = Number(openingLeft.match(/calc\(([-\d.]+)px/)?.[1]);
+    const openingScreenX = authoredLeft + state._reviewOriginPx - scrollHost.scrollLeft;
+
+    engine.commentAnchors = [{
+      commentId: 'later-left', source, startRunIndex: 0, endRunIndex: 1,
+      reference: { source, runIndex: 1, affinity: 'preceding' },
+    }] as CommentAnchorRange[];
+    engine.setLayoutComplete(true);
+    publishDocxLayout(doc, { pageCount: 3, exact: true, complete: true });
+
+    expect(state._slots.get(0)!.wrapper.style.left).toBe(openingLeft);
+    expect(state._reviewOriginPx).toBeGreaterThan(0);
+    expect(scrollHost.scrollLeft).toBe(state._reviewOriginPx);
+    expect(authoredLeft + state._reviewOriginPx - scrollHost.scrollLeft).toBe(openingScreenX);
+    scrollHost.scrollTop = 10_000;
+    scrollHost.dispatch('scroll');
+    expect(state._slots.get(2)!.wrapper.style.left).toBe(openingLeft);
+    viewer.relayout();
+    expect(state._slots.get(2)!.wrapper.style.left).toBe(openingLeft);
+    expect(authoredLeft + state._reviewOriginPx - scrollHost.scrollLeft).toBe(openingScreenX);
+    viewer.destroy();
+  });
+
+  it.each(['main', 'worker'] as const)(
+    'waits for a later progressive %s-mode comment instead of treating it as absent',
+    async (mode) => {
+      installDom();
+      const engine = new FakeDocxEngine(3, [{ widthPt: 612, heightPt: 792 }], mode);
+      const source = { story: 'body', storyInstance: 'body', path: [2] } as const;
+      const anchors = [{
+        commentId: 'later', source, startRunIndex: 0, endRunIndex: 1,
+        reference: { source, runIndex: 1, affinity: 'preceding' },
+      }] as CommentAnchorRange[];
+      engine.setLayoutComplete(false);
+      engine.comments = [{ id: 'later', author: 'Ada', text: 'Later review' }];
+      engine.commentAnchors = [];
+      engine.collectPageRuns = async (page) => page === 2 ? [{
+        text: 'later', source, sourceRunIndex: 0,
+        x: 20, y: 20, w: 80, h: 14, fontSize: 12, font: '12px sans-serif',
+      }] : [];
+      const doc = engine.asDoc();
+      const container = makeContainer();
+      const viewer = DocxScrollViewer.fromDocument(
+        container as unknown as HTMLElement,
+        doc,
+        { comments: true },
+      ) as DocxScrollViewer;
+      const state = viewer as unknown as {
+        _slots: Map<number, {
+          canvas: FakeEl;
+          dispatcher: unknown;
+          wrapper: FakeEl;
+          commentTintLayer: FakeEl | null;
+          commentMargin: FakeEl | null;
+        }>;
+      };
+      const spacer = container.children[0]!.children[0]!.children[0]!;
+      const scrollHost = container.children[0]!.children[0]!;
+      scrollHost.scrollTop = 17;
+      const openingScale = viewer.getScale();
+      const openingHeight = spacer.style.height;
+      const openingWidth = parseFloat(spacer.style.width);
+      const openingSlots = new Map(state._slots);
+      const openingLeft = state._slots.get(0)!.wrapper.style.left;
+      expect([...state._slots.values()].every((slot) =>
+        slot.commentTintLayer !== null && slot.commentMargin !== null)).toBe(true);
+
+      let settled = false;
+      const navigation = viewer.goToComment('later').then((result) => {
+        settled = true;
+        return result;
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      engine.commentAnchors = anchors;
+      engine.setPageCount(3);
+      engine.setLayoutComplete(true);
+      publishDocxLayout(doc, { pageCount: 3, exact: true, complete: true });
+      expect([...state._slots.values()].every((slot) =>
+        slot.commentTintLayer !== null && slot.commentMargin !== null)).toBe(true);
+      expect(viewer.getScale()).toBe(openingScale);
+      expect(spacer.style.height).toBe(openingHeight);
+      expect(scrollHost.scrollTop).toBe(17);
+      expect(parseFloat(spacer.style.width)).toBeGreaterThan(openingWidth);
+      for (const [index, openingSlot] of openingSlots) {
+        expect(state._slots.get(index)?.canvas).toBe(openingSlot.canvas);
+        expect(state._slots.get(index)?.dispatcher).toBe(openingSlot.dispatcher);
+        expect(state._slots.get(index)?.wrapper.style.left).toBe(openingLeft);
+      }
+      await expect(navigation).resolves.toBe(true);
+      expect(state._slots.get(2)?.wrapper.style.left).toBe(openingLeft);
+      viewer.relayout();
+      expect(state._slots.get(2)?.wrapper.style.left).toBe(openingLeft);
+      viewer.destroy();
+    },
+  );
+
   it('can keep authored range highlighting while an application owns the comment list', async () => {
     installDom();
     const engine = new FakeDocxEngine(1, [{ widthPt: 612, heightPt: 792 }]);
@@ -351,9 +512,7 @@ describe('DocxScrollViewer — opt-in comment cards', () => {
       { comments: true },
     );
     await vi.waitFor(() => expect(engine.renderCalls).toHaveLength(1));
-    const scrollHost = container.children[0]!.children[0]!;
-    const page = scrollHost.children.find((child) => child !== scrollHost.children[0])!;
-    expect(page.children.some((child) => child.style.cssText.includes('overflow-y:auto'))).toBe(false);
+    expect((viewer as unknown as { _commentMarginExtent(): number })._commentMarginExtent()).toBe(0);
     viewer.destroy();
   });
 
@@ -368,9 +527,7 @@ describe('DocxScrollViewer — opt-in comment cards', () => {
       { comments: true },
     );
     await vi.waitFor(() => expect(engine.renderCalls).toHaveLength(1));
-    const scrollHost = container.children[0]!.children[0]!;
-    const page = scrollHost.children.find((child) => child !== scrollHost.children[0])!;
-    expect(page.children.some((child) => child.style.cssText.includes('overflow-y:auto'))).toBe(false);
+    expect((viewer as unknown as { _commentMarginExtent(): number })._commentMarginExtent()).toBe(0);
     viewer.destroy();
   });
 

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -8,6 +8,7 @@ import {
 } from '@silurus/ooxml-core/internal/virtual-scroll';
 import {
   createCanvasElementOutlineLayer,
+  CanvasViewerErrorRouter,
   renderCanvasElementOutline,
   resolveCanvasViewerMode,
   StaticCanvasRenderDispatcher,
@@ -280,6 +281,7 @@ export class DocxScrollViewer implements ZoomableViewer {
   private get _doc(): DocxDocument | null { return this._documentOwner.current; }
   private readonly _borrowed: boolean;
   private readonly _opts: DocxScrollViewerOptions;
+  private readonly _errorRouter: CanvasViewerErrorRouter;
   private readonly _container: HTMLElement;
   private readonly _wrapper: HTMLDivElement;
   private readonly _scrollHost: HTMLDivElement;
@@ -363,8 +365,13 @@ export class DocxScrollViewer implements ZoomableViewer {
   /** Latest list-navigation request. Older async scans may populate caches but
    * must never restore their scroll/selection after a newer click. */
   private _commentNavigationGeneration = 0;
+  /** Latest default internal-link navigation; later clicks supersede work that
+   * is still waiting for the authoritative bookmark projection. */
+  private _internalHyperlinkGeneration = 0;
   private _commentAnchorRangesForMargin: ReturnType<DocxDocument['commentAnchorRanges']> | null = null;
   private _commentAnchorIds: ReadonlySet<string> = new Set();
+  /** Horizontal origin used only for a reachable left-hand review rail. */
+  private _reviewOriginPx = 0;
   private _commentGeometryScheduled = false;
   private _commentGeometryFrame: number | null = null;
   private readonly _pendingCommentGeometry = new Map<number, {
@@ -442,6 +449,9 @@ export class DocxScrollViewer implements ZoomableViewer {
     (page) => this._collectPageRuns(page),
   );
   private _findActive = false;
+  /** Covers the pre-search progressive wait before DocxFindController.find()
+   * can establish its own cancellation generation. */
+  private _findRequestGeneration = 0;
   /** ECMA-376 §17.13.5 — current tracked-change view. A LAYOUT axis (deletions
    *  change line breaking and pagination), so it selects which retained layout
    *  variant the viewer reads geometry from; toggle it with
@@ -481,6 +491,7 @@ export class DocxScrollViewer implements ZoomableViewer {
     }
     this._container = container;
     this._opts = opts;
+    this._errorRouter = new CanvasViewerErrorRouter('DocxScrollViewer', opts.onError);
     this._showTrackedChanges = opts.showTrackedChanges === true;
     // `??` (not `||`): a caller's explicit `false` must disable the shadow, not
     // fall through to the default.
@@ -646,6 +657,7 @@ export class DocxScrollViewer implements ZoomableViewer {
       }), (ownedDocument) => {
         this._invalidateElementContext(false);
         elementInvalidated = true;
+        this._findRequestGeneration++;
         this._find.invalidate();
         this._findActive = false;
         this._activeCommentId = null;
@@ -692,10 +704,9 @@ export class DocxScrollViewer implements ZoomableViewer {
   /**
    * Whether every page has been laid out.
    *
-   * Only ever false under {@link DocxScrollViewerOptions.progressiveLayout},
-   * between the opening pages appearing and the full layout replacing them.
-   * While false, {@link pageCount} is the pages available so far, not the
-   * document's total.
+   * False while progressive pagination is pending and remains false if that
+   * background work fails. While false, {@link pageCount} is provisional;
+   * {@link waitUntilLayoutComplete} distinguishes pending work from failure.
    */
   get layoutComplete(): boolean {
     return this._doc?.layoutComplete ?? true;
@@ -706,12 +717,15 @@ export class DocxScrollViewer implements ZoomableViewer {
    *
    * Await this before anything that must see every page — a total page count,
    * printing, export. {@link findText} does so internally. Resolves immediately
-   * unless progressive layout actually deferred work.
+   * unless progressive layout actually deferred work, and rejects if that
+   * background pagination fails.
    */
   async waitUntilLayoutComplete(): Promise<void> {
     // Optional-called because an INJECTED engine (fromDocument) may predate this
     // method; a document that cannot defer layout is already complete.
-    await this._doc?.waitUntilLayoutComplete?.();
+    await this._errorRouter.ownBackgroundLifecycle(async () => {
+      await this._doc?.waitUntilLayoutComplete?.();
+    });
   }
 
   private _bindLayoutDocument(doc: DocxDocument): void {
@@ -747,10 +761,14 @@ export class DocxScrollViewer implements ZoomableViewer {
   private _onLayoutPublication(doc: DocxDocument, publication: DocxLayoutPublication): void {
     if (this._destroyed || doc !== this._doc) return;
     if (publication.error !== undefined) {
-      this._reportRenderError(publication.error);
+      this._errorRouter.reportBackground(
+        publication.error,
+        this._opts.onLayoutComplete !== undefined,
+      );
       return;
     }
     this._find.invalidate();
+    this._refreshCommentSurface();
     if (!publication.complete) {
       // Keep only the newest background prefix. pageCount and callbacks still
       // report what the document can serve, but the native scrollbar stays on
@@ -778,6 +796,14 @@ export class DocxScrollViewer implements ZoomableViewer {
     }
     this._pendingLayoutPublication = null;
     this._applyLayoutPublication(publication);
+  }
+
+  /** Refresh only the empty review layers created with each comment-enabled
+   * slot. Progressive anchor discovery never detaches a painted page canvas. */
+  private _refreshCommentSurface(): void {
+    if (!this._commentsEnabled() || this._slots.size === 0) return;
+    this._syncSpacerWidth();
+    for (const [page, slot] of this._slots) this._redrawSlotComments(page, slot);
   }
 
   /** Admit one layout publication to scroll geometry and refresh every mounted
@@ -848,18 +874,10 @@ export class DocxScrollViewer implements ZoomableViewer {
     const { left, right } = this._padH();
     const available = cw - left - right;
     if (available <= 0) return 0;
-    // Cards and the page share the same absolute zoom. Fit the composite
-    // analytically instead of subtracting a margin measured at the previous
-    // scale; the latter creates a ResizeObserver feedback loop and can inflate
-    // the cards after successive re-fits.
-    const naturalPageWidth = this._doc?.pageSize(0).widthPt
-      ? this._doc.pageSize(0).widthPt * PT_TO_PX
-      : 0;
-    const fit = this._hasCommentMargin() && naturalPageWidth > 0
-      ? available * naturalPageWidth /
-        (naturalPageWidth + COMMENT_MARGIN_GAP_PX + READ_ONLY_COMMENT_MARGIN_WIDTH_PX)
-      : available;
-    return fit > 0 ? fit : 0; // gutters ≥ container ⇒ defer (same as zero-width)
+    // Fit the authored page itself. Review cards are an adjacent horizontal
+    // surface, so their late discovery never changes page scale or vertical
+    // scroll extent.
+    return available;
   }
 
   private _hasCommentMargin(): boolean {
@@ -1101,7 +1119,19 @@ export class DocxScrollViewer implements ZoomableViewer {
       const w = this._pageWidthPx(i);
       if (w > maxW) maxW = w;
     }
-    this._spacer.style.width = `${maxW + this._commentMarginExtent() + left + right}px`;
+    const marginExtent = this._commentMarginExtent();
+    const next = this._commentSide() === 'left' ? marginExtent : 0;
+    const delta = next - this._reviewOriginPx;
+    const targetScrollLeft = Math.max(0, this._scrollHost.scrollLeft + delta);
+    // Establish the new native scroll range before applying compensation.
+    // Browsers clamp scrollLeft to the current range at assignment time.
+    this._spacer.style.width = `${maxW + marginExtent + left + right}px`;
+    if (delta === 0) return;
+    this._reviewOriginPx = next;
+    (this._scrollHost.style as CSSStyleDeclaration & Record<string, string>)[
+      '--ooxml-review-origin-x'
+    ] = `${next}px`;
+    this._scrollHost.scrollLeft = targetScrollLeft;
   }
 
   private _onScroll(): void {
@@ -1216,12 +1246,12 @@ export class DocxScrollViewer implements ZoomableViewer {
     let commentTintLayer: HTMLDivElement | null = null;
     let commentMargin: HTMLDivElement | null = null;
     let commentDecorationLayer: HTMLDivElement | null = null;
-    if (this._hasDisplayableComments()) {
+    if (this._commentsEnabled()) {
       commentTintLayer = document.createElement('div');
       commentTintLayer.style.cssText =
         'position:absolute;inset:0;overflow:hidden;pointer-events:none;';
       wrapper.appendChild(commentTintLayer);
-      if (this._hasCommentMargin()) {
+      if (this._commentsOptions()?.cards !== false) {
         commentMargin = document.createElement('div');
         commentMargin.style.cssText =
           'position:absolute;top:0;height:100%;box-sizing:border-box;' +
@@ -1326,12 +1356,10 @@ export class DocxScrollViewer implements ZoomableViewer {
     // pins it at `padL` and the overflow scrolls right. Formula deliberately
     // duplicated per viewer (one line; not hoisted to core).
     const { left: padL } = this._padH();
-    const cw = this._scrollHost.clientWidth;
-    const marginExtent = this._commentMarginExtent();
-    const compositeWidth = wpx + marginExtent;
-    const compositeLeft = Math.max(padL, (cw - compositeWidth) / 2);
-    slot.wrapper.style.left = `${compositeLeft +
-      (this._commentSide() === 'left' ? marginExtent : 0)}px`;
+    const authoredLeft = Math.max(padL, (this._scrollHost.clientWidth - wpx) / 2);
+    slot.wrapper.style.left = this._commentSide() === 'left' && this._commentsEnabled()
+      ? `calc(${authoredLeft}px + var(--ooxml-review-origin-x, 0px))`
+      : `${authoredLeft}px`;
   }
 
   /** Device-pixel ratio for a render (opts override → window → 1). */
@@ -1478,11 +1506,25 @@ export class DocxScrollViewer implements ZoomableViewer {
         openExternalHyperlink(target.url);
         return;
       }
-      // Internal anchor (IX-nav): map the bookmark name to its destination page
-      // and scroll to it. `undefined` ⇒ no bookmark of that name ⇒ inert.
-      const page = this._doc?.getBookmarkPage(target.ref);
-      if (page !== undefined) this.scrollToPage(page);
+      const doc = this._doc;
+      if (!doc) return;
+      const generation = ++this._internalHyperlinkGeneration;
+      void this._navigateInternalHyperlink(doc, target.ref, generation)
+        .catch((error) => this._reportRenderError(error));
     };
+  }
+
+  private async _navigateInternalHyperlink(
+    doc: DocxDocument,
+    ref: string,
+    generation: number,
+  ): Promise<void> {
+    if (!doc.layoutComplete) await doc.waitUntilLayoutComplete();
+    if (this._destroyed || this._doc !== doc || generation !== this._internalHyperlinkGeneration) {
+      return;
+    }
+    const page = doc.getBookmarkPage(ref);
+    if (page !== undefined) this.scrollToPage(page);
   }
 
   /** A width-measurer primed with a run's `font` — used ONLY to clamp a §17.3.2.10
@@ -1514,10 +1556,7 @@ export class DocxScrollViewer implements ZoomableViewer {
   /** Route an async render failure to `onError`, or `console.error` when none is
    *  set (so failures are never fully silent), and never after teardown. */
   private _reportRenderError(err: unknown): void {
-    if (this._destroyed) return;
-    const e = err instanceof Error ? err : new Error(String(err));
-    if (this._opts.onError) this._opts.onError(e);
-    else console.error('[ooxml] DocxScrollViewer render failed:', e);
+    this._errorRouter.report(err);
   }
 
   /**
@@ -2205,13 +2244,11 @@ export class DocxScrollViewer implements ZoomableViewer {
       this._overscan(),
     );
     const pageWidth = this._pageWidthPx(page);
-    const marginExtent = this._commentMarginExtent();
     const { left: paddingLeft } = this._padH();
-    const compositeLeft = Math.max(
+    const pageLeft = Math.max(
       paddingLeft,
-      (this._scrollHost.clientWidth - pageWidth - marginExtent) / 2,
-    );
-    const pageLeft = compositeLeft + (this._commentSide() === 'left' ? marginExtent : 0);
+      (this._scrollHost.clientWidth - pageWidth) / 2,
+    ) + this._reviewOriginPx;
     const maxTop = Math.max(0, range.totalHeight - this._scrollHost.clientHeight);
     const spacerWidth = this._spacer.offsetWidth || Number.parseFloat(this._spacer.style.width) || 0;
     const maxLeft = Math.max(0, spacerWidth - this._scrollHost.clientWidth);
@@ -2323,29 +2360,55 @@ export class DocxScrollViewer implements ZoomableViewer {
     if (!doc || !doc.comments.some((comment) =>
       comment.id === commentId && comment.parentId === undefined)) return false;
     const generation = ++this._commentNavigationGeneration;
-    const anchors = doc.commentAnchorRanges().filter((anchor) => anchor.commentId === commentId);
-    if (anchors.length === 0) return false;
-
+    const startedWithProvisionalLayout = !doc.layoutComplete;
+    let anchors = doc.commentAnchorRanges().filter((anchor) => anchor.commentId === commentId);
     const requestedPage = opts?.pageIndex;
-    if (requestedPage !== undefined && (
-      !Number.isInteger(requestedPage) || requestedPage < 0 || requestedPage >= doc.pageCount
-    )) return false;
-
+    if (requestedPage !== undefined && (!Number.isInteger(requestedPage) || requestedPage < 0)) {
+      return false;
+    }
     let page = requestedPage ?? this._commentPageById.get(commentId);
     let targetRun: Readonly<DocxTextRunInfo> | undefined;
-    if (requestedPage === undefined && page === undefined) {
+    const scanAvailablePages = async (): Promise<number | undefined> => {
       const allAnchors = doc.commentAnchorRanges();
       while (page === undefined && this._commentScanFrontier < doc.pageCount) {
         const index = this._commentScanFrontier;
         const runs = await this._commentRunsForPage(index, doc);
         if (this._destroyed) throw new Error('DocxScrollViewer is destroyed');
         if (this._doc !== doc || generation !== this._commentNavigationGeneration || !runs) {
-          return false;
+          return undefined;
         }
         this._indexCommentPages(index, runs, allAnchors);
         page = this._commentPageById.get(commentId);
       }
+      return page;
+    };
+
+    if (requestedPage === undefined && page === undefined && anchors.length > 0) {
+      await scanAvailablePages();
     }
+
+    // A progressive prefix can prove that a comment is present without yet
+    // proving its page. Worker partials may expose no anchor projection at all.
+    // In either case, "not in the prefix" is not "does not exist": finish the
+    // canonical layout, discard provisional page joins, and retry once.
+    const needsAuthoritativeLayout = startedWithProvisionalLayout && (
+      (requestedPage !== undefined && requestedPage >= doc.pageCount) ||
+      (requestedPage === undefined && page === undefined)
+    );
+    if (needsAuthoritativeLayout) {
+      await this._errorRouter.ownBackgroundLifecycle(() => doc.waitUntilLayoutComplete());
+      if (this._destroyed) throw new Error('DocxScrollViewer is destroyed');
+      if (this._doc !== doc || generation !== this._commentNavigationGeneration) return false;
+      anchors = doc.commentAnchorRanges().filter((anchor) => anchor.commentId === commentId);
+      this._commentPageById.clear();
+      this._commentRunsByPage.clear();
+      this._commentIndexedPages.clear();
+      this._commentScanFrontier = 0;
+      page = requestedPage;
+      if (requestedPage === undefined && anchors.length > 0) await scanAvailablePages();
+    }
+    if (anchors.length === 0) return false;
+    if (requestedPage !== undefined && requestedPage >= doc.pageCount) return false;
     if (page === undefined) return false;
     const runs = await this._commentRunsForPage(page, doc);
     if (this._destroyed) throw new Error('DocxScrollViewer is destroyed');
@@ -2371,6 +2434,7 @@ export class DocxScrollViewer implements ZoomableViewer {
     opts: FindMatchesOptions = {},
   ): Promise<FindMatch<DocxMatchLocation>[]> {
     if (!this._doc) return [];
+    const generation = ++this._findRequestGeneration;
     // Search spans every page, so a progressively-loaded document has to finish
     // laying out first — otherwise the search silently covers only the pages
     // that happen to exist yet. Guarded on the document actually being
@@ -2378,11 +2442,18 @@ export class DocxScrollViewer implements ZoomableViewer {
     // synchronously: `findText()` followed immediately by `clearFind()` must
     // cancel the find, which it cannot do if the find has not begun.
     if (this._doc.layoutComplete === false) {
-      await this._doc.waitUntilLayoutComplete();
-      if (this._destroyed || !this._doc) return [];
+      const doc = this._doc;
+      await this._errorRouter.ownBackgroundLifecycle(
+        () => doc.waitUntilLayoutComplete(),
+      );
+      if (this._destroyed || this._doc !== doc || generation !== this._findRequestGeneration) {
+        return [];
+      }
     }
     this._findActive = query.length > 0;
-    const matches = await this._find.find(query, opts);
+    const matches = await this._errorRouter.ownAwaitable(
+      () => this._find.find(query, opts),
+    );
     this._redrawHighlights();
     return matches;
   }
@@ -2399,6 +2470,7 @@ export class DocxScrollViewer implements ZoomableViewer {
 
   /** Clear the current query and every mounted highlight. */
   clearFind(): void {
+    this._findRequestGeneration++;
     this._findActive = false;
     this._find.invalidate();
     this._redrawHighlights();
@@ -2882,6 +2954,8 @@ export class DocxScrollViewer implements ZoomableViewer {
   destroy(): void {
     if (this._destroyed) return;
     this._destroyed = true;
+    this._findRequestGeneration++;
+    this._errorRouter.close();
     this._unbindLayoutDocument();
     this._layoutViewGeneration++;
     this._resetCommentNavigation();

--- a/packages/docx/src/viewer-internal-nav.test.ts
+++ b/packages/docx/src/viewer-internal-nav.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { DocxViewer } from './viewer.js';
 import { DocxDocument } from './document.js';
+import { publishDocxLayout } from './document-layout-events.js';
 import { installDom, makeEl, FakeDocxEngine } from './scroll-viewer-test-dom.js';
 import type { HyperlinkTarget } from '@silurus/ooxml-core';
 
@@ -54,6 +55,31 @@ describe('DocxViewer — internal-anchor click default (IX-nav)', () => {
     click({ kind: 'internal', ref: 'DoesNotExist' });
     expect(engine.bookmarkCalls).toContain('DoesNotExist'); // tried
     expect(goTo).not.toHaveBeenCalled(); // but did not navigate
+    v.destroy();
+  });
+
+  it('waits for the authoritative bookmark projection during progressive layout', async () => {
+    installDom();
+    const engine = new FakeDocxEngine(1, PAGE);
+    engine.setLayoutComplete(false);
+    const doc = engine.asDoc();
+    const v = DocxViewer.fromDocument(
+      makeEl('canvas') as unknown as HTMLCanvasElement,
+      doc,
+    ) as DocxViewer;
+    const click = (
+      v as unknown as { _hyperlinkHandler: () => (t: HyperlinkTarget) => void }
+    )._hyperlinkHandler();
+    const goTo = vi.spyOn(v, 'goToPage');
+
+    click({ kind: 'internal', ref: 'Later' });
+    expect(engine.bookmarkCalls).not.toContain('Later');
+
+    engine.bookmarkPages.set('Later', 2);
+    engine.setPageCount(3);
+    engine.setLayoutComplete(true);
+    publishDocxLayout(doc, { pageCount: 3, exact: true, complete: true });
+    await vi.waitFor(() => expect(goTo).toHaveBeenCalledWith(2));
     v.destroy();
   });
 

--- a/packages/docx/src/viewer-layout-error-routing.test.ts
+++ b/packages/docx/src/viewer-layout-error-routing.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DocxDocument, type LoadOptions } from './document.js';
+import { publishDocxLayout } from './document-layout-events.js';
+import { DocxViewer } from './viewer.js';
+import { DocxScrollViewer } from './scroll-viewer.js';
+import { FakeDocxEngine, installDom, makeContainer, makeEl } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+type Surface = DocxViewer | DocxScrollViewer;
+
+async function loadedSurface(
+  kind: 'viewer' | 'scroll',
+  callbacks: Pick<LoadOptions, 'onLayoutComplete'> & { onError?: (error: Error) => void },
+): Promise<{ engine: FakeDocxEngine; surface: Surface; loadOptions: LoadOptions }> {
+  installDom();
+  const engine = new FakeDocxEngine(1, [{ widthPt: 612, heightPt: 792 }]);
+  engine.setLayoutComplete(false);
+  const load = vi.spyOn(DocxDocument, 'load').mockResolvedValue(engine.asDoc());
+  const surface = kind === 'viewer'
+    ? new DocxViewer(makeEl('canvas') as unknown as HTMLCanvasElement, callbacks)
+    : new DocxScrollViewer(makeContainer() as unknown as HTMLElement, callbacks);
+  await surface.load('progressive.docx');
+  return { engine, surface, loadOptions: load.mock.calls[0]![1] as LoadOptions };
+}
+
+describe.each(['viewer', 'scroll'] as const)('DOCX %s progressive failure routing', (kind) => {
+  it('routes an actively awaited failure only through the returned Promise', async () => {
+    const onError = vi.fn();
+    const { engine, surface } = await loadedSurface(kind, { onError });
+    const error = new Error('layout failed');
+    const waiting = surface.waitUntilLayoutComplete();
+    engine.setLayoutFailure(error);
+    publishDocxLayout(engine.asDoc(), {
+      pageCount: 1, exact: false, complete: false, error,
+    });
+
+    await expect(waiting).rejects.toBe(error);
+    expect(onError).not.toHaveBeenCalled();
+    surface.destroy();
+  });
+
+  it('routes an unawaited failure once through onError', async () => {
+    const onError = vi.fn();
+    const { engine, surface } = await loadedSurface(kind, { onError });
+    const error = new Error('layout failed');
+    engine.setLayoutFailure(error);
+    publishDocxLayout(engine.asDoc(), {
+      pageCount: 1, exact: false, complete: false, error,
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(error);
+    surface.destroy();
+  });
+
+  it('leaves an explicitly configured completion callback as the sole owner', async () => {
+    const onError = vi.fn();
+    const onLayoutComplete = vi.fn();
+    const { engine, surface, loadOptions } = await loadedSurface(
+      kind,
+      { onError, onLayoutComplete },
+    );
+    const error = new Error('layout failed');
+    engine.setLayoutFailure(error);
+    loadOptions.onLayoutComplete?.(error);
+    publishDocxLayout(engine.asDoc(), {
+      pageCount: 1, exact: false, complete: false, error,
+    });
+
+    expect(onLayoutComplete).toHaveBeenCalledTimes(1);
+    expect(onLayoutComplete).toHaveBeenCalledWith(error);
+    expect(onError).not.toHaveBeenCalled();
+    surface.destroy();
+  });
+});

--- a/packages/docx/src/viewer-progressive.test.ts
+++ b/packages/docx/src/viewer-progressive.test.ts
@@ -131,4 +131,64 @@ describe('DocxViewer progressive layout', () => {
       ._loadingLayer.style.display).toBe('none');
     viewer.destroy();
   });
+
+  it('waits for authoritative pages before a full-document find', async () => {
+    installDom();
+    const engine = new FakeDocxEngine(1, PAGE);
+    engine.setLayoutComplete(false);
+    engine.feedTextRuns = [{
+      text: 'opening', x: 0, y: 0, w: 10, h: 10, fontSize: 10, font: '10px serif',
+    }];
+    const doc = engine.asDoc();
+    const viewer = DocxViewer.fromDocument(
+      makeEl('canvas') as unknown as HTMLCanvasElement,
+      doc,
+    ) as DocxViewer;
+    const findController = (viewer as unknown as { _find: { find: unknown } })._find;
+    const laterMatch = {
+      matchIndex: 0,
+      text: 'later',
+      location: { page: 2, runIndex: 0, startOffset: 0, endOffset: 5 },
+    };
+    const findSpy = vi.spyOn(
+      findController as { find: (query: string) => Promise<unknown[]> },
+      'find',
+    ).mockResolvedValue([laterMatch]);
+    const find = viewer.findText('later');
+    await Promise.resolve();
+    expect(engine.renderCalls.filter((call) => call.page > 0)).toHaveLength(0);
+
+    engine.feedTextRuns = [{
+      text: 'later', x: 0, y: 0, w: 10, h: 10, fontSize: 10, font: '10px serif',
+    }];
+    engine.setPageCount(3);
+    engine.setLayoutComplete(true);
+    publishDocxLayout(doc, { pageCount: 3, exact: true, complete: true });
+    await expect(find).resolves.toEqual([laterMatch]);
+    expect(findSpy).toHaveBeenCalledWith('later', {});
+    viewer.destroy();
+  });
+
+  it('does not start a deferred find after clearFind()', async () => {
+    installDom();
+    const engine = new FakeDocxEngine(1, PAGE);
+    engine.setLayoutComplete(false);
+    const doc = engine.asDoc();
+    const viewer = DocxViewer.fromDocument(
+      makeEl('canvas') as unknown as HTMLCanvasElement,
+      doc,
+    ) as DocxViewer;
+    const findController = (viewer as unknown as { _find: { find: unknown } })._find;
+    const findSpy = vi.spyOn(findController as { find: (query: string) => Promise<unknown[]> }, 'find');
+
+    const pending = viewer.findText('later');
+    viewer.clearFind();
+    engine.setPageCount(3);
+    engine.setLayoutComplete(true);
+    publishDocxLayout(doc, { pageCount: 3, exact: true, complete: true });
+
+    await expect(pending).resolves.toEqual([]);
+    expect(findSpy).not.toHaveBeenCalled();
+    viewer.destroy();
+  });
 });

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -134,6 +134,9 @@ export class DocxViewer implements ZoomableViewer {
   private _elementLayer: HTMLDivElement | null = null;
   /** IX2 — find state (per-page runs, matches, active cursor). */
   private _find: DocxFindController;
+  /** Covers the pre-search progressive wait that the controller's own
+   * generation cannot see until find() starts. */
+  private _findRequestGeneration = 0;
   /** A 2d context used only to measure text for highlight geometry (its own
    *  1×1 offscreen canvas, so measuring never touches the visible canvas). */
   private _measureCtx: CanvasRenderingContext2D | null = null;
@@ -149,7 +152,11 @@ export class DocxViewer implements ZoomableViewer {
   private _layoutViewGeneration = 0;
   private _navigationGeneration = 0;
   private _layoutUnsubscribe: (() => void) | null = null;
+  /** Latest default internal-link navigation; a newer click supersedes an older
+   * one that is still waiting for progressive pagination. */
+  private _internalHyperlinkGeneration = 0;
   private readonly _layoutWaiters = new Set<() => void>();
+  private _layoutFailed = false;
   private readonly _loadingLayer: HTMLDivElement;
   private _elementClickListener: ((event: MouseEvent) => void) | null = null;
   private _contextMenuListener: ((event: MouseEvent) => void) | null = null;
@@ -297,6 +304,7 @@ export class DocxViewer implements ZoomableViewer {
         this._invalidateElementContext(false);
         elementInvalidated = true;
         this._renderDispatcher.begin();
+        this._findRequestGeneration++;
         this._find.invalidate();
         this._unbindLayoutDocument();
       });
@@ -322,14 +330,16 @@ export class DocxViewer implements ZoomableViewer {
     return this._currentPage;
   }
 
-  /** Whether every page has been laid out. */
+  /** True only after the authoritative document layout succeeds. */
   get layoutComplete(): boolean {
     return this._doc?.layoutComplete ?? true;
   }
 
-  /** Resolve once the authoritative layout has replaced any provisional pages. */
+  /** Resolve after authoritative layout; rejects if background pagination fails. */
   async waitUntilLayoutComplete(): Promise<void> {
-    await this._doc?.waitUntilLayoutComplete?.();
+    await this._errorRouter.ownBackgroundLifecycle(async () => {
+      await this._doc?.waitUntilLayoutComplete?.();
+    });
   }
 
   /** The underlying <canvas> element. */
@@ -483,8 +493,21 @@ export class DocxViewer implements ZoomableViewer {
     query: string,
     opts: FindMatchesOptions = {},
   ): Promise<FindMatch<DocxMatchLocation>[]> {
-    if (!this._doc) return [];
-    const matches = await this._find.find(query, opts);
+    const doc = this._doc;
+    if (!doc) return [];
+    const generation = ++this._findRequestGeneration;
+    // Preserve the established synchronous empty-query cancellation contract.
+    // A real full-document search must wait for authoritative pagination or its
+    // result would silently describe only the opening prefix.
+    if (query.length > 0 && !doc.layoutComplete) {
+      await this._errorRouter.ownBackgroundLifecycle(() => doc.waitUntilLayoutComplete());
+      if (this._destroyed || this._doc !== doc || generation !== this._findRequestGeneration) {
+        return [];
+      }
+    }
+    const matches = await this._errorRouter.ownAwaitable(
+      () => this._find.find(query, opts),
+    );
     // Redraw the current page's highlights (matches on it become visible without
     // navigating). Cheap DOM geometry — no page re-render.
     this._redrawHighlights();
@@ -508,6 +531,7 @@ export class DocxViewer implements ZoomableViewer {
 
   /** IX2 — clear all highlights and reset the find state. */
   clearFind(): void {
+    this._findRequestGeneration++;
     this._find.invalidate();
     this._redrawHighlights();
   }
@@ -671,6 +695,7 @@ export class DocxViewer implements ZoomableViewer {
   destroy(): void {
     if (this._destroyed) return;
     this._destroyed = true;
+    this._findRequestGeneration++;
     this._layoutViewGeneration++;
     this._unbindLayoutDocument();
     // First line: block any render rejection racing in from surfacing on a dead
@@ -793,6 +818,7 @@ export class DocxViewer implements ZoomableViewer {
 
   private _bindLayoutDocument(doc: DocxDocument): void {
     this._unbindLayoutDocument();
+    this._layoutFailed = false;
     let initial = true;
     this._layoutUnsubscribe = subscribeDocxLayout(
       doc,
@@ -815,6 +841,7 @@ export class DocxViewer implements ZoomableViewer {
   private _unbindLayoutDocument(): void {
     this._layoutUnsubscribe?.();
     this._layoutUnsubscribe = null;
+    this._layoutFailed = false;
     this._cancelPendingNavigation();
   }
 
@@ -822,7 +849,11 @@ export class DocxViewer implements ZoomableViewer {
     if (this._destroyed || doc !== this._doc) return;
     this._wakeLayoutWaiters();
     if (publication.error !== undefined) {
-      this._reportRenderError(publication.error);
+      this._layoutFailed = true;
+      this._errorRouter.reportBackground(
+        publication.error,
+        this._opts.onLayoutComplete !== undefined,
+      );
       return;
     }
     this._find.invalidate();
@@ -835,16 +866,21 @@ export class DocxViewer implements ZoomableViewer {
     page: number,
     generation: number,
   ): Promise<void> {
-    while (
-      !this._destroyed
-      && generation === this._navigationGeneration
-      && doc === this._doc
-      && page >= doc.pageCount
-      && !doc.layoutComplete
-    ) {
-      await new Promise<void>((resolve) => { this._layoutWaiters.add(resolve); });
-    }
-    if (doc === this._doc && doc.layoutComplete) await doc.waitUntilLayoutComplete();
+    await this._errorRouter.ownBackgroundLifecycle(async () => {
+      while (
+        !this._destroyed
+        && generation === this._navigationGeneration
+        && doc === this._doc
+        && page >= doc.pageCount
+        && !doc.layoutComplete
+        && !this._layoutFailed
+      ) {
+        await new Promise<void>((resolve) => { this._layoutWaiters.add(resolve); });
+      }
+      if (doc === this._doc && (doc.layoutComplete || this._layoutFailed)) {
+        await doc.waitUntilLayoutComplete();
+      }
+    });
   }
 
   private _wakeLayoutWaiters(): void {
@@ -999,12 +1035,24 @@ export class DocxViewer implements ZoomableViewer {
         openExternalHyperlink(target.url, undefined, this._hostWindow);
         return;
       }
-      // Internal anchor (IX-nav): map the bookmark name to its destination page
-      // and navigate. `undefined` ⇒ no bookmark of that name ⇒ inert.
-      const page = this._doc?.getBookmarkPage(target.ref);
-      if (page !== undefined) {
-        void this.goToPage(page).catch((error) => this._reportRenderError(error));
-      }
+      const doc = this._doc;
+      if (!doc) return;
+      const generation = ++this._internalHyperlinkGeneration;
+      void this._navigateInternalHyperlink(doc, target.ref, generation)
+        .catch((error) => this._reportRenderError(error));
     };
+  }
+
+  private async _navigateInternalHyperlink(
+    doc: DocxDocument,
+    ref: string,
+    generation: number,
+  ): Promise<void> {
+    if (!doc.layoutComplete) await doc.waitUntilLayoutComplete();
+    if (this._destroyed || this._doc !== doc || generation !== this._internalHyperlinkGeneration) {
+      return;
+    }
+    const page = doc.getBookmarkPage(ref);
+    if (page !== undefined) await this.goToPage(page);
   }
 }

--- a/packages/docx/src/worker-protocol.ts
+++ b/packages/docx/src/worker-protocol.ts
@@ -60,12 +60,9 @@ export type DocumentLayoutMeta = Pick<
  * Provisional layout geometry published by the render worker while it is still
  * paginating under `progressiveLayout`.
  *
- * Deliberately a strict SUBSET of {@link DocumentMeta}. The two anchor-range
- * fields are omitted because building them needs a whole-document run index
- * (`textRunSourceIndexForDocument`), which costs more per publication than the
- * publication saves — and a prefix's answers would be wrong for the pages that
- * do not exist yet. `DocumentMeta` already treats both as absent-tolerant, so
- * the host simply leaves them unset until the authoritative `parsedMeta`.
+ * Layout-derived indexes describe exactly the published prefix. They come from
+ * the same projector as authoritative metadata, so opening pages have the same
+ * bookmark, comment and tracked-change capabilities in main and worker modes.
  */
 export interface DocumentLayoutPartial {
   /** Pages published so far — NOT the document's total. */
@@ -76,6 +73,10 @@ export interface DocumentLayoutPartial {
    *  built from the prefix pages this publication just laid out. Anchors beyond
    *  the prefix are simply absent until layout completes. */
   bookmarkPages: [string, number][];
+  /** Comment anchors resolvable within the published prefix. */
+  commentAnchorRanges?: CommentAnchorRange[];
+  /** Revision anchors resolvable within the published prefix. */
+  revisionAnchorRanges?: RevisionAnchorRange[];
   /** Whether these pages are known to match the final layout. Always false
    *  today because later convergence can still replace a checkpoint. */
   exact: boolean;

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.82.1",
+  "version": "0.83.0",
   "description": "Internal workspace adapter for DOCX / XLSX / PPTX Markdown projection",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.82.1"
+version = "0.83.0"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.82.1",
+  "version": "0.83.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.82.1",
+  "version": "0.83.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/src/presentation-destroy.test.ts
+++ b/packages/pptx/src/presentation-destroy.test.ts
@@ -7,6 +7,7 @@ import {
   type FontPreloadEntry,
 } from '@silurus/ooxml-core';
 import { BoundedRawPartCache } from '@silurus/ooxml-core/internal/bounded-raw-part-cache';
+import { ProgressiveLayoutLifecycle } from '@silurus/ooxml-core/internal/progressive-layout-lifecycle';
 import { PptxPresentation } from './presentation';
 import { loadEmbeddedFonts } from './embedded-fonts';
 import type { PptxEmbeddedFontRef } from './worker-protocol';
@@ -99,6 +100,7 @@ describe('PptxPresentation.destroy() — rejects in-flight worker requests', () 
     instance._googleFontFaces = [];
     instance._embeddedFontFaces = [];
     instance._layoutWaiters = new Set();
+    instance._layoutLifecycle = new ProgressiveLayoutLifecycle();
     instance._fetchImage = () => Promise.resolve(new Blob());
     return { pres: instance as unknown as DestroyProbe, bridge, worker };
   }

--- a/packages/pptx/src/presentation-progressive.test.ts
+++ b/packages/pptx/src/presentation-progressive.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { WorkerBridgeTransport } from '@silurus/ooxml-core';
+import { ProgressiveLayoutLifecycle } from '@silurus/ooxml-core/internal/progressive-layout-lifecycle';
+import { ProgressiveLayoutObserverNotifier } from '@silurus/ooxml-core/internal/progressive-layout-observers';
 import {
   PULL_SESSION_PROTOCOL,
   type PullSessionCommand,
@@ -14,6 +16,8 @@ import type {
 import type { Slide } from './types.js';
 
 type PullResponse = PullSessionResponse<ArrayBuffer, number>;
+
+afterEach(() => vi.useRealTimers());
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -52,6 +56,8 @@ function pullResponse(
 
 describe('PptxPresentation progressive layout lifecycle', () => {
   it('accepts worker-mode prefix pushes before the correlated final response', async () => {
+    vi.useFakeTimers();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const finalResponse = deferred<RenderWorkerResponse>();
     const bootstrap = {
       slideCount: 2,
@@ -75,12 +81,30 @@ describe('PptxPresentation progressive layout lifecycle', () => {
       hidden: false,
       mediaElements: [],
     }));
+    let requestOptions: { timeoutMs?: number | false } | undefined;
+    const protocolOrder: string[] = [];
     const bridge = {
-      request: (build: (id: number) => RenderWorkerRequest) => {
+      request: (
+        build: (id: number) => RenderWorkerRequest,
+        _transfer: Transferable[] | undefined,
+        options: { timeoutMs?: number | false } | undefined,
+      ) => {
         const request = build(41);
-        expect(request).toMatchObject({ kind: 'parse', id: 41, progressiveLayout: true });
-        return finalResponse.promise;
+        if (request.kind === 'parse') {
+          expect(request).toMatchObject({ kind: 'parse', id: 41, progressiveLayout: true });
+          requestOptions = options;
+          return finalResponse.promise;
+        }
+        if (request.kind === 'renderSlide') {
+          protocolOrder.push('renderSlide');
+          return Promise.resolve({
+            kind: 'slideRendered', id: request.id, bitmap: {} as ImageBitmap, runs: [],
+          });
+        }
+        throw new Error(`unexpected request ${request.kind}`);
       },
+      post: vi.fn(() => protocolOrder.push('continuePresentationPreflight')),
+      terminate: vi.fn(),
     };
     const instance = Object.create(PptxPresentation.prototype) as Record<string, unknown>;
     Object.assign(instance, {
@@ -89,8 +113,8 @@ describe('PptxPresentation progressive layout lifecycle', () => {
       _destroyed: false,
       _layoutWaiters: new Set(),
       _availableSlideCount: 0,
-      _layoutComplete: true,
-      _layoutError: undefined,
+      _layoutLifecycle: new ProgressiveLayoutLifecycle(),
+      _layoutObservers: new ProgressiveLayoutObserverNotifier(),
       _parseRequestId: null,
       _progressive: null,
       _metrics: null,
@@ -99,7 +123,10 @@ describe('PptxPresentation progressive layout lifecycle', () => {
     const lifecycle = {
       firstPublication: deferred<void>(),
       published: false,
+      deferred: false,
       settled: false,
+      onProgress: () => { throw new Error('progress observer failed'); },
+      onComplete: () => { throw new Error('complete observer failed'); },
     };
     const policy = { maxArchiveEntryBytes: null, maxTotalInflatedBytes: null } as const;
 
@@ -108,13 +135,16 @@ describe('PptxPresentation progressive layout lifecycle', () => {
         buffer: ArrayBuffer,
         resourcePolicy: typeof policy,
         useGoogleFonts: boolean,
-        timeoutMs: undefined,
+      timeoutMs: number,
         onUsage: undefined,
         renderers: undefined,
         progressive: typeof lifecycle,
       ): Promise<void>;
-    })._parse(new ArrayBuffer(4), policy, false, undefined, undefined, undefined, lifecycle);
+    })._parse(new ArrayBuffer(4), policy, false, 500, undefined, undefined, lifecycle);
     await Promise.resolve();
+    expect(requestOptions).toEqual({ timeoutMs: false });
+
+    await vi.advanceTimersByTimeAsync(40);
 
     (presentation as unknown as {
       _onWorkerLayoutPush(response: RenderWorkerResponse): void;
@@ -127,6 +157,11 @@ describe('PptxPresentation progressive layout lifecycle', () => {
       fontPreloadNames: [],
     });
     await parsing;
+    await presentation.renderSlideToBitmap(0);
+    await vi.waitFor(() => expect(bridge.post).toHaveBeenCalledTimes(1));
+    expect(protocolOrder).toEqual(['renderSlide', 'continuePresentationPreflight']);
+    await vi.advanceTimersByTimeAsync(40);
+    expect(bridge.terminate).not.toHaveBeenCalled();
     expect(presentation.slideCount).toBe(2);
     expect(presentation.availableSlideCount).toBe(1);
     expect(presentation.layoutComplete).toBe(false);
@@ -143,10 +178,13 @@ describe('PptxPresentation progressive layout lifecycle', () => {
     await presentation.waitUntilLayoutComplete();
     expect(presentation.availableSlideCount).toBe(2);
     expect(presentation.layoutComplete).toBe(true);
+    expect(consoleError).toHaveBeenCalledTimes(2);
+    consoleError.mockRestore();
   });
 
   it('publishes the opening slide while keeping the final slide count stable', async () => {
     const releaseSecondSlide = deferred<void>();
+    let secondSlidePullStarted = false;
     const slideIndexBySession = new Map<number, number>();
     let pullRequestId = 1;
     const transport: WorkerBridgeTransport<PullResponse> = {
@@ -155,7 +193,10 @@ describe('PptxPresentation progressive layout lifecycle', () => {
         if (command.kind === 'pull') {
           const index = slideIndexBySession.get(command.sessionId);
           if (index === undefined) throw new Error('missing slide session');
-          if (index === 1) await releaseSecondSlide.promise;
+          if (index === 1) {
+            secondSlidePullStarted = true;
+            await releaseSecondSlide.promise;
+          }
           const payload = new TextEncoder().encode(JSON.stringify(slide(index))).buffer;
           return pullResponse(command, {
             kind: 'chunk',
@@ -216,6 +257,8 @@ describe('PptxPresentation progressive layout lifecycle', () => {
     instance._embeddedFontAuthoredFamilies = new Map();
     instance._destroyed = false;
     instance._layoutWaiters = new Set();
+    instance._layoutLifecycle = new ProgressiveLayoutLifecycle();
+    instance._layoutObservers = new ProgressiveLayoutObserverNotifier();
     const presentation = instance as unknown as PptxPresentation;
     const partials: number[] = [];
     const completions: unknown[] = [];
@@ -237,6 +280,7 @@ describe('PptxPresentation progressive layout lifecycle', () => {
           onComplete: (error?: unknown) => void;
           firstPublication: ReturnType<typeof deferred<void>>;
           published: boolean;
+          deferred: boolean;
           settled: boolean;
         },
       ): Promise<void>;
@@ -252,6 +296,7 @@ describe('PptxPresentation progressive layout lifecycle', () => {
         onComplete: (error) => completions.push(error),
         firstPublication: deferred<void>(),
         published: false,
+        deferred: false,
         settled: false,
       },
     );
@@ -262,6 +307,13 @@ describe('PptxPresentation progressive layout lifecycle', () => {
     expect(presentation.getNotes(0)).toBe('notes-1');
     expect(presentation.getNotes(1)).toBeNull();
     expect(partials).toEqual([]);
+    expect(secondSlidePullStarted).toBe(false);
+
+    // The opening publication releases the load continuation before the next
+    // host task starts slide 2 preflight. A Viewer can therefore enqueue the
+    // opening paint/resource work in this gap, matching worker-mode ACK gating.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(secondSlidePullStarted).toBe(true);
 
     let completed = false;
     const completion = presentation.waitUntilLayoutComplete().then(() => {
@@ -338,6 +390,8 @@ describe('PptxPresentation progressive layout lifecycle', () => {
       _mode: 'main', _bridge: bridge, _googleFontFaces: [], _embeddedFontFaces: [],
       _embeddedFontAliases: new Map(), _embeddedFontAuthoredFamilies: new Map(),
       _destroyed: false, _layoutWaiters: new Set(),
+      _layoutLifecycle: new ProgressiveLayoutLifecycle(),
+      _layoutObservers: new ProgressiveLayoutObserverNotifier(),
     });
     const presentation = instance as unknown as PptxPresentation;
     const failures: unknown[] = [];
@@ -355,6 +409,7 @@ describe('PptxPresentation progressive layout lifecycle', () => {
           onComplete: (error?: unknown) => void;
           firstPublication: ReturnType<typeof deferred<void>>;
           published: boolean;
+          deferred: boolean;
           settled: boolean;
         },
       ): Promise<void>;
@@ -362,12 +417,288 @@ describe('PptxPresentation progressive layout lifecycle', () => {
       onComplete: (error) => failures.push(error),
       firstPublication: deferred<void>(),
       published: false,
+      deferred: false,
       settled: false,
     });
 
     releaseFailure.resolve();
     await expect(presentation.waitUntilLayoutComplete()).rejects.toThrow('later slide failed');
-    expect(presentation.layoutComplete).toBe(true);
+    expect(presentation.layoutComplete).toBe(false);
     expect(failures[0]).toBeInstanceOf(Error);
+  });
+
+  it('terminates a worker protocol that publishes a malformed prefix and rejects completion', async () => {
+    const finalResponse = deferred<RenderWorkerResponse>();
+    const bootstrap = {
+      slideCount: 2,
+      slideWidth: 9144000,
+      slideHeight: 6858000,
+      defaultTextColor: null,
+      majorFont: null,
+      minorFont: null,
+      hlinkColor: null,
+      folHlinkColor: null,
+      embeddedFonts: [],
+      slides: [0, 1].map((index) => ({
+        index,
+        partName: `ppt/slides/slide${index + 1}.xml`,
+      })),
+    } as const;
+    const facts = [0, 1].map((index) => ({
+      index,
+      partName: `ppt/slides/slide${index + 1}.xml`,
+      notes: null,
+      hidden: false,
+      mediaElements: [],
+    }));
+    const bridge = {
+      request: (build: (id: number) => RenderWorkerRequest) => {
+        const request = build(73);
+        expect(request.kind).toBe('parse');
+        return finalResponse.promise;
+      },
+      post: vi.fn(),
+      terminate: vi.fn(() => finalResponse.reject(new Error('worker terminated'))),
+    };
+    const instance = Object.create(PptxPresentation.prototype) as Record<string, unknown>;
+    Object.assign(instance, {
+      _mode: 'worker', _bridge: bridge, _destroyed: false,
+      _layoutWaiters: new Set(), _availableSlideCount: 0,
+      _layoutLifecycle: new ProgressiveLayoutLifecycle(),
+      _layoutObservers: new ProgressiveLayoutObserverNotifier(),
+      _parseRequestId: null, _progressive: null, _metrics: null,
+    });
+    const presentation = instance as unknown as PptxPresentation;
+    const lifecycle = {
+      firstPublication: deferred<void>(), published: false, deferred: false, settled: false,
+    };
+    const policy = { maxArchiveEntryBytes: null, maxTotalInflatedBytes: null } as const;
+    const parsing = (presentation as unknown as {
+      _parse(
+        buffer: ArrayBuffer,
+        resourcePolicy: typeof policy,
+        useGoogleFonts: boolean,
+        timeoutMs: undefined,
+        onUsage: undefined,
+        renderers: undefined,
+        progressive: typeof lifecycle,
+      ): Promise<void>;
+    })._parse(new ArrayBuffer(4), policy, false, undefined, undefined, undefined, lifecycle);
+    await Promise.resolve();
+    const push = (response: RenderWorkerResponse) => (presentation as unknown as {
+      _onWorkerLayoutPush(value: RenderWorkerResponse): void;
+    })._onWorkerLayoutPush(response);
+    push({
+      kind: 'presentationLayoutPartial', forId: 73, bootstrap,
+      availableSlides: 1, slide: facts[0], fontPreloadNames: [],
+    });
+    await parsing;
+
+    push({
+      kind: 'presentationLayoutPartial', forId: 73,
+      availableSlides: 3, slide: facts[1], fontPreloadNames: [],
+    });
+
+    await expect(presentation.waitUntilLayoutComplete())
+      .rejects.toThrow('PPTX progressive worker published a non-sequential slide');
+    expect(bridge.terminate).toHaveBeenCalledTimes(1);
+    expect(presentation.layoutComplete).toBe(false);
+  });
+
+  it.each(['main', 'worker'] as const)(
+    'treats a one-slide progressive %s load as complete without a deferred callback',
+    async (mode) => {
+      const bootstrap = {
+        slideCount: 1,
+        slideWidth: 9144000,
+        slideHeight: 6858000,
+        defaultTextColor: null,
+        majorFont: null,
+        minorFont: null,
+        hlinkColor: null,
+        folHlinkColor: null,
+        embeddedFonts: [],
+        slides: [{ index: 0, partName: 'ppt/slides/slide1.xml' }],
+      } as const;
+      const facts = {
+        index: 0,
+        partName: 'ppt/slides/slide1.xml',
+        notes: null,
+        hidden: false,
+        mediaElements: [],
+      } as const;
+      const bridge = { post: vi.fn(), terminate: vi.fn() };
+      const instance = Object.create(PptxPresentation.prototype) as Record<string, unknown>;
+      Object.assign(instance, {
+        _mode: mode, _bridge: bridge, _destroyed: false,
+        _layoutWaiters: new Set(), _availableSlideCount: 0,
+        _layoutLifecycle: new ProgressiveLayoutLifecycle(),
+        _layoutObservers: new ProgressiveLayoutObserverNotifier(),
+        _parseRequestId: mode === 'worker' ? 91 : null,
+        _progressive: null, _metrics: null,
+      });
+      const presentation = instance as unknown as PptxPresentation;
+      const onComplete = vi.fn();
+      const lifecycle = {
+        firstPublication: deferred<void>(), published: false, deferred: false,
+        settled: false, onComplete,
+      };
+      instance._progressive = lifecycle;
+      const complete = { ...bootstrap, slides: [facts], fontPreloadNames: [] };
+
+      if (mode === 'worker') {
+        (presentation as unknown as {
+          _onWorkerLayoutPush(response: RenderWorkerResponse): void;
+        })._onWorkerLayoutPush({
+          kind: 'presentationLayoutPartial', forId: 91, bootstrap,
+          availableSlides: 1, slide: facts, fontPreloadNames: [],
+        });
+      } else {
+        (presentation as unknown as {
+          _applyProgressivePrefix(prefix: typeof complete, progressive: typeof lifecycle): void;
+        })._applyProgressivePrefix(complete, lifecycle);
+      }
+      let loadReleased = false;
+      void lifecycle.firstPublication.promise.then(() => { loadReleased = true; });
+      await Promise.resolve();
+      expect(loadReleased).toBe(false);
+      (presentation as unknown as {
+        _finishProgressiveLayout(prefix: typeof complete, progressive: typeof lifecycle): void;
+      })._finishProgressiveLayout(complete, lifecycle);
+      await lifecycle.firstPublication.promise;
+
+      expect(lifecycle.deferred).toBe(false);
+      expect(presentation.layoutComplete).toBe(true);
+      expect(onComplete).not.toHaveBeenCalled();
+    },
+  );
+
+  it('completes an actual one-slide main parse before releasing load', async () => {
+    const bootstrap = {
+      slideCount: 1, slideWidth: 9144000, slideHeight: 6858000,
+      defaultTextColor: null, majorFont: null, minorFont: null,
+      hlinkColor: null, folHlinkColor: null, embeddedFonts: [],
+      slides: [{ index: 0, partName: 'ppt/slides/slide1.xml' }],
+    } as const;
+    let slideSessionId = 0;
+    let requestId = 1;
+    const transport: WorkerBridgeTransport<PullResponse> = {
+      request: async (build) => {
+        const command = build(requestId++) as PullSessionCommand<number>;
+        if (command.kind === 'pull') {
+          const payload = new TextEncoder().encode(JSON.stringify(slide(0))).buffer;
+          return pullResponse(command, {
+            kind: 'chunk', sequence: command.sequence, byteLength: payload.byteLength,
+            done: true, payload,
+          });
+        }
+        return pullResponse(command, { kind: 'accepted', command: command.kind });
+      },
+      forgetOrphaned: () => undefined,
+      terminate: () => undefined,
+    };
+    const bridge = {
+      request: async (build: (id: number) => PptxWorkerRequest) => {
+        const request = build(requestId++);
+        if (request.kind === 'parse') return { kind: 'presentationOpened', id: request.id, bootstrap };
+        if (request.kind === 'openSlideSession') {
+          slideSessionId = request.sessionId;
+          return { ...request, kind: 'slideSessionOpened' as const };
+        }
+        throw new Error(`unexpected request ${request.kind}`);
+      },
+      transport: () => transport,
+    };
+    const instance = Object.create(PptxPresentation.prototype) as Record<string, unknown>;
+    Object.assign(instance, {
+      _mode: 'main', _bridge: bridge, _googleFontFaces: [], _embeddedFontFaces: [],
+      _embeddedFontAliases: new Map(), _embeddedFontAuthoredFamilies: new Map(),
+      _destroyed: false, _layoutWaiters: new Set(),
+      _layoutLifecycle: new ProgressiveLayoutLifecycle(),
+      _layoutObservers: new ProgressiveLayoutObserverNotifier(),
+    });
+    const presentation = instance as unknown as PptxPresentation;
+    const onComplete = vi.fn();
+    const lifecycle = {
+      firstPublication: deferred<void>(), published: false, deferred: false,
+      settled: false, onComplete,
+    };
+    const policy = { maxArchiveEntryBytes: null, maxTotalInflatedBytes: null } as const;
+
+    await (presentation as unknown as {
+      _parse(
+        buffer: ArrayBuffer, resourcePolicy: typeof policy, useGoogleFonts: boolean,
+        timeoutMs: undefined, onUsage: undefined, renderers: undefined,
+        progressive: typeof lifecycle,
+      ): Promise<void>;
+    })._parse(new ArrayBuffer(4), policy, false, undefined, undefined, undefined, lifecycle);
+
+    expect(slideSessionId).toBeGreaterThan(0);
+    expect(presentation.layoutComplete).toBe(true);
+    expect(presentation.availableSlideCount).toBe(1);
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('waits for the authoritative final response in an actual one-slide worker parse', async () => {
+    const finalResponse = deferred<RenderWorkerResponse>();
+    const bootstrap = {
+      slideCount: 1, slideWidth: 9144000, slideHeight: 6858000,
+      defaultTextColor: null, majorFont: null, minorFont: null,
+      hlinkColor: null, folHlinkColor: null, embeddedFonts: [],
+      slides: [{ index: 0, partName: 'ppt/slides/slide1.xml' }],
+    } as const;
+    const facts = {
+      index: 0, partName: 'ppt/slides/slide1.xml', notes: null,
+      hidden: false, mediaElements: [],
+    } as const;
+    const bridge = {
+      request: (build: (id: number) => RenderWorkerRequest) => {
+        const request = build(91);
+        expect(request.kind).toBe('parse');
+        return finalResponse.promise;
+      },
+      post: vi.fn(), terminate: vi.fn(),
+    };
+    const instance = Object.create(PptxPresentation.prototype) as Record<string, unknown>;
+    Object.assign(instance, {
+      _mode: 'worker', _bridge: bridge, _destroyed: false,
+      _layoutWaiters: new Set(), _availableSlideCount: 0,
+      _layoutLifecycle: new ProgressiveLayoutLifecycle(),
+      _layoutObservers: new ProgressiveLayoutObserverNotifier(),
+      _parseRequestId: null, _progressive: null, _metrics: null,
+    });
+    const presentation = instance as unknown as PptxPresentation;
+    const onComplete = vi.fn();
+    const lifecycle = {
+      firstPublication: deferred<void>(), published: false, deferred: false,
+      settled: false, onComplete,
+    };
+    const policy = { maxArchiveEntryBytes: null, maxTotalInflatedBytes: null } as const;
+    let released = false;
+    const parsing = (presentation as unknown as {
+      _parse(
+        buffer: ArrayBuffer, resourcePolicy: typeof policy, useGoogleFonts: boolean,
+        timeoutMs: undefined, onUsage: undefined, renderers: undefined,
+        progressive: typeof lifecycle,
+      ): Promise<void>;
+    })._parse(new ArrayBuffer(4), policy, false, undefined, undefined, undefined, lifecycle)
+      .then(() => { released = true; });
+    await Promise.resolve();
+    (presentation as unknown as {
+      _onWorkerLayoutPush(response: RenderWorkerResponse): void;
+    })._onWorkerLayoutPush({
+      kind: 'presentationLayoutPartial', forId: 91, bootstrap,
+      availableSlides: 1, slide: facts, fontPreloadNames: [],
+    });
+    await vi.waitFor(() => expect(bridge.post).toHaveBeenCalledTimes(1));
+    expect(released).toBe(false);
+
+    finalResponse.resolve({
+      kind: 'presentationReady', id: 91,
+      preflight: { ...bootstrap, slides: [facts], fontPreloadNames: [] },
+    });
+    await parsing;
+    expect(presentation.layoutComplete).toBe(true);
+    expect(onComplete).not.toHaveBeenCalled();
   });
 });

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -49,6 +49,8 @@ import {
   type WorkerRendererDescriptors,
 } from '@silurus/ooxml-core/worker';
 import { BoundedRawPartCache } from '@silurus/ooxml-core/internal/bounded-raw-part-cache';
+import { ProgressiveLayoutLifecycle } from '@silurus/ooxml-core/internal/progressive-layout-lifecycle';
+import { ProgressiveLayoutObserverNotifier } from '@silurus/ooxml-core/internal/progressive-layout-observers';
 import { PPTX_GOOGLE_FONTS } from './google-fonts';
 import {
   findPreflightMimeType,
@@ -82,6 +84,7 @@ import {
   type PptxSlidePoint,
 } from './element-selection';
 import { publishPptxLayout } from './presentation-layout-events';
+import { yieldToHostTaskQueue } from './worker-task-scheduler';
 
 /** Options for {@link PptxPresentation.load}. */
 export type LoadOptions = CoreLoadOptions & {
@@ -106,11 +109,13 @@ export type LoadOptions = CoreLoadOptions & {
    * ScrollViewer's extent and scrollbar stable while later slides prepare.
    */
   progressiveLayout?: boolean;
-  /** Called as the sequential preflight commits slides. */
+  /** Called as the sequential preflight commits slides. Observer failures are isolated. */
   onLayoutProgress?: (progress: Readonly<ProgressiveLayoutProgress>) => void;
-  /** Called for each additional paintable prefix after `load()` resolves. */
+  /** Called for each additional paintable prefix after `load()` resolves. Observer failures are isolated. */
   onLayoutPartial?: (progress: Readonly<ProgressiveLayoutPartial>) => void;
-  /** Called once background preflight completes, or with its failure. */
+  /** Called once background preflight completes, or with its failure. Only
+   * fires when progressive loading actually deferred work after `load()`.
+   * Observer failures are isolated. */
   onLayoutComplete?: (error?: unknown) => void;
 };
 
@@ -136,6 +141,7 @@ interface ProgressiveLoad {
   readonly onComplete?: LoadOptions['onLayoutComplete'];
   readonly firstPublication: Deferred<void>;
   published: boolean;
+  deferred: boolean;
   settled: boolean;
 }
 
@@ -217,11 +223,13 @@ export class PptxPresentation {
   private _preflight: PresentationPreflight | null = null;
   /** Paintable prefix under progressiveLayout; final slideCount is bootstrap-owned. */
   private _availableSlideCount = 0;
-  private _layoutComplete = true;
+  private readonly _layoutLifecycle = new ProgressiveLayoutLifecycle();
+  private readonly _layoutObservers = new ProgressiveLayoutObserverNotifier();
   private _layoutCompletion: Promise<void> | null = null;
-  private _layoutError: unknown = undefined;
   private _parseRequestId: number | null = null;
   private _progressive: ProgressiveLoad | null = null;
+  private _progressiveWatchdog: ReturnType<typeof setTimeout> | undefined;
+  private _progressiveWatchdogMs: number | undefined;
   private readonly _layoutWaiters = new Set<() => void>();
   private _slides: PptxSlideRepository | null = null;
   private _slidePullClient: PptxSlidePullClient | null = null;
@@ -384,6 +392,7 @@ export class PptxPresentation {
             onComplete: opts.onLayoutComplete,
             firstPublication: deferred<void>(),
             published: false,
+            deferred: false,
             settled: false,
           } satisfies ProgressiveLoad
         : undefined;
@@ -591,6 +600,12 @@ export class PptxPresentation {
         });
         await ensureFonts();
         this._applyProgressivePrefix(builder.snapshot(), progressive);
+        if (slideIndex === 0 && progressive.deferred) {
+          // Match the worker-mode acknowledgement gate: once the opening slide
+          // is publishable, let load() continuations enqueue its paint/resource
+          // work before preflight starts pulling the next slide.
+          await yieldToHostTaskQueue();
+        }
       }
       await embeddedFontLoad;
       this._finishProgressiveLayout(builder.finish(), progressive);
@@ -611,6 +626,7 @@ export class PptxPresentation {
     renderers: WorkerRendererDescriptors | undefined,
     progressive: ProgressiveLoad,
   ): Promise<void> {
+    this._progressiveWatchdogMs = timeoutMs;
     const parsed = this._bridge.request(
       (id) => {
         this._parseRequestId = id;
@@ -620,8 +636,12 @@ export class PptxPresentation {
         } satisfies RenderWorkerRequest;
       },
       [buffer],
-      { timeoutMs },
+      // Healthy progressive work may exceed this interval while continuing to
+      // publish slides. Measure silence between publications instead of using
+      // an absolute deadline for the authoritative final response.
+      { timeoutMs: false },
     );
+    this._rearmProgressiveWatchdog();
     this._layoutCompletion = parsed.then(
       (response) => {
         this._parseRequestId = null;
@@ -671,6 +691,7 @@ export class PptxPresentation {
       !this._progressive
     ) return;
     try {
+      this._rearmProgressiveWatchdog();
       if (response.usage) this._metrics?.observeUsage(response.usage);
       if (response.bootstrap) this._bootstrap = normalizePresentationBootstrap(response.bootstrap);
       const bootstrap = this._bootstrap;
@@ -687,8 +708,28 @@ export class PptxPresentation {
         }),
         this._progressive,
       );
+      // Acknowledge only after Window crosses a task boundary. load() promise
+      // continuations can enqueue the opening-slide render first; Worker message
+      // ordering then handles that request before this ACK releases preflight of
+      // the next slide.
+      void yieldToHostTaskQueue().then(() => {
+        if (this._destroyed || this._parseRequestId !== response.forId) return;
+        this._bridge.post({
+          kind: 'continuePresentationPreflight',
+          forId: response.forId,
+          availableSlides: response.availableSlides,
+        } satisfies RenderWorkerRequest);
+      }).catch((error) => {
+        if (this._destroyed || this._parseRequestId !== response.forId || !this._progressive) return;
+        this._failProgressiveLayout(error, this._progressive);
+        this._bridge.terminate();
+      });
     } catch (error) {
       this._failProgressiveLayout(error, this._progressive);
+      // The worker is blocked on this publication's acknowledgement. A
+      // malformed prefix cannot be acknowledged safely, so terminate the
+      // bridge to reject the pending parse request and settle `_layoutCompletion`.
+      this._bridge.terminate();
     }
   }
 
@@ -699,9 +740,19 @@ export class PptxPresentation {
     if (progressive.settled || this._destroyed) return;
     this._preflight = prefix;
     this._availableSlideCount = prefix.slides.length;
-    this._layoutComplete = false;
+    if (!progressive.published && prefix.slides.length === prefix.slideCount) {
+      // Nothing remains deferred. Keep the prefix internal until the
+      // authoritative finish path publishes one complete snapshot; callers of
+      // load() must not observe a provisional lifecycle for a one-slide deck.
+      progressive.published = true;
+      progressive.deferred = false;
+      return;
+    }
+    this._layoutLifecycle.begin();
     this._wakeLayoutWaiters();
-    progressive.onProgress?.({ committedUnits: this._availableSlideCount });
+    this._layoutObservers.notify(
+      'onLayoutProgress', progressive.onProgress, { committedUnits: this._availableSlideCount },
+    );
     publishPptxLayout(this, {
       availableSlides: this._availableSlideCount,
       slideCount: this.slideCount,
@@ -710,10 +761,11 @@ export class PptxPresentation {
     });
     if (!progressive.published) {
       progressive.published = true;
+      progressive.deferred = prefix.slides.length < prefix.slideCount;
       progressive.firstPublication.resolve();
       return;
     }
-    progressive.onPartial?.({
+    this._layoutObservers.notify('onLayoutPartial', progressive.onPartial, {
       availableUnits: this._availableSlideCount,
       totalUnits: this.slideCount,
       exact: false,
@@ -726,10 +778,11 @@ export class PptxPresentation {
   ): void {
     if (progressive.settled || this._destroyed) return;
     progressive.settled = true;
+    this._clearProgressiveWatchdog();
     this._preflight = preflight;
     this._bootstrap ??= preflight;
     this._availableSlideCount = preflight.slideCount;
-    this._layoutComplete = true;
+    this._layoutLifecycle.succeed();
     this._wakeLayoutWaiters();
     progressive.firstPublication.resolve();
     publishPptxLayout(this, {
@@ -738,28 +791,30 @@ export class PptxPresentation {
       exact: true,
       complete: true,
     });
-    if (progressive.published) progressive.onComplete?.();
+    if (progressive.deferred) {
+      this._layoutObservers.notify('onLayoutComplete', progressive.onComplete);
+    }
   }
 
   private _failProgressiveLayout(error: unknown, progressive: ProgressiveLoad): void {
     if (progressive.settled) return;
     progressive.settled = true;
+    this._clearProgressiveWatchdog();
     if (this._destroyed) return;
     if (!progressive.published) {
       progressive.firstPublication.reject(error);
       return;
     }
-    this._layoutError = error;
-    this._layoutComplete = true;
+    const layoutError = this._layoutLifecycle.fail(error);
     this._wakeLayoutWaiters();
     publishPptxLayout(this, {
       availableSlides: this._availableSlideCount,
       slideCount: this.slideCount,
       exact: false,
-      complete: true,
-      error,
+      complete: false,
+      error: layoutError,
     });
-    progressive.onComplete?.(error);
+    this._layoutObservers.notify('onLayoutComplete', progressive.onComplete, layoutError);
   }
 
   private _wakeLayoutWaiters(): void {
@@ -767,15 +822,34 @@ export class PptxPresentation {
     this._layoutWaiters.clear();
   }
 
+  private _rearmProgressiveWatchdog(): void {
+    if (this._progressiveWatchdogMs === undefined) return;
+    clearTimeout(this._progressiveWatchdog);
+    this._progressiveWatchdog = setTimeout(() => {
+      const progressive = this._progressive;
+      const silenceMs = this._progressiveWatchdogMs;
+      if (!progressive || progressive.settled || silenceMs === undefined || this._destroyed) return;
+      const error = new Error(`worker layout produced no progress for ${silenceMs}ms`);
+      this._failProgressiveLayout(error, progressive);
+      this._bridge.terminate();
+    }, this._progressiveWatchdogMs);
+  }
+
+  private _clearProgressiveWatchdog(): void {
+    clearTimeout(this._progressiveWatchdog);
+    this._progressiveWatchdog = undefined;
+    this._progressiveWatchdogMs = undefined;
+  }
+
   private async _waitForSlide(slideIndex: number): Promise<void> {
     while (
       !this._destroyed &&
       slideIndex >= this._availableSlideCount &&
-      !this._layoutComplete
+      !this._layoutLifecycle.settled
     ) {
       await new Promise<void>((resolve) => this._layoutWaiters.add(resolve));
     }
-    if (this._layoutComplete) await this.waitUntilLayoutComplete();
+    if (slideIndex >= this._availableSlideCount) await this.waitUntilLayoutComplete();
   }
 
   private _assertSlideIndex(slideIndex: number): void {
@@ -790,13 +864,13 @@ export class PptxPresentation {
   /** Slides whose compact facts and full model can currently be painted. */
   get availableSlideCount(): number { return this._availableSlideCount; }
 
-  /** False only while an opt-in progressive preflight continues. */
-  get layoutComplete(): boolean { return this._layoutComplete; }
+  /** True only when every slide is paintable; remains false after background failure. */
+  get layoutComplete(): boolean { return this._layoutLifecycle.complete; }
 
   /** Wait until all slides are paintable; rethrows a post-load background failure. */
   async waitUntilLayoutComplete(): Promise<void> {
     if (this._layoutCompletion) await this._layoutCompletion;
-    if (this._layoutError !== undefined) throw this._layoutError;
+    this._layoutLifecycle.throwIfFailed();
   }
 
   /** Slide width in EMU. */
@@ -817,8 +891,9 @@ export class PptxPresentation {
    * Speaker-notes text for a slide (`ppt/notesSlides/notesSlideN.xml`,
    * ECMA-376 §13.3.5 — Notes Slide). Returns the notes-body text as a single
    * string (paragraphs joined with `\n`), or `null` when the slide has no
-   * notes part. The notes are parsed at {@link load} time, so this is a
-   * synchronous lookup.
+   * notes part. This is a synchronous lookup. During progressive loading its
+   * answer is authoritative only for `slideIndex < availableSlideCount`; await
+   * {@link waitUntilLayoutComplete} before scanning the whole deck.
    *
    * `slideIndex` is 0-based. Unlike navigation methods it is *not* clamped:
    * an out-of-range or non-integer index returns `null` rather than the notes
@@ -842,7 +917,9 @@ export class PptxPresentation {
    * share this compact mode-independent projection; modern replies remain
    * nested under their root. Use it for fully custom UI, or opt into the
    * ScrollViewer's marker-and-card view. Returns `[]` for an invalid or
-   * comment-free slide. */
+   * comment-free slide. During progressive loading, `[]` for an unavailable
+   * slide means "not known yet"; inspect only `slideIndex < availableSlideCount`
+   * or await {@link waitUntilLayoutComplete} before a whole-deck scan. */
   getComments(slideIndex: number): readonly Readonly<PptxComment>[] {
     return Number.isInteger(slideIndex)
       ? (this._preflight?.slides[slideIndex]?.comments ?? [])
@@ -854,7 +931,9 @@ export class PptxPresentation {
    * (`<p:sld show="0">`, ECMA-376 §19.3.1.38). Like {@link getNotes} the index
    * is NOT clamped — out-of-range / non-integer ⇒ `false`. This is a *fact*
    * about the model; deciding what to do with a hidden slide (skip / dim) is the
-   * caller's policy (see {@link PptxViewer}'s `hiddenSlideMode` modes).
+   * caller's policy (see {@link PptxViewer}'s `hiddenSlideMode` modes). During
+   * progressive loading this fact is authoritative only below
+   * {@link availableSlideCount}; await completion before scanning every slide.
    */
   isHidden(slideIndex: number): boolean {
     return Number.isInteger(slideIndex)
@@ -1273,6 +1352,7 @@ export class PptxPresentation {
   /** Terminate the worker and release all resources. */
   destroy(): void {
     this._destroyed = true;
+    this._clearProgressiveWatchdog();
     this._slidePullClient?.cancelAll();
     this._bridge.terminate();
     this._slides?.clear();
@@ -1281,9 +1361,8 @@ export class PptxPresentation {
     this._bootstrap = null;
     this._preflight = null;
     this._availableSlideCount = 0;
-    this._layoutComplete = true;
+    this._layoutLifecycle.succeed();
     this._layoutCompletion = null;
-    this._layoutError = undefined;
     this._progressive = null;
     this._parseRequestId = null;
     this._wakeLayoutWaiters();

--- a/packages/pptx/src/progressive-preflight-gate.test.ts
+++ b/packages/pptx/src/progressive-preflight-gate.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { ProgressivePreflightGate } from './progressive-preflight-gate.js';
+
+describe('ProgressivePreflightGate', () => {
+  it('cannot continue the next slide until the matching host acknowledgement', async () => {
+    const gate = new ProgressivePreflightGate();
+    let continued = false;
+    const checkpoint = gate.wait(7, 1).then(() => { continued = true; });
+
+    expect(gate.continue(8, 1)).toBe(false);
+    expect(gate.continue(7, 2)).toBe(false);
+    await Promise.resolve();
+    expect(continued).toBe(false);
+
+    expect(gate.continue(7, 1)).toBe(true);
+    await checkpoint;
+    expect(continued).toBe(true);
+  });
+
+  it('releases an obsolete checkpoint when a new parse resets the worker', async () => {
+    const gate = new ProgressivePreflightGate();
+    const obsolete = gate.wait(7, 1);
+    gate.reset();
+    await expect(obsolete).resolves.toBeUndefined();
+  });
+});

--- a/packages/pptx/src/progressive-preflight-gate.ts
+++ b/packages/pptx/src/progressive-preflight-gate.ts
@@ -1,0 +1,38 @@
+/** Worker-side acknowledgement gate for progressive PPTX preflight.
+ *
+ * The worker registers a checkpoint before publishing a slide prefix. The host
+ * acknowledges it only after crossing its own task boundary, which gives load
+ * continuations time to enqueue an opening-slide render. Messages sent by one
+ * host to one Worker are ordered, so that render request is handled before the
+ * acknowledgement lets the next slide's preflight begin.
+ */
+export class ProgressivePreflightGate {
+  private pending: {
+    readonly parseId: number;
+    readonly availableSlides: number;
+    readonly resolve: () => void;
+  } | null = null;
+
+  wait(parseId: number, availableSlides: number): Promise<void> {
+    this.reset();
+    return new Promise<void>((resolve) => {
+      this.pending = { parseId, availableSlides, resolve };
+    });
+  }
+
+  continue(parseId: number, availableSlides: number): boolean {
+    const pending = this.pending;
+    if (!pending || pending.parseId !== parseId || pending.availableSlides !== availableSlides) {
+      return false;
+    }
+    this.pending = null;
+    pending.resolve();
+    return true;
+  }
+
+  reset(): void {
+    const pending = this.pending;
+    this.pending = null;
+    pending?.resolve();
+  }
+}

--- a/packages/pptx/src/render-worker.ts
+++ b/packages/pptx/src/render-worker.ts
@@ -36,6 +36,7 @@ import type {
 } from './worker-protocol';
 import { findPptxElementBoundsByIds, hitTestPptxSlideContext } from './element-selection';
 import { excludeEmbeddedFontFamilies, loadEmbeddedFonts } from './embedded-fonts';
+import { ProgressivePreflightGate } from './progressive-preflight-gate';
 
 const host = new WasmParserHost<PptxArchive>(init, {
   freeArchive: (archive) => archive.free(),
@@ -59,6 +60,7 @@ let preflightBuilder: PresentationPreflightBuilder | null = null;
 let slides: PptxSlideRepository | null = null;
 let availableSlideCount = 0;
 const slideAvailabilityWaiters = new Set<() => void>();
+const progressivePreflightGate = new ProgressivePreflightGate();
 let generation = 0;
 let nextOperationId = 1;
 type PresentationLifecycleState = 'empty' | 'opening' | 'ready' | 'failed';
@@ -135,6 +137,7 @@ function getFontBytes(path: string): Promise<Uint8Array> {
 }
 
 async function openPresentation(request: Extract<RenderWorkerRequest, { kind: 'parse' }>) {
+  progressivePreflightGate.reset();
   await slidePull.reset();
   slides?.clear();
   slides = null;
@@ -192,6 +195,9 @@ async function openPresentation(request: Extract<RenderWorkerRequest, { kind: 'p
       const slide = preflightBuilder.latestSlide;
       if (!slide) throw new Error(`PPTX progressive preflight lost slide ${index}`);
       wakeSlideAvailabilityWaiters();
+      // Register before publishing so even an immediate host acknowledgement
+      // cannot race past the checkpoint.
+      const hostAcknowledgement = progressivePreflightGate.wait(request.id, availableSlideCount);
       post({
         kind: 'presentationLayoutPartial',
         forId: request.id,
@@ -201,6 +207,7 @@ async function openPresentation(request: Extract<RenderWorkerRequest, { kind: 'p
         fontPreloadNames: preflightBuilder.currentFontPreloadNames,
         usage: resourceUsage,
       });
+      await hostAcknowledgement;
     }
     preflight = preflightBuilder.finish();
     preflightBuilder = null;
@@ -268,6 +275,10 @@ self.onmessage = async (event: MessageEvent<RenderWorkerRequest>) => {
   const request = event.data;
   if (request.kind === 'init') {
     host.setWasmInput(decodeDataUrl(request.wasmUrl) ?? request.wasmUrl);
+    return;
+  }
+  if (request.kind === 'continuePresentationPreflight') {
+    progressivePreflightGate.continue(request.forId, request.availableSlides);
     return;
   }
 
@@ -403,6 +414,7 @@ self.onmessage = async (event: MessageEvent<RenderWorkerRequest>) => {
       wakeSlideAvailabilityWaiters();
     }
     if (request.kind === 'parse') {
+      progressivePreflightGate.reset();
       slides?.clear();
       slides = null;
       preflight = null;

--- a/packages/pptx/src/scroll-viewer-progressive.test.ts
+++ b/packages/pptx/src/scroll-viewer-progressive.test.ts
@@ -66,4 +66,263 @@ describe('PptxScrollViewer progressive layout', () => {
     expect(onVisibleSlideChange).toHaveBeenLastCalledWith(0, 4, true);
     viewer.destroy();
   });
+
+  it.each(['main', 'worker'] as const)(
+    'discovers later comments and rebuilds a borrowed %s-mode surface',
+    async (mode) => {
+      installDom();
+      const engine = new FakePptxEngine(3, WIDTH, HEIGHT, mode);
+      engine.commentsBySlide = [[], [], [{
+        id: 'later-comment', author: 'Reviewer', text: 'Later', x: 100, y: 100,
+      }]];
+      engine.setLayoutProgress(1, false);
+      const container = makeContainer();
+      const viewer = PptxScrollViewer.fromPresentation(
+        container as unknown as HTMLElement,
+        engine.asPres(),
+        { comments: true, overscan: 0 },
+      ) as PptxScrollViewer;
+      const state = viewer as unknown as {
+        _hasComments: boolean;
+        _slots: Map<number, {
+          canvas: FakeEl;
+          dispatcher: unknown;
+          wrapper: FakeEl;
+          commentMarkerLayer: FakeEl | null;
+          commentMargin: FakeEl | null;
+        }>;
+      };
+      const spacer = container.children[0]!.children[0]!.children[0]!;
+      const scrollHost = container.children[0]!.children[0]!;
+      scrollHost.scrollTop = 19;
+      const openingScale = viewer.getScale();
+      const openingHeight = spacer.style.height;
+      const openingWidth = parseFloat(spacer.style.width);
+      const openingSlots = new Map(state._slots);
+      const openingLeft = state._slots.get(0)!.wrapper.style.left;
+      expect(state._hasComments).toBe(false);
+      expect([...state._slots.values()].every((slot) =>
+        slot.commentMarkerLayer !== null && slot.commentMargin !== null)).toBe(true);
+
+      engine.setLayoutProgress(3, true);
+      await vi.waitFor(() => expect(state._hasComments).toBe(true));
+      expect([...state._slots.values()].every((slot) =>
+        slot.commentMarkerLayer !== null && slot.commentMargin !== null)).toBe(true);
+      expect(viewer.getScale()).toBe(openingScale);
+      expect(spacer.style.height).toBe(openingHeight);
+      expect(scrollHost.scrollTop).toBe(19);
+      expect(parseFloat(spacer.style.width)).toBeGreaterThan(openingWidth);
+      for (const [index, openingSlot] of openingSlots) {
+        expect(state._slots.get(index)?.canvas).toBe(openingSlot.canvas);
+        expect(state._slots.get(index)?.dispatcher).toBe(openingSlot.dispatcher);
+        expect(state._slots.get(index)?.wrapper.style.left).toBe(openingLeft);
+      }
+      scrollHost.scrollTop = 10_000;
+      scrollHost.dispatch('scroll');
+      expect(state._slots.get(2)?.wrapper.style.left).toBe(openingLeft);
+      viewer.relayout();
+      expect(state._slots.get(2)?.wrapper.style.left).toBe(openingLeft);
+      viewer.destroy();
+    },
+  );
+
+  it('keeps authored slide screen position stable when a left review rail appears', async () => {
+    installDom();
+    const engine = new FakePptxEngine(3, WIDTH, HEIGHT, 'worker');
+    engine.commentsBySlide = [[], [], [{
+      id: 'later-left', author: 'Reviewer', text: 'Later', x: 100, y: 100,
+    }]];
+    engine.setLayoutProgress(1, false);
+    const container = makeContainer();
+    const viewer = PptxScrollViewer.fromPresentation(
+      container as unknown as HTMLElement,
+      engine.asPres(),
+      { comments: { side: 'left' }, overscan: 0 },
+    ) as PptxScrollViewer;
+    const state = viewer as unknown as {
+      _hasComments: boolean;
+      _reviewOriginPx: number;
+      _slots: Map<number, { wrapper: FakeEl }>;
+    };
+    const scrollHost = container.children[0]!.children[0]!;
+    const spacer = scrollHost.children[0]!;
+    let browserScrollLeft = 0;
+    Object.defineProperty(scrollHost, 'scrollLeft', {
+      configurable: true,
+      get: () => browserScrollLeft,
+      set: (value: number) => {
+        const max = Math.max(0, parseFloat(spacer.style.width) - scrollHost.clientWidth);
+        browserScrollLeft = Math.min(max, Math.max(0, value));
+      },
+    });
+    const openingLeft = state._slots.get(0)!.wrapper.style.left;
+    const authoredLeft = Number(openingLeft.match(/calc\(([-\d.]+)px/)?.[1]);
+    const openingScreenX = authoredLeft + state._reviewOriginPx - scrollHost.scrollLeft;
+
+    engine.setLayoutProgress(3, true);
+    await vi.waitFor(() => expect(state._hasComments).toBe(true));
+    expect(state._slots.get(0)!.wrapper.style.left).toBe(openingLeft);
+    expect(state._reviewOriginPx).toBeGreaterThan(0);
+    expect(scrollHost.scrollLeft).toBe(state._reviewOriginPx);
+    expect(authoredLeft + state._reviewOriginPx - scrollHost.scrollLeft).toBe(openingScreenX);
+
+    scrollHost.scrollTop = 10_000;
+    scrollHost.dispatch('scroll');
+    expect(state._slots.get(2)!.wrapper.style.left).toBe(openingLeft);
+    viewer.relayout();
+    expect(state._slots.get(2)!.wrapper.style.left).toBe(openingLeft);
+    expect(authoredLeft + state._reviewOriginPx - scrollHost.scrollLeft).toBe(openingScreenX);
+    viewer.destroy();
+  });
+
+  it.each(['main', 'worker'] as const)(
+    'discovers later comments after a self-loaded %s-mode presentation publishes them',
+    async (mode) => {
+      installDom();
+      const engine = new FakePptxEngine(3, WIDTH, HEIGHT, mode);
+      engine.commentsBySlide = [[], [], [{
+        id: 'later-comment', author: 'Reviewer', text: 'Later', x: 100, y: 100,
+      }]];
+      engine.setLayoutProgress(1, false);
+      vi.spyOn(PptxPresentation, 'load').mockResolvedValue(engine.asPres());
+      const viewer = new PptxScrollViewer(makeContainer() as unknown as HTMLElement, {
+        comments: true,
+        progressiveLayout: true,
+        mode,
+        overscan: 0,
+      });
+      await viewer.load('deck.pptx');
+      const state = viewer as unknown as {
+        _hasComments: boolean;
+        _slots: Map<number, { commentMarkerLayer: FakeEl | null }>;
+      };
+      expect(state._hasComments).toBe(false);
+
+      engine.setLayoutProgress(3, true);
+      await vi.waitFor(() => expect(state._hasComments).toBe(true));
+      expect([...state._slots.values()].every((slot) => slot.commentMarkerLayer !== null)).toBe(true);
+      viewer.destroy();
+    },
+  );
+
+  it.each(['main', 'worker'] as const)(
+    'waits for a later comment slide in %s mode instead of treating it as absent',
+    async (mode) => {
+      installDom();
+      const engine = new FakePptxEngine(3, WIDTH, HEIGHT, mode);
+      engine.commentsBySlide = [[], [], [{
+        id: 'later-comment', author: 'Reviewer', text: 'Later', x: 100, y: 100,
+      }]];
+      engine.setLayoutProgress(1, false);
+      const viewer = PptxScrollViewer.fromPresentation(
+        makeContainer() as unknown as HTMLElement,
+        engine.asPres(),
+      ) as PptxScrollViewer;
+
+      let settled = false;
+      const navigation = viewer.goToComment(2, 0).then((result) => {
+        settled = true;
+        return result;
+      });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      engine.setLayoutProgress(3, true);
+      await expect(navigation).resolves.toBe(true);
+      viewer.destroy();
+    },
+  );
+
+  it.each(['main', 'worker'] as const)(
+    'does not retain %s render work for unavailable slots that scroll out before publication',
+    async (mode) => {
+    installDom();
+    const engine = new FakePptxEngine(8, WIDTH, HEIGHT, mode);
+    engine.setLayoutProgress(1, false);
+    const container = makeContainer(200, 400);
+    const viewer = PptxScrollViewer.fromPresentation(
+      container as unknown as HTMLElement,
+      engine.asPres(),
+      { overscan: 3 },
+    ) as PptxScrollViewer;
+    const scrollHost = container.children[0]!.children[0]!;
+
+    const calls = mode === 'main' ? engine.renderCalls : engine.bitmapCalls;
+    expect(calls.map((call) => call.slide)).toEqual([0]);
+    scrollHost.scrollTop = 10_000;
+    scrollHost.dispatch('scroll');
+    expect(viewer.mountedSlideIndicesForTest()).not.toContain(1);
+
+    engine.setLayoutProgress(2, false);
+    await Promise.resolve();
+    expect(calls.some((call) => call.slide === 1)).toBe(false);
+
+    viewer.scrollToSlide(1);
+    await vi.waitFor(() => expect(calls.filter((call) => call.slide === 1)).toHaveLength(1));
+    viewer.destroy();
+    },
+  );
+
+  it('settles a superseded future-comment wait immediately', async () => {
+    installDom();
+    const engine = new FakePptxEngine(3, WIDTH, HEIGHT);
+    engine.commentsBySlide = [[], [], [{
+      id: 'later-comment', author: 'Reviewer', text: 'Later', x: 100, y: 100,
+    }]];
+    engine.setLayoutProgress(1, false);
+    const viewer = PptxScrollViewer.fromPresentation(
+      makeContainer() as unknown as HTMLElement,
+      engine.asPres(),
+    ) as PptxScrollViewer;
+
+    const first = viewer.goToComment(2, 0);
+    await expect(viewer.goToComment(0, 0)).resolves.toBe(false);
+    await expect(first).resolves.toBe(false);
+    viewer.destroy();
+  });
+
+  it('keeps a concurrent progressive failure on the canceled comment-navigation Promise', async () => {
+    installDom();
+    const engine = new FakePptxEngine(3, WIDTH, HEIGHT);
+    engine.commentsBySlide = [[], [], [{
+      id: 'later-comment', author: 'Reviewer', text: 'Later', x: 100, y: 100,
+    }]];
+    engine.setLayoutProgress(1, false);
+    const onError = vi.fn();
+    const viewer = PptxScrollViewer.fromPresentation(
+      makeContainer() as unknown as HTMLElement,
+      engine.asPres(),
+      { onError },
+    ) as PptxScrollViewer;
+    const failure = new Error('layout failed during comment cancellation');
+
+    const first = viewer.goToComment(2, 0);
+    void viewer.goToComment(0, 0);
+    engine.setLayoutProgress(1, false, failure);
+
+    await expect(first).rejects.toBe(failure);
+    expect(onError).not.toHaveBeenCalled();
+    viewer.destroy();
+  });
+
+  it('does not lose a layout failure when clearFind supersedes a progressive search', async () => {
+    installDom();
+    const engine = new FakePptxEngine(3, WIDTH, HEIGHT);
+    engine.setLayoutProgress(1, false);
+    const onError = vi.fn();
+    const viewer = PptxScrollViewer.fromPresentation(
+      makeContainer() as unknown as HTMLElement,
+      engine.asPres(),
+      { onError },
+    ) as PptxScrollViewer;
+    const failure = new Error('layout failed during find cancellation');
+
+    const find = viewer.findText('needle');
+    viewer.clearFind();
+    engine.setLayoutProgress(1, false, failure);
+
+    await expect(find).rejects.toBe(failure);
+    expect(onError).not.toHaveBeenCalled();
+    viewer.destroy();
+  });
 });

--- a/packages/pptx/src/scroll-viewer-test-dom.ts
+++ b/packages/pptx/src/scroll-viewer-test-dom.ts
@@ -429,7 +429,9 @@ export class FakePptxEngine {
     this._layoutComplete = complete;
     this._layoutFailure = error;
     this._resolveLayout = null;
-    if (!complete) {
+    if (error !== undefined) {
+      this._layoutDeferred = Promise.resolve();
+    } else if (!complete) {
       this._layoutDeferred = new Promise<void>((resolve) => { this._resolveLayout = resolve; });
     }
     publishPptxLayout(this, {

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -331,9 +331,7 @@ describe('PptxScrollViewer — opt-in comment cards', () => {
       engine.asPres(),
       { comments: { connectors: {} } },
     );
-    const scrollHost = container.children[0]!.children[0]!;
-    const slide = scrollHost.children.find((child) => child !== scrollHost.children[0])!;
-    expect(slide.children.some((child) => child.style.cssText.includes('overflow-y:auto'))).toBe(false);
+    expect((viewer as unknown as { _commentMarginExtent(): number })._commentMarginExtent()).toBe(0);
     viewer.destroy();
   });
 
@@ -527,7 +525,7 @@ describe('PptxScrollViewer — opt-in comment cards', () => {
     const viewer = PptxScrollViewer.fromPresentation(
       container as unknown as HTMLElement,
       engine.asPres(),
-      { comments: { connectors: {} } },
+      { comments: { connectors: {} }, zoomMax: 10 },
     );
     await waitForBuiltInCommentUi(viewer);
     const scrollHost = container.children[0]!.children[0]!;

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -5,6 +5,7 @@ import {
 } from '@silurus/ooxml-core/internal/virtual-scroll';
 import {
   createCanvasElementOutlineLayer,
+  CanvasViewerErrorRouter,
   renderCanvasElementOutline,
   resolveCanvasViewerMode,
   StaticCanvasRenderDispatcher,
@@ -277,6 +278,7 @@ export class PptxScrollViewer implements ZoomableViewer {
   private get _pres(): PptxPresentation | null { return this._presentationOwner.current; }
   private readonly _borrowed: boolean;
   private readonly _opts: PptxScrollViewerOptions;
+  private readonly _errorRouter: CanvasViewerErrorRouter;
   private readonly _container: HTMLElement;
   private readonly _wrapper: HTMLDivElement;
   private readonly _scrollHost: HTMLDivElement;
@@ -340,6 +342,14 @@ export class PptxScrollViewer implements ZoomableViewer {
     readonly connectorsOnly: boolean;
   }>();
   private _hasComments = false;
+  /** Horizontal origin used only for a reachable left-hand review rail. */
+  private _reviewOriginPx = 0;
+  /** Opening prefix already inspected for authored comments. Progressive
+   * presentations make metadata authoritative one slide at a time, so a
+   * negative scan is provisional until this frontier reaches slideCount. */
+  private _commentScanFrontier = 0;
+  private readonly _layoutWaiters = new Set<() => void>();
+  private _layoutFailed = false;
   private _elementHitGeneration = 0;
   private readonly _elementHitTolerance: number;
   /** Set by `destroy()`. Async render callbacks (main + worker) check it before
@@ -407,6 +417,7 @@ export class PptxScrollViewer implements ZoomableViewer {
     () => this.slideCount,
     (slide) => this._collectSlideRuns(slide),
   );
+  private _findGeneration = 0;
   private _findActive = false;
   private _findMeasureCtx: CanvasRenderingContext2D | null | undefined;
 
@@ -443,6 +454,7 @@ export class PptxScrollViewer implements ZoomableViewer {
     }
     this._container = container;
     this._opts = opts;
+    this._errorRouter = new CanvasViewerErrorRouter('PptxScrollViewer', opts.onError);
     const elementHitTolerance = opts.elementHitTolerance ?? 6;
     if (!Number.isFinite(elementHitTolerance) || elementHitTolerance < 0) {
       throw new RangeError('elementHitTolerance must be a finite non-negative number.');
@@ -456,8 +468,7 @@ export class PptxScrollViewer implements ZoomableViewer {
     if (borrowedPresentation) {
       this._presentationOwner = new TerminalResourceOwner('PptxScrollViewer', borrowedPresentation, false);
       this._mode = resolveCanvasViewerMode('PptxScrollViewer', opts.mode, borrowedPresentation);
-      this._hasComments = (opts.comments === true || typeof opts.comments === 'object')
-        && this._presentationHasComments(borrowedPresentation);
+      this._scanAvailableComments(borrowedPresentation, false);
     } else {
       this._presentationOwner = new TerminalResourceOwner('PptxScrollViewer');
       this._mode = resolveCanvasViewerMode('PptxScrollViewer', opts.mode, undefined);
@@ -608,11 +619,13 @@ export class PptxScrollViewer implements ZoomableViewer {
         // destroys the prior worker, whose pending hit requests reject on close.
         this._invalidateElementSelection(false);
         selectionInvalidated = true;
-        this._find.invalidate();
+        this._invalidateFind();
         this._findActive = false;
         this._activeCommentId = null;
         this._activeCommentSlide = null;
         this._hasComments = false;
+        this._commentScanFrontier = 0;
+        this._beginCommentNavigation();
         this._unbindLayoutPresentation();
         if (ownedPresentation) {
           for (const [idx, slot] of [...this._slots]) this._recycleSlot(idx, slot);
@@ -623,12 +636,13 @@ export class PptxScrollViewer implements ZoomableViewer {
       if (this._destroyed) throw new Error('PptxScrollViewer is destroyed');
       // A successful reload replaces the selection surface. Retire hit tests
       // issued against the old engine and notify that its element focus ended.
-      this._find.invalidate();
+      this._invalidateFind();
       this._findActive = false;
       this._activeCommentId = null;
       this._activeCommentSlide = null;
-      this._hasComments = this._commentsEnabled()
-        && this._presentationHasComments(pres);
+      this._hasComments = false;
+      this._commentScanFrontier = 0;
+      this._scanAvailableComments(pres, false);
       this._bindLayoutPresentation(pres);
       // Lay out + mount the first window now that the engine exists (mirrors the
       // borrowed-engine path in the constructor). relayout() is idempotent and
@@ -655,14 +669,16 @@ export class PptxScrollViewer implements ZoomableViewer {
     return this._pres?.availableSlideCount ?? this.slideCount;
   }
 
-  /** Whether all slides are paintable. */
+  /** True only after every slide became paintable successfully. */
   get layoutComplete(): boolean {
     return this._pres?.layoutComplete ?? true;
   }
 
-  /** Wait until all slides are paintable. */
+  /** Wait until every slide is paintable; rejects if progressive preparation fails. */
   async waitUntilLayoutComplete(): Promise<void> {
-    await this._pres?.waitUntilLayoutComplete?.();
+    await this._errorRouter.ownBackgroundLifecycle(async () => {
+      await this._pres?.waitUntilLayoutComplete?.();
+    });
   }
 
   /** Uniform slide width in CSS px at the current scale. `_scale` is a
@@ -694,15 +710,11 @@ export class PptxScrollViewer implements ZoomableViewer {
     const { left, right } = this._padH();
     const available = cw - left - right;
     if (available <= 0) return 0;
-    // Cards, authored markers, and the slide share one absolute zoom. Compute
-    // the composite fit in one pass so a resize never feeds the old card scale
-    // back into the next base-scale calculation.
-    const naturalSlideWidth = this._pres ? this._pres.slideWidth / EMU_PER_PX : 0;
-    const fit = this._hasCommentMargin() && naturalSlideWidth > 0
-      ? available * naturalSlideWidth /
-        (naturalSlideWidth + COMMENT_MARGIN_GAP_PX + COMMENT_MARGIN_WIDTH_PX)
-      : available;
-    return fit > 0 ? fit : 0; // gutters ≥ container ⇒ defer (same as zero-width)
+    // Fit the authored slide itself. Review cards are an adjacent horizontal
+    // surface and may extend the horizontal scroll range, but must never change
+    // slide scale or vertical scroll geometry when progressive metadata reveals
+    // a later comment.
+    return available;
   }
 
   private _commentMarginExtent(): number {
@@ -750,13 +762,34 @@ export class PptxScrollViewer implements ZoomableViewer {
     margin.dataset.ooxmlCommentZoom = String(zoom);
   }
 
-  private _presentationHasComments(presentation: PptxPresentation): boolean {
+  /** Inspect only the prefix whose slide metadata is authoritative. When a
+   * later publication reveals the first comment, enable the already-present
+   * review layers and horizontal extent without replacing the authored canvas
+   * or changing fit/vertical geometry. */
+  private _scanAvailableComments(
+    presentation: PptxPresentation,
+    rebuildMountedSurface: boolean,
+  ): void {
+    if (!this._commentsEnabled() || this._hasComments) return;
     const includeResolved = this._commentsOptions()?.includeResolved === true;
-    for (let i = 0; i < presentation.slideCount; i++) {
-      if (presentation.getComments(i).some((comment) => includeResolved ||
-        (comment.status !== 'resolved' && comment.status !== 'closed'))) return true;
+    const available = Math.min(presentation.availableSlideCount, presentation.slideCount);
+    for (let i = this._commentScanFrontier; i < available; i++) {
+      if (!presentation.getComments(i).some((comment) => includeResolved ||
+        (comment.status !== 'resolved' && comment.status !== 'closed'))) continue;
+      this._commentScanFrontier = available;
+      this._hasComments = true;
+      if (rebuildMountedSurface) this._refreshDiscoveredComments();
+      return;
     }
-    return false;
+    this._commentScanFrontier = Math.max(this._commentScanFrontier, available);
+  }
+
+  private _refreshDiscoveredComments(): void {
+    // Comment-enabled slots own empty review layers from birth. Revealing later
+    // metadata therefore updates only those layers: the painted canvas,
+    // dispatcher, slide scale, stride, scrollTop, and spacer height stay intact.
+    this._syncSpacerWidth();
+    for (const [slide, slot] of this._slots) this._redrawSlotComments(slide, slot);
   }
 
   /** Base scale: the DIMENSIONLESS multiplier that fits the (uniform) slide
@@ -923,7 +956,19 @@ export class PptxScrollViewer implements ZoomableViewer {
    *  current slide px width. */
   private _syncSpacerWidth(): void {
     const { left, right } = this._padH();
-    this._spacer.style.width = `${this._slideWidthPx() + this._commentMarginExtent() + left + right}px`;
+    const marginExtent = this._commentMarginExtent();
+    const next = this._commentSide() === 'left' ? marginExtent : 0;
+    const delta = next - this._reviewOriginPx;
+    const targetScrollLeft = Math.max(0, this._scrollHost.scrollLeft + delta);
+    // Establish the new native scroll range before applying compensation.
+    // Browsers clamp scrollLeft to the current range at assignment time.
+    this._spacer.style.width = `${this._slideWidthPx() + marginExtent + left + right}px`;
+    if (delta === 0) return;
+    this._reviewOriginPx = next;
+    (this._scrollHost.style as CSSStyleDeclaration & Record<string, string>)[
+      '--ooxml-review-origin-x'
+    ] = `${next}px`;
+    this._scrollHost.scrollLeft = targetScrollLeft;
   }
 
   private _onScroll(): void {
@@ -1040,12 +1085,12 @@ export class PptxScrollViewer implements ZoomableViewer {
     let commentMarkerLayer: HTMLDivElement | null = null;
     let commentMargin: HTMLDivElement | null = null;
     let commentDecorationLayer: HTMLDivElement | null = null;
-    if (this._commentsEnabled() && this._hasComments) {
+    if (this._commentsEnabled()) {
       commentMarkerLayer = document.createElement('div');
       commentMarkerLayer.style.cssText =
         'position:absolute;inset:0;overflow:hidden;pointer-events:none;';
       wrapper.appendChild(commentMarkerLayer);
-      if (this._hasCommentMargin()) {
+      if (this._commentsOptions()?.cards !== false) {
         commentMargin = document.createElement('div');
         commentMargin.style.cssText =
           'position:absolute;top:0;height:100%;box-sizing:border-box;' +
@@ -1180,12 +1225,10 @@ export class PptxScrollViewer implements ZoomableViewer {
     // pins it at `padL` and the overflow scrolls right. Formula deliberately
     // duplicated per viewer (one line; not hoisted to core).
     const { left: padL } = this._padH();
-    const cw = this._scrollHost.clientWidth;
-    const marginExtent = this._commentMarginExtent();
-    const compositeWidth = wpx + marginExtent;
-    const compositeLeft = Math.max(padL, (cw - compositeWidth) / 2);
-    slot.wrapper.style.left = `${compositeLeft +
-      (this._commentSide() === 'left' ? marginExtent : 0)}px`;
+    const authoredLeft = Math.max(padL, (this._scrollHost.clientWidth - wpx) / 2);
+    slot.wrapper.style.left = this._commentSide() === 'left' && this._commentsEnabled()
+      ? `calc(${authoredLeft}px + var(--ooxml-review-origin-x, 0px))`
+      : `${authoredLeft}px`;
   }
 
   /** Device-pixel ratio for a render (opts override → window → 1). */
@@ -1224,6 +1267,17 @@ export class PptxScrollViewer implements ZoomableViewer {
     if (!this._pres) return null;
     // Slot-identity guard: this slot is already rendering / has rendered slide i.
     if (slot.renderedSlide === i) return null;
+    if (i >= this.availableSlideCount && !this.layoutComplete) {
+      // A virtual slot is only a stable placeholder until its metadata is
+      // published. Do not start a Presentation wait/render here: the slot may be
+      // recycled long before that slide becomes available, amplifying work and
+      // retaining resources for an off-screen page. Layout publication below
+      // dispatches only the placeholders that are still mounted.
+      slot.renderedSlide = -1;
+      slot.mediaInteractive = false;
+      slot.loadingLayer.style.display = 'flex';
+      return null;
+    }
     slot.renderedSlide = i;
     const renderGeneration = ++slot.renderGeneration;
     slot.loadingLayer.style.display =
@@ -1365,6 +1419,8 @@ export class PptxScrollViewer implements ZoomableViewer {
   private _unbindLayoutPresentation(): void {
     this._layoutUnsubscribe?.();
     this._layoutUnsubscribe = null;
+    this._layoutFailed = false;
+    this._wakeLayoutWaiters();
   }
 
   private _onLayoutPublication(
@@ -1372,11 +1428,63 @@ export class PptxScrollViewer implements ZoomableViewer {
     publication: PptxLayoutPublication,
   ): void {
     if (this._destroyed || presentation !== this._pres) return;
+    this._wakeLayoutWaiters();
     if (publication.error !== undefined) {
-      this._reportRenderError(publication.error);
+      this._layoutFailed = true;
+      this._errorRouter.reportBackground(
+        publication.error,
+        this._opts.onLayoutComplete !== undefined,
+      );
       return;
     }
+    this._scanAvailableComments(presentation, true);
+    const mediaRange = this._opts.enableMediaPlayback ? this._mediaRange() : null;
+    for (const [slideIndex, slot] of this._slots) {
+      if (slideIndex >= presentation.availableSlideCount || slot.renderedSlide === slideIndex) continue;
+      void this._renderSlot(
+        slideIndex,
+        slot,
+        !!mediaRange && this._rangeContains(mediaRange, slideIndex),
+      );
+    }
     if (this._lastRange) this._emitVisibleSlideChange(this._lastRange);
+  }
+
+  private _wakeLayoutWaiters(): void {
+    for (const resolve of this._layoutWaiters) resolve();
+    this._layoutWaiters.clear();
+  }
+
+  /** Supersede pending comment navigation and release availability waits now. */
+  private _beginCommentNavigation(): number {
+    const generation = ++this._commentNavigationGeneration;
+    this._wakeLayoutWaiters();
+    return generation;
+  }
+
+  private async _waitForSlideMetadata(
+    presentation: PptxPresentation,
+    slideIndex: number,
+    generation: number,
+  ): Promise<boolean> {
+    return await this._errorRouter.ownBackgroundLifecycle(async () => {
+      while (
+        !this._destroyed &&
+        generation === this._commentNavigationGeneration &&
+        presentation === this._pres &&
+        slideIndex >= presentation.availableSlideCount &&
+        !presentation.layoutComplete &&
+        !this._layoutFailed
+      ) {
+        await new Promise<void>((resolve) => this._layoutWaiters.add(resolve));
+      }
+      if (this._destroyed || presentation !== this._pres) return false;
+      if (presentation.layoutComplete || this._layoutFailed) {
+        await presentation.waitUntilLayoutComplete?.();
+      }
+      if (generation !== this._commentNavigationGeneration) return false;
+      return slideIndex < presentation.availableSlideCount;
+    });
   }
 
   private _emitVisibleSlideChange(range: VisibleWindow): void {
@@ -1501,10 +1609,7 @@ export class PptxScrollViewer implements ZoomableViewer {
   /** Route an async render failure to `onError`, or `console.error` when none is
    *  set (so failures are never fully silent), and never after teardown. */
   private _reportRenderError(err: unknown): void {
-    if (this._destroyed) return;
-    const e = err instanceof Error ? err : new Error(String(err));
-    if (this._opts.onError) this._opts.onError(e);
-    else console.error('[ooxml] PptxScrollViewer render failed:', e);
+    this._errorRouter.report(err);
   }
 
   /**
@@ -2243,13 +2348,11 @@ export class PptxScrollViewer implements ZoomableViewer {
       ? anchored.y + (hasPosition ? comment.y as number : 0)
       : comment.y as number;
     const width = this._slideWidthPx();
-    const marginExtent = this._commentMarginExtent();
     const { left: paddingLeft } = this._padH();
-    const compositeLeft = Math.max(
+    const slideLeft = Math.max(
       paddingLeft,
-      (this._scrollHost.clientWidth - width - marginExtent) / 2,
-    );
-    const slideLeft = compositeLeft + (this._commentSide() === 'left' ? marginExtent : 0);
+      (this._scrollHost.clientWidth - width) / 2,
+    ) + this._reviewOriginPx;
     const range = this._rangeAt(0, this._overscan());
     const maxTop = Math.max(0, range.totalHeight - this._scrollHost.clientHeight);
     const spacerWidth = this._spacer.offsetWidth || Number.parseFloat(this._spacer.style.width) || 0;
@@ -2324,11 +2427,19 @@ export class PptxScrollViewer implements ZoomableViewer {
     if (!presentation || !Number.isInteger(slideIndex) || !Number.isInteger(commentIndex)) {
       return false;
     }
-    if (slideIndex < 0 || slideIndex >= presentation.slideCount) return false;
+    if (slideIndex < 0 || slideIndex >= presentation.slideCount || commentIndex < 0) return false;
+    const generation = this._beginCommentNavigation();
+    if (slideIndex >= presentation.availableSlideCount && !presentation.layoutComplete) {
+      const available = await this._waitForSlideMetadata(presentation, slideIndex, generation);
+      if (!available) return false;
+    }
+    if (this._destroyed) throw new Error('PptxScrollViewer is destroyed');
+    if (generation !== this._commentNavigationGeneration || presentation !== this._pres) {
+      return false;
+    }
     const comment = presentation.getComments(slideIndex)[commentIndex];
     if (!comment) return false;
 
-    const generation = ++this._commentNavigationGeneration;
     const bounds = await this._resolveSlideCommentElementBounds(slideIndex, comment);
     if (this._destroyed) throw new Error('PptxScrollViewer is destroyed');
     if (generation !== this._commentNavigationGeneration || presentation !== this._pres) {
@@ -2357,9 +2468,23 @@ export class PptxScrollViewer implements ZoomableViewer {
     query: string,
     opts: FindMatchesOptions = {},
   ): Promise<FindMatch<PptxMatchLocation>[]> {
-    if (!this._pres) return [];
+    const presentation = this._pres;
+    if (!presentation) return [];
+    const generation = ++this._findGeneration;
     this._findActive = query.length > 0;
-    const matches = await this._find.find(query, opts);
+    if (query.length === 0) {
+      this._find.invalidate();
+      this._redrawHighlights();
+      return [];
+    }
+    if (!presentation.layoutComplete) {
+      await this._errorRouter.ownBackgroundLifecycle(
+        () => presentation.waitUntilLayoutComplete(),
+      );
+    }
+    if (this._destroyed || generation !== this._findGeneration || presentation !== this._pres) return [];
+    const matches = await this._errorRouter.ownAwaitable(() => this._find.find(query, opts));
+    if (this._destroyed || generation !== this._findGeneration || presentation !== this._pres) return [];
     this._redrawHighlights();
     return matches;
   }
@@ -2377,8 +2502,13 @@ export class PptxScrollViewer implements ZoomableViewer {
   /** Clear the current query and every mounted highlight. */
   clearFind(): void {
     this._findActive = false;
-    this._find.invalidate();
+    this._invalidateFind();
     this._redrawHighlights();
+  }
+
+  private _invalidateFind(): void {
+    this._findGeneration++;
+    this._find.invalidate();
   }
 
   private async _activateMatch(
@@ -2934,7 +3064,9 @@ export class PptxScrollViewer implements ZoomableViewer {
   destroy(): void {
     if (this._destroyed) return;
     this._destroyed = true;
-    this._find.invalidate();
+    this._beginCommentNavigation();
+    this._errorRouter.close();
+    this._invalidateFind();
     this._findActive = false;
     this._unbindLayoutPresentation();
     if (this._selectionChangeListener) {

--- a/packages/pptx/src/viewer-layout-error-routing.test.ts
+++ b/packages/pptx/src/viewer-layout-error-routing.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PptxPresentation, type LoadOptions } from './presentation.js';
+import { publishPptxLayout } from './presentation-layout-events.js';
+import { PptxViewer } from './viewer.js';
+import { PptxScrollViewer } from './scroll-viewer.js';
+import { FakePptxEngine, installDom, makeContainer, makeEl } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+type Surface = PptxViewer | PptxScrollViewer;
+
+async function loadedSurface(
+  kind: 'viewer' | 'scroll',
+  callbacks: Pick<LoadOptions, 'onLayoutComplete'> & { onError?: (error: Error) => void },
+): Promise<{ engine: FakePptxEngine; surface: Surface; loadOptions: LoadOptions }> {
+  installDom();
+  const engine = new FakePptxEngine(2, 9144000, 5143500);
+  engine.setLayoutProgress(1, false);
+  const load = vi.spyOn(PptxPresentation, 'load').mockResolvedValue(engine.asPres());
+  const surface = kind === 'viewer'
+    ? new PptxViewer(makeEl('canvas') as unknown as HTMLCanvasElement, callbacks)
+    : new PptxScrollViewer(makeContainer(200, 50) as unknown as HTMLElement, {
+        ...callbacks,
+        overscan: 0,
+      });
+  await surface.load('progressive.pptx');
+  return { engine, surface, loadOptions: load.mock.calls[0]![1] as LoadOptions };
+}
+
+describe.each(['viewer', 'scroll'] as const)('PPTX %s progressive failure routing', (kind) => {
+  it('routes an actively awaited failure only through the returned Promise', async () => {
+    const onError = vi.fn();
+    const { engine, surface } = await loadedSurface(kind, { onError });
+    const error = new Error('layout failed');
+    const waiting = surface.waitUntilLayoutComplete();
+    engine.setLayoutProgress(1, false, error);
+
+    await expect(waiting).rejects.toBe(error);
+    expect(onError).not.toHaveBeenCalled();
+    surface.destroy();
+  });
+
+  it('routes a progressive search failure only through the find Promise', async () => {
+    const onError = vi.fn();
+    const { engine, surface } = await loadedSurface(kind, { onError });
+    const error = new Error('layout failed during find');
+    vi.spyOn(engine, 'collectSlideRuns').mockImplementation(async (slide) => {
+      if (slide >= engine.availableSlideCount) await engine.waitUntilLayoutComplete();
+      return [];
+    });
+    const searching = surface.findText('needle');
+    engine.setLayoutProgress(1, false, error);
+
+    await expect(searching).rejects.toBe(error);
+    expect(onError).not.toHaveBeenCalled();
+    surface.destroy();
+  });
+
+  it('routes an unawaited failure once through onError', async () => {
+    const onError = vi.fn();
+    const { engine, surface } = await loadedSurface(kind, { onError });
+    const error = new Error('layout failed');
+    engine.setLayoutProgress(1, false, error);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(error);
+    surface.destroy();
+  });
+
+  it('leaves an explicitly configured completion callback as the sole owner', async () => {
+    const onError = vi.fn();
+    const onLayoutComplete = vi.fn();
+    const { engine, surface, loadOptions } = await loadedSurface(
+      kind,
+      { onError, onLayoutComplete },
+    );
+    const error = new Error('layout failed');
+    engine.setLayoutProgress(1, false, error);
+    loadOptions.onLayoutComplete?.(error);
+
+    expect(onLayoutComplete).toHaveBeenCalledTimes(1);
+    expect(onLayoutComplete).toHaveBeenCalledWith(error);
+    expect(onError).not.toHaveBeenCalled();
+    surface.destroy();
+  });
+});

--- a/packages/pptx/src/viewer-progressive.test.ts
+++ b/packages/pptx/src/viewer-progressive.test.ts
@@ -121,4 +121,65 @@ describe('PptxViewer progressive layout', () => {
     expect(viewer.slideIndex).toBe(2);
     viewer.destroy();
   });
+
+  it('settles superseded navigation immediately instead of waiting for another layout publication', async () => {
+    const canvas = mountCanvas();
+    const engine = new FakePptxEngine(3, WIDTH, HEIGHT);
+    engine.setLayoutProgress(1, false);
+    const viewer = PptxViewer.fromPresentation(
+      canvas as unknown as HTMLCanvasElement,
+      engine.asPres(),
+    ) as PptxViewer;
+
+    let firstSettled = false;
+    const first = viewer.goToSlide(2).then(() => { firstSettled = true; });
+    await viewer.goToSlide(0);
+    await first;
+
+    expect(firstSettled).toBe(true);
+    expect(viewer.slideIndex).toBe(0);
+    viewer.destroy();
+  });
+
+  it('keeps a concurrent progressive failure on the canceled navigation Promise channel', async () => {
+    const canvas = mountCanvas();
+    const engine = new FakePptxEngine(3, WIDTH, HEIGHT);
+    engine.setLayoutProgress(1, false);
+    const onError = vi.fn();
+    const viewer = PptxViewer.fromPresentation(
+      canvas as unknown as HTMLCanvasElement,
+      engine.asPres(),
+      { onError },
+    ) as PptxViewer;
+    const failure = new Error('layout failed during navigation cancellation');
+
+    const navigation = viewer.goToSlide(2);
+    void viewer.goToSlide(0);
+    engine.setLayoutProgress(1, false, failure);
+
+    await expect(navigation).rejects.toBe(failure);
+    expect(onError).not.toHaveBeenCalled();
+    viewer.destroy();
+  });
+
+  it('does not lose a layout failure when clearFind supersedes a progressive search', async () => {
+    const canvas = mountCanvas();
+    const engine = new FakePptxEngine(3, WIDTH, HEIGHT);
+    engine.setLayoutProgress(1, false);
+    const onError = vi.fn();
+    const viewer = PptxViewer.fromPresentation(
+      canvas as unknown as HTMLCanvasElement,
+      engine.asPres(),
+      { onError },
+    ) as PptxViewer;
+    const failure = new Error('layout failed during find cancellation');
+
+    const find = viewer.findText('needle');
+    viewer.clearFind();
+    engine.setLayoutProgress(1, false, failure);
+
+    await expect(find).rejects.toBe(failure);
+    expect(onError).not.toHaveBeenCalled();
+    viewer.destroy();
+  });
 });

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -187,6 +187,7 @@ export class PptxViewer implements ZoomableViewer {
   private elementLayer: HTMLDivElement | null = null;
   /** IX2 — find state (per-slide runs, matches, active cursor). */
   private _find: PptxFindController;
+  private _findGeneration = 0;
   /** Private 2d context for measuring highlight text (own 1×1 canvas). */
   private _measureCtx: CanvasRenderingContext2D | null = null;
   private readonly presentationOwner: TerminalResourceOwner<PptxPresentation>;
@@ -212,6 +213,7 @@ export class PptxViewer implements ZoomableViewer {
   private readonly _loadingLayer: HTMLSpanElement;
   private _layoutUnsubscribe: (() => void) | null = null;
   private readonly _layoutWaiters = new Set<() => void>();
+  private _layoutFailed = false;
   private _navigationGeneration = 0;
   private _renderProgressGeneration = 0;
   private _lastReportedSlide = -1;
@@ -364,7 +366,7 @@ export class PptxViewer implements ZoomableViewer {
         this._invalidateElementSelection(false);
         selectionInvalidated = true;
         this.renderDispatcher.begin();
-        this._find.invalidate();
+        this._invalidateFind();
         this.handle?.destroy();
         this.handle = null;
         this._unbindLayoutPresentation();
@@ -377,12 +379,12 @@ export class PptxViewer implements ZoomableViewer {
       // Discard the stale slide's media handle before swapping engines so its RAF
       // loop / object URLs don't outlive the replaced presentation.
       this._bindLayoutPresentation(engine);
-      const navigationGeneration = ++this._navigationGeneration;
+      const navigationGeneration = this._beginNavigation();
       this.currentSlide = await this._initialSlide(navigationGeneration);
       if (navigationGeneration !== this._navigationGeneration || engine !== this.engine) return;
       this._renderedSlide = -1;
       // A new presentation invalidates any prior find state.
-      this._find.invalidate();
+      this._invalidateFind();
       await this.renderCurrentSlide();
     } catch (err) {
       if (this.destroyed) throw new Error('PptxViewer is destroyed');
@@ -395,7 +397,7 @@ export class PptxViewer implements ZoomableViewer {
 
   /** Navigate to a specific slide (0-indexed). */
   async goToSlide(index: number): Promise<void> {
-    const generation = ++this._navigationGeneration;
+    const generation = this._beginNavigation();
     await this._goToSlide(index, generation);
   }
 
@@ -413,13 +415,13 @@ export class PptxViewer implements ZoomableViewer {
   }
 
   async nextSlide(): Promise<void> {
-    const generation = ++this._navigationGeneration;
+    const generation = this._beginNavigation();
     const next = await this._step(1, generation);
     await this._goToSlide(next, generation);
   }
 
   async prevSlide(): Promise<void> {
-    const generation = ++this._navigationGeneration;
+    const generation = this._beginNavigation();
     const next = await this._step(-1, generation);
     await this._goToSlide(next, generation);
   }
@@ -467,7 +469,7 @@ export class PptxViewer implements ZoomableViewer {
    * while on a hidden slide advances to the nearest visible slide.
    */
   async setHiddenSlideMode(mode: HiddenSlideMode): Promise<void> {
-    const generation = ++this._navigationGeneration;
+    const generation = this._beginNavigation();
     this._hiddenMode = mode;
     let next = this.currentSlide;
     if (mode === 'skip' && this.engine) {
@@ -492,7 +494,8 @@ export class PptxViewer implements ZoomableViewer {
   /** The current hidden-slide mode. */
   get hiddenSlideMode(): HiddenSlideMode { return this._hiddenMode; }
 
-  /** Number of non-hidden slides (absolute `slideCount` is unchanged). */
+  /** Number of non-hidden slides (absolute `slideCount` is unchanged). During
+   * progressive loading this is provisional until {@link layoutComplete}. */
   get visibleSlideCount(): number {
     if (!this.engine) return 0;
     const engine = this.engine;
@@ -507,14 +510,18 @@ export class PptxViewer implements ZoomableViewer {
   get layoutComplete(): boolean { return this.engine?.layoutComplete ?? true; }
   /** Wait until all slides are paintable. */
   async waitUntilLayoutComplete(): Promise<void> {
-    await this.engine?.waitUntilLayoutComplete?.();
+    await this.errorRouter.ownBackgroundLifecycle(async () => {
+      await this.engine?.waitUntilLayoutComplete?.();
+    });
   }
 
   /**
    * Speaker-notes text for a slide (`ppt/notesSlides/notesSlideN.xml`,
    * ECMA-376 §13.3.5). Passthrough to {@link PptxPresentation.getNotes}:
    * 0-based index, returns `null` when the slide has no notes part, the index
-   * is out of range, or nothing is loaded yet.
+   * is out of range, or nothing is loaded yet. During progressive loading the
+   * answer is authoritative only below {@link availableSlideCount}; await
+   * {@link waitUntilLayoutComplete} before scanning the whole deck.
    */
   getNotes(slideIndex: number): string | null {
     return this.engine?.getNotes(slideIndex) ?? null;
@@ -702,7 +709,11 @@ export class PptxViewer implements ZoomableViewer {
       this._find.setSlideRuns(slide, runs);
       this._buildHighlightLayer(runs, targetWidth, cssHeight);
     } catch (err) {
-      if (!this.renderDispatcher.isCurrent(generation)) return;
+      // Superseded paint failures are stale, but a same-presentation terminal
+      // layout failure still belongs to the public navigation Promise that was
+      // waiting for it. Do not turn cancellation into silent data loss.
+      if (!this.renderDispatcher.isCurrent(generation) &&
+          !(engine === this.engine && this._layoutFailed)) return;
       throw err;
     } finally {
       if (progressGeneration === this._renderProgressGeneration) this._setLoading(false);
@@ -711,6 +722,7 @@ export class PptxViewer implements ZoomableViewer {
 
   private _bindLayoutPresentation(presentation: PptxPresentation): void {
     this._unbindLayoutPresentation();
+    this._layoutFailed = false;
     let initial = true;
     this._layoutUnsubscribe = subscribePptxLayout(
       presentation,
@@ -734,10 +746,18 @@ export class PptxViewer implements ZoomableViewer {
   private _unbindLayoutPresentation(): void {
     this._layoutUnsubscribe?.();
     this._layoutUnsubscribe = null;
+    this._layoutFailed = false;
     this._navigationGeneration++;
     this._renderProgressGeneration++;
     this._wakeLayoutWaiters();
     this._setLoading(false);
+  }
+
+  /** Supersede every pending navigation and wake its availability wait now. */
+  private _beginNavigation(): number {
+    const generation = ++this._navigationGeneration;
+    this._wakeLayoutWaiters();
+    return generation;
   }
 
   private _onLayoutPublication(
@@ -747,7 +767,11 @@ export class PptxViewer implements ZoomableViewer {
     if (this.destroyed || presentation !== this.engine) return;
     this._wakeLayoutWaiters();
     if (publication.error !== undefined) {
-      this._reportRenderError(publication.error);
+      this._layoutFailed = true;
+      this.errorRouter.reportBackground(
+        publication.error,
+        this.opts.onLayoutComplete !== undefined,
+      );
       return;
     }
     if (this._renderedSlide !== this.currentSlide) return;
@@ -759,18 +783,24 @@ export class PptxViewer implements ZoomableViewer {
     slide: number,
     isCurrent: () => boolean,
   ): Promise<boolean> {
-    while (
-      !this.destroyed &&
-      isCurrent() &&
-      presentation === this.engine &&
-      slide >= presentation.availableSlideCount &&
-      !presentation.layoutComplete
-    ) {
-      await new Promise<void>((resolve) => this._layoutWaiters.add(resolve));
-    }
-    if (this.destroyed || !isCurrent() || presentation !== this.engine) return false;
-    if (presentation.layoutComplete) await presentation.waitUntilLayoutComplete?.();
-    return slide < presentation.availableSlideCount;
+    return await this.errorRouter.ownBackgroundLifecycle(async () => {
+      while (
+        !this.destroyed &&
+        isCurrent() &&
+        presentation === this.engine &&
+        slide >= presentation.availableSlideCount &&
+        !presentation.layoutComplete &&
+        !this._layoutFailed
+      ) {
+        await new Promise<void>((resolve) => this._layoutWaiters.add(resolve));
+      }
+      if (this.destroyed || presentation !== this.engine) return false;
+      if (presentation.layoutComplete || this._layoutFailed) {
+        await presentation.waitUntilLayoutComplete?.();
+      }
+      if (!isCurrent()) return false;
+      return slide < presentation.availableSlideCount;
+    });
   }
 
   private _wakeLayoutWaiters(): void {
@@ -854,8 +884,22 @@ export class PptxViewer implements ZoomableViewer {
     query: string,
     opts: FindMatchesOptions = {},
   ): Promise<FindMatch<PptxMatchLocation>[]> {
-    if (!this.engine) return [];
-    const matches = await this._find.find(query, opts);
+    const engine = this.engine;
+    if (!engine) return [];
+    const generation = ++this._findGeneration;
+    if (query.length === 0) {
+      this._find.invalidate();
+      this._redrawHighlights();
+      return [];
+    }
+    if (!engine.layoutComplete) {
+      await this.errorRouter.ownBackgroundLifecycle(
+        () => engine.waitUntilLayoutComplete(),
+      );
+    }
+    if (this.destroyed || generation !== this._findGeneration || engine !== this.engine) return [];
+    const matches = await this.errorRouter.ownAwaitable(() => this._find.find(query, opts));
+    if (this.destroyed || generation !== this._findGeneration || engine !== this.engine) return [];
     this._redrawHighlights();
     return matches;
   }
@@ -876,8 +920,13 @@ export class PptxViewer implements ZoomableViewer {
 
   /** IX2 — clear all highlights and reset the find state. */
   clearFind(): void {
-    this._find.invalidate();
+    this._invalidateFind();
     this._redrawHighlights();
+  }
+
+  private _invalidateFind(): void {
+    this._findGeneration++;
+    this._find.invalidate();
   }
 
   private async _activateMatch(
@@ -1130,7 +1179,7 @@ export class PptxViewer implements ZoomableViewer {
     // IX2 — drop the find state (matches + cached runs) so a stale
     // findNext()/findPrev() after teardown returns null instead of a match
     // pointing into a dead viewer.
-    this._find.invalidate();
+    this._invalidateFind();
     if (this.selectionChangeListener) {
       this.wrapper.ownerDocument.removeEventListener('selectionchange', this.selectionChangeListener);
       this.selectionChangeListener = null;

--- a/packages/pptx/src/worker-protocol.ts
+++ b/packages/pptx/src/worker-protocol.ts
@@ -81,6 +81,7 @@ export type PptxWorkerResponse =
 // while complete Slide models never cross into Window.
 export type RenderWorkerRequest =
   | { kind: 'init'; wasmUrl: string }
+  | { kind: 'continuePresentationPreflight'; forId: number; availableSlides: number }
   | {
       kind: 'parse';
       id: number;

--- a/packages/pptx/src/worker-task-scheduler.test.ts
+++ b/packages/pptx/src/worker-task-scheduler.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { yieldToHostTaskQueue } from './worker-task-scheduler.js';
+
+describe('yieldToHostTaskQueue', () => {
+  it('crosses a worker task boundary instead of only draining microtasks', async () => {
+    const order: string[] = [];
+    const yielded = yieldToHostTaskQueue().then(() => order.push('continued'));
+    queueMicrotask(() => order.push('host-message-dispatched'));
+
+    await yielded;
+    expect(order).toEqual(['host-message-dispatched', 'continued']);
+  });
+});

--- a/packages/pptx/src/worker-task-scheduler.ts
+++ b/packages/pptx/src/worker-task-scheduler.ts
@@ -1,0 +1,19 @@
+/**
+ * Cross a host task boundary before acknowledging a progressive worker prefix.
+ *
+ * `await Promise.resolve()` only drains microtasks. A MessageChannel task lets
+ * the `load()` continuation enqueue its opening-slide render first; Worker
+ * message ordering then puts that render ahead of the acknowledgement that
+ * releases the next preflight unit. The channel is one-shot and promptly closed.
+ */
+export function yieldToHostTaskQueue(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = () => {
+      channel.port1.close();
+      channel.port2.close();
+      resolve();
+    };
+    channel.port2.postMessage(undefined);
+  });
+}

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity local viewer for Office files (.docx / .xlsx / .pptx), powered by Rust/WASM and Canvas. Optional MCP integration can share requested context with an AI agent.",
-  "version": "0.82.1",
+  "version": "0.83.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.82.1",
+  "version": "0.83.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/scripts/check-docx-layout-boundaries.mjs
+++ b/scripts/check-docx-layout-boundaries.mjs
@@ -2380,12 +2380,19 @@ function workerMetadataAuthorityIsCanonical(source) {
     && ts.isSpreadElement(bookmarkValue.elements[0])
     ? bookmarkValue.elements[0]
     : null;
-  const commentCall = ts.isPropertyAssignment(comments)
-    ? callOf(unwrapStaticExpression(comments.initializer), 'collectLayoutSourceCommentRangesIfPresent')
+  const commentValue = ts.isPropertyAssignment(comments)
+    ? unwrapStaticExpression(comments.initializer)
     : null;
-  const revisionCall = ts.isPropertyAssignment(revisions)
-    ? callOf(unwrapStaticExpression(revisions.initializer), 'collectLayoutSourceRevisionRangesIfPresent')
+  const revisionValue = ts.isPropertyAssignment(revisions)
+    ? unwrapStaticExpression(revisions.initializer)
     : null;
+  const commentCall = commentValue && ts.isConditionalExpression(commentValue)
+    ? callOf(unwrapStaticExpression(commentValue.whenTrue), 'collectLayoutSourceCommentRangesIfPresent')
+    : null;
+  const revisionCall = revisionValue && ts.isConditionalExpression(revisionValue)
+    ? callOf(unwrapStaticExpression(revisionValue.whenTrue), 'collectLayoutSourceRevisionRangesIfPresent')
+    : null;
+  const reviewIndexCalls = callsNamed(projector.body, 'reviewProjectionIndexForDocument');
   if (!ts.isPropertyAssignment(pageCount)
     || pageCount.initializer.getText(source) !== 'layout.pages.length'
     || !pageSizesCall
@@ -2395,10 +2402,20 @@ function workerMetadataAuthorityIsCanonical(source) {
     || pageSizesCall.expression.expression.getText(source) !== 'layout.pages'
     || !bookmarkSpread
     || callOf(bookmarkSpread.expression, 'buildBookmarkPageMap')?.arguments[0]?.getText(source) !== 'layout'
+    || reviewIndexCalls.length !== 1
+    || reviewIndexCalls[0].arguments.map((argument) => argument.getText(source)).join(',') !== 'layout'
+    || !commentValue
+    || !ts.isConditionalExpression(commentValue)
+    || !revisionValue
+    || !ts.isConditionalExpression(revisionValue)
+    || commentValue.condition.getText(source) !== 'hasComments'
+    || commentValue.whenFalse.getText(source) !== '[]'
+    || revisionValue.condition.getText(source) !== 'hasRevisions'
+    || revisionValue.whenFalse.getText(source) !== '[]'
     || commentCall?.arguments.map((argument) => argument.getText(source)).join(',')
-      !== 'review.comments,source,renderedRunIndex'
+      !== 'review.comments,source,reviewIndex!.renderedRunIndex,reviewProjection'
     || revisionCall?.arguments.map((argument) => argument.getText(source)).join(',')
-      !== 'review.revisions,source,renderedRunIndex') return false;
+      !== 'review.revisions,source,reviewIndex!.renderedRunIndex,reviewProjection') return false;
 
   const selector = selectors[0];
   const sources = variableDeclarationsNamed(selector, 'source');

--- a/scripts/check-docx-layout-boundaries.test.mjs
+++ b/scripts/check-docx-layout-boundaries.test.mjs
@@ -243,14 +243,25 @@ function production(state, table, para, group) {
       + '  return { layoutServices, layoutVariants: variants.store, defaultCurrentDateMs };\n'
       + '}\n');
   write(root, 'packages/docx/src/render-worker-metadata.ts',
-    'export function projectRenderWorkerLayoutMeta(layout, source, review) {\n'
-      + '  const renderedRunIndex = textRunSourceIndexForDocument(layout);\n'
+    'export function projectRenderWorkerLayoutMeta(layout, source, review, options = {}) {\n'
+      + '  const hasComments = review.comments.length > 0;\n'
+      + '  const hasRevisions = review.revisions.length > 0;\n'
+      + '  const reviewIndex = hasComments || hasRevisions\n'
+      + '    ? reviewProjectionIndexForDocument(layout)\n'
+      + '    : undefined;\n'
+      + '  const reviewProjection = options.provisional && reviewIndex\n'
+      + '    ? { completedSourceKeys: reviewIndex.completedSourceKeys }\n'
+      + '    : undefined;\n'
       + '  return {\n'
       + '    pageCount: layout.pages.length,\n'
       + '    pageSizes: layout.pages.map((page) => page.geometry),\n'
       + '    bookmarkPages: [...buildBookmarkPageMap(layout)],\n'
-      + '    commentAnchorRanges: collectLayoutSourceCommentRangesIfPresent(review.comments, source, renderedRunIndex),\n'
-      + '    revisionAnchorRanges: collectLayoutSourceRevisionRangesIfPresent(review.revisions, source, renderedRunIndex),\n'
+      + '    commentAnchorRanges: hasComments\n'
+      + '      ? collectLayoutSourceCommentRangesIfPresent(review.comments, source, reviewIndex!.renderedRunIndex, reviewProjection)\n'
+      + '      : [],\n'
+      + '    revisionAnchorRanges: hasRevisions\n'
+      + '      ? collectLayoutSourceRevisionRangesIfPresent(review.revisions, source, reviewIndex!.renderedRunIndex, reviewProjection)\n'
+      + '      : [],\n'
       + '  };\n'
       + '}\n'
       + 'export function renderWorkerLayoutMeta(doc, review, currentDateMs, showTrackedChanges) {\n'
@@ -1929,6 +1940,9 @@ test('worker parse metadata comes from the retained selected-variant route', () 
     ['foreign metadata page count', 'render-worker-metadata.ts', 'pageCount: layout.pages.length', 'pageCount: foreignLayout.pages.length'],
     ['foreign metadata page sizes', 'render-worker-metadata.ts', 'pageSizes: layout.pages.map', 'pageSizes: foreignLayout.pages.map'],
     ['foreign metadata bookmarks', 'render-worker-metadata.ts', 'buildBookmarkPageMap(layout)', 'buildBookmarkPageMap(foreignLayout)'],
+    ['foreign review projection index', 'render-worker-metadata.ts', 'reviewProjectionIndexForDocument(layout)', 'reviewProjectionIndexForDocument(foreignLayout)'],
+    ['unconditional comment projection', 'render-worker-metadata.ts', 'commentAnchorRanges: hasComments', 'commentAnchorRanges: true'],
+    ['foreign comment run index', 'render-worker-metadata.ts', 'reviewIndex!.renderedRunIndex', 'foreignReviewIndex.renderedRunIndex'],
     ['foreign runtime metadata layout', 'render-worker-metadata.ts', 'doc.layoutVariants.layoutFor(normalizeLayoutOptions(', 'foreignLayoutFor(normalizeLayoutOptions('],
   ]) {
     const root = initializeCanonicalFixture(`docx-layout-boundary-worker-metadata-${name}-`);

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -48,6 +48,12 @@ export default defineConfig({
         '@silurus/ooxml-core/internal/canvas-viewer-mechanics': fileURLToPath(
           new URL('../packages/core/src/internal/canvas-viewer-mechanics.ts', import.meta.url),
         ),
+        '@silurus/ooxml-core/internal/progressive-layout-lifecycle': fileURLToPath(
+          new URL('../packages/core/src/internal/progressive-layout-lifecycle.ts', import.meta.url),
+        ),
+        '@silurus/ooxml-core/internal/progressive-layout-observers': fileURLToPath(
+          new URL('../packages/core/src/internal/progressive-layout-observers.ts', import.meta.url),
+        ),
         '@silurus/ooxml-core/internal/chart-context': fileURLToPath(
           new URL('../packages/core/src/internal/chart-context.ts', import.meta.url),
         ),

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.82.1",
+  "version": "0.83.0",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",

--- a/site/src/announcement-content.test.ts
+++ b/site/src/announcement-content.test.ts
@@ -10,6 +10,37 @@ const siteFooter = readFileSync(new URL('./components/SiteFooter.astro', import.
 const capabilities = readFileSync(new URL('./components/Capabilities.astro', import.meta.url), 'utf8');
 const readme = readFileSync(new URL('../../README.md', import.meta.url), 'utf8');
 
+describe('v0.83 progressive viewing announcement', () => {
+  const announcement = announcements.find((item) => item.slug === 'v083-progressive-viewing');
+
+  it('leads with user outcomes and keeps implementation detail last', () => {
+    expect(announcement).toMatchObject({
+      label: 'Release note',
+      version: 'v0.83.0',
+      title: 'Open large Word and PowerPoint files sooner in v0.83.0',
+    });
+    expect(announcement?.sections[0]).toMatchObject({ title: 'In short', kind: 'summary' });
+    expect(announcement?.sections.at(-1)?.title).toBe('Technical note');
+
+    const userFacingText = announcement?.sections.slice(0, -1).flatMap((section) => [
+      section.title,
+      ...section.paragraphs,
+      ...(section.bullets ?? []),
+      ...(section.examples?.map(({ code }) => code) ?? []),
+    ]).join('\n') ?? '';
+
+    for (const outcome of ['opening pages', 'opening slide', 'large Word tables', 'Long web addresses', 'embedded fonts']) {
+      expect(userFacingText).toContain(outcome);
+    }
+    expect(userFacingText).toContain('No migration is required');
+    expect(userFacingText).toContain('progressiveLayout: true');
+    expect(userFacingText).toContain('waitUntilLayoutComplete()');
+    expect(userFacingText).toContain('showTrackedChanges: true');
+    expect(userFacingText).not.toMatch(/paginator|preflight|worker protocol|layout slice/i);
+    expect(userFacingText).not.toMatch(/\b(?:KB|KiB|gzip|ms)\b/);
+  });
+});
+
 describe('v0.82 review announcement', () => {
   const announcement = announcements.find((item) => item.slug === 'v082-review-comments');
 
@@ -83,7 +114,7 @@ describe('v0.81 ChartEx migration guide', () => {
 
 describe('stable documentation boundaries', () => {
   it('keeps the current bundle measurements on one stable page', () => {
-    expect(bundleSizePage).toContain('Current production assets in v0.82.1');
+    expect(bundleSizePage).toContain('Current production assets in v0.83.0');
     expect(bundleSizePage).toContain('DOCX static JavaScript');
     expect(bundleSizePage).toContain('XLSX static JavaScript');
     expect(bundleSizePage).toContain('PPTX static JavaScript');

--- a/site/src/components/Capabilities.astro
+++ b/site/src/components/Capabilities.astro
@@ -8,7 +8,7 @@ const cols = [
       'Inline / anchored images and DrawingML shapes with image fills',
       'CJK typography: ruby, vertical writing & line grids',
       'Math equations, classic charts and optional ChartEx / 3-D / Region Map rendering',
-      'Text / element context, virtualized scroll, zoom, find & links',
+      'Tracked-change markup, text / element context, progressive virtualized scroll, zoom, find & links',
     ],
   },
   {
@@ -29,8 +29,8 @@ const cols = [
       'Preset / custom shapes, groups and SmartArt text',
       'Gradient fills, picture effects and 3D shading',
       'Classic combo and stock charts, plus optional ChartEx / 3-D / Region Maps',
-      'WordArt, math equations and embedded audio / video',
-      'Text / element context, virtualized scroll, zoom, find & links',
+      'WordArt, embedded fonts, math equations and embedded audio / video',
+      'Text / element context, progressive virtualized scroll, zoom, find & links',
     ],
   },
 ];

--- a/site/src/lib/announcements.ts
+++ b/site/src/lib/announcements.ts
@@ -36,6 +36,74 @@ export interface Announcement {
 
 export const announcements: readonly Announcement[] = [
   {
+    slug: 'v083-progressive-viewing',
+    date: '2026-08-28',
+    label: 'Release note',
+    version: 'v0.83.0',
+    title: 'Open large Word and PowerPoint files sooner in v0.83.0',
+    summary: 'v0.83.0 can show the opening pages or slides sooner for large Word and PowerPoint files, speeds up large Word tables, and uses embedded PowerPoint fonts when available.',
+    audience: 'Applications that open larger DOCX or PPTX files, or need closer PowerPoint font fidelity. Existing viewer setup continues to work unchanged.',
+    sections: [
+      {
+        title: 'In short',
+        kind: 'summary',
+        paragraphs: [
+          'Large Word documents and PowerPoint presentations can now become useful before all background preparation finishes. Progressive viewing is opt-in, so existing applications keep their current loading behavior.',
+        ],
+        bullets: [
+          'Show the opening pages of a DOCX file while the remaining pages are prepared.',
+          'Show the opening slide of a PPTX file while later slides are prepared, with a stable scrollbar from the first view.',
+          'Open documents with large Word tables faster and render PowerPoint text with embedded fonts when the presentation provides them.',
+        ],
+      },
+      {
+        title: 'Start viewing sooner',
+        paragraphs: [
+          'Enable progressiveLayout on a Word or PowerPoint Viewer when showing useful content quickly matters more than waiting for the entire document. It works with both the regular and worker rendering modes; worker mode also keeps more of the remaining work away from the application UI.',
+          'Word publishes pages as pagination advances. PowerPoint knows the final slide count at the start, so its scrollbar remains stable and slides that are not ready yet show a loading state.',
+          'Until Word pagination completes, pageCount means the pages available so far. PowerPoint slideCount is final from the first view, while availableSlideCount reports how many opening slides are ready.',
+        ],
+        examples: [
+          {
+            title: 'Enable progressive viewing',
+            code: `import { DocxScrollViewer } from '@silurus/ooxml/docx';
+import { PptxScrollViewer } from '@silurus/ooxml/pptx';
+
+const wordViewer = new DocxScrollViewer(wordContainer, {
+  progressiveLayout: true,
+});
+
+const slideViewer = new PptxScrollViewer(slideContainer, {
+  progressiveLayout: true,
+});`,
+          },
+        ],
+      },
+      {
+        title: 'Rendering and review improvements',
+        paragraphs: [
+          'Documents with large Word tables avoid repeated pagination work, reducing the wait for the completed document.',
+          'Long web addresses in Word documents now wrap naturally within the page instead of leaving a large gap or being clipped at the edge.',
+          'PowerPoint can use fonts embedded in a presentation in both rendering modes. Text that extends beyond its shape also remains selectable.',
+          'Word can now display tracked changes with author-coloured underlines, strikethroughs and margin change bars using showTrackedChanges: true. The accepted-final view remains the default.',
+        ],
+      },
+      {
+        title: 'Upgrading',
+        paragraphs: [
+          'No migration is required. Progressive viewing and tracked-change markup are both opt-in, and existing Viewer options keep their previous defaults.',
+          'If an operation needs the completed document, such as printing, exporting or showing a final Word page count, await waitUntilLayoutComplete() first. Ordinary viewing can begin as soon as load() resolves.',
+        ],
+      },
+      {
+        title: 'Technical note',
+        paragraphs: [
+          'DOCX progressive layout resumes one pagination session instead of rebuilding earlier pages. PPTX prepares slides in order after an initial presentation bootstrap, which makes the final slide count and scroll extent available from first paint. Both formats share the same progressive callbacks and completion-waiting lifecycle. Worker mode reduces competition with the application UI; it does not guarantee a shorter total preparation time.',
+        ],
+      },
+    ],
+  },
+  {
     slug: 'v082-review-comments',
     date: '2026-08-26',
     label: 'Release note',

--- a/site/src/lib/api-reference.test.ts
+++ b/site/src/lib/api-reference.test.ts
@@ -110,6 +110,8 @@ describe('official-site API reference', () => {
       expect(progressive?.desc, apiClass.name).toContain('pages available so far');
       expect(progressive?.detailsHref, apiClass.name).toBe('/docx#progressive-layout');
       expect(options.map(({ name }) => name), apiClass.name).toEqual(expect.arrayContaining([
+        'showTrackedChanges',
+        'currentDate',
         'sliceLayout',
         'onLayoutProgress',
         'onLayoutPartial',
@@ -119,11 +121,13 @@ describe('official-site API reference', () => {
         .toContain('availableUnits: number; totalUnits?: number; exact: boolean');
       expect(options.find(({ name }) => name === 'onLayoutComplete')?.type, apiClass.name)
         .toBe('(error?: unknown) => void');
+      expect(options.find(({ name }) => name === 'currentDate')?.desc, apiClass.name)
+        .toContain('layout variant');
 
       const pageCount = apiClass.methods.find(({ sig }) => sig === 'get pageCount(): number');
       expect(pageCount?.desc, apiClass.name).toContain('available so far');
-      expect(apiClass.methods.find(({ sig }) => sig === 'get layoutComplete(): boolean'), apiClass.name)
-        .toBeDefined();
+      expect(apiClass.methods.find(({ sig }) => sig === 'get layoutComplete(): boolean')?.desc, apiClass.name)
+        .toContain('remains false');
       expect(apiClass.methods.find(({ sig }) => sig === 'waitUntilLayoutComplete(): Promise<void>')?.desc, apiClass.name)
         .toContain('authoritative full layout');
     }
@@ -150,8 +154,8 @@ describe('official-site API reference', () => {
         .toContain('availableUnits: number; totalUnits?: number; exact: boolean');
       expect(apiClass.methods.find(({ sig }) => sig === 'get availableSlideCount(): number'), apiClass.name)
         .toBeDefined();
-      expect(apiClass.methods.find(({ sig }) => sig === 'get layoutComplete(): boolean'), apiClass.name)
-        .toBeDefined();
+      expect(apiClass.methods.find(({ sig }) => sig === 'get layoutComplete(): boolean')?.desc, apiClass.name)
+        .toContain('remains false');
       expect(apiClass.methods.find(({ sig }) => sig === 'waitUntilLayoutComplete(): Promise<void>'), apiClass.name)
         .toBeDefined();
     }

--- a/site/src/lib/api-reference.ts
+++ b/site/src/lib/api-reference.ts
@@ -81,7 +81,7 @@ const GFONTS = { name: 'useGoogleFonts', type: 'boolean', def: 'false', desc: 'L
 const PASSWORD = { name: 'password', type: 'string', def: 'undefined', desc: 'Password for an Agile-encrypted OOXML file. Available on self-loading Viewer constructors and headless load(); borrowed fromDocument(), fromPresentation(), and fromWorkbook() factories omit load-only options because their engine is already loaded.', emphasis: 'Available on self-loading Viewer constructors and headless load()' };
 const DPR = { name: 'dpr', type: 'number', def: 'devicePixelRatio', desc: 'Device pixel ratio for the backing store (crispness on HiDPI).' };
 const WASM_URL = { name: 'wasmUrl', type: 'string | URL', def: 'bundled asset', desc: 'Override the URL the parser worker fetches the WebAssembly module from. By default each format resolves the `*_parser_bg.wasm` asset that ships next to its bundle (relative to the module URL); set this to serve it from a CDN or a self-hosted path instead (a relative value resolves against the document URL). Pointing it at a mismatched or missing file makes load() reject when the worker instantiates it.', emphasis: 'Override the URL the parser worker fetches the WebAssembly module from.' };
-const WORKER_TIMEOUT = { name: 'workerTimeoutMs', type: 'number', def: 'unlimited', desc: 'Reject the parse if the worker does not answer within this many ms — an opt-in safety net for a wedged / crashed worker that would otherwise leave load() pending forever. Unlimited by default (a large document with heavy media can legitimately take tens of seconds). A worker that throws or fails to load already rejects immediately regardless; this only covers the "silent, never-responds" case.', emphasis: 'Reject the parse if the worker does not answer within this many ms' };
+const WORKER_TIMEOUT = { name: 'workerTimeoutMs', type: 'number', def: 'unlimited', desc: 'Opt-in worker liveness limit. Ordinary worker requests use it as their response deadline. Worker-mode progressive loads restart this silence interval whenever the worker reports progress. This allows active long-running work to continue. Silence before first paint rejects load(); silence afterward keeps layoutComplete false and rejects waitUntilLayoutComplete(), while configured completion/error callbacks receive the failure. Worker exceptions still reject immediately. Unlimited by default.', emphasis: 'Worker-mode progressive loads restart this silence interval whenever the worker reports progress.' };
 const MATH = { name: 'math', type: 'MathRenderer', def: 'undefined', desc: 'Opt-in OMML equation engine (MathJax + STIX Two Math, ~3 MB). Import it from the separate @silurus/ooxml/math entry — `import { math } from "@silurus/ooxml/math"` — and pass it to render equations in either mode. Omit it and equations are skipped; the MathJax asset is not fetched. When passed, that standalone asset is fetched lazily the first time a document contains an equation.', emphasis: 'Opt-in OMML equation engine (MathJax + STIX Two Math, ~3 MB).' };
 const THREE_D = { name: 'threeD', type: 'ChartThreeDRenderer', def: 'undefined', desc: 'Opt-in model-space 3-D chart renderer. Import `threeD` from the separate `@silurus/ooxml/three-d` entry and inject it once. Omit it to use the canonical 2-D fallback and avoid loading or evaluating the mesh/camera implementation in main mode. The self-contained worker asset retains the worker-side implementation. It renders the view angle authored in OOXML in main and worker modes.', emphasis: 'Opt-in model-space 3-D chart renderer.' };
 const REGION_MAP = { name: 'regionMap', type: 'ChartRegionMapRenderer', def: 'undefined', desc: 'Opt-in offline ChartEx Region Map renderer using a pinned, public-domain Natural Earth country asset. Import `regionMap` from `@silurus/ooxml/region-map` and inject it once. Unsupported cached or sub-country views fail closed. The built-in renderer works in main and worker modes.', emphasis: 'Opt-in offline ChartEx Region Map renderer' };
@@ -115,18 +115,34 @@ const DOCX_PROGRESSIVE_LAYOUT: ApiOption = {
   detailsHref: '/docx#progressive-layout',
   detailsLabel: 'Progressive layout guide',
 };
+const DOCX_SHOW_TRACKED_CHANGES: ApiOption = {
+  name: 'showTrackedChanges',
+  type: 'boolean',
+  def: 'false',
+  desc: 'Select the tracked-change markup layout from the initial load. Insertions use author-coloured underlines, deletions use author-coloured strikethroughs, and changed lines receive margin bars. Because this changes line breaks and pagination, set the initial view here and use setLayoutView() or setShowTrackedChanges() for later changes.',
+};
+const DOCX_CURRENT_DATE: ApiOption = {
+  name: 'currentDate',
+  type: 'Date | number',
+  def: 'load time',
+  desc: 'Date used to resolve DATE and TIME fields. It participates in the retained layout variant, so pass it at load time when deterministic field values or pagination are required.',
+};
+const DOCX_LAYOUT_VIEW_OPTIONS: readonly ApiOption[] = [
+  DOCX_SHOW_TRACKED_CHANGES,
+  DOCX_CURRENT_DATE,
+];
 const DOCX_SLICE_LAYOUT: ApiOption = {
   name: 'sliceLayout',
   type: 'boolean',
   def: 'false',
-  desc: 'Yield to the browser between pagination slices while load() still waits for the complete document. Use progressiveLayout instead when opening pages should become available before full pagination finishes.',
+  desc: 'In main mode, yield to the browser between pagination slices while load() still waits for the complete document. Worker mode already keeps pagination off the UI thread; without progressiveLayout this option has no additional effect there. Use progressiveLayout when opening pages should become available before full pagination finishes.',
   detailsHref: '/docx#progressive-layout',
   detailsLabel: 'Progressive layout guide',
 };
 const DOCX_LAYOUT_PROGRESS: ApiOption = {
   name: 'onLayoutProgress',
   type: '(progress: Readonly<{ committedUnits: number }>) => void',
-  desc: 'Receive pagination telemetry from resumable layout passes. committedUnits can move backward while convergence revises provisional work; it counts pages, so use pageCount and the Viewer page callbacks for application navigation UI.',
+  desc: 'Receive pagination telemetry from resumable layout passes. It implies sliced layout in main mode and is also delivered by progressiveLayout in main or worker mode; a non-progressive worker load does not publish intermediate progress. committedUnits can move backward while convergence revises provisional work; it counts pages, so use pageCount and the Viewer page callbacks for application navigation UI. Observer exceptions are reported once and never change the layout result.',
   emphasis: 'committedUnits can move backward while convergence revises provisional work',
   detailsHref: '/docx#progressive-layout',
   detailsLabel: 'Progressive layout guide',
@@ -134,14 +150,14 @@ const DOCX_LAYOUT_PROGRESS: ApiOption = {
 const DOCX_LAYOUT_PARTIAL: ApiOption = {
   name: 'onLayoutPartial',
   type: '(progress: Readonly<{ availableUnits: number; totalUnits?: number; exact: boolean }>) => void',
-  desc: 'Receive each later provisional page publication after the initial load publication. availableUnits is the pages available so far; totalUnits is omitted until DOCX pagination knows the final count, and exact is currently always false.',
+  desc: 'Receive each later provisional page publication after the initial load publication. availableUnits is the pages available so far; totalUnits is omitted until DOCX pagination knows the final count, and exact is currently always false. Observer exceptions are reported once and never change the layout result.',
   detailsHref: '/docx#progressive-layout',
   detailsLabel: 'Progressive layout guide',
 };
 const DOCX_LAYOUT_COMPLETE: ApiOption = {
   name: 'onLayoutComplete',
   type: '(error?: unknown) => void',
-  desc: 'Called once the authoritative full layout replaces the provisional one, or with the background failure. It fires only when progressiveLayout actually deferred work after load() resolved.',
+  desc: 'Called once the authoritative full layout replaces the provisional one, or with the background failure. It fires only when progressiveLayout actually deferred work after load() resolved. Observer exceptions are reported once and never change the layout result.',
   detailsHref: '/docx#progressive-layout',
   detailsLabel: 'Progressive layout guide',
 };
@@ -157,21 +173,21 @@ const PPTX_PROGRESSIVE_LAYOUT: ApiOption = {
 const PPTX_LAYOUT_PROGRESS: ApiOption = {
   name: 'onLayoutProgress',
   type: '(progress: Readonly<{ committedUnits: number }>) => void',
-  desc: 'Called as the sequential preflight commits each paintable slide. committedUnits counts slides.',
+  desc: 'Called as the sequential preflight commits each paintable slide. committedUnits counts slides. Observer exceptions are reported once and never change the layout result.',
   detailsHref: '/pptx#progressive-layout',
   detailsLabel: 'Progressive layout guide',
 };
 const PPTX_LAYOUT_PARTIAL: ApiOption = {
   name: 'onLayoutPartial',
   type: '(progress: Readonly<{ availableUnits: number; totalUnits?: number; exact: boolean }>) => void',
-  desc: 'Called for each additional paintable prefix after load() resolves. availableUnits counts paintable slides, totalUnits is the final slide count, and exact is false until completion.',
+  desc: 'Called for each additional paintable prefix after load() resolves. availableUnits counts paintable slides, totalUnits is the final slide count, and exact is false until completion. Observer exceptions are reported once and never change the layout result.',
   detailsHref: '/pptx#progressive-layout',
   detailsLabel: 'Progressive layout guide',
 };
 const PPTX_LAYOUT_COMPLETE: ApiOption = {
   name: 'onLayoutComplete',
   type: '(error?: unknown) => void',
-  desc: 'Called once every slide is paintable, or with the background failure. It fires only when progressiveLayout deferred work after load() resolved.',
+  desc: 'Called once every slide is paintable, or with the background failure. It fires only when progressiveLayout deferred work after load() resolved. Observer exceptions are reported once and never change the layout result.',
   detailsHref: '/pptx#progressive-layout',
   detailsLabel: 'Progressive layout guide',
 };
@@ -256,12 +272,12 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { sig: 'get slideIndex(): number', desc: 'Current slide index.' },
         { sig: 'get slideCount(): number', desc: 'Total slides (0 until loaded).' },
         { sig: 'get availableSlideCount(): number', desc: 'Paintable opening-slide prefix. Equals slideCount outside progressive loading.' },
-        { sig: 'get layoutComplete(): boolean', desc: 'Whether every slide is paintable.' },
+        { sig: 'get layoutComplete(): boolean', desc: 'True only when every slide is paintable. It remains false if background preparation fails; waitUntilLayoutComplete() reports that failure.' },
         { sig: 'waitUntilLayoutComplete(): Promise<void>', desc: 'Wait until every slide is paintable; rejects if background preflight fails.' },
         { sig: 'get hiddenSlideMode(): "show" | "skip" | "dim"', desc: 'The current hidden-slide mode.' },
         { sig: 'setHiddenSlideMode(mode: "show" | "skip" | "dim"): Promise<void>', desc: 'Switch the hidden-slide mode at runtime and re-render. Entering `skip` while on a hidden slide advances to the nearest visible slide.' },
-        { sig: 'get visibleSlideCount(): number', desc: 'Number of non-hidden slides (the absolute slideCount is unchanged).' },
-        { sig: 'getNotes(slideIndex: number): string | null', desc: 'Speaker-notes text for a slide (0-based); null when the slide has no notes part or the index is out of range.' },
+        { sig: 'get visibleSlideCount(): number', desc: 'Number of non-hidden slides. During progressive loading this is provisional until layoutComplete; the absolute slideCount remains unchanged.' },
+        { sig: 'getNotes(slideIndex: number): string | null', desc: 'Speaker-notes text for a slide (0-based). During progressive loading the answer is authoritative only below availableSlideCount; await waitUntilLayoutComplete() before scanning the whole deck.' },
         { sig: 'get canvasElement(): HTMLCanvasElement', desc: 'The underlying canvas.' },
         { sig: 'getSelectionContext(options?: PptxSelectionContextOptions): PptxSelectionContext | null', desc: 'Return the current bounded, JSON-serializable text or element focus snapshot. Throws after destroy().' },
         RESOURCE_METRICS_METHOD,
@@ -277,13 +293,14 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { sig: 'static load(source, options?): Promise<PptxPresentation>', desc: 'Parse a deck from a URL or ArrayBuffer. With progressiveLayout, resolve when the opening slide is paintable.' },
         { sig: 'get slideCount(): number', desc: 'Total slides.' },
         { sig: 'get availableSlideCount(): number', desc: 'Paintable opening-slide prefix; slideCount remains final throughout.' },
-        { sig: 'get layoutComplete(): boolean', desc: 'Whether every slide is paintable.' },
+        { sig: 'get layoutComplete(): boolean', desc: 'True only when every slide is paintable. It remains false if background preparation fails; waitUntilLayoutComplete() reports that failure.' },
         { sig: 'waitUntilLayoutComplete(): Promise<void>', desc: 'Wait until every slide is paintable; rejects if background preflight fails.' },
         { sig: 'renderSlide(canvas, index, opts?: { width?, dpr?, onTextRun?, dim? }): Promise<void>', desc: 'Render one slide into the given canvas at the given width. `onTextRun` receives each rendered segment as `PptxTextRunInfo`, including the source shape’s slide-local `shapeId` when authored, so callers can build a transparent selection overlay or stable shape mapping; `dim` (a DimOptions) paints a translucent wash over the finished slide (hidden-slide dimming). Equations render when a `math` engine was passed to `load`. Unavailable in `mode: "worker"` — use renderSlideToBitmap.' },
         { sig: 'renderSlideToBitmap(index, opts?: { width?, dpr?, dim? }): Promise<ImageBitmap>', desc: 'Render one slide and return it as an ImageBitmap (both modes; in worker mode slide paint, equations, ChartEx, 3-D charts and Region Maps run off the main thread). `dim` paints a translucent overlay over the slide (hidden-slide dimming). The bitmap is caller-owned: pass it to `transferFromImageBitmap` (which consumes it) or call `bitmap.close()`.', emphasis: 'The bitmap is caller-owned: pass it to `transferFromImageBitmap` (which consumes it) or call `bitmap.close()`.' },
         { sig: 'presentSlide(canvas, index, opts?: PresentSlideOptions): Promise<PresentationHandle>', desc: 'Render a slide and attach canvas-native audio/video playback, returning a handle with play() / pause() / destroy(). Initial render and media acquisition failures reject this Promise. PresentSlideOptions.onError observes decode or playback failures that occur only after the handle has been returned. Works in both modes — in `mode: "worker"` the base slide and text-run geometry are produced off-thread and the video overlay is composited on the main thread.' },
-        { sig: 'getNotes(slideIndex: number): string | null', desc: 'Speaker-notes text for a slide (0-based; ECMA-376 §13.3.5). Returns null when the slide has no notes part or the index is out of range.' },
-        { sig: 'getComments(slideIndex: number): readonly Readonly<PptxComment>[]', desc: 'Detached comment threads for one slide. Modern comments expose slide, drawing-element, or text-range anchors; classic comments retain their authored slide point.' },
+        { sig: 'getNotes(slideIndex: number): string | null', desc: 'Speaker-notes text for a slide (0-based; ECMA-376 §13.3.5). During progressive loading, null for an index at or beyond availableSlideCount means the slide is not ready, not necessarily that it has no notes. Await completion before a whole-deck scan.' },
+        { sig: 'getComments(slideIndex: number): readonly Readonly<PptxComment>[]', desc: 'Detached comment threads for one slide. During progressive loading, results are authoritative only below availableSlideCount; await waitUntilLayoutComplete() before scanning the whole deck. Modern comments expose slide, drawing-element, or text-range anchors; classic comments retain their authored slide point.' },
+        { sig: 'isHidden(slideIndex: number): boolean', desc: 'Whether a slide is authored as hidden. During progressive loading, results are authoritative only below availableSlideCount; await completion before scanning every slide.' },
         { sig: 'get slideWidth(): number', desc: 'Slide width in EMU (0 until loaded).' },
         { sig: 'get slideHeight(): number', desc: 'Slide height in EMU (0 until loaded).' },
         { sig: 'get mode(): "main" | "worker"', desc: 'The render mode this engine was loaded with. A borrowed engine’s mode decides whether slides render via renderSlide (main) or renderSlideToBitmap (worker).' },
@@ -345,7 +362,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { sig: 'relayout(): void', desc: 'Force a re-fit + re-mount of the visible window. Called automatically after load / resize / zoom; use it when the container resizes in a way a ResizeObserver cannot observe (e.g. a late web-font load). Idempotent.' },
         { sig: 'get slideCount(): number', desc: 'Total slides (0 until loaded).' },
         { sig: 'get availableSlideCount(): number', desc: 'Paintable opening-slide prefix; the full scroll extent already uses slideCount.' },
-        { sig: 'get layoutComplete(): boolean', desc: 'Whether every slide is paintable.' },
+        { sig: 'get layoutComplete(): boolean', desc: 'True only when every slide is paintable. It remains false if background preparation fails; waitUntilLayoutComplete() reports that failure.' },
         { sig: 'waitUntilLayoutComplete(): Promise<void>', desc: 'Wait until every slide is paintable; rejects if background preflight fails.' },
         { sig: 'get topVisibleSlide(): number', desc: 'Index of the top-most visible slide.' },
         { sig: 'getSelectionContext(options?: PptxSelectionContextOptions): PptxSelectionContext | null', desc: 'Return the current mounted text selection, selected comment thread, or clicked-element context.' },
@@ -366,7 +383,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         GFONTS,
         PASSWORD,
         { name: 'enableTextSelection', type: 'boolean', def: 'false', desc: 'Overlay a transparent text layer for native selection & copy.' },
-        { name: 'showTrackedChanges', type: 'boolean', def: 'false', desc: 'ECMA-376 §17.13.5 tracked-change view. Default: the FINAL state (deletions and moved-away text hidden). `true` renders the markup view: insertions underlined and deletions struck through in a stable per-author colour, with a margin change bar beside changed lines. A layout axis — the two views paginate differently.' },
+        ...DOCX_LAYOUT_VIEW_OPTIONS,
         { name: 'enableElementSelection', type: 'boolean', def: 'false', desc: 'Enable read-only picture, chart, and shape selection with a non-editable outline and element context. No editor model is added.' },
         { name: 'onSelectionContextChange', type: '(context: DocxSelectionContext | null) => void', desc: 'Receive bounded detached text or element context. This callback does not enable element hit-testing by itself.' },
         CONTEXT_MENU('DocxSelectionContext'),
@@ -403,7 +420,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         ...findMethods('DocxMatchLocation'),
         { sig: 'get pageCount(): number', desc: 'Pages available so far (0 until loaded); authoritative only when layoutComplete is true.' },
         { sig: 'get currentPage(): number', desc: 'Current page index.' },
-        { sig: 'get layoutComplete(): boolean', desc: 'True when pageCount and the document layout are authoritative; false while progressive layout is still publishing pages.' },
+        { sig: 'get layoutComplete(): boolean', desc: 'True only after the authoritative document layout succeeds. It is false while progressive layout is publishing pages and remains false if background pagination fails; waitUntilLayoutComplete() reports that failure.' },
         { sig: 'waitUntilLayoutComplete(): Promise<void>', desc: 'Wait for the authoritative full layout before operations that require the final page count. Rejects if background pagination fails after load() resolved.' },
         { sig: 'get canvasElement(): HTMLCanvasElement', desc: 'The underlying canvas.' },
         { sig: 'getSelectionContext(options?: DocxSelectionContextOptions): DocxSelectionContext | null', desc: 'Return the current bounded native-text or clicked-element snapshot. Throws after destroy().' },
@@ -415,17 +432,18 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
       name: 'DocxDocument',
       ctor: 'await DocxDocument.load(source, options?)',
       note: 'Headless engine — render any page into any canvas you supply.',
-      options: [GFONTS, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, MODE, DOCX_PROGRESSIVE_LAYOUT, DOCX_SLICE_LAYOUT, DOCX_LAYOUT_PROGRESS, DOCX_LAYOUT_PARTIAL, DOCX_LAYOUT_COMPLETE],
+      options: [GFONTS, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, MODE, ...DOCX_LAYOUT_VIEW_OPTIONS, DOCX_PROGRESSIVE_LAYOUT, DOCX_SLICE_LAYOUT, DOCX_LAYOUT_PROGRESS, DOCX_LAYOUT_PARTIAL, DOCX_LAYOUT_COMPLETE],
       methods: [
         { sig: 'static load(source, options?): Promise<DocxDocument>', desc: 'Parse a document from a URL or ArrayBuffer. With progressiveLayout, resolve when the opening pages are paintable while pagination continues in the background.' },
         { sig: 'get comments(): readonly Readonly<DocComment>[]', desc: 'Immutable detached comments and replies stored in the document.' },
         { sig: 'get revisions(): readonly Readonly<DocRevision>[]', desc: 'Immutable detached WordprocessingML body-story insertion, deletion, and move records. This is the current DOCX change-history API, not a cross-format revision contract.' },
-        { sig: 'commentAnchorRanges(): readonly CommentAnchorRange[]', desc: 'Logical comment ranges that can be joined to rendered text runs.' },
+        { sig: 'commentAnchorRanges(): readonly CommentAnchorRange[]', desc: 'Logical comment ranges for the currently available page prefix. Await waitUntilLayoutComplete() before treating this as a full-document projection.' },
         { sig: 'getCommentThreads(pageIndex: number, options?: DocxPageCommentThreadsOptions): Promise<readonly Readonly<ResolvedDocxCommentThread>[]>', desc: 'Resolve top-level threads with rendered anchor geometry on one page. Cross-page ranges and repeating stories can occur in more than one page result; each result contains only that page’s rectangles.' },
-        { sig: 'revisionAnchorRanges(): readonly RevisionAnchorRange[]', desc: 'Logical tracked-change ranges that can be joined to rendered text runs.' },
+        { sig: 'revisionAnchorRanges(): readonly RevisionAnchorRange[]', desc: 'Logical tracked-change ranges for the currently available page prefix. Await waitUntilLayoutComplete() before treating this as a full-document projection.' },
+        { sig: 'getBookmarkPage(name: string): number | undefined', desc: 'Resolve a bookmark in the currently available page prefix. Await waitUntilLayoutComplete() before concluding that an unresolved name is absent from the document.' },
         { sig: 'collectPageRuns(index, options?): Promise<DocxTextRunInfo[]>', desc: 'Collect the same immutable text-run geometry emitted while rendering one page.' },
         { sig: 'get pageCount(): number', desc: 'Pages available so far; authoritative only when layoutComplete is true.' },
-        { sig: 'get layoutComplete(): boolean', desc: 'True when pageCount and the document layout are authoritative; false while progressive layout is still publishing pages.' },
+        { sig: 'get layoutComplete(): boolean', desc: 'True only after the authoritative document layout succeeds. It is false while progressive layout is publishing pages and remains false if background pagination fails; waitUntilLayoutComplete() reports that failure.' },
         { sig: 'waitUntilLayoutComplete(): Promise<void>', desc: 'Wait for the authoritative full layout. Rejects if background pagination fails after load() resolved.' },
         { sig: 'pageSize(pageIndex: number): { widthPt, heightPt }', desc: 'Page size in pt for a page (ECMA-376 §17.6.13 / §17.6.11 — per section, so a mixed portrait/landscape document returns different sizes per page). Available in both modes; index is clamped. `{ 0, 0 }` means "not loaded". Returns a fresh object per call.', emphasis: '`{ 0, 0 }` means "not loaded".' },
         { sig: 'get mode(): "main" | "worker"', desc: 'The render mode this engine was loaded with. A borrowed engine’s mode decides whether pages render via renderPage (main) or renderPageToBitmap (worker).' },
@@ -453,7 +471,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { name: 'zoomMin / zoomMax', type: 'number', def: '0.1 / 4', desc: 'Absolute zoom scale bounds (10%–400%).' },
         { name: 'refitOnResize', type: 'boolean', def: 'true', desc: 'Re-fit to the container width when it resizes. Set false to preserve an absolute scale independently of viewport width; explicit fitWidth() / fitPage() still work.' },
         { name: 'enableTextSelection', type: 'boolean', def: 'false', desc: 'Overlay a transparent, selectable text layer per page for native copy in both render modes.' },
-        { name: 'showTrackedChanges', type: 'boolean', def: 'false', desc: 'ECMA-376 §17.13.5 tracked-change view. Default: the FINAL state (deletions and moved-away text hidden). `true` renders the markup view: insertions underlined and deletions struck through in a stable per-author colour, with a margin change bar beside changed lines. A layout axis — the two views paginate differently.' },
+        ...DOCX_LAYOUT_VIEW_OPTIONS,
         { name: 'comments', type: 'boolean | DocxCommentsOptions', def: 'false', desc: 'Show read-only document comment highlights, message icons, and built-in margin cards. Pass `cards: false` for an application-owned list that retains Viewer-owned range highlighting, or `markers: false` to hide only the icons. The options object also controls resolved-thread visibility, side, and optional connectors. Theme cards, highlights, and markers with CSS custom properties or documented classes on the Viewer container.', detailsHref: '/review-ui', detailsLabel: 'Comment UI guide' },
         { name: 'enableElementSelection', type: 'boolean', def: 'false', desc: 'Enable read-only drawing selection on mounted pages with a non-editable outline and element context.' },
         { name: 'onSelectionContextChange', type: '(context: DocxSelectionContext | null) => void', desc: 'Receive bounded detached text, selected-comment, or element context for external AI/MCP integrations. This callback does not enable element hit-testing.' },
@@ -492,7 +510,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { sig: 'relayout(): void', desc: 'Force a re-fit + re-mount of the visible window. Called automatically after load / resize / zoom; use it when the container resizes in a way a ResizeObserver cannot observe (e.g. a late web-font load). Idempotent.' },
         { sig: 'get pageCount(): number', desc: 'Pages available so far (0 until loaded); authoritative only when layoutComplete is true.' },
         { sig: 'get topVisiblePage(): number', desc: 'Index of the top-most visible page.' },
-        { sig: 'get layoutComplete(): boolean', desc: 'True when pageCount and the document layout are authoritative; false while progressive layout is still publishing pages.' },
+        { sig: 'get layoutComplete(): boolean', desc: 'True only after the authoritative document layout succeeds. It is false while progressive layout is publishing pages and remains false if background pagination fails; waitUntilLayoutComplete() reports that failure.' },
         { sig: 'waitUntilLayoutComplete(): Promise<void>', desc: 'Wait for the authoritative full layout before operations that require the final page count. Rejects if background pagination fails after load() resolved.' },
         { sig: 'getSelectionContext(options?: DocxSelectionContextOptions): DocxSelectionContext | null', desc: 'Return the current mounted text selection, selected comment thread, or clicked-element context.' },
         RESOURCE_METRICS_METHOD,

--- a/site/src/lib/try.test.ts
+++ b/site/src/lib/try.test.ts
@@ -70,6 +70,7 @@ vi.mock('@silurus/ooxml-docx', () => {
 vi.mock('@silurus/ooxml-pptx', () => {
   class PptxScrollViewer {
     slideCount = 6;
+    availableSlideCount = 6;
     destroyed = false;
     readonly relayout = vi.fn();
     readonly events: string[] = [];
@@ -84,13 +85,17 @@ vi.mock('@silurus/ooxml-pptx', () => {
     }
     load(): Promise<void> {
       this.events.push('load');
-      if (this.opts.progressiveLayout && mocks.deferPptxLayout) this.layoutComplete = false;
+      if (this.opts.progressiveLayout && mocks.deferPptxLayout) {
+        this.layoutComplete = false;
+        this.availableSlideCount = 2;
+      }
       return Promise.resolve();
     }
     waitUntilLayoutComplete(): Promise<void> {
       if (this.layoutComplete) return Promise.resolve();
       return new Promise<void>((resolve) => {
         this.resolveLayout = () => {
+          this.availableSlideCount = this.slideCount;
           this.layoutComplete = true;
           resolve();
         };
@@ -277,10 +282,15 @@ describe('Try Yours ScrollViewer integration', () => {
     const result = await renderFile(stage(), file('progressive.pptx'));
     const viewer = mocks.pptx[0];
 
-    expect(result.units).toBe(6);
+    expect(result.units).toBe(2);
     expect(result.finalUnits).toBeDefined();
+    expect(viewer.opts.overscan).toBe(0);
+    expect(viewer.relayout).not.toHaveBeenCalled();
+
     viewer.resolveLayout();
     await expect(result.finalUnits).resolves.toBe(6);
+    expect(viewer.opts.overscan).toBe(6);
+    expect(viewer.relayout).toHaveBeenCalledTimes(1);
   });
 
   it.each([

--- a/site/src/lib/try.ts
+++ b/site/src/lib/try.ts
@@ -139,19 +139,27 @@ export async function renderFile(stage: HTMLElement, file: File): Promise<Render
       viewer.destroy();
       throw new SupersededRenderError();
     }
-    // Browser-native Find only sees mounted DOM. Keep every selectable overlay
-    // mounted in Try Yours by setting the finite parsed slide count as overscan;
-    // the package default remains virtualized for normal integrations.
-    viewerOptions.overscan = viewer.slideCount;
-    viewer.relayout();
     activeCleanup = () => viewer.destroy();
+
+    const mountAllSlides = (): number => {
+      assertCurrentRender(generation);
+      // Native Find needs every slide's text layer in the DOM. Keep the opening
+      // progressive window virtualized, then expand only after every slide is
+      // paintable so unfinished slides do not create a deck-wide waiter set.
+      viewerOptions.overscan = viewer.slideCount;
+      viewer.relayout();
+      return viewer.slideCount;
+    };
+
+    if (viewer.layoutComplete) {
+      return { format: 'pptx', units: mountAllSlides(), unitLabel: 'slide' };
+    }
+
     return {
       format: 'pptx',
-      units: viewer.slideCount,
+      units: viewer.availableSlideCount,
       unitLabel: 'slide',
-      ...(viewer.layoutComplete
-        ? {}
-        : { finalUnits: viewer.waitUntilLayoutComplete().then(() => viewer.slideCount) }),
+      finalUnits: viewer.waitUntilLayoutComplete().then(mountAllSlides),
     };
   }
 

--- a/site/src/pages/bundle-size.astro
+++ b/site/src/pages/bundle-size.astro
@@ -15,7 +15,7 @@ import SiteFooter from '../components/SiteFooter.astro';
       <div class="wrap">
         <p class="eyebrow">Current measurement</p>
         <h1>Bundle size.</h1>
-        <p>Current production assets in v0.82.1.</p>
+        <p>Current production assets in v0.83.0.</p>
       </div>
     </header>
 
@@ -28,8 +28,8 @@ import SiteFooter from '../components/SiteFooter.astro';
           <tbody>
             <tr>
               <th>DOCX static JavaScript</th>
-              <td>1,871 KiB</td>
-              <td>453 KiB</td>
+              <td>1,910 KiB</td>
+              <td>462 KiB</td>
             </tr>
             <tr>
               <th>XLSX static JavaScript</th>
@@ -38,8 +38,8 @@ import SiteFooter from '../components/SiteFooter.astro';
             </tr>
             <tr>
               <th>PPTX static JavaScript</th>
-              <td>1,244 KiB</td>
-              <td>288 KiB</td>
+              <td>1,281 KiB</td>
+              <td>296 KiB</td>
             </tr>
           </tbody>
         </table>
@@ -67,7 +67,7 @@ import SiteFooter from '../components/SiteFooter.astro';
           <tbody>
             <tr><th>DOCX parser WASM</th><td>1,781 KiB</td><td>740 KiB</td></tr>
             <tr><th>XLSX parser WASM</th><td>1,577 KiB</td><td>650 KiB</td></tr>
-            <tr><th>PPTX parser WASM</th><td>1,624 KiB</td><td>641 KiB</td></tr>
+            <tr><th>PPTX parser WASM</th><td>1,638 KiB</td><td>645 KiB</td></tr>
             <tr><th>MathJax runtime</th><td>3,025 KiB</td><td>1,084 KiB</td></tr>
           </tbody>
         </table>

--- a/site/src/try-loading.test.ts
+++ b/site/src/try-loading.test.ts
@@ -43,7 +43,7 @@ describe('Try Yours parsing progress', () => {
     const branch = renderer.match(/if \(ext === 'pptx'\) \{([\s\S]*?)\n  \}\n\n  const host/)?.[1] ?? '';
     expect(branch).toContain("mode: 'worker'");
     expect(branch).toContain('progressiveLayout: true');
-    expect(branch).toContain('viewer.waitUntilLayoutComplete()');
+    expect(branch).toContain('viewer.waitUntilLayoutComplete().then(mountAllSlides)');
   });
 
   it('keeps the preview frame for XLSX as well as DOCX and PPTX', () => {


### PR DESCRIPTION
## Summary

- release progressive DOCX and PPTX viewing with a shared completion lifecycle
- improve large-document interaction, Word tracked-change output, PowerPoint embedded-font rendering, and long-address wrapping
- update versions, changelog, announcement, API/capability docs, bundle measurements, and framework examples for 0.83.0

## Verification

- DOCX architecture final checker and 89 boundary tests
- DOCX compatibility, public API, package-build, and typecheck gates
- 3,355 DOCX tests; full repository run with 8,511 passing tests and two unrelated Skia pixel tests passing on focused rerun
- fixed-baseline complete private-corpus VRT; all intentional differences individually compared with Office output
- production build, site build, Storybook build, and MCP cargo check
- final npm tarball: publint and ESM type-resolution checks
- React, Solid, Svelte, and Vue examples installed from the final tarball and built successfully
- VS Code extension packaged successfully

## Compatibility

No migration is required. Progressive layout and tracked-change markup remain opt-in; existing defaults are preserved.