### PR TITLE
fix(pptx): harden table text selection semantics

### DIFF
--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -1556,7 +1556,10 @@ export interface PptxTextRunInfo {
     rotation: number;
     shapeFlipH?: boolean;
     shapeFlipV?: boolean;
-    tableCellSeparator?: '\t' | '\n';
+    tableCell?: Readonly<{
+        row: number;
+        column: number;
+    }>;
     textBodyRotation?: number;
     hyperlink?: HyperlinkTarget;
 }

--- a/packages/pptx/src/find-highlight-layer.test.ts
+++ b/packages/pptx/src/find-highlight-layer.test.ts
@@ -108,6 +108,30 @@ describe('buildPptxHighlightLayer', () => {
     expect(shapeDiv.children[0].style.background).toBe(DEFAULT_FIND_ACTIVE_HIGHLIGHT);
   });
 
+  it('composes frame flips with shape and text-body rotation', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const runs = [run({
+      text: 'abc', rotation: 30, textBodyRotation: 90, shapeFlipH: true,
+    })];
+    const matches: PptxHighlightMatch[] = [
+      { slices: [{ runIndex: 0, start: 0, end: 3 }], active: false },
+    ];
+
+    buildPptxHighlightLayer(
+      layer as unknown as HTMLDivElement,
+      runs,
+      matches,
+      100,
+      100,
+      measureForFont,
+    );
+
+    expect(layer.children[0].style.transform).toBe(
+      'rotate(30deg) scale(-1, 1) rotate(90deg)',
+    );
+  });
+
   it('groups boxes from the same shape under one div', () => {
     vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
     const layer = makeEl('div');

--- a/packages/pptx/src/find-highlight-layer.ts
+++ b/packages/pptx/src/find-highlight-layer.ts
@@ -21,6 +21,7 @@ import {
   type MatchRunSlice,
 } from '@silurus/ooxml-core';
 import type { PptxTextRunInfo } from './renderer';
+import { pptxRunFrameKey, pptxRunFrameTransform } from './run-frame-transform.js';
 
 export interface PptxHighlightMatch {
   slices: MatchRunSlice[];
@@ -73,8 +74,8 @@ export function buildPptxHighlightLayer(
   // scale with it under the shape's rotate().
   const shapeMap = new Map<string, { div: HTMLDivElement; w: number; h: number }>();
   const shapeDiv = (run: PptxTextRunInfo): { div: HTMLDivElement; w: number; h: number } => {
-    const totalRot = run.rotation + (run.textBodyRotation ?? 0);
-    const key = `${run.shapeX},${run.shapeY},${run.shapeW},${run.shapeH},${totalRot}`;
+    const transform = pptxRunFrameTransform(run);
+    const key = pptxRunFrameKey(run, transform);
     let entry = shapeMap.get(key);
     if (!entry) {
       const div = document.createElement('div');
@@ -83,9 +84,9 @@ export function buildPptxHighlightLayer(
         `left:${overlayPercent(run.shapeX, cssWidth)};top:${overlayPercent(run.shapeY, cssHeight)};` +
         `width:${overlayPercent(run.shapeW, cssWidth)};height:${overlayPercent(run.shapeH, cssHeight)};` +
         `pointer-events:none;overflow:hidden;`;
-      if (totalRot !== 0) {
+      if (transform) {
         div.style.transformOrigin = 'center center';
-        div.style.transform = `rotate(${totalRot}deg)`;
+        div.style.transform = transform;
       }
       entry = { div, w: run.shapeW, h: run.shapeH };
       shapeMap.set(key, entry);

--- a/packages/pptx/src/find.test.ts
+++ b/packages/pptx/src/find.test.ts
@@ -7,7 +7,7 @@ import type { PptxTextRunInfo } from './renderer';
  * slide's runs, matches across run boundaries, aggregates in document order
  * tagged `{ slide }`, and cycles the active match across slides.
  */
-function run(text: string): PptxTextRunInfo {
+function run(text: string, overrides: Partial<PptxTextRunInfo> = {}): PptxTextRunInfo {
   return {
     text,
     inShapeX: 0,
@@ -21,6 +21,7 @@ function run(text: string): PptxTextRunInfo {
     shapeW: 100,
     shapeH: 20,
     rotation: 0,
+    ...overrides,
   };
 }
 
@@ -45,6 +46,20 @@ describe('PptxFindController.find', () => {
     const matches = await c.find('Hello');
     expect(matches).toHaveLength(1);
     expect(matches[0].text).toBe('Hello');
+  });
+
+  it('matches across runs in one table cell but never across cell boundaries', async () => {
+    const sameCell = await controllerFor([[
+      run('Hel', { elementIndex: 0, tableCell: { row: 0, column: 0 } }),
+      run('lo', { elementIndex: 0, tableCell: { row: 0, column: 0 } }),
+    ]]).find('Hello');
+    expect(sameCell).toHaveLength(1);
+
+    const adjacentCells = await controllerFor([[
+      run('foo', { elementIndex: 0, tableCell: { row: 0, column: 0 } }),
+      run('bar', { elementIndex: 0, tableCell: { row: 0, column: 1 } }),
+    ]]).find('foobar');
+    expect(adjacentCells).toEqual([]);
   });
 
   it('is case-insensitive by default; caseSensitive honored', async () => {

--- a/packages/pptx/src/find.ts
+++ b/packages/pptx/src/find.ts
@@ -33,6 +33,36 @@ interface PptxResolvedMatch {
   slices: TextMatch['slices'];
 }
 
+function sameSearchContainer(left: PptxTextRunInfo, right: PptxTextRunInfo): boolean {
+  const leftCell = left.tableCell;
+  const rightCell = right.tableCell;
+  if (!leftCell && !rightCell) return true;
+  if (!leftCell || !rightCell) return false;
+  return left.elementIndex === right.elementIndex &&
+    left.origin === right.origin &&
+    left.shapeId === right.shapeId &&
+    leftCell.row === rightCell.row &&
+    leftCell.column === rightCell.column;
+}
+
+/**
+ * The shared core index joins adjacent drawing runs, which is correct within a
+ * text body. Table cells are separate text containers, so reject only matches
+ * whose run slices cross such a boundary. Keeping one slide-wide index avoids
+ * per-cell indices and preserves the existing linear scan and run offsets.
+ */
+function matchStaysWithinSearchContainer(
+  runs: PptxTextRunInfo[],
+  slices: TextMatch['slices'],
+): boolean {
+  for (let index = 1; index < slices.length; index++) {
+    const left = runs[slices[index - 1].runIndex];
+    const right = runs[slices[index].runIndex];
+    if (!left || !right || !sameSearchContainer(left, right)) return false;
+  }
+  return true;
+}
+
 export class PptxFindController {
   private _slideRuns = new Map<number, PptxTextRunInfo[]>();
   private _matches: PptxResolvedMatch[] = [];
@@ -136,8 +166,9 @@ export class PptxFindController {
       const runs = committedRuns.get(slide) ?? [];
       const index = buildTextIndex(runs);
       for (const tm of findMatches(index, query, opts)) {
+        if (!matchStaysWithinSearchContainer(runs, tm.slices)) continue;
         const text = tm.slices
-          .map((s) => runs[s.runIndex].text.slice(s.start, s.end))
+          .map((slice) => runs[slice.runIndex].text.slice(slice.start, slice.end))
           .join('');
         matches.push({ slide, text, slices: tm.slices });
       }

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -197,8 +197,12 @@ export interface PptxTextRunInfo {
   shapeFlipH?: boolean;
   /** Mirror the selection frame vertically before any text-body rotation. */
   shapeFlipV?: boolean;
-  /** Plain-text separator appended after this table cell by the selection layer. */
-  tableCellSeparator?: '\t' | '\n';
+  /**
+   * Zero-based logical grid address when this run belongs to a DrawingML table cell.
+   * This is semantic identity only; consumers decide how cell boundaries affect
+   * selection, search, or serialization.
+   */
+  tableCell?: Readonly<{ row: number; column: number }>;
   /**
    * Additional rotation from a vertical text body (`vert="vert"` → 90,
    * `vert="vert270"` → -90). The CSS overlay must add this to `rotation`.
@@ -5943,42 +5947,44 @@ export function renderTable(
     for (let ri = 0; ri < el.rows.length; ri++) { rowTop[ri] = y; y += rowHeights[ri]; }
   }
 
-  // The canvas rotates/flips the complete graphic frame around the authored
-  // table centre. The selection overlay groups runs by their cell-sized text
-  // frame, so move each cell centre through that same outer transform and carry
-  // the rotation/flips to the DOM group. Applying the transform around the
-  // moved cell centre is geometrically equivalent to applying it around the
-  // complete table centre, while preserving the cell as the local frame for
-  // vertical text-body rotation.
-  const frameW = emuToPx(el.width, scale);
-  const frameH = emuToPx(el.height, scale);
-  const frameCx = x0 + frameW / 2;
-  const frameCy = y0 + frameH / 2;
-  const rotationRad = (el.rotation * Math.PI) / 180;
-  const rotationCos = Math.cos(rotationRad);
-  const rotationSin = Math.sin(rotationRad);
-  const tableTextRunForCell = (
-    separator: '\t' | '\n',
-  ): TextRunCallback | undefined => onTextRun
-    ? (run) => {
-        let dx = run.shapeX + run.shapeW / 2 - frameCx;
-        let dy = run.shapeY + run.shapeH / 2 - frameCy;
-        if (el.flipH) dx = -dx;
-        if (el.flipV) dy = -dy;
-        const cellCx = frameCx + rotationCos * dx - rotationSin * dy;
-        const cellCy = frameCy + rotationSin * dx + rotationCos * dy;
-        onTextRun({
-          ...run,
-          ...(el.id === undefined ? {} : { shapeId: el.id }),
-          shapeX: cellCx - run.shapeW / 2,
-          shapeY: cellCy - run.shapeH / 2,
-          rotation: el.rotation,
-          ...(el.flipH ? { shapeFlipH: true } : {}),
-          ...(el.flipV ? { shapeFlipV: true } : {}),
-          tableCellSeparator: separator,
-        });
-      }
-    : undefined;
+  // Text-run geometry is needed only by selection/find consumers. Ordinary
+  // paint-only renders avoid frame trigonometry. A single callback reads the
+  // current synchronous cell state, avoiding one closure allocation per cell.
+  let tableTextRun: TextRunCallback | undefined;
+  let textRunCell: Readonly<{ row: number; column: number }> = { row: 0, column: 0 };
+  if (onTextRun) {
+    // The canvas rotates/flips the complete graphic frame around the authored
+    // table centre. The overlays group runs by their cell-sized text frame, so
+    // move each cell centre through that same outer transform and carry the
+    // rotation/flips to the DOM group. Applying the transform around the moved
+    // cell centre is geometrically equivalent to applying it around the table
+    // centre while preserving the local frame for vertical-text rotation.
+    const frameW = emuToPx(el.width, scale);
+    const frameH = emuToPx(el.height, scale);
+    const frameCx = x0 + frameW / 2;
+    const frameCy = y0 + frameH / 2;
+    const rotationRad = (el.rotation * Math.PI) / 180;
+    const rotationCos = Math.cos(rotationRad);
+    const rotationSin = Math.sin(rotationRad);
+    tableTextRun = (run) => {
+      let dx = run.shapeX + run.shapeW / 2 - frameCx;
+      let dy = run.shapeY + run.shapeH / 2 - frameCy;
+      if (el.flipH) dx = -dx;
+      if (el.flipV) dy = -dy;
+      const cellCx = frameCx + rotationCos * dx - rotationSin * dy;
+      const cellCy = frameCy + rotationSin * dx + rotationCos * dy;
+      onTextRun({
+        ...run,
+        ...(el.id === undefined ? {} : { shapeId: el.id }),
+        shapeX: cellCx - run.shapeW / 2,
+        shapeY: cellCy - run.shapeH / 2,
+        rotation: el.rotation,
+        ...(el.flipH ? { shapeFlipH: true } : {}),
+        ...(el.flipV ? { shapeFlipV: true } : {}),
+        tableCell: textRunCell,
+      });
+    };
+  }
 
   // ECMA-376 border-collapse: paint every cell's fill + text body FIRST, then
   // every cell's borders, so a neighbouring cell's background fill can never
@@ -6027,7 +6033,7 @@ export function renderTable(
   }
 
   // Pass 1: fills + text bodies.
-  for (const { cell, colX, rowY, cellW, cellH, ci, span } of jobs) {
+  for (const { cell, colX, rowY, cellW, cellH, ci, ri } of jobs) {
     const fillPaint = resolveShapeFill(
       cell.fill,
       ctx,
@@ -6043,7 +6049,13 @@ export function renderTable(
     }
     // Text body — default run colour comes from the table style's tcTxStyle
     // (e.g. white header text on an accent fill); a run's explicit colour wins.
+    // ECMA-376 Part 1 DrawingML CT_TableCell permits txBody to be absent. Empty
+    // cells therefore emit no fabricated text run; the logical address on real
+    // runs is enough for consumers to stop search matches at cell boundaries.
     if (cell.textBody) {
+      if (tableTextRun) {
+        textRunCell = { row: ri, column: ci };
+      }
       const cellDefaultColor = cell.textColor ? hexToRgba(cell.textColor) : null;
       renderTextBody(
         ctx,
@@ -6060,7 +6072,7 @@ export function renderTable(
         '#000000',
         slideNumber,
         rc,
-        tableTextRunForCell(ci + span >= numCols ? '\n' : '\t'),
+        tableTextRun,
       );
     }
   }

--- a/packages/pptx/src/run-frame-transform.ts
+++ b/packages/pptx/src/run-frame-transform.ts
@@ -1,0 +1,28 @@
+import type { PptxTextRunInfo } from './renderer.js';
+
+/**
+ * CSS transform for a PPTX run's local frame. ECMA-376 Part 1 DrawingML
+ * `CT_Transform2D` defines the graphic-frame `rot`, `flipH`, and `flipV` values;
+ * those outer transforms precede the text body's vertical-text rotation, so the
+ * order cannot be reduced to one summed rotation when a flip exists. Kept in
+ * the PPTX package because this is PresentationML/DrawingML frame geometry, not
+ * a format-independent canvas primitive.
+ */
+export function pptxRunFrameTransform(run: PptxTextRunInfo): string {
+  const textBodyRotation = run.textBodyRotation ?? 0;
+  const flipH = run.shapeFlipH === true;
+  const flipV = run.shapeFlipV === true;
+  if (flipH || flipV) {
+    return `rotate(${run.rotation}deg) ` +
+      `scale(${flipH ? -1 : 1}, ${flipV ? -1 : 1})` +
+      (textBodyRotation === 0 ? '' : ` rotate(${textBodyRotation}deg)`);
+  }
+  const totalRotation = run.rotation + textBodyRotation;
+  return totalRotation === 0 ? '' : `rotate(${totalRotation}deg)`;
+}
+
+/** Stable grouping key shared by selection and find-highlight overlays. */
+export function pptxRunFrameKey(run: PptxTextRunInfo, transform: string): string {
+  return `${run.shapeX},${run.shapeY},${run.shapeW},${run.shapeH},` +
+    transform;
+}

--- a/packages/pptx/src/table-border-single-draw.test.ts
+++ b/packages/pptx/src/table-border-single-draw.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { Stroke } from '@silurus/ooxml-core';
-import { renderSlide, renderTable } from './renderer.js';
-import type { Slide, TableCell, TableElement, TableRow, TextBody } from './types';
+import { renderTable } from './renderer.js';
+import type { TableCell, TableElement, TableRow, TextBody } from './types';
 
 // DrawingML `<a:tbl>` — end-to-end render: an interior gridline SHARED by two
 // adjacent cells is drawn exactly ONCE (not once per cell), and when the two
@@ -83,21 +83,6 @@ function tableOf(rows: TableCell[][], cols: number[]): TableElement {
   };
 }
 
-function selectableTextBody(text: string): TextBody {
-  return ({
-    verticalAnchor: 'ctr',
-    paragraphs: [{
-      alignment: 'l', marL: 0, marR: 0, indent: 0,
-      spaceBefore: null, spaceAfter: null, spaceLine: null,
-      runs: [{ type: 'text', text, fontSize: 12, fontFamily: 'Arial' }],
-      bullet: { type: 'none' }, eaLnBrk: true,
-    }],
-    defaultFontSize: null, defaultBold: null, defaultItalic: null,
-    lIns: 0, rIns: 0, tIns: 0, bIns: 0,
-    wrap: 'square', vert: 'horz', autoFit: 'none',
-  }) as unknown as TextBody;
-}
-
 // scale=1 ⇒ emuToPx is identity; a 60pt (60*EMU) column ⇒ 60px wide. Two 60pt
 // columns put the shared vertical gridline at x=60. Rows are 20pt ⇒ shared
 // horizontal line at y=20.
@@ -127,101 +112,6 @@ function rgba(hex: string): string {
 }
 
 describe('DrawingML <a:tbl> — shared interior gridline drawn once (spec-silent)', () => {
-  it('emits selectable text runs for table cells in row-major order', () => {
-    const t = tableOf([
-      [cell({ textBody: selectableTextBody('A') }), cell({ textBody: selectableTextBody('B') })],
-    ], [COL, COL]);
-    t.id = '27';
-    t.rows[0].height = 30 * EMU;
-    t.height = 30 * EMU;
-    const { ctx } = makeRecordingCtx();
-    const runs: import('./renderer.js').PptxTextRunInfo[] = [];
-
-    renderTable(
-      ctx,
-      t,
-      SCALE,
-      undefined,
-      { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
-      (run) => runs.push(run),
-    );
-
-    expect(runs.map((run) => run.text)).toEqual(['A', 'B']);
-    expect(runs.map((run) => ({
-      shapeId: run.shapeId,
-      shapeX: run.shapeX,
-      shapeY: run.shapeY,
-      shapeW: run.shapeW,
-      shapeH: run.shapeH,
-      rotation: run.rotation,
-    }))).toEqual([
-      { shapeId: '27', shapeX: 0, shapeY: 0, shapeW: 60, shapeH: 30, rotation: 0 },
-      { shapeId: '27', shapeX: 60, shapeY: 0, shapeW: 60, shapeH: 30, rotation: 0 },
-    ]);
-  });
-
-  it('maps cell selection frames through the table rotation and flip', () => {
-    const t = tableOf([
-      [
-        cell({ textBody: selectableTextBody('A') }),
-        cell({ textBody: selectableTextBody('B') }),
-      ],
-    ], [COL, COL]);
-    t.rotation = 90;
-    t.flipH = true;
-    t.rows[0].height = 30 * EMU;
-    t.height = 30 * EMU;
-    const { ctx } = makeRecordingCtx();
-    const runs: import('./renderer.js').PptxTextRunInfo[] = [];
-
-    renderTable(
-      ctx,
-      t,
-      SCALE,
-      undefined,
-      { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
-      (run) => runs.push(run),
-    );
-
-    expect(runs.map((run) => ({
-      text: run.text,
-      shapeX: run.shapeX,
-      shapeY: run.shapeY,
-      rotation: run.rotation,
-      shapeFlipH: run.shapeFlipH,
-    }))).toEqual([
-      { text: 'A', shapeX: 30, shapeY: 30, rotation: 90, shapeFlipH: true },
-      { text: 'B', shapeX: 30, shapeY: -30, rotation: 90, shapeFlipH: true },
-    ]);
-  });
-
-  it('carries table element identity through the slide render pipeline', async () => {
-    const t = tableOf([[cell({ textBody: selectableTextBody('Selectable') })]], [COL]);
-    t.id = '31';
-    const { ctx } = makeRecordingCtx();
-    const canvas = {
-      width: 0,
-      height: 0,
-      getContext: () => ctx,
-    } as unknown as OffscreenCanvas;
-    const slide: Slide = {
-      index: 0,
-      slideNumber: 1,
-      background: null,
-      elements: [t],
-      elementSources: [{ origin: 'layout' }],
-    };
-    const runs: import('./renderer.js').PptxTextRunInfo[] = [];
-
-    await renderSlide(canvas, slide, t.width, t.height, { width: 60, dpr: 1 }, (run) => {
-      runs.push(run);
-    });
-
-    expect(runs).not.toHaveLength(0);
-    expect(runs.every((run) =>
-      run.shapeId === '31' && run.elementIndex === 0 && run.origin === 'layout')).toBe(true);
-  });
-
   it('does not grow an authored row from substituted-font design metrics', () => {
     // ECMA-376 §21.1.2.2.5/.11: 120% line spacing is based on the largest
     // authored text size. 16pt * 120% + 3pt after + 2 * 8.5pt insets = 39.2pt,

--- a/packages/pptx/src/table-text-selection.test.ts
+++ b/packages/pptx/src/table-text-selection.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderSlide, renderTable, type PptxTextRunInfo } from './renderer.js';
+import type { Slide, TableCell, TableElement, TableRow, TextBody } from './types.js';
+
+const EMU = 12_700;
+const SCALE = 1 / EMU;
+const COL = 60 * EMU;
+const renderContext = { themeMajorFont: null, themeMinorFont: null, dpr: 1 } as const;
+
+afterEach(() => vi.restoreAllMocks());
+
+function recordingContext(): CanvasRenderingContext2D {
+  const ctx = {
+    canvas: { width: 1000, height: 1000 },
+    lineWidth: 1,
+    strokeStyle: '#000000',
+    fillStyle: '#000000',
+    lineCap: 'butt' as CanvasLineCap,
+    lineJoin: 'miter' as CanvasLineJoin,
+    globalAlpha: 1,
+    save() {}, restore() {},
+    beginPath() {}, closePath() {}, moveTo() {}, lineTo() {}, stroke() {},
+    fill() {}, fillRect() {}, strokeRect() {}, clearRect() {}, clip() {}, rect() {},
+    scale() {}, translate() {}, rotate() {}, setTransform() {}, transform() {}, resetTransform() {},
+    setLineDash() {}, getLineDash() { return []; },
+    drawImage() {}, arc() {}, arcTo() {}, ellipse() {},
+    quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    createPattern() { return null; },
+    measureText: () => ({
+      width: 0,
+      fontBoundingBoxAscent: 8,
+      fontBoundingBoxDescent: 2,
+      actualBoundingBoxAscent: 8,
+      actualBoundingBoxDescent: 2,
+    } as TextMetrics),
+    fillText() {}, strokeText() {},
+    font: '10px sans-serif',
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+    direction: 'ltr' as CanvasDirection,
+    letterSpacing: '0px',
+    globalCompositeOperation: 'source-over' as GlobalCompositeOperation,
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+function cell(overrides: Partial<TableCell> = {}): TableCell {
+  return {
+    textBody: null, fill: null,
+    borderL: null, borderR: null, borderT: null, borderB: null,
+    diagonalTL: null, diagonalTR: null,
+    gridSpan: 1, rowSpan: 1, hMerge: false, vMerge: false,
+    ...overrides,
+  } as TableCell;
+}
+
+function tableOf(rows: TableCell[][], cols: number[]): TableElement {
+  const rowHeight = 20 * EMU;
+  const tableRows: TableRow[] = rows.map((cells) => ({ height: rowHeight, cells }));
+  return {
+    type: 'table', x: 0, y: 0,
+    width: cols.reduce((sum, width) => sum + width, 0),
+    height: rowHeight * rows.length,
+    rotation: 0, flipH: false, flipV: false,
+    cols, rows: tableRows,
+  };
+}
+
+function textBody(text: string): TextBody {
+  return ({
+    verticalAnchor: 'ctr',
+    paragraphs: [{
+      alignment: 'l', marL: 0, marR: 0, indent: 0,
+      spaceBefore: null, spaceAfter: null, spaceLine: null,
+      runs: [{ type: 'text', text, fontSize: 12, fontFamily: 'Arial' }],
+      bullet: { type: 'none' }, eaLnBrk: true,
+    }],
+    defaultFontSize: null, defaultBold: null, defaultItalic: null,
+    lIns: 0, rIns: 0, tIns: 0, bIns: 0,
+    wrap: 'square', vert: 'horz', autoFit: 'none',
+  }) as unknown as TextBody;
+}
+
+function collectRuns(table: TableElement): PptxTextRunInfo[] {
+  const runs: PptxTextRunInfo[] = [];
+  renderTable(
+    recordingContext(),
+    table,
+    SCALE,
+    undefined,
+    renderContext,
+    (run) => runs.push(run),
+  );
+  return runs;
+}
+
+describe('DrawingML table text selection runs', () => {
+  it('emits table cell identity and geometry in row-major order', () => {
+    const table = tableOf([[
+      cell({ textBody: textBody('A') }),
+      cell({ textBody: textBody('B') }),
+    ]], [COL, COL]);
+    table.id = '27';
+    table.rows[0].height = 30 * EMU;
+    table.height = 30 * EMU;
+
+    const runs = collectRuns(table);
+
+    expect(runs.map((run) => ({
+      text: run.text,
+      shapeId: run.shapeId,
+      tableCell: run.tableCell,
+      shapeX: run.shapeX,
+      shapeY: run.shapeY,
+      shapeW: run.shapeW,
+      shapeH: run.shapeH,
+      rotation: run.rotation,
+    }))).toEqual([
+      {
+        text: 'A', shapeId: '27', tableCell: { row: 0, column: 0 },
+        shapeX: 0, shapeY: 0, shapeW: 60, shapeH: 30, rotation: 0,
+      },
+      {
+        text: 'B', shapeId: '27', tableCell: { row: 0, column: 1 },
+        shapeX: 60, shapeY: 0, shapeW: 60, shapeH: 30, rotation: 0,
+      },
+    ]);
+  });
+
+  it('keeps empty cells as semantic gaps instead of fabricating selectable text', () => {
+    const table = tableOf([[
+      cell({ textBody: textBody('A') }),
+      cell({ textBody: null }),
+      cell({ textBody: textBody('C') }),
+    ]], [COL, COL, COL]);
+
+    expect(collectRuns(table).map((run) => ({
+      text: run.text,
+      tableCell: run.tableCell,
+    }))).toEqual([
+      { text: 'A', tableCell: { row: 0, column: 0 } },
+      { text: 'C', tableCell: { row: 0, column: 2 } },
+    ]);
+  });
+
+  it('skips selection transform math when no text-run callback is requested', () => {
+    const table = tableOf([[cell({ textBody: textBody('A') })]], [COL]);
+    const cos = vi.spyOn(Math, 'cos');
+    const sin = vi.spyOn(Math, 'sin');
+
+    renderTable(recordingContext(), table, SCALE, undefined, renderContext);
+
+    expect(cos).not.toHaveBeenCalled();
+    expect(sin).not.toHaveBeenCalled();
+  });
+
+  it('maps cell frames through table rotation and horizontal flip', () => {
+    const table = tableOf([[
+      cell({ textBody: textBody('A') }),
+      cell({ textBody: textBody('B') }),
+    ]], [COL, COL]);
+    table.rotation = 90;
+    table.flipH = true;
+    table.rows[0].height = 30 * EMU;
+    table.height = 30 * EMU;
+
+    expect(collectRuns(table).map((run) => ({
+      text: run.text,
+      shapeX: run.shapeX,
+      shapeY: run.shapeY,
+      rotation: run.rotation,
+      shapeFlipH: run.shapeFlipH,
+    }))).toEqual([
+      { text: 'A', shapeX: 30, shapeY: 30, rotation: 90, shapeFlipH: true },
+      { text: 'B', shapeX: 30, shapeY: -30, rotation: 90, shapeFlipH: true },
+    ]);
+  });
+
+  it('maps cell frames through a vertical table flip', () => {
+    const table = tableOf([
+      [cell({ textBody: textBody('Top') })],
+      [cell({ textBody: textBody('Bottom') })],
+    ], [COL]);
+    table.flipV = true;
+
+    expect(collectRuns(table).map((run) => ({
+      text: run.text,
+      shapeY: run.shapeY,
+      shapeFlipV: run.shapeFlipV,
+      tableCell: run.tableCell,
+    }))).toEqual([
+      { text: 'Top', shapeY: 20, shapeFlipV: true, tableCell: { row: 0, column: 0 } },
+      { text: 'Bottom', shapeY: 0, shapeFlipV: true, tableCell: { row: 1, column: 0 } },
+    ]);
+  });
+
+  it('maps cell frames through an arbitrary authored rotation', () => {
+    const table = tableOf([[
+      cell({ textBody: textBody('A') }),
+      cell({ textBody: textBody('B') }),
+    ]], [COL, COL]);
+    table.rotation = 30;
+    table.rows[0].height = 30 * EMU;
+    table.height = 30 * EMU;
+
+    const runs = collectRuns(table);
+
+    // Cell centres are ±30px from the table centre. Applying the authored 30°
+    // frame rotation gives offsets ±(30*cos(30°), 30*sin(30°)).
+    expect(runs[0].shapeX).toBeCloseTo(4.0192, 4);
+    expect(runs[0].shapeY).toBeCloseTo(-15, 4);
+    expect(runs[1].shapeX).toBeCloseTo(55.9808, 4);
+    expect(runs[1].shapeY).toBeCloseTo(15, 4);
+    expect(runs.map((run) => run.rotation)).toEqual([30, 30]);
+  });
+
+  it('carries table element identity through the slide render pipeline', async () => {
+    const table = tableOf([[cell({ textBody: textBody('Selectable') })]], [COL]);
+    table.id = '31';
+    const context = recordingContext();
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: () => context,
+    } as unknown as OffscreenCanvas;
+    const slide: Slide = {
+      index: 0,
+      slideNumber: 1,
+      background: null,
+      elements: [table],
+      elementSources: [{ origin: 'layout' }],
+    };
+    const runs: PptxTextRunInfo[] = [];
+
+    await renderSlide(canvas, slide, table.width, table.height, { width: 60, dpr: 1 }, (run) => {
+      runs.push(run);
+    });
+
+    expect(runs).not.toHaveLength(0);
+    expect(runs.every((run) =>
+      run.shapeId === '31' && run.elementIndex === 0 && run.origin === 'layout')).toBe(true);
+  });
+});

--- a/packages/pptx/src/text-layer.test.ts
+++ b/packages/pptx/src/text-layer.test.ts
@@ -136,22 +136,18 @@ describe('buildPptxTextLayer (extracted from PptxViewer._buildTextLayer)', () =>
     expect(layer.children.length).toBe(2);
   });
 
-  it('preserves table cell boundaries as tabs and line breaks for native copy', () => {
+  it('keeps native copy content limited to rendered text runs', () => {
     vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
     const layer = makeEl('div');
     buildPptxTextLayer(
       layer as unknown as HTMLDivElement,
-      [
-        run({ text: 'A', shapeX: 0, tableCellSeparator: '\t' }),
-        run({ text: 'B', shapeX: 100, tableCellSeparator: '\n' }),
-      ],
+      [run({ text: 'A', shapeX: 0, tableCell: { row: 0, column: 0 } })],
       960,
       540,
     );
 
     expect(layer.children.map((group) => group.children.map((child) => child.textContent))).toEqual([
-      ['A', '\t'],
-      ['B', '\n'],
+      ['A'],
     ]);
   });
 

--- a/packages/pptx/src/text-layer.ts
+++ b/packages/pptx/src/text-layer.ts
@@ -1,5 +1,6 @@
 import { overlayPercent, type HyperlinkTarget } from '@silurus/ooxml-core';
 import type { PptxTextRunInfo } from './renderer';
+import { pptxRunFrameKey, pptxRunFrameTransform } from './run-frame-transform.js';
 
 function setSelectionData(element: HTMLElement, key: string, value?: string): void {
   if (element.dataset) {
@@ -59,24 +60,14 @@ export function buildPptxTextLayer(
   setSelectionData(layer, 'slideIndex', slideIndex === undefined ? undefined : String(slideIndex));
 
   // Group runs by shape (same shapeX/shapeY/rotation)
-  type ShapeKey = string;
-  const shapeMap = new Map<ShapeKey, {
-    div: HTMLDivElement;
-    x: number;
-    y: number;
-    w: number;
-    h: number;
-    rot: number;
-    tableCellSeparator?: '\t' | '\n';
-  }>();
+  const shapeMap = new Map<string, { div: HTMLDivElement; w: number; h: number }>();
 
   const ownerDocument = layer.ownerDocument ?? document;
   for (const [runIndex, run] of runs.entries()) {
-    const totalRot = run.rotation + (run.textBodyRotation ?? 0);
-    const flipH = run.shapeFlipH === true;
-    const flipV = run.shapeFlipV === true;
-    const key = `${run.shapeX},${run.shapeY},${run.shapeW},${run.shapeH},${totalRot},${flipH},${flipV},${run.tableCellSeparator ?? ''}`;
-    if (!shapeMap.has(key)) {
+    const transform = pptxRunFrameTransform(run);
+    const key = pptxRunFrameKey(run, transform);
+    let shape = shapeMap.get(key);
+    if (!shape) {
       const div = ownerDocument.createElement('div');
       // The shape frame is placed as a % of the slide box so it tracks the
       // canvas's actual rendered size; its width/height are % too, so the child
@@ -91,30 +82,15 @@ export function buildPptxTextLayer(
         // not autofit. Match the canvas renderer by keeping those runs selectable;
         // the outer slide text layer still clips anything past the slide edge.
         `pointer-events:all;overflow:visible;`;
-      if (flipH || flipV) {
-        const textBodyRotation = run.textBodyRotation ?? 0;
+      if (transform) {
         div.style.transformOrigin = 'center center';
-        div.style.transform =
-          `rotate(${run.rotation}deg) ` +
-          `scale(${flipH ? -1 : 1}, ${flipV ? -1 : 1})` +
-          (textBodyRotation === 0 ? '' : ` rotate(${textBodyRotation}deg)`);
-      } else if (totalRot !== 0) {
-        div.style.transformOrigin = 'center center';
-        div.style.transform = `rotate(${totalRot}deg)`;
+        div.style.transform = transform;
       }
-      shapeMap.set(key, {
-        div,
-        x: run.shapeX,
-        y: run.shapeY,
-        w: run.shapeW,
-        h: run.shapeH,
-        rot: totalRot,
-        tableCellSeparator: run.tableCellSeparator,
-      });
+      shape = { div, w: run.shapeW, h: run.shapeH };
+      shapeMap.set(key, shape);
       layer.appendChild(div);
     }
 
-    const shape = shapeMap.get(key)!;
     const span = ownerDocument.createElement('span');
     setSelectionData(span, 'ooxmlSelectionRun', 'pptx');
     setSelectionData(span, 'runIndex', String(runIndex));
@@ -152,21 +128,5 @@ export function buildPptxTextLayer(
       });
     }
     shape.div.appendChild(span);
-  }
-
-  // Absolutely positioned cell groups do not contribute whitespace to the
-  // browser's copied plain text. Add an invisible terminal text node per cell
-  // so an ordinary native selection crossing cells serializes in row-major
-  // order with tabs between columns and a line break at the row boundary. This
-  // does not change pointer hit-testing or introduce a cell-range selection
-  // model; partial text selection inside a cell remains browser-native.
-  for (const shape of shapeMap.values()) {
-    if (shape.tableCellSeparator === undefined) continue;
-    const separator = ownerDocument.createElement('span');
-    separator.textContent = shape.tableCellSeparator;
-    separator.style.cssText =
-      'position:absolute;left:100%;top:100%;font:1px sans-serif;line-height:1px;' +
-      'white-space:pre;color:transparent;pointer-events:none;';
-    shape.div.appendChild(separator);
   }
 }

--- a/tests/smoke/layouts.spec.ts
+++ b/tests/smoke/layouts.spec.ts
@@ -118,6 +118,35 @@ test.describe('Layouts smoke — pptx', () => {
     expect(await canvasHasInk(page, EXPECTED.pptx - 1)).toBe(true);
   });
 
+  test('ScrollView exposes table runs to native browser selection', async ({ page }) => {
+    await openStory(page, 'pptxviewer-examples--scroll-view');
+    await waitForLoaded(page, new RegExp(`Loaded ${EXPECTED.pptx} slides`));
+
+    const selected = await page.evaluate(() => {
+      const runs = [...document.querySelectorAll<HTMLElement>(
+        '[data-ooxml-selection-run="pptx"]',
+      )];
+      const start = runs.find((run) => run.textContent === 'Taxon');
+      const surface = start?.parentElement?.parentElement;
+      const end = surface
+        ? [...surface.querySelectorAll<HTMLElement>('[data-ooxml-selection-run="pptx"]')]
+            .find((run) => run.textContent === 'Birds')
+        : undefined;
+      if (!start?.firstChild || !end?.firstChild) return null;
+      const range = document.createRange();
+      range.setStart(start.firstChild, 2);
+      range.setEnd(end.firstChild, 3);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      return selection?.toString() ?? null;
+    });
+
+    expect(selected).not.toBeNull();
+    expect(selected).toMatch(/^xon/);
+    expect(selected).toMatch(/Bir$/);
+  });
+
   test('ThumbnailGrid renders every slide', async ({ page }) => {
     await openStory(page, 'pptxviewer-examples--thumbnail-grid');
     await waitForLoaded(page, new RegExp(`Loaded ${EXPECTED.pptx} slides`));


### PR DESCRIPTION
## Summary

- remove the synthetic tab/newline spans from PPTX table selection overlays and keep copying browser-native
- attach zero-based logical cell coordinates to table text runs so find matches cannot cross cell boundaries, including empty-cell gaps
- share DrawingML frame transforms between selection and find highlights, and avoid selection transform work in paint-only renders
- move table-selection coverage out of the border test and add a three-engine partial-selection smoke test

## Specification and scope

ECMA-376 Part 1 DrawingML CT_TableCell permits txBody to be absent, so empty cells do not fabricate text runs. OOXML does not define browser clipboard serialization; this follow-up intentionally makes no PowerPoint-specific TSV claim and preserves ordinary native text selection.

Follow-up to #1409 and #1408.

## Verification

- Full PPTX Vitest suite: 112 files, 764 tests
- TypeScript project build
- Root package build
- DOCX/XLSX/PPTX public API and viewer symmetry checks
- Partial PPTX table selection in Chrome, Firefox, and WebKit
- PPTX main/worker selection, find, highlight, and zoom equivalence