### PR TITLE
chore(release): 0.83.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ the corresponding minor release.
 
 ## Unreleased
 
+## 0.83.2 — 2026-09-01
+
+Compatible patch release improving zoom controls and Word compatibility, with
+no integration changes.
+
+- **consistent zoom steps:** Ctrl/Command + mouse-wheel zoom now advances by
+  the same percentage steps as the viewer controls across Word, Excel and
+  PowerPoint, including the VS Code extension.
+- **Word legacy layout:** retain positioned VML content, its authored wrapping,
+  and field-result formatting more faithfully so older Word documents keep
+  their intended page composition.
+- **compatibility:** no option, method or existing default is removed or
+  renamed. No application migration is required from 0.83.1.
+
 ## 0.83.1 — 2026-08-30
 
 Compatible patch release adding native text selection inside PowerPoint tables

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.83.1"
+version = "0.83.2"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/README.md
+++ b/README.md
@@ -676,6 +676,7 @@ file without uploading it.
 | | SVG images (`asvg:svgBlip` MS-2016 extension — vector drawn from the embedded `.svg`, raster fallback) | ✅ |
 | | Text boxes / drawing shapes (inline and anchored `wps:wsp` / `wps:txbx`, including solid, gradient, and image fills; `a:prstGeom` — 186 preset geometries via the shared engine; connector arrow heads `headEnd` / `tailEnd` (§20.1.8.3) and `prstDash` dash patterns (§20.1.8.48)). Text-box paragraphs run through the **same line-layout engine as body text**, so kinsoku 行頭/行末禁則 (§17.15.1.58–60), UAX#9 bidi (`w:bidi`, §17.3.1.6), justification (§17.18.44) and tab stops (§17.3.1.37) all apply inside a box | ✅ |
 | | WMF **and EMF** metafile images (legacy vector, incl. inside text boxes) — rasterized via a built-in player: window→viewport mapping (MS-EMF map modes, world transform), pens/brushes, poly/rect/ellipse, text-out, path clipping, and embedded DIB blits | ✅ |
+| | Legacy VML content — positioned shapes, text boxes, image previews, and authored text wrapping | ✅ |
 | | OLE embedded objects (`w:object` — the baked VML `v:imagedata` preview is drawn; the embedded app is not run) | ✅ |
 | **Advanced** | Footnotes — reference markers + bottom-of-page bodies with separator rule, numbered (`w:footnoteReference` / `w:footnoteRef`, §17.11) | ✅ |
 | | Endnotes — reference markers + bodies at document end (`w:endnoteReference`, §17.11) | ✅ |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.83.1",
+  "version": "0.83.2",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.83.1",
+  "version": "0.83.2",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.83.1",
+  "version": "0.83.2",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.83.1",
+  "version": "0.83.2",
   "description": "Internal workspace adapter for DOCX / XLSX / PPTX Markdown projection",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.83.1"
+version = "0.83.2"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.83.1",
+  "version": "0.83.2",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.83.1",
+  "version": "0.83.2",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity local viewer for Office files (.docx / .xlsx / .pptx), powered by Rust/WASM and Canvas. Optional MCP integration can share requested context with an AI agent.",
-  "version": "0.83.1",
+  "version": "0.83.2",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.83.1",
+  "version": "0.83.2",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.83.1",
+  "version": "0.83.2",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",

--- a/site/src/announcement-content.test.ts
+++ b/site/src/announcement-content.test.ts
@@ -114,7 +114,7 @@ describe('v0.81 ChartEx migration guide', () => {
 
 describe('stable documentation boundaries', () => {
   it('keeps the current bundle measurements on one stable page', () => {
-    expect(bundleSizePage).toContain('Current production assets in v0.83.1');
+    expect(bundleSizePage).toContain('Current production assets in v0.83.2');
     expect(bundleSizePage).toContain('DOCX static JavaScript');
     expect(bundleSizePage).toContain('XLSX static JavaScript');
     expect(bundleSizePage).toContain('PPTX static JavaScript');

--- a/site/src/pages/bundle-size.astro
+++ b/site/src/pages/bundle-size.astro
@@ -15,7 +15,7 @@ import SiteFooter from '../components/SiteFooter.astro';
       <div class="wrap">
         <p class="eyebrow">Current measurement</p>
         <h1>Bundle size.</h1>
-        <p>Current production assets in v0.83.1.</p>
+        <p>Current production assets in v0.83.2.</p>
       </div>
     </header>
 
@@ -39,7 +39,7 @@ import SiteFooter from '../components/SiteFooter.astro';
             <tr>
               <th>PPTX static JavaScript</th>
               <td>1,284 KiB</td>
-              <td>296 KiB</td>
+              <td>297 KiB</td>
             </tr>
           </tbody>
         </table>
@@ -65,7 +65,7 @@ import SiteFooter from '../components/SiteFooter.astro';
             <tr><th>Asset</th><th>Raw</th><th>gzip</th></tr>
           </thead>
           <tbody>
-            <tr><th>DOCX parser WASM</th><td>1,782 KiB</td><td>740 KiB</td></tr>
+            <tr><th>DOCX parser WASM</th><td>1,784 KiB</td><td>741 KiB</td></tr>
             <tr><th>XLSX parser WASM</th><td>1,577 KiB</td><td>650 KiB</td></tr>
             <tr><th>PPTX parser WASM</th><td>1,638 KiB</td><td>645 KiB</td></tr>
             <tr><th>MathJax runtime</th><td>3,025 KiB</td><td>1,084 KiB</td></tr>


### PR DESCRIPTION
## Summary
- release consistent Ctrl/Command + wheel zoom steps across DOCX, XLSX, PPTX, and the VS Code extension
- release improved Word compatibility for positioned VML content, authored wrapping, and field-result formatting
- bump all shipped packages and the MCP server to 0.83.2
- refresh the capability table and measured production bundle sizes

## Compatibility
No public option, method, or existing default is removed or renamed. No migration is required from 0.83.1.

## Verification
- TypeScript and public API symmetry
- full package, site, and Storybook builds
- production-site browser tests
- Rust check, fmt, and clippy
- DOCX architecture and compatibility gates
- full Vitest corpus; the two known parallel Skia pixel tests pass in isolation
- README screenshots regenerated byte-identically