### PR TITLE
fix(docx): keep borrowed layout views coherent

### DIFF
--- a/packages/docx/src/document-active-view.test.ts
+++ b/packages/docx/src/document-active-view.test.ts
@@ -10,6 +10,7 @@ import {
   documentLayoutRuntimeOf,
 } from './layout/runtime-state.js';
 import { installStubCanvas, syntheticDocxModel } from './testing/synthetic-document.js';
+import { activeDocxLayoutViewOf } from './document-layout-view.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // `load({ currentDate, showTrackedChanges })` primes and records the variant
@@ -62,6 +63,27 @@ function documentWithActiveView(view: {
 
 beforeAll(() => {
   installStubCanvas();
+});
+
+describe('activeDocxLayoutViewOf', () => {
+  it('exposes the canonical active layout axes for borrowing viewers', () => {
+    const { doc } = documentWithActiveView({
+      currentDate: DATED,
+      showTrackedChanges: true,
+    });
+    expect(activeDocxLayoutViewOf(doc)).toEqual({
+      currentDate: DATED.getTime(),
+      showTrackedChanges: true,
+    });
+  });
+
+  it('reports the load-time default field date for the final view', () => {
+    const { doc } = documentWithActiveView({});
+    expect(activeDocxLayoutViewOf(doc)).toEqual({
+      currentDate: CURRENT_DATE_MS,
+      showTrackedChanges: false,
+    });
+  });
 });
 
 describe('omitted per-call options select the active load-time variant', () => {

--- a/packages/docx/src/document-layout-view.ts
+++ b/packages/docx/src/document-layout-view.ts
@@ -1,0 +1,20 @@
+import type { DocxDocument } from './document.js';
+import { documentLayoutRuntimeOf } from './layout/runtime-state.js';
+
+/** Internal bridge used when a Viewer borrows an already-loaded document.
+ *
+ * The selected view belongs to DocxDocument's retained-layout runtime. Keeping
+ * this accessor outside the public class surface lets both Viewer factories
+ * inherit that authority without exposing layout bookkeeping as public API.
+ */
+export function activeDocxLayoutViewOf(document: DocxDocument): Readonly<{
+  showTrackedChanges: boolean;
+  currentDate: number;
+}> {
+  const runtime = documentLayoutRuntimeOf(document);
+  const active = runtime.activeLayoutOptions;
+  return {
+    showTrackedChanges: active?.showTrackedChanges === true,
+    currentDate: active?.currentDateMs ?? runtime.defaultCurrentDateMs,
+  };
+}

--- a/packages/docx/src/document-layout-view.ts
+++ b/packages/docx/src/document-layout-view.ts
@@ -1,5 +1,33 @@
 import type { DocxDocument } from './document.js';
+import { normalizeLayoutOptions } from './layout/options.js';
 import { documentLayoutRuntimeOf } from './layout/runtime-state.js';
+
+export interface ActiveDocxLayoutView {
+  readonly showTrackedChanges: boolean;
+  readonly currentDate: number;
+}
+
+export interface DocxLayoutViewPublication {
+  readonly view: Readonly<ActiveDocxLayoutView>;
+  /** Monotonic per-document installation order. Reentrant listeners may see a
+   * newer publication before an outer dispatch resumes, so consumers reject
+   * any generation they have already passed. */
+  readonly generation: number;
+  /** Viewer whose awaited method owns the repaint for this installation. */
+  readonly requester?: object;
+}
+
+type Listener = (publication: DocxLayoutViewPublication) => void;
+interface Subscription {
+  readonly notify: Listener;
+  readonly report: (error: unknown) => void;
+}
+
+const listeners = new WeakMap<object, Set<Subscription>>();
+const generations = new WeakMap<object, number>();
+/** Non-public request metadata. The symbol is stripped from normalized layout
+ * options and never crosses the worker boundary. */
+export const docxLayoutViewRequester = Symbol('docxLayoutViewRequester');
 
 /** Internal bridge used when a Viewer borrows an already-loaded document.
  *
@@ -7,14 +35,77 @@ import { documentLayoutRuntimeOf } from './layout/runtime-state.js';
  * this accessor outside the public class surface lets both Viewer factories
  * inherit that authority without exposing layout bookkeeping as public API.
  */
-export function activeDocxLayoutViewOf(document: DocxDocument): Readonly<{
-  showTrackedChanges: boolean;
-  currentDate: number;
-}> {
+export function activeDocxLayoutViewOf(document: DocxDocument): Readonly<ActiveDocxLayoutView> {
   const runtime = documentLayoutRuntimeOf(document);
   const active = runtime.activeLayoutOptions;
   return {
     showTrackedChanges: active?.showTrackedChanges === true,
     currentDate: active?.currentDateMs ?? runtime.defaultCurrentDateMs,
+  };
+}
+
+/** Select a view on behalf of one Viewer while retaining the document as the
+ * sole authority. The boolean result is false when a newer concurrent worker
+ * selection won, so the stale caller must not install its requested local state. */
+export async function selectDocxLayoutView(
+  document: DocxDocument,
+  view: Readonly<{ showTrackedChanges?: boolean; currentDate?: Date | number }>,
+  requester: object,
+): Promise<boolean> {
+  const runtime = documentLayoutRuntimeOf(document);
+  const normalized = normalizeLayoutOptions(
+    view.currentDate,
+    runtime.defaultCurrentDateMs,
+    view.showTrackedChanges === true,
+  );
+  const requested = Object.freeze({
+    showTrackedChanges: normalized.showTrackedChanges === true,
+    currentDate: normalized.currentDateMs,
+  });
+  const internalView = {
+    showTrackedChanges: requested.showTrackedChanges,
+    currentDate: requested.currentDate,
+    [docxLayoutViewRequester]: requester,
+  };
+  await document.setLayoutView(internalView);
+  const active = activeDocxLayoutViewOf(document);
+  return active.currentDate === requested.currentDate
+    && active.showTrackedChanges === requested.showTrackedChanges;
+}
+
+/** Publish an installed document-global view to every borrowing Viewer. Called
+ * only after geometry and worker metadata have atomically adopted that view. */
+export function publishDocxLayoutView(
+  document: DocxDocument,
+  requester?: object,
+): void {
+  const view = Object.freeze({ ...activeDocxLayoutViewOf(document) });
+  const generation = (generations.get(document) ?? 0) + 1;
+  generations.set(document, generation);
+  const publication = Object.freeze({ view, generation, requester });
+  for (const subscription of [...(listeners.get(document) ?? [])]) {
+    try {
+      subscription.notify(publication);
+    } catch (error) {
+      try { subscription.report(error); } catch {}
+    }
+  }
+}
+
+export function subscribeDocxLayoutView(
+  document: DocxDocument,
+  listener: Listener,
+  report: (error: unknown) => void,
+): () => void {
+  let registered = listeners.get(document);
+  if (!registered) {
+    registered = new Set();
+    listeners.set(document, registered);
+  }
+  const subscription = Object.freeze({ notify: listener, report });
+  registered.add(subscription);
+  return () => {
+    registered?.delete(subscription);
+    if (registered?.size === 0) listeners.delete(document);
   };
 }

--- a/packages/docx/src/document-worker-progressive.test.ts
+++ b/packages/docx/src/document-worker-progressive.test.ts
@@ -6,6 +6,11 @@ import { WorkerBridge, type WorkerLike } from '@silurus/ooxml-core';
 import { DocxDocument } from './document';
 import { attachDocumentLayoutRuntime, documentLayoutRuntimeOf } from './layout/runtime-state.js';
 import { subscribeDocxLayout } from './document-layout-events.js';
+import {
+  selectDocxLayoutView,
+  subscribeDocxLayoutView,
+  type DocxLayoutViewPublication,
+} from './document-layout-view.js';
 import type {
   DocumentLayoutPartial,
   DocumentMeta,
@@ -444,6 +449,66 @@ describe('progressive pushes and request correlation', () => {
 });
 
 describe('worker layout-view metadata switch', () => {
+  it('publishes only the winning concurrent view after matching geometry is installed', async () => {
+    const resolvers: Array<(value: RenderWorkerResponse) => void> = [];
+    const document = Object.create(DocxDocument.prototype) as DocxDocument;
+    Object.assign(document, {
+      _mode: 'worker',
+      _document: null,
+      _source: null,
+      _meta: fullMeta(11),
+      _layoutViewGeneration: 0,
+      _bridge: {
+        request: () => new Promise<RenderWorkerResponse>((resolve) => resolvers.push(resolve)),
+      },
+    });
+    attachDocumentLayoutRuntime(document, 0);
+    documentLayoutRuntimeOf(document).activeLayoutOptions = {
+      currentDateMs: 0,
+      showTrackedChanges: false,
+    };
+    const publications: DocxLayoutViewPublication[] = [];
+    const unsubscribe = subscribeDocxLayoutView(
+      document,
+      (publication) => publications.push(publication),
+      vi.fn(),
+    );
+
+    const staleRequester = {};
+    const winningRequester = {};
+    const stale = selectDocxLayoutView(document, {
+      showTrackedChanges: true,
+      currentDate: 10,
+    }, staleRequester);
+    const winning = selectDocxLayoutView(document, {
+      showTrackedChanges: true,
+      currentDate: 20,
+    }, winningRequester);
+    expect(resolvers).toHaveLength(2);
+
+    resolvers[0]!({
+      type: 'layoutViewSelected',
+      id: 1,
+      meta: fullMeta(13),
+    } as RenderWorkerResponse);
+    await expect(stale).resolves.toBe(false);
+    expect(publications).toEqual([]);
+
+    resolvers[1]!({
+      type: 'layoutViewSelected',
+      id: 2,
+      meta: fullMeta(14),
+    } as RenderWorkerResponse);
+    await expect(winning).resolves.toBe(true);
+    expect(document.pageCount).toBe(14);
+    expect(publications).toEqual([{
+      view: { showTrackedChanges: true, currentDate: 20 },
+      generation: 1,
+      requester: winningRequester,
+    }]);
+    unsubscribe();
+  });
+
   it('keeps the old variant active until matching worker geometry is ready', async () => {
     let resolveMeta!: (value: RenderWorkerResponse) => void;
     const metaResponse = new Promise<RenderWorkerResponse>((resolve) => {

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -93,6 +93,10 @@ import { PaginationAbortError } from './layout/pagination-scheduler.js';
 import { normalizeLayoutOptions, type LayoutOptions } from './layout/options.js';
 import type { LayoutVariantStore } from './layout/variant-store.js';
 import { publishDocxLayout } from './document-layout-events.js';
+import {
+  docxLayoutViewRequester,
+  publishDocxLayoutView,
+} from './document-layout-view.js';
 
 /** Options for {@link DocxDocument.load}. Extends the shared load-options type
  *  from `@silurus/ooxml-core` (`useGoogleFonts`, `resourceLimits`, and the
@@ -1497,6 +1501,11 @@ export class DocxDocument {
   async setLayoutView(
     view: Readonly<{ showTrackedChanges?: boolean; currentDate?: Date | number }> = {},
   ): Promise<void> {
+    // Request ownership is explicit input metadata. It is captured before a
+    // worker request yields, stripped by normalization, and never serialized.
+    const requester = (view as Readonly<{
+      [docxLayoutViewRequester]?: object;
+    }>)[docxLayoutViewRequester];
     const runtime = documentLayoutRuntimeOf(this);
     const next = normalizeLayoutOptions(
       view.currentDate,
@@ -1522,6 +1531,7 @@ export class DocxDocument {
       runtime.activeLayoutOptions = next;
       this._meta = { ...this._meta, ...variant.meta };
       this._invalidateLayoutDerivedCaches();
+      publishDocxLayoutView(this, requester);
       return;
     }
 
@@ -1529,6 +1539,7 @@ export class DocxDocument {
     // Bookmark pages and the review anchor caches are derived from the
     // layout, so they belong to the variant that produced them.
     this._invalidateLayoutDerivedCaches();
+    publishDocxLayoutView(this, requester);
   }
 
   /** Lazily build (and cache) the `bookmarkName → page index` map from either

--- a/packages/docx/src/layout/variant-store.test.ts
+++ b/packages/docx/src/layout/variant-store.test.ts
@@ -91,4 +91,52 @@ describe('LayoutVariantStore', () => {
     expect(store.layoutFor({ currentDateMs: 101 })).toBe(rebuiltFirst);
     expect(builds).toEqual([100, 101, 102, 101]);
   });
+
+  it('retains the final and markup pair for one explicit field date', () => {
+    const builds: string[] = [];
+    const store = new LayoutVariantStore(
+      services('text:a'),
+      { currentDateMs: 100 },
+      (options) => {
+        builds.push(`${options.currentDateMs}:${options.showTrackedChanges === true}`);
+        return emptyLayout();
+      },
+    );
+
+    const datedFinal = store.layoutFor({ currentDateMs: 101 });
+    const datedMarkup = store.layoutFor({ currentDateMs: 101, showTrackedChanges: true });
+    expect(store.layoutFor({ currentDateMs: 101 })).toBe(datedFinal);
+    expect(store.layoutFor({ currentDateMs: 101, showTrackedChanges: true })).toBe(datedMarkup);
+    expect(builds).toEqual(['101:false', '101:true']);
+
+    // Selecting another explicit date replaces the previous date's bounded
+    // pair instead of retaining unbounded field-date variants.
+    store.layoutFor({ currentDateMs: 102 });
+    expect(store.layoutFor({ currentDateMs: 101 })).not.toBe(datedFinal);
+    expect(builds).toEqual(['101:false', '101:true', '102:false', '101:false']);
+  });
+
+  it('evicts the old explicit-date pair before building the next date', () => {
+    let oldPairDuringBuild: [boolean, boolean] | undefined;
+    let store!: LayoutVariantStore;
+    store = new LayoutVariantStore(
+      services('text:a'),
+      { currentDateMs: 100 },
+      (options) => {
+        if (options.currentDateMs === 102) {
+          oldPairDuringBuild = [
+            store.hasLayoutFor({ currentDateMs: 101 }),
+            store.hasLayoutFor({ currentDateMs: 101, showTrackedChanges: true }),
+          ];
+        }
+        return emptyLayout();
+      },
+    );
+    store.layoutFor({ currentDateMs: 101 });
+    store.layoutFor({ currentDateMs: 101, showTrackedChanges: true });
+
+    store.layoutFor({ currentDateMs: 102 });
+
+    expect(oldPairDuringBuild).toEqual([false, false]);
+  });
 });

--- a/packages/docx/src/layout/variant-store.ts
+++ b/packages/docx/src/layout/variant-store.ts
@@ -32,7 +32,8 @@ export class LayoutVariantStore {
   readonly #variants = new Map<string, DeepReadonly<DocumentLayout>>();
   readonly #defaultOptions: LayoutOptions;
   readonly #defaultKey: string;
-  #activeNonDefaultKey: string | null = null;
+  #activeNonDefaultDateMs: number | null = null;
+  readonly #activeNonDefaultKeys = new Set<string>();
 
   constructor(
     services: LayoutServices,
@@ -60,13 +61,10 @@ export class LayoutVariantStore {
     const key = layoutOptionsKey(normalized, this.#services);
     let layout = this.#variants.get(key);
     if (!layout) {
+      // Evict the previous explicit-date pair before constructing the next
+      // whole-document graph, keeping peak retained layout memory bounded.
+      this.#prepareRetention(key, normalized);
       layout = deepFreezeDocumentLayout(this.#build(normalized) as DocumentLayout);
-      if (key !== this.#defaultKey) {
-        if (this.#activeNonDefaultKey !== null && this.#activeNonDefaultKey !== key) {
-          this.#variants.delete(this.#activeNonDefaultKey);
-        }
-        this.#activeNonDefaultKey = key;
-      }
       this.#variants.set(key, layout);
     }
     return Object.freeze({ key, options: normalized, layout });
@@ -93,8 +91,8 @@ export class LayoutVariantStore {
    * builder) under its options key, so every later synchronous `select` — the
    * render path included — hits it instead of rebuilding.
    *
-   * Retention follows the same one-non-default-variant policy as `select`, so
-   * priming cannot grow the cache beyond what building normally would.
+   * Retention follows the same bounded explicit-date-pair policy as `select`,
+   * so priming cannot grow the cache beyond what building normally would.
    */
   prime(
     options: LayoutOptions,
@@ -104,7 +102,7 @@ export class LayoutVariantStore {
     const key = layoutOptionsKey(normalized, this.#services);
     const existing = this.#variants.get(key);
     if (existing) return existing;
-    return this.#store(key, layout);
+    return this.#store(key, normalized, layout);
   }
 
   /**
@@ -124,19 +122,32 @@ export class LayoutVariantStore {
     const normalized = Object.isFrozen(options) ? options : Object.freeze({ ...options });
     const key = layoutOptionsKey(normalized, this.#services);
     if ((this.#variants.get(key) ?? null) !== expected) return null;
-    return this.#store(key, layout);
+    return this.#store(key, normalized, layout);
   }
 
-  #store(key: string, layout: DocumentLayout): DeepReadonly<DocumentLayout> {
+  #store(
+    key: string,
+    options: LayoutOptions,
+    layout: DocumentLayout,
+  ): DeepReadonly<DocumentLayout> {
+    this.#prepareRetention(key, options);
     const frozen = deepFreezeDocumentLayout(layout);
-    if (key !== this.#defaultKey) {
-      if (this.#activeNonDefaultKey !== null && this.#activeNonDefaultKey !== key) {
-        this.#variants.delete(this.#activeNonDefaultKey);
-      }
-      this.#activeNonDefaultKey = key;
-    }
     this.#variants.set(key, frozen);
     return frozen;
+  }
+
+  /** Keep the permanent load-time default plus final/markup layouts for one
+   * explicit field date. A different date evicts that whole bounded pair. */
+  #prepareRetention(key: string, options: LayoutOptions): void {
+    if (key === this.#defaultKey) return;
+    if (this.#activeNonDefaultDateMs !== options.currentDateMs) {
+      for (const retainedKey of this.#activeNonDefaultKeys) {
+        this.#variants.delete(retainedKey);
+      }
+      this.#activeNonDefaultKeys.clear();
+      this.#activeNonDefaultDateMs = options.currentDateMs;
+    }
+    this.#activeNonDefaultKeys.add(key);
   }
 
   /** Whether a layout for these options is already available synchronously. */

--- a/packages/docx/src/scroll-viewer-progressive.test.ts
+++ b/packages/docx/src/scroll-viewer-progressive.test.ts
@@ -338,7 +338,7 @@ describe('DocxScrollViewer — growing page count', () => {
 
     await viewer.setShowTrackedChanges(true);
     expect(engine.layoutViews).toEqual([
-      { showTrackedChanges: true, currentDate: undefined },
+      { showTrackedChanges: true, currentDate: 0 },
     ]);
     viewer.destroy();
   });

--- a/packages/docx/src/scroll-viewer-test-dom.ts
+++ b/packages/docx/src/scroll-viewer-test-dom.ts
@@ -8,6 +8,11 @@ import type { DocxElementContext, DocxPagePoint } from './selection-context';
 import type { DocComment } from './types';
 import type { DocxElementContextOptions } from './element-context';
 import { DocxScrollViewer, type DocxScrollViewerOptions } from './scroll-viewer';
+import {
+  attachDocumentLayoutRuntime,
+  documentLayoutRuntimeOf,
+} from './layout/runtime-state.js';
+import { normalizeLayoutOptions } from './layout/options.js';
 
 /** Test-only adapter for mechanics cases that need a preloaded engine. Public
  * callers use `DocxScrollViewer.fromDocument()` directly. */
@@ -354,6 +359,26 @@ export interface RenderCall {
  *  observable. */
 export class FakeDocxEngine {
   destroyed = false;
+  /** The layout view selected by load()/setLayoutView(). Borrowing viewers must
+   *  inherit this instead of silently falling back to their option defaults. */
+  get layoutView(): Readonly<{
+    showTrackedChanges: boolean;
+    currentDate: number;
+  }> {
+    const runtime = documentLayoutRuntimeOf(this);
+    return {
+      showTrackedChanges: runtime.activeLayoutOptions?.showTrackedChanges === true,
+      currentDate: runtime.activeLayoutOptions?.currentDateMs ?? runtime.defaultCurrentDateMs,
+    };
+  }
+  set layoutView(view: Readonly<{ showTrackedChanges: boolean; currentDate: number }>) {
+    const runtime = documentLayoutRuntimeOf(this);
+    runtime.activeLayoutOptions = normalizeLayoutOptions(
+      view.currentDate,
+      runtime.defaultCurrentDateMs,
+      view.showTrackedChanges,
+    );
+  }
   renderCalls: RenderCall[] = [];
   bitmapCalls: RenderCall[] = [];
   createdBitmaps: Array<{ width: number; height: number; close: ReturnType<typeof vi.fn> }> = [];
@@ -384,7 +409,9 @@ export class FakeDocxEngine {
     private _sizes: Array<{ widthPt: number; heightPt: number }>,
     private _mode: 'main' | 'worker' = 'main',
     private deferred = false,
-  ) {}
+  ) {
+    attachDocumentLayoutRuntime(this, 0);
+  }
   /** Grow (or shrink) the document, as progressive layout does when the
    *  authoritative layout replaces the provisional prefix. */
   setPageCount(pageCount: number): void {
@@ -417,6 +444,12 @@ export class FakeDocxEngine {
 
   setLayoutView(view: { showTrackedChanges?: boolean; currentDate?: Date | number }): void {
     this.layoutViews.push(view);
+    this.layoutView = {
+      showTrackedChanges: view.showTrackedChanges === true,
+      currentDate: typeof view.currentDate === 'number'
+        ? view.currentDate
+        : view.currentDate?.getTime() ?? this.layoutView.currentDate,
+    };
   }
 
   get pageCount(): number {

--- a/packages/docx/src/scroll-viewer-test-dom.ts
+++ b/packages/docx/src/scroll-viewer-test-dom.ts
@@ -13,6 +13,10 @@ import {
   documentLayoutRuntimeOf,
 } from './layout/runtime-state.js';
 import { normalizeLayoutOptions } from './layout/options.js';
+import {
+  docxLayoutViewRequester,
+  publishDocxLayoutView,
+} from './document-layout-view.js';
 
 /** Test-only adapter for mechanics cases that need a preloaded engine. Public
  * callers use `DocxScrollViewer.fromDocument()` directly. */
@@ -443,13 +447,25 @@ export class FakeDocxEngine {
   layoutViews: Array<{ showTrackedChanges?: boolean; currentDate?: Date | number }> = [];
 
   setLayoutView(view: { showTrackedChanges?: boolean; currentDate?: Date | number }): void {
-    this.layoutViews.push(view);
-    this.layoutView = {
+    this.layoutViews.push({
+      showTrackedChanges: view.showTrackedChanges,
+      currentDate: view.currentDate,
+    });
+    const requester = (view as typeof view & {
+      [docxLayoutViewRequester]?: object;
+    })[docxLayoutViewRequester];
+    const next = {
       showTrackedChanges: view.showTrackedChanges === true,
       currentDate: typeof view.currentDate === 'number'
         ? view.currentDate
         : view.currentDate?.getTime() ?? this.layoutView.currentDate,
     };
+    if (
+      this.layoutView.showTrackedChanges === next.showTrackedChanges
+      && this.layoutView.currentDate === next.currentDate
+    ) return;
+    this.layoutView = next;
+    publishDocxLayoutView(this.asDoc(), requester);
   }
 
   get pageCount(): number {

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -1869,10 +1869,20 @@ describe('DocxScrollViewer — element context', () => {
     };
   }
 
-  async function setupElementContext(opts: ConstructorParameters<typeof DocxScrollViewer>[1]) {
+  async function setupElementContext(
+    opts: NonNullable<ConstructorParameters<typeof DocxScrollViewer>[1]> = {},
+  ) {
     installDom();
     const container = makeContainer(200, 400);
     const engine = new FakeDocxEngine(1, [{ widthPt: 100, heightPt: 200 }]);
+    if (opts.currentDate !== undefined || opts.showTrackedChanges !== undefined) {
+      engine.layoutView = {
+        showTrackedChanges: opts.showTrackedChanges === true,
+        currentDate: opts.currentDate instanceof Date
+          ? opts.currentDate.getTime()
+          : opts.currentDate ?? engine.layoutView.currentDate,
+      };
+    }
     engine.elementContext = elementContext();
     const v = makeBorrowedDocxScrollViewer(container as unknown as HTMLElement, {
       document: engine.asDoc(), gap: 10, paddingLeft: 0, paddingRight: 0, ...opts,
@@ -1971,7 +1981,7 @@ describe('DocxScrollViewer — element context', () => {
     expect(mounted.engine.elementContextCalls).toEqual([{
       pageIndex: 0,
       point: { xPt: 50, yPt: 100 },
-      options: { currentDate, maxTextCharacters: 65_536 },
+      options: { currentDate: currentDate.getTime(), maxTextCharacters: 65_536 },
     }]);
     expect(mounted.v.getSelectionContext()).toMatchObject({
       format: 'docx', kind: 'element', elementType: 'chart',

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -19,6 +19,7 @@ import { eventTargetsDataAttributeWithin } from '@silurus/ooxml-core/internal/do
 import type { ReadOnlyCommentMarginGeometry } from '@silurus/ooxml-core/internal/read-only-comment-decoration';
 import { DocxDocument } from './document';
 import type { LoadOptions } from './document';
+import { activeDocxLayoutViewOf } from './document-layout-view.js';
 import type { DocxTextRunInfo } from './renderer';
 import { buildDocxTextLayer } from './text-layer';
 import { DocxFindController, type DocxMatchLocation } from './find';
@@ -462,17 +463,24 @@ export class DocxScrollViewer implements ZoomableViewer {
   /**
    * Create a Scroll Viewer that borrows an already-loaded document.
    *
-   * The document's render mode is authoritative. The returned Viewer cannot
-   * load another source, and destroying it leaves the caller-owned document
-   * open. The initial virtual window is laid out during construction.
+   * The document's render mode and active layout view are authoritative. The
+   * returned Viewer cannot load another source, and destroying it leaves the
+   * caller-owned document open. The initial virtual window is laid out during
+   * construction.
    */
   static fromDocument(
     container: HTMLElement,
     document: DocxDocument,
     opts: Omit<DocxScrollViewerOptions, keyof LoadOptions> = {},
   ): Omit<DocxScrollViewer, 'load'> {
+    const layoutView = activeDocxLayoutViewOf(document);
     return new DocxScrollViewer(container, {
       ...opts,
+      // The caller-owned document has already selected these pagination axes.
+      // Seed the viewer from that authoritative state: LoadOptions are omitted
+      // from this factory's opts and its local defaults can therefore disagree.
+      currentDate: layoutView.currentDate,
+      showTrackedChanges: layoutView.showTrackedChanges,
       [borrowedDocumentOption]: document,
     } as InternalDocxScrollViewerOptions);
   }

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -19,7 +19,12 @@ import { eventTargetsDataAttributeWithin } from '@silurus/ooxml-core/internal/do
 import type { ReadOnlyCommentMarginGeometry } from '@silurus/ooxml-core/internal/read-only-comment-decoration';
 import { DocxDocument } from './document';
 import type { LoadOptions } from './document';
-import { activeDocxLayoutViewOf } from './document-layout-view.js';
+import {
+  activeDocxLayoutViewOf,
+  selectDocxLayoutView,
+  subscribeDocxLayoutView,
+  type DocxLayoutViewPublication,
+} from './document-layout-view.js';
 import type { DocxTextRunInfo } from './renderer';
 import { buildDocxTextLayer } from './text-layer';
 import { DocxFindController, type DocxMatchLocation } from './find';
@@ -458,7 +463,12 @@ export class DocxScrollViewer implements ZoomableViewer {
    *  variant the viewer reads geometry from; toggle it with
    *  {@link setShowTrackedChanges}. */
   private _showTrackedChanges: boolean;
+  /** Canonical epoch milliseconds for the document-global field-date layout
+   * axis. Kept beside `_showTrackedChanges` because borrowed documents can
+   * change either axis after construction. */
+  private _currentDate: Date | number | undefined;
   private _layoutViewGeneration = 0;
+  private _layoutViewPublicationGeneration = 0;
 
   /**
    * Create a Scroll Viewer that borrows an already-loaded document.
@@ -501,6 +511,7 @@ export class DocxScrollViewer implements ZoomableViewer {
     this._opts = opts;
     this._errorRouter = new CanvasViewerErrorRouter('DocxScrollViewer', opts.onError);
     this._showTrackedChanges = opts.showTrackedChanges === true;
+    this._currentDate = opts.currentDate;
     // `??` (not `||`): a caller's explicit `false` must disable the shadow, not
     // fall through to the default.
     this._pageShadow = opts.pageShadow ?? DEFAULT_PAGE_SHADOW;
@@ -654,9 +665,9 @@ export class DocxScrollViewer implements ZoomableViewer {
         // final view while every render asks for the markup view, and the first
         // paint pays a full synchronous repagination.
         ...(this._showTrackedChanges ? { showTrackedChanges: true } : {}),
-        ...(this._opts.currentDate === undefined
+        ...(this._currentDate === undefined
           ? {}
-          : { currentDate: this._opts.currentDate }),
+          : { currentDate: this._currentDate }),
         ...(this._opts.progressiveLayout ? { progressiveLayout: true } : {}),
         ...(this._opts.sliceLayout ? { sliceLayout: true } : {}),
         onLayoutProgress: this._opts.onLayoutProgress,
@@ -738,10 +749,16 @@ export class DocxScrollViewer implements ZoomableViewer {
 
   private _bindLayoutDocument(doc: DocxDocument): void {
     this._unbindLayoutDocument();
+    this._layoutViewPublicationGeneration = 0;
     this._presentedPageCount = doc.pageCount;
     this._pendingLayoutPublication = null;
+    const unsubscribeView = subscribeDocxLayoutView(
+      doc,
+      (publication) => this._onLayoutViewPublication(doc, publication),
+      (error) => this._reportRenderError(error),
+    );
     let initial = true;
-    this._layoutUnsubscribe = subscribeDocxLayout(
+    const unsubscribeLayout = subscribeDocxLayout(
       doc,
       () => ({
         pageCount: doc.pageCount,
@@ -757,6 +774,10 @@ export class DocxScrollViewer implements ZoomableViewer {
       },
       (error) => this._reportRenderError(error),
     );
+    this._layoutUnsubscribe = () => {
+      unsubscribeLayout();
+      unsubscribeView();
+    };
   }
 
   private _unbindLayoutDocument(): void {
@@ -804,6 +825,29 @@ export class DocxScrollViewer implements ZoomableViewer {
     }
     this._pendingLayoutPublication = null;
     this._applyLayoutPublication(publication);
+  }
+
+  private _onLayoutViewPublication(
+    doc: DocxDocument,
+    publication: DocxLayoutViewPublication,
+  ): void {
+    if (
+      this._destroyed
+      || doc !== this._doc
+      || publication.generation <= this._layoutViewPublicationGeneration
+    ) return;
+    this._layoutViewPublicationGeneration = publication.generation;
+    if (publication.requester === this) return;
+    this._layoutViewGeneration++;
+    this._showTrackedChanges = publication.view.showTrackedChanges;
+    this._currentDate = publication.view.currentDate;
+    this._find.invalidate();
+    this._pendingLayoutPublication = null;
+    this._applyLayoutPublication({
+      pageCount: doc.pageCount,
+      exact: true,
+      complete: doc.layoutComplete,
+    });
   }
 
   /** Refresh only the empty review layers created with each comment-enabled
@@ -1434,7 +1478,7 @@ export class DocxScrollViewer implements ZoomableViewer {
         width: widthPx, // this page's own px width → uniform px-per-pt scale (§7)
         dpr,
         defaultTextColor: this._opts.defaultTextColor,
-        currentDate: this._opts.currentDate,
+        currentDate: this._currentDate,
         ...(this._showTrackedChanges ? { showTrackedChanges: true } : {}),
         onTextRun,
       });
@@ -1622,7 +1666,7 @@ export class DocxScrollViewer implements ZoomableViewer {
         width: widthPx,
         dpr,
         defaultTextColor: this._opts.defaultTextColor,
-        currentDate: this._opts.currentDate,
+        currentDate: this._currentDate,
         ...(this._showTrackedChanges ? { showTrackedChanges: true } : {}),
         onTextRun: wantRuns ? (r) => runs.push(r) : undefined,
       });
@@ -2095,7 +2139,7 @@ export class DocxScrollViewer implements ZoomableViewer {
       width: widthPx,
       dpr,
       defaultTextColor: this._opts.defaultTextColor,
-      currentDate: this._opts.currentDate,
+      currentDate: this._currentDate,
       ...(this._showTrackedChanges ? { showTrackedChanges: true } : {}),
       onTextRun,
     })
@@ -2167,19 +2211,22 @@ export class DocxScrollViewer implements ZoomableViewer {
     const generation = ++this._layoutViewGeneration;
     const doc = this._doc;
     if (this._showTrackedChanges === value) {
-      await doc?.setLayoutView?.({
+      if (doc) await selectDocxLayoutView(doc, {
         showTrackedChanges: value,
-        currentDate: this._opts.currentDate,
-      });
+        currentDate: this._currentDate,
+      }, this);
       return;
     }
     // The markup view is a different retained layout with its own pagination,
     // so move the document's active variant before reading any geometry from
     // it — page count and page heights are about to change.
-    await doc?.setLayoutView?.({
-      showTrackedChanges: value,
-      currentDate: this._opts.currentDate,
-    });
+    const selected = doc
+      ? await selectDocxLayoutView(doc, {
+          showTrackedChanges: value,
+          currentDate: this._currentDate,
+        }, this)
+      : true;
+    if (!selected) return;
     if (this._destroyed || generation !== this._layoutViewGeneration || doc !== this._doc) return;
     this._showTrackedChanges = value;
     this._find.invalidate();
@@ -2330,7 +2377,7 @@ export class DocxScrollViewer implements ZoomableViewer {
       if (!entry || entry.scale !== scale) {
         const runs = doc.collectPageRuns(page, {
           width: this._pageWidthPx(page),
-          currentDate: this._opts.currentDate,
+          currentDate: this._currentDate,
           ...(this._showTrackedChanges ? { showTrackedChanges: true } : {}),
         });
         entry = { scale, runs };
@@ -2496,7 +2543,7 @@ export class DocxScrollViewer implements ZoomableViewer {
     if (!this._doc) return [];
     return this._doc.collectPageRuns(page, {
       width: this._pageWidthPx(page),
-      currentDate: this._opts.currentDate,
+      currentDate: this._currentDate,
       ...(this._showTrackedChanges ? { showTrackedChanges: true } : {}),
     });
   }
@@ -2939,7 +2986,7 @@ export class DocxScrollViewer implements ZoomableViewer {
         xPt: localX / rect.width * pageSize.widthPt,
         yPt: localY / rect.height * pageSize.heightPt,
       }, {
-        currentDate: this._opts.currentDate,
+        currentDate: this._currentDate,
         ...(this._showTrackedChanges ? { showTrackedChanges: true } : {}),
         maxTextCharacters: MAX_DOCX_ELEMENT_TEXT_CHARACTERS,
       });

--- a/packages/docx/src/show-tracked-changes-option.test.ts
+++ b/packages/docx/src/show-tracked-changes-option.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { DocxViewer } from './viewer.js';
 import { DocxDocument } from './document.js';
+import { subscribeDocxLayoutView } from './document-layout-view.js';
 import {
   installDom,
   makeEl,
@@ -70,6 +71,107 @@ describe('DocxViewer — showTrackedChanges option', () => {
     await v.setShowTrackedChanges(false);
     expect(engine.renderCalls.length).toBe(count);
     v.destroy();
+  });
+});
+
+describe.each(['main', 'worker'] as const)(
+  'DocxViewer — shared borrowed document (%s mode)',
+  (mode) => {
+    it('keeps geometry and paint on the document\'s post-construction active view', async () => {
+      installDom();
+      const engine = new FakeDocxEngine(2, PAGE, mode);
+      engine.layoutView = { showTrackedChanges: false, currentDate: 10 };
+      const viewers = [makeEl('canvas'), makeEl('canvas')].map((canvas) =>
+        DocxViewer.fromDocument(canvas as unknown as HTMLCanvasElement, engine.asDoc()));
+      await Promise.all(viewers.map((viewer) => viewer.goToPage(0)));
+
+      const calls = mode === 'worker' ? engine.bitmapCalls : engine.renderCalls;
+      const beforeExternalSwitch = calls.length;
+      await engine.setLayoutView({ showTrackedChanges: true, currentDate: 20 });
+      await Promise.resolve();
+
+      expect(calls.length).toBeGreaterThan(beforeExternalSwitch);
+      for (const call of calls.slice(beforeExternalSwitch)) {
+        expect(call.showTrackedChanges).toBe(true);
+        expect(call.currentDate).toBe(20);
+      }
+
+      const beforeViewerSwitch = calls.length;
+      await viewers[1]!.setShowTrackedChanges(false);
+      await Promise.resolve();
+
+      expect(calls.length).toBeGreaterThan(beforeViewerSwitch);
+      for (const call of calls.slice(beforeViewerSwitch)) {
+        expect(call.showTrackedChanges ?? false).toBe(false);
+        expect(call.currentDate).toBe(20);
+      }
+      for (const viewer of viewers) viewer.destroy();
+    });
+  },
+);
+
+describe('DocxViewer — layout-view publication ordering', () => {
+  it('rejects an older outer publication after a listener installs a newer view', async () => {
+    installDom();
+    const engine = new FakeDocxEngine(1, PAGE);
+    engine.layoutView = { showTrackedChanges: false, currentDate: 0 };
+    const unsubscribe = subscribeDocxLayoutView(
+      engine.asDoc(),
+      (publication) => {
+        if (publication.view.currentDate === 10) {
+          engine.setLayoutView({ showTrackedChanges: true, currentDate: 20 });
+        }
+      },
+      vi.fn(),
+    );
+    const viewers = [makeEl('canvas'), makeEl('canvas')].map((canvas) =>
+      DocxViewer.fromDocument(canvas as unknown as HTMLCanvasElement, engine.asDoc()));
+    await Promise.all(viewers.map((viewer) => viewer.goToPage(0)));
+
+    const before = engine.renderCalls.length;
+    engine.setLayoutView({ showTrackedChanges: true, currentDate: 10 });
+    await Promise.resolve();
+
+    expect(engine.layoutView).toEqual({ showTrackedChanges: true, currentDate: 20 });
+    expect(engine.renderCalls.length).toBeGreaterThan(before);
+    for (const call of engine.renderCalls.slice(before)) {
+      expect(call.showTrackedChanges).toBe(true);
+      expect(call.currentDate).toBe(20);
+    }
+
+    unsubscribe();
+    for (const viewer of viewers) viewer.destroy();
+  });
+
+  it('awaits its owned repaint and preserves repaint rejection', async () => {
+    installDom();
+    const engine = new FakeDocxEngine(1, PAGE, 'main', true);
+    const onError = vi.fn();
+    const viewer = DocxViewer.fromDocument(
+      makeEl('canvas') as unknown as HTMLCanvasElement,
+      engine.asDoc(),
+      { onError },
+    );
+    const initial = viewer.goToPage(0);
+    engine.renderCalls.at(-1)!.resolve();
+    await initial;
+
+    let settled = false;
+    const beforeSwitch = engine.renderCalls.length;
+    const switching = viewer.setShowTrackedChanges(true).then(() => { settled = true; });
+    await vi.waitFor(() => expect(engine.renderCalls.length).toBe(beforeSwitch + 1));
+    expect(settled).toBe(false);
+    engine.renderCalls.at(-1)!.resolve();
+    await switching;
+    expect(settled).toBe(true);
+
+    const beforeFailure = engine.renderCalls.length;
+    const failing = viewer.setShowTrackedChanges(false);
+    await vi.waitFor(() => expect(engine.renderCalls.length).toBe(beforeFailure + 1));
+    engine.renderCalls.at(-1)!.reject(new Error('repaint failed'));
+    await expect(failing).rejects.toThrow('repaint failed');
+    expect(onError).not.toHaveBeenCalled();
+    viewer.destroy();
   });
 });
 
@@ -201,3 +303,58 @@ describe('DocxScrollViewer — showTrackedChanges in worker mode', () => {
     v.destroy();
   });
 });
+
+describe.each(['main', 'worker'] as const)(
+  'DocxScrollViewer — shared borrowed document (%s mode)',
+  (mode) => {
+    it('keeps every viewer on the document\'s post-construction active view', async () => {
+      installDom();
+      const engine = new FakeDocxEngine(
+        2,
+        [{ widthPt: 100, heightPt: 200 }],
+        mode,
+      );
+      engine.layoutView = { showTrackedChanges: false, currentDate: 10 };
+      const viewers = [makeContainer(200, 400), makeContainer(200, 400)].map((container) => {
+        const viewer = makeBorrowedDocxScrollViewer(container as unknown as HTMLElement, {
+          document: engine.asDoc(),
+          gap: 10,
+          overscan: 1,
+          paddingLeft: 0,
+          paddingRight: 0,
+        });
+        const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+        scrollHost.clientHeight = 400;
+        scrollHost.clientWidth = 200;
+        viewer.relayout();
+        return viewer;
+      });
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const calls = mode === 'worker' ? engine.bitmapCalls : engine.renderCalls;
+      const beforeExternalSwitch = calls.length;
+      await engine.setLayoutView({ showTrackedChanges: true, currentDate: 20 });
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(calls.length).toBeGreaterThan(beforeExternalSwitch);
+      for (const call of calls.slice(beforeExternalSwitch)) {
+        expect(call.showTrackedChanges).toBe(true);
+        expect(call.currentDate).toBe(20);
+      }
+
+      const beforeViewerSwitch = calls.length;
+      await viewers[1]!.setShowTrackedChanges(false);
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(calls.length).toBeGreaterThan(beforeViewerSwitch);
+      for (const call of calls.slice(beforeViewerSwitch)) {
+        expect(call.showTrackedChanges ?? false).toBe(false);
+        expect(call.currentDate).toBe(20);
+      }
+      for (const viewer of viewers) viewer.destroy();
+    });
+  },
+);

--- a/packages/docx/src/show-tracked-changes-option.test.ts
+++ b/packages/docx/src/show-tracked-changes-option.test.ts
@@ -76,6 +76,10 @@ describe('DocxViewer — showTrackedChanges option', () => {
 async function setupScroll(
   opts: Record<string, unknown> = {},
   mode: 'main' | 'worker' = 'main',
+  layoutView?: Readonly<{
+    showTrackedChanges: boolean;
+    currentDate: number;
+  }>,
 ) {
   installDom();
   const container = makeContainer(200, 400);
@@ -88,6 +92,10 @@ async function setupScroll(
     ],
     mode,
   );
+  engine.layoutView = layoutView ?? {
+    showTrackedChanges: opts.showTrackedChanges === true,
+    currentDate: typeof opts.currentDate === 'number' ? opts.currentDate : 0,
+  };
   const v = makeBorrowedDocxScrollViewer(container as unknown as HTMLElement, {
     document: engine.asDoc(),
     gap: 10,
@@ -107,6 +115,38 @@ async function setupScroll(
 }
 
 describe('DocxScrollViewer — showTrackedChanges option (main mode)', () => {
+  it('inherits an already-loaded document\'s active markup view', async () => {
+    const currentDate = 1_700_000_000_000;
+    const { v, engine } = await setupScroll(
+      {},
+      'main',
+      { showTrackedChanges: true, currentDate },
+    );
+    expect(engine.renderCalls.length).toBeGreaterThan(0);
+    for (const call of engine.renderCalls) {
+      expect(call.showTrackedChanges).toBe(true);
+      expect(call.currentDate).toBe(currentDate);
+    }
+
+    const before = engine.renderCalls.length;
+    await v.setShowTrackedChanges(false);
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // The first OFF is a real transition, not a stale-state no-op, and it keeps
+    // the borrowed document's other layout axis intact.
+    expect(engine.renderCalls.length).toBeGreaterThan(before);
+    expect(engine.layoutViews.at(-1)).toEqual({
+      showTrackedChanges: false,
+      currentDate,
+    });
+    for (const call of engine.renderCalls.slice(before)) {
+      expect(call.showTrackedChanges ?? false).toBe(false);
+      expect(call.currentDate).toBe(currentDate);
+    }
+    v.destroy();
+  });
+
   it('renders the final view by default', async () => {
     const { v, engine } = await setupScroll();
     expect(engine.renderCalls.length).toBeGreaterThan(0);

--- a/packages/docx/src/viewer-destroy.test.ts
+++ b/packages/docx/src/viewer-destroy.test.ts
@@ -112,6 +112,36 @@ describe('DocxViewer.destroy() — canvas reparent return', () => {
     expect(engine.destroyed).toBe(false);
   });
 
+  it('inherits the borrowed document\'s active layout view', async () => {
+    const { canvas } = mount();
+    const engine = new FakeDocxEngine(1, [{ widthPt: 612, heightPt: 792 }]);
+    engine.layoutView = {
+      showTrackedChanges: true,
+      currentDate: 1_700_000_000_000,
+    };
+    const viewer = DocxViewer.fromDocument(
+      canvas as unknown as HTMLCanvasElement,
+      engine.asDoc(),
+    );
+
+    await viewer.goToPage(0);
+    expect(engine.renderCalls.at(-1)).toMatchObject({
+      showTrackedChanges: true,
+      currentDate: 1_700_000_000_000,
+    });
+
+    await viewer.setShowTrackedChanges(false);
+    expect(engine.layoutViews.at(-1)).toEqual({
+      showTrackedChanges: false,
+      currentDate: 1_700_000_000_000,
+    });
+    expect(engine.renderCalls.at(-1)).toMatchObject({
+      showTrackedChanges: false,
+      currentDate: 1_700_000_000_000,
+    });
+    viewer.destroy();
+  });
+
   it('rejects a borrowed mode conflict before reparenting the canvas', () => {
     const { parent, canvas } = mount();
     const engine = new FakeDocxEngine(1, [{ widthPt: 612, heightPt: 792 }], 'worker');

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -1,6 +1,11 @@
 import { DocxDocument } from './document';
 import type { LoadOptions } from './document';
-import { activeDocxLayoutViewOf } from './document-layout-view.js';
+import {
+  activeDocxLayoutViewOf,
+  selectDocxLayoutView,
+  subscribeDocxLayoutView,
+  type DocxLayoutViewPublication,
+} from './document-layout-view.js';
 import type { RenderPageOptions } from './types';
 import type { DocxTextRunInfo } from './renderer';
 import { buildDocxTextLayer } from './text-layer';
@@ -151,6 +156,7 @@ export class DocxViewer implements ZoomableViewer {
   private _elementContext: DocxElementContext | null = null;
   private _elementHitGeneration = 0;
   private _layoutViewGeneration = 0;
+  private _layoutViewPublicationGeneration = 0;
   private _navigationGeneration = 0;
   private _layoutUnsubscribe: (() => void) | null = null;
   /** Latest default internal-link navigation; a newer click supersedes an older
@@ -824,8 +830,14 @@ export class DocxViewer implements ZoomableViewer {
   private _bindLayoutDocument(doc: DocxDocument): void {
     this._unbindLayoutDocument();
     this._layoutFailed = false;
+    this._layoutViewPublicationGeneration = 0;
+    const unsubscribeView = subscribeDocxLayoutView(
+      doc,
+      (publication) => this._onLayoutViewPublication(doc, publication),
+      (error) => this._reportRenderError(error),
+    );
     let initial = true;
-    this._layoutUnsubscribe = subscribeDocxLayout(
+    const unsubscribeLayout = subscribeDocxLayout(
       doc,
       () => ({
         pageCount: doc.pageCount,
@@ -841,6 +853,10 @@ export class DocxViewer implements ZoomableViewer {
       },
       (error) => this._reportRenderError(error),
     );
+    this._layoutUnsubscribe = () => {
+      unsubscribeLayout();
+      unsubscribeView();
+    };
   }
 
   private _unbindLayoutDocument(): void {
@@ -863,6 +879,28 @@ export class DocxViewer implements ZoomableViewer {
     }
     this._find.invalidate();
     this._currentPage = Math.max(0, Math.min(this._currentPage, publication.pageCount - 1));
+    void this._render().catch((error) => this._reportRenderError(error));
+  }
+
+  private _onLayoutViewPublication(
+    doc: DocxDocument,
+    publication: DocxLayoutViewPublication,
+  ): void {
+    if (
+      this._destroyed
+      || doc !== this._doc
+      || publication.generation <= this._layoutViewPublicationGeneration
+    ) return;
+    this._layoutViewPublicationGeneration = publication.generation;
+    if (publication.requester === this) return;
+    this._layoutViewGeneration++;
+    this._opts = {
+      ...this._opts,
+      currentDate: publication.view.currentDate,
+      showTrackedChanges: publication.view.showTrackedChanges,
+    };
+    this._find.invalidate();
+    this._currentPage = Math.max(0, Math.min(this._currentPage, doc.pageCount - 1));
     void this._render().catch((error) => this._reportRenderError(error));
   }
 
@@ -917,20 +955,23 @@ export class DocxViewer implements ZoomableViewer {
     if ((this._opts.showTrackedChanges === true) === value) {
       // Still forward the installed value: it cancels an older in-flight
       // worker switch that has not become this viewer's state yet.
-      await doc?.setLayoutView?.({
+      if (doc) await selectDocxLayoutView(doc, {
         showTrackedChanges: value,
         currentDate: this._opts.currentDate,
-      });
+      }, this);
       return;
     }
     const nextOptions = { ...this._opts, showTrackedChanges: value };
     // The markup view paginates differently, so the document's geometry
     // accessors must follow it — and the current page may no longer exist:
     // hiding deletions can shorten the document past where the reader is.
-    await doc?.setLayoutView?.({
-      showTrackedChanges: value,
-      currentDate: nextOptions.currentDate,
-    });
+    const selected = doc
+      ? await selectDocxLayoutView(doc, {
+          showTrackedChanges: value,
+          currentDate: nextOptions.currentDate,
+        }, this)
+      : true;
+    if (!selected) return;
     if (this._destroyed || generation !== this._layoutViewGeneration || doc !== this._doc) return;
     this._opts = nextOptions;
     this._find.invalidate();

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -1,5 +1,6 @@
 import { DocxDocument } from './document';
 import type { LoadOptions } from './document';
+import { activeDocxLayoutViewOf } from './document-layout-view.js';
 import type { RenderPageOptions } from './types';
 import type { DocxTextRunInfo } from './renderer';
 import { buildDocxTextLayer } from './text-layer';
@@ -163,17 +164,21 @@ export class DocxViewer implements ZoomableViewer {
   /**
    * Create a Viewer that borrows an already-loaded document.
    *
-   * The document's render mode is authoritative. The returned Viewer cannot
-   * load another source, and destroying it leaves the caller-owned document
-   * open. Call {@link goToPage} to render the initial page.
+   * The document's render mode and active layout view are authoritative. The
+   * returned Viewer cannot load another source, and destroying it leaves the
+   * caller-owned document open. Call {@link goToPage} to render the initial
+   * page.
    */
   static fromDocument(
     canvas: HTMLCanvasElement,
     document: DocxDocument,
     opts: Omit<DocxViewerOptions, keyof LoadOptions> = {},
   ): Omit<DocxViewer, 'load'> {
+    const layoutView = activeDocxLayoutViewOf(document);
     return new DocxViewer(canvas, {
       ...opts,
+      currentDate: layoutView.currentDate,
+      showTrackedChanges: layoutView.showTrackedChanges,
       [borrowedDocumentOption]: document,
     } as InternalDocxViewerOptions);
   }


### PR DESCRIPTION
## Summary

- inherit the active tracked-changes and field-date axes when a DOCX viewer borrows an already-loaded document
- publish later document-global view selections to every borrowed `DocxViewer` and `DocxScrollViewer`, with stale-generation rejection for main-thread reentrancy and worker races
- preserve the requesting viewer's awaited repaint contract while sibling viewers repaint from the same installed geometry
- retain a bounded final/markup layout pair for one explicit field date, avoiding repeat pagination without unbounded cache growth

## Root cause

`fromDocument` intentionally omits load options, but the viewer initialized its tracked-changes state from those absent options. A document loaded in the markup variant could therefore be mounted by a viewer that believed it was already in the final variant, causing the first toggle off to skip mounted-slot repaint.

A construction-time snapshot alone was insufficient because the active layout view belongs to the shared document. Later external selections or another viewer's toggle could otherwise leave document geometry and sibling paint options on different variants.

## Design

The retained document runtime remains the sole layout-view authority. Each installed view is published with a per-document monotonic generation. A non-public origin token assigns the awaited repaint to the requesting viewer; other borrowers repaint from the publication. The token is removed by option normalization and never enters cache keys or the worker protocol.

This stays DOCX-local because tracked-change projection and field-date layout convergence are not shared XLSX/PPTX concepts. No new Office compatibility rule, numeric tuning, or sample-specific heuristic is introduced.

## Specification

ECMA-376 Part 1 §17.13.5.14 defines `w:del` run content as deleted content tracked as a revision. The final and markup projections can have different line breaking and pagination, so geometry and paint must use the same normalized layout variant. ECMA-376 does not define viewer state ownership; this change enforces that internal invariant without changing revision projection.

## Verification

- full DOCX Vitest suite: 3,368 passed, 1 skipped
- browser conformance: 66 passed across Chromium, Firefox, and WebKit
- TypeScript typecheck
- DOCX final layout-boundary checker and 89 boundary tests
- 17 DOCX compatibility tests
- 26 public API tests and built declaration baseline checks
- 2 DOCX package-build tests
- independent specification, performance, and package-boundary adversarial reviews: APPROVE
- full repository: 8,524 passed; two unrelated Node pixel-equality cases fail identically at the merge base under full parallel execution and pass in isolation

Fixes #1405
