### PR TITLE
fix(pptx): make table text selectable

### DIFF
--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -1554,6 +1554,9 @@ export interface PptxTextRunInfo {
     shapeW: number;
     shapeH: number;
     rotation: number;
+    shapeFlipH?: boolean;
+    shapeFlipV?: boolean;
+    tableCellSeparator?: '\t' | '\n';
     textBodyRotation?: number;
     hyperlink?: HyperlinkTarget;
 }

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -193,6 +193,12 @@ export interface PptxTextRunInfo {
   shapeH: number;
   /** Shape rotation in degrees (clockwise). */
   rotation: number;
+  /** Mirror the selection frame horizontally before any text-body rotation. */
+  shapeFlipH?: boolean;
+  /** Mirror the selection frame vertically before any text-body rotation. */
+  shapeFlipV?: boolean;
+  /** Plain-text separator appended after this table cell by the selection layer. */
+  tableCellSeparator?: '\t' | '\n';
   /**
    * Additional rotation from a vertical text body (`vert="vert"` → 90,
    * `vert="vert270"` → -90). The CSS overlay must add this to `rotation`.
@@ -5827,7 +5833,14 @@ export function applyFrameTransform(
   ctx.translate(-(x + w / 2), -(y + h / 2));
 }
 
-export function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: number, slideNumber?: number, rc: RenderContext = { themeMajorFont: null, themeMinorFont: null, dpr: 1 }) {
+export function renderTable(
+  ctx: CanvasRenderingContext2D,
+  el: TableElement,
+  scale: number,
+  slideNumber?: number,
+  rc: RenderContext = { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
+  onTextRun?: TextRunCallback,
+) {
   ctx.save();
   applyFrameTransform(ctx, el, scale);
   const x0 = emuToPx(el.x, scale);
@@ -5930,6 +5943,43 @@ export function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, sca
     for (let ri = 0; ri < el.rows.length; ri++) { rowTop[ri] = y; y += rowHeights[ri]; }
   }
 
+  // The canvas rotates/flips the complete graphic frame around the authored
+  // table centre. The selection overlay groups runs by their cell-sized text
+  // frame, so move each cell centre through that same outer transform and carry
+  // the rotation/flips to the DOM group. Applying the transform around the
+  // moved cell centre is geometrically equivalent to applying it around the
+  // complete table centre, while preserving the cell as the local frame for
+  // vertical text-body rotation.
+  const frameW = emuToPx(el.width, scale);
+  const frameH = emuToPx(el.height, scale);
+  const frameCx = x0 + frameW / 2;
+  const frameCy = y0 + frameH / 2;
+  const rotationRad = (el.rotation * Math.PI) / 180;
+  const rotationCos = Math.cos(rotationRad);
+  const rotationSin = Math.sin(rotationRad);
+  const tableTextRunForCell = (
+    separator: '\t' | '\n',
+  ): TextRunCallback | undefined => onTextRun
+    ? (run) => {
+        let dx = run.shapeX + run.shapeW / 2 - frameCx;
+        let dy = run.shapeY + run.shapeH / 2 - frameCy;
+        if (el.flipH) dx = -dx;
+        if (el.flipV) dy = -dy;
+        const cellCx = frameCx + rotationCos * dx - rotationSin * dy;
+        const cellCy = frameCy + rotationSin * dx + rotationCos * dy;
+        onTextRun({
+          ...run,
+          ...(el.id === undefined ? {} : { shapeId: el.id }),
+          shapeX: cellCx - run.shapeW / 2,
+          shapeY: cellCy - run.shapeH / 2,
+          rotation: el.rotation,
+          ...(el.flipH ? { shapeFlipH: true } : {}),
+          ...(el.flipV ? { shapeFlipV: true } : {}),
+          tableCellSeparator: separator,
+        });
+      }
+    : undefined;
+
   // ECMA-376 border-collapse: paint every cell's fill + text body FIRST, then
   // every cell's borders, so a neighbouring cell's background fill can never
   // overpaint the half of a shared gridline an adjacent cell already drew.
@@ -5977,7 +6027,7 @@ export function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, sca
   }
 
   // Pass 1: fills + text bodies.
-  for (const { cell, colX, rowY, cellW, cellH } of jobs) {
+  for (const { cell, colX, rowY, cellW, cellH, ci, span } of jobs) {
     const fillPaint = resolveShapeFill(
       cell.fill,
       ctx,
@@ -5995,7 +6045,23 @@ export function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, sca
     // (e.g. white header text on an accent fill); a run's explicit colour wins.
     if (cell.textBody) {
       const cellDefaultColor = cell.textColor ? hexToRgba(cell.textColor) : null;
-      renderTextBody(ctx, cell.textBody, colX, rowY, cellW, cellH, scale, cellDefaultColor, 0, false, false, '#000000', slideNumber, rc);
+      renderTextBody(
+        ctx,
+        cell.textBody,
+        colX,
+        rowY,
+        cellW,
+        cellH,
+        scale,
+        cellDefaultColor,
+        0,
+        false,
+        false,
+        '#000000',
+        slideNumber,
+        rc,
+        tableTextRunForCell(ci + span >= numCols ? '\n' : '\t'),
+      );
     }
   }
 
@@ -6598,7 +6664,14 @@ async function renderSlideLeased(
     } else if (el.type === 'picture') {
       await renderPicture(ctx, el, scale, superseded, opts.fetchImage);
     } else if (el.type === 'table') {
-      renderTable(ctx, el, scale, slideNumber, rc);
+      const elementTextRun: TextRunCallback | undefined = onTextRun
+        ? (run) => onTextRun({
+            ...run,
+            elementIndex,
+            origin: slide.elementSources?.[elementIndex]?.origin ?? 'slide',
+          })
+        : undefined;
+      renderTable(ctx, el, scale, slideNumber, rc, elementTextRun);
     } else if (el.type === 'media') {
       await renderMedia(
         ctx,

--- a/packages/pptx/src/table-border-single-draw.test.ts
+++ b/packages/pptx/src/table-border-single-draw.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { Stroke } from '@silurus/ooxml-core';
-import { renderTable } from './renderer.js';
-import type { TableCell, TableElement, TableRow, TextBody } from './types';
+import { renderSlide, renderTable } from './renderer.js';
+import type { Slide, TableCell, TableElement, TableRow, TextBody } from './types';
 
 // DrawingML `<a:tbl>` — end-to-end render: an interior gridline SHARED by two
 // adjacent cells is drawn exactly ONCE (not once per cell), and when the two
@@ -83,6 +83,21 @@ function tableOf(rows: TableCell[][], cols: number[]): TableElement {
   };
 }
 
+function selectableTextBody(text: string): TextBody {
+  return ({
+    verticalAnchor: 'ctr',
+    paragraphs: [{
+      alignment: 'l', marL: 0, marR: 0, indent: 0,
+      spaceBefore: null, spaceAfter: null, spaceLine: null,
+      runs: [{ type: 'text', text, fontSize: 12, fontFamily: 'Arial' }],
+      bullet: { type: 'none' }, eaLnBrk: true,
+    }],
+    defaultFontSize: null, defaultBold: null, defaultItalic: null,
+    lIns: 0, rIns: 0, tIns: 0, bIns: 0,
+    wrap: 'square', vert: 'horz', autoFit: 'none',
+  }) as unknown as TextBody;
+}
+
 // scale=1 ⇒ emuToPx is identity; a 60pt (60*EMU) column ⇒ 60px wide. Two 60pt
 // columns put the shared vertical gridline at x=60. Rows are 20pt ⇒ shared
 // horizontal line at y=20.
@@ -112,6 +127,101 @@ function rgba(hex: string): string {
 }
 
 describe('DrawingML <a:tbl> — shared interior gridline drawn once (spec-silent)', () => {
+  it('emits selectable text runs for table cells in row-major order', () => {
+    const t = tableOf([
+      [cell({ textBody: selectableTextBody('A') }), cell({ textBody: selectableTextBody('B') })],
+    ], [COL, COL]);
+    t.id = '27';
+    t.rows[0].height = 30 * EMU;
+    t.height = 30 * EMU;
+    const { ctx } = makeRecordingCtx();
+    const runs: import('./renderer.js').PptxTextRunInfo[] = [];
+
+    renderTable(
+      ctx,
+      t,
+      SCALE,
+      undefined,
+      { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
+      (run) => runs.push(run),
+    );
+
+    expect(runs.map((run) => run.text)).toEqual(['A', 'B']);
+    expect(runs.map((run) => ({
+      shapeId: run.shapeId,
+      shapeX: run.shapeX,
+      shapeY: run.shapeY,
+      shapeW: run.shapeW,
+      shapeH: run.shapeH,
+      rotation: run.rotation,
+    }))).toEqual([
+      { shapeId: '27', shapeX: 0, shapeY: 0, shapeW: 60, shapeH: 30, rotation: 0 },
+      { shapeId: '27', shapeX: 60, shapeY: 0, shapeW: 60, shapeH: 30, rotation: 0 },
+    ]);
+  });
+
+  it('maps cell selection frames through the table rotation and flip', () => {
+    const t = tableOf([
+      [
+        cell({ textBody: selectableTextBody('A') }),
+        cell({ textBody: selectableTextBody('B') }),
+      ],
+    ], [COL, COL]);
+    t.rotation = 90;
+    t.flipH = true;
+    t.rows[0].height = 30 * EMU;
+    t.height = 30 * EMU;
+    const { ctx } = makeRecordingCtx();
+    const runs: import('./renderer.js').PptxTextRunInfo[] = [];
+
+    renderTable(
+      ctx,
+      t,
+      SCALE,
+      undefined,
+      { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
+      (run) => runs.push(run),
+    );
+
+    expect(runs.map((run) => ({
+      text: run.text,
+      shapeX: run.shapeX,
+      shapeY: run.shapeY,
+      rotation: run.rotation,
+      shapeFlipH: run.shapeFlipH,
+    }))).toEqual([
+      { text: 'A', shapeX: 30, shapeY: 30, rotation: 90, shapeFlipH: true },
+      { text: 'B', shapeX: 30, shapeY: -30, rotation: 90, shapeFlipH: true },
+    ]);
+  });
+
+  it('carries table element identity through the slide render pipeline', async () => {
+    const t = tableOf([[cell({ textBody: selectableTextBody('Selectable') })]], [COL]);
+    t.id = '31';
+    const { ctx } = makeRecordingCtx();
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: () => ctx,
+    } as unknown as OffscreenCanvas;
+    const slide: Slide = {
+      index: 0,
+      slideNumber: 1,
+      background: null,
+      elements: [t],
+      elementSources: [{ origin: 'layout' }],
+    };
+    const runs: import('./renderer.js').PptxTextRunInfo[] = [];
+
+    await renderSlide(canvas, slide, t.width, t.height, { width: 60, dpr: 1 }, (run) => {
+      runs.push(run);
+    });
+
+    expect(runs).not.toHaveLength(0);
+    expect(runs.every((run) =>
+      run.shapeId === '31' && run.elementIndex === 0 && run.origin === 'layout')).toBe(true);
+  });
+
   it('does not grow an authored row from substituted-font design metrics', () => {
     // ECMA-376 §21.1.2.2.5/.11: 120% line spacing is based on the largest
     // authored text size. 16pt * 120% + 3pt after + 2 * 8.5pt insets = 39.2pt,

--- a/packages/pptx/src/text-layer.test.ts
+++ b/packages/pptx/src/text-layer.test.ts
@@ -136,6 +136,25 @@ describe('buildPptxTextLayer (extracted from PptxViewer._buildTextLayer)', () =>
     expect(layer.children.length).toBe(2);
   });
 
+  it('preserves table cell boundaries as tabs and line breaks for native copy', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    buildPptxTextLayer(
+      layer as unknown as HTMLDivElement,
+      [
+        run({ text: 'A', shapeX: 0, tableCellSeparator: '\t' }),
+        run({ text: 'B', shapeX: 100, tableCellSeparator: '\n' }),
+      ],
+      960,
+      540,
+    );
+
+    expect(layer.children.map((group) => group.children.map((child) => child.textContent))).toEqual([
+      ['A', '\t'],
+      ['B', '\n'],
+    ]);
+  });
+
   it('applies a CSS rotate() to a rotated shape (rotation + textBodyRotation)', () => {
     vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
     const layer = makeEl('div');
@@ -147,6 +166,22 @@ describe('buildPptxTextLayer (extracted from PptxViewer._buildTextLayer)', () =>
     // string, so the recording stub records them under their camelCase keys.
     expect(shapeDiv.style.transformOrigin).toBe('center center');
     expect(shapeDiv.style.transform).toBe('rotate(120deg)');
+  });
+
+  it('composes a table-frame flip between its frame and text-body rotations', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    buildPptxTextLayer(
+      layer as unknown as HTMLDivElement,
+      [run({ rotation: 30, textBodyRotation: 90, shapeFlipH: true })],
+      960,
+      540,
+    );
+
+    expect(layer.children[0].style.transformOrigin).toBe('center center');
+    expect(layer.children[0].style.transform).toBe(
+      'rotate(30deg) scale(-1, 1) rotate(90deg)',
+    );
   });
 
   it('does not set a transform for an unrotated shape', () => {

--- a/packages/pptx/src/text-layer.ts
+++ b/packages/pptx/src/text-layer.ts
@@ -60,12 +60,22 @@ export function buildPptxTextLayer(
 
   // Group runs by shape (same shapeX/shapeY/rotation)
   type ShapeKey = string;
-  const shapeMap = new Map<ShapeKey, { div: HTMLDivElement; x: number; y: number; w: number; h: number; rot: number }>();
+  const shapeMap = new Map<ShapeKey, {
+    div: HTMLDivElement;
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    rot: number;
+    tableCellSeparator?: '\t' | '\n';
+  }>();
 
   const ownerDocument = layer.ownerDocument ?? document;
   for (const [runIndex, run] of runs.entries()) {
     const totalRot = run.rotation + (run.textBodyRotation ?? 0);
-    const key = `${run.shapeX},${run.shapeY},${run.shapeW},${run.shapeH},${totalRot}`;
+    const flipH = run.shapeFlipH === true;
+    const flipV = run.shapeFlipV === true;
+    const key = `${run.shapeX},${run.shapeY},${run.shapeW},${run.shapeH},${totalRot},${flipH},${flipV},${run.tableCellSeparator ?? ''}`;
     if (!shapeMap.has(key)) {
       const div = ownerDocument.createElement('div');
       // The shape frame is placed as a % of the slide box so it tracks the
@@ -81,11 +91,26 @@ export function buildPptxTextLayer(
         // not autofit. Match the canvas renderer by keeping those runs selectable;
         // the outer slide text layer still clips anything past the slide edge.
         `pointer-events:all;overflow:visible;`;
-      if (totalRot !== 0) {
+      if (flipH || flipV) {
+        const textBodyRotation = run.textBodyRotation ?? 0;
+        div.style.transformOrigin = 'center center';
+        div.style.transform =
+          `rotate(${run.rotation}deg) ` +
+          `scale(${flipH ? -1 : 1}, ${flipV ? -1 : 1})` +
+          (textBodyRotation === 0 ? '' : ` rotate(${textBodyRotation}deg)`);
+      } else if (totalRot !== 0) {
         div.style.transformOrigin = 'center center';
         div.style.transform = `rotate(${totalRot}deg)`;
       }
-      shapeMap.set(key, { div, x: run.shapeX, y: run.shapeY, w: run.shapeW, h: run.shapeH, rot: totalRot });
+      shapeMap.set(key, {
+        div,
+        x: run.shapeX,
+        y: run.shapeY,
+        w: run.shapeW,
+        h: run.shapeH,
+        rot: totalRot,
+        tableCellSeparator: run.tableCellSeparator,
+      });
       layer.appendChild(div);
     }
 
@@ -127,5 +152,21 @@ export function buildPptxTextLayer(
       });
     }
     shape.div.appendChild(span);
+  }
+
+  // Absolutely positioned cell groups do not contribute whitespace to the
+  // browser's copied plain text. Add an invisible terminal text node per cell
+  // so an ordinary native selection crossing cells serializes in row-major
+  // order with tabs between columns and a line break at the row boundary. This
+  // does not change pointer hit-testing or introduce a cell-range selection
+  // model; partial text selection inside a cell remains browser-native.
+  for (const shape of shapeMap.values()) {
+    if (shape.tableCellSeparator === undefined) continue;
+    const separator = ownerDocument.createElement('span');
+    separator.textContent = shape.tableCellSeparator;
+    separator.style.cssText =
+      'position:absolute;left:100%;top:100%;font:1px sans-serif;line-height:1px;' +
+      'white-space:pre;color:transparent;pointer-events:none;';
+    shape.div.appendChild(separator);
   }
 }


### PR DESCRIPTION
## Summary

- emit PPTX table-cell text runs to the existing native text-selection overlay in both main and worker render modes
- keep selection geometry aligned for rotated, flipped, and vertically oriented table text
- preserve copied cell boundaries as tabs and row boundaries as line breaks

This addresses the narrower table text-selection problem reported in #1408. It does not add XLSX-style cell-range selection or change the existing partial text-selection model.

## Verification

- PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm exec vitest run packages/pptx/src (111 files, 758 tests)
- TypeScript project build
- PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm --filter @silurus/ooxml-pptx build:ci
- git diff --check
- Storybook browser verification against the public PPTX table sample in main and worker modes, including native drag selection and clipboard text