### PR TITLE
feat(core): add opt-in TIFF image codec

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,11 @@
       "import": "./dist/chart-ex.mjs",
       "default": "./dist/chart-ex.mjs"
     },
+    "./tiff": {
+      "types": "./dist/types/tiff.d.ts",
+      "import": "./dist/tiff.mjs",
+      "default": "./dist/tiff.mjs"
+    },
     "./node": {
       "types": "./dist/types/node.d.ts",
       "import": "./dist/node.mjs",
@@ -111,6 +116,7 @@
     "check:optional-three-d": "node scripts/check-optional-three-d.mjs dist",
     "check:optional-region-map": "node scripts/check-optional-region-map.mjs dist",
     "check:optional-chart-ex": "node scripts/check-optional-chart-ex.mjs dist",
+    "check:optional-tiff": "node scripts/check-optional-tiff.mjs dist",
     "lint": "ast-grep scan",
     "lint:test": "ast-grep test --skip-snapshot-tests",
     "test:docx-boundaries": "node --test scripts/check-docx-layout-boundaries.test.mjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,6 +44,7 @@
     "./internal/comment-context": "./src/internal/comment-context.ts",
     "./internal/runtime-generation": "./src/internal/runtime-generation.ts",
     "./internal/three-d-renderer": "./src/chart/three-d-renderer.ts",
+    "./internal/tiff-renderer": "./src/image/tiff.ts",
     "./internal/virtual-scroll": "./src/internal/virtual-scroll.ts",
     "./internal/script-preload-accumulator": "./src/internal/script-preload-accumulator.ts",
     "./internal/wasm-runtime-generation": "./src/internal/wasm-runtime-generation.ts",

--- a/packages/core/src/image/bitmap-image-by-path.ts
+++ b/packages/core/src/image/bitmap-image-by-path.ts
@@ -42,6 +42,7 @@ import {
   MAX_DECODED_IMAGE_BYTES,
   OoxmlDecodedImageLimitError,
 } from './pixel-budget.js';
+import type { TiffRenderer } from './tiff-contract.js';
 
 type FetchImage = (path: string, mime: string) => Promise<Blob>;
 export type DecodedBitmapCacheOwner = object;
@@ -245,6 +246,8 @@ export interface CachedBitmapOptions {
   /** Enable the docx cosmetic window/device-frame suppression heuristic. Default
    *  false = spec-clean. Only docx opts in. */
   suppressBoundaryFrame?: boolean;
+  /** Optional TIFF codec retained by the owning document. */
+  tiff?: TiffRenderer;
 }
 
 interface ProducedBitmap {
@@ -392,7 +395,7 @@ export function getCachedBitmapByPath(
   fetchImage: FetchImage,
   opts: CachedBitmapOptions = {},
 ): Promise<ImageBitmap | null> {
-  const { widthPt = 0, heightPt = 0, suppressBoundaryFrame = false } = opts;
+  const { widthPt = 0, heightPt = 0, suppressBoundaryFrame = false, tiff } = opts;
   return getCachedDecodedBitmap(
     BASE_CACHE_NAMESPACE,
     imagePath,
@@ -403,6 +406,7 @@ export function getCachedBitmapByPath(
         widthPt,
         heightPt,
         suppressBoundaryFrame,
+        tiff,
       });
       return { bitmap, owned: true };
     },

--- a/packages/core/src/image/raster-dimensions.test.ts
+++ b/packages/core/src/image/raster-dimensions.test.ts
@@ -183,6 +183,25 @@ function jpegMalformedSegLen(): Uint8Array {
   return b;
 }
 
+function tiffHeader(w: number, h: number, byteOrder: 'little' | 'big'): Uint8Array {
+  const little = byteOrder === 'little';
+  const bytes = new Uint8Array(38);
+  const view = new DataView(bytes.buffer);
+  bytes.set(little ? [0x49, 0x49] : [0x4d, 0x4d], 0);
+  view.setUint16(2, 42, little);
+  view.setUint32(4, 8, little);
+  view.setUint16(8, 2, little);
+  view.setUint16(10, 256, little);
+  view.setUint16(12, 4, little);
+  view.setUint32(14, 1, little);
+  view.setUint32(18, w, little);
+  view.setUint16(22, 257, little);
+  view.setUint16(24, 4, little);
+  view.setUint32(26, 1, little);
+  view.setUint32(30, h, little);
+  return bytes;
+}
+
 describe('sniffRasterDimensions — reads declared pixel dimensions from the header', () => {
   it('reads PNG IHDR dimensions', () => {
     expect(sniffRasterDimensions(pngHeader(1920, 1080))).toEqual({ width: 1920, height: 1080 });
@@ -223,6 +242,13 @@ describe('sniffRasterDimensions — reads declared pixel dimensions from the hea
     expect(sniffRasterDimensions(jpegHeader(3264, 2448, 400))).toEqual({
       width: 3264,
       height: 2448,
+    });
+  });
+
+  it.each(['little', 'big'] as const)('reads TIFF IFD dimensions (%s endian)', (byteOrder) => {
+    expect(sniffRasterDimensions(tiffHeader(776, 31, byteOrder))).toEqual({
+      width: 776,
+      height: 31,
     });
   });
 

--- a/packages/core/src/image/raster-dimensions.ts
+++ b/packages/core/src/image/raster-dimensions.ts
@@ -11,12 +11,13 @@
 // This module sniffs the pixel dimensions straight from the image header (no
 // full decode) so an over-budget image can be refused BEFORE it ever reaches
 // `createImageBitmap`. It recognizes the raster formats OOXML embeds — PNG,
-// JPEG, GIF, BMP, WebP — and returns `null` for anything it does not recognize
+// JPEG, GIF, BMP, WebP, TIFF — and returns `null` for anything it does not recognize
 // (SVG, metafiles, truncated/garbage headers), leaving the caller to fall back
 // to its normal path. Recognizing "too big" is a safe superset: an unrecognized
 // header simply isn't blocked here.
 
 import { MAX_RASTER_DIMENSION, MAX_RASTER_PIXELS } from './pixel-budget.js';
+import { sniffTiffDimensions } from './tiff-contract.js';
 
 /** Read a big-endian u16 at `o` (bounds already checked by the caller). */
 function beU16(b: Uint8Array, o: number): number {
@@ -134,6 +135,17 @@ export function sniffRasterDimensions(head: Uint8Array): RasterDimensions | null
   // holds [precision u8][height u16][width u16], big-endian.
   if (n >= 4 && head[0] === 0xff && head[1] === 0xd8) {
     return sniffJpegSof(head);
+  }
+
+  // TIFF — classic TIFF starts with byte order (`II`/`MM`), magic 42, then a
+  // u32 offset to its first IFD. Width/height are IFD tags 256/257. The IFD may
+  // live beyond the caller's header prefix, in which case this safely returns
+  // null and the TIFF decoder validates dimensions before allocating pixels.
+  if (
+    n >= 4
+    && ((head[0] === 0x49 && head[1] === 0x49) || (head[0] === 0x4d && head[1] === 0x4d))
+  ) {
+    return sniffTiffDimensions(head);
   }
 
   return null;

--- a/packages/core/src/image/tiff-contract.ts
+++ b/packages/core/src/image/tiff-contract.ts
@@ -1,0 +1,51 @@
+/** Optional TIFF codec contract shared by DOCX, XLSX and PPTX. */
+export interface TiffRenderer {
+  /** Decode one complete classic-TIFF part into a browser-owned bitmap. */
+  render(bytes: Uint8Array): Promise<ImageBitmap | null>;
+}
+
+/** Content-sniff classic TIFF byte order + version, independent of MIME. */
+export function isTiff(bytes: Uint8Array): boolean {
+  if (bytes.length < 4) return false;
+  const little = bytes[0] === 0x49 && bytes[1] === 0x49;
+  const big = bytes[0] === 0x4d && bytes[1] === 0x4d;
+  if (!little && !big) return false;
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint16(2, little) === 42;
+}
+
+/**
+ * Read first-IFD dimensions from a TIFF header prefix. This intentionally owns
+ * only the two scalar fields needed by the always-on decode-bomb guard; the
+ * optional codec owns full IFD and strip parsing.
+ */
+export function sniffTiffDimensions(bytes: Uint8Array): { width: number; height: number } | null {
+  if (!isTiff(bytes) || bytes.length < 8) return null;
+  const little = bytes[0] === 0x49;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const contains = (offset: number, length: number) => Number.isSafeInteger(offset)
+    && offset >= 0
+    && length >= 0
+    && offset <= view.byteLength - length;
+  const ifdOffset = view.getUint32(4, little);
+  if (!contains(ifdOffset, 2)) return null;
+  const count = view.getUint16(ifdOffset, little);
+  if (!contains(ifdOffset + 2, count * 12 + 4)) return null;
+  let width: number | undefined;
+  let height: number | undefined;
+  for (let index = 0; index < count; index++) {
+    const offset = ifdOffset + 2 + index * 12;
+    const tag = view.getUint16(offset, little);
+    if (tag !== 256 && tag !== 257) continue;
+    const type = view.getUint16(offset + 2, little);
+    const valueCount = view.getUint32(offset + 4, little);
+    if (valueCount !== 1 || (type !== 1 && type !== 3 && type !== 4)) return null;
+    const value = type === 1
+      ? view.getUint8(offset + 8)
+      : type === 3
+        ? view.getUint16(offset + 8, little)
+        : view.getUint32(offset + 8, little);
+    if (tag === 256) width = value;
+    else height = value;
+  }
+  return width === undefined || height === undefined ? null : { width, height };
+}

--- a/packages/core/src/image/tiff.test.ts
+++ b/packages/core/src/image/tiff.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { decodeTiffRgba, renderTiffToBitmap } from './tiff.js';
+import { isTiff } from './tiff-contract.js';
+
+type ByteOrder = 'little' | 'big';
+
+interface TiffFixtureOptions {
+  byteOrder?: ByteOrder;
+  width?: number;
+  height?: number;
+  rowsPerStrip?: number;
+  compression?: number;
+  photometric?: number;
+  pixels?: number[];
+}
+
+/**
+ * Build a synthetic TIFF 6.0 separated-image fixture. It deliberately uses
+ * multiple strips so the decoder cannot accidentally assume one contiguous
+ * pixel block. No private document bytes are committed in this test.
+ */
+function cmykTiff({
+  byteOrder = 'little',
+  width = 2,
+  height = 2,
+  rowsPerStrip = 1,
+  compression = 1,
+  photometric = 5,
+  pixels = [
+    0, 0, 0, 0,
+    255, 0, 0, 0,
+    0, 255, 0, 128,
+    0, 0, 255, 255,
+  ],
+}: TiffFixtureOptions = {}): Uint8Array {
+  const little = byteOrder === 'little';
+  const entries = 9;
+  const ifdOffset = 8;
+  const ifdBytes = 2 + entries * 12 + 4;
+  const bitsOffset = ifdOffset + ifdBytes;
+  const stripCount = Math.ceil(height / rowsPerStrip);
+  const stripOffsetsOffset = bitsOffset + 8;
+  const stripByteCountsOffset = stripOffsetsOffset + stripCount * 4;
+  const pixelOffset = stripByteCountsOffset + stripCount * 4;
+  const bytesPerRow = width * 4;
+  const total = pixelOffset + pixels.length;
+  const bytes = new Uint8Array(total);
+  const view = new DataView(bytes.buffer);
+  const u16 = (offset: number, value: number) => view.setUint16(offset, value, little);
+  const u32 = (offset: number, value: number) => view.setUint32(offset, value, little);
+
+  bytes.set(little ? [0x49, 0x49] : [0x4d, 0x4d], 0);
+  u16(2, 42);
+  u32(4, ifdOffset);
+  u16(ifdOffset, entries);
+
+  let entry = ifdOffset + 2;
+  const scalar = (tag: number, type: 3 | 4, value: number) => {
+    u16(entry, tag);
+    u16(entry + 2, type);
+    u32(entry + 4, 1);
+    if (type === 3) u16(entry + 8, value);
+    else u32(entry + 8, value);
+    entry += 12;
+  };
+  const offsetArray = (tag: number, count: number, offset: number) => {
+    u16(entry, tag);
+    u16(entry + 2, 4);
+    u32(entry + 4, count);
+    u32(entry + 8, offset);
+    entry += 12;
+  };
+
+  scalar(256, 4, width); // ImageWidth
+  scalar(257, 4, height); // ImageLength
+  u16(entry, 258); // BitsPerSample = [8,8,8,8]
+  u16(entry + 2, 3);
+  u32(entry + 4, 4);
+  u32(entry + 8, bitsOffset);
+  entry += 12;
+  scalar(259, 3, compression);
+  scalar(262, 3, photometric); // Separated
+  offsetArray(273, stripCount, stripOffsetsOffset);
+  scalar(277, 3, 4); // SamplesPerPixel
+  scalar(278, 4, rowsPerStrip);
+  offsetArray(279, stripCount, stripByteCountsOffset);
+  u32(entry, 0); // next IFD
+
+  for (let i = 0; i < 4; i++) u16(bitsOffset + i * 2, 8);
+  let sourceOffset = 0;
+  for (let strip = 0; strip < stripCount; strip++) {
+    const rows = Math.min(rowsPerStrip, height - strip * rowsPerStrip);
+    const byteCount = rows * bytesPerRow;
+    u32(stripOffsetsOffset + strip * 4, pixelOffset + sourceOffset);
+    u32(stripByteCountsOffset + strip * 4, byteCount);
+    sourceOffset += byteCount;
+  }
+  bytes.set(pixels, pixelOffset);
+  return bytes;
+}
+
+describe('TIFF 6.0 decoder', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it.each<ByteOrder>(['little', 'big'])('decodes uncompressed chunky CMYK strips (%s endian)', (byteOrder) => {
+    const bytes = cmykTiff({ byteOrder });
+    expect(isTiff(bytes)).toBe(true);
+    const decoded = decodeTiffRgba(bytes);
+    expect(decoded).not.toBeNull();
+    expect(decoded && { width: decoded.width, height: decoded.height }).toEqual({
+      width: 2,
+      height: 2,
+    });
+    expect(Array.from(decoded?.data ?? [])).toEqual([
+      255, 255, 255, 255,
+      0, 255, 255, 255,
+      127, 0, 127, 255,
+      0, 0, 0, 255,
+    ]);
+  });
+
+  it('rejects unsupported compression, colour classes, and malformed strip ranges without guessing', () => {
+    expect(decodeTiffRgba(cmykTiff({ compression: 5 }))).toBeNull(); // LZW
+    expect(decodeTiffRgba(cmykTiff({ photometric: 2 }))).toBeNull(); // RGB
+    const malformed = cmykTiff();
+    // First StripOffsets value is outside the file.
+    new DataView(malformed.buffer).setUint32(130, 0xfffffff0, true);
+    expect(decodeTiffRgba(malformed)).toBeNull();
+  });
+
+  it('rasterizes decoded pixels through an auxiliary canvas, not browser TIFF decoding', async () => {
+    const captured: number[] = [];
+    const canvas = class {
+      width: number;
+      height: number;
+      constructor(width: number, height: number) {
+        this.width = width;
+        this.height = height;
+      }
+      getContext() {
+        return {
+          createImageData: (width: number, height: number) => ({
+            width,
+            height,
+            data: new Uint8ClampedArray(width * height * 4),
+          }),
+          putImageData: (image: ImageData) => captured.push(...image.data),
+        };
+      }
+    };
+    vi.stubGlobal('OffscreenCanvas', canvas);
+    const bitmap = { width: 2, height: 2, close() {} } as unknown as ImageBitmap;
+    const create = vi.fn(async (source: unknown) => {
+      expect(source).toBeInstanceOf(canvas);
+      return bitmap;
+    });
+    vi.stubGlobal('createImageBitmap', create);
+
+    await expect(renderTiffToBitmap(cmykTiff())).resolves.toBe(bitmap);
+    expect(captured).toEqual([
+      255, 255, 255, 255,
+      0, 255, 255, 255,
+      127, 0, 127, 255,
+      0, 0, 0, 255,
+    ]);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/image/tiff.ts
+++ b/packages/core/src/image/tiff.ts
@@ -1,0 +1,223 @@
+// TIFF Revision 6.0 decoder for OOXML image parts. ECMA-376 Part 1 §15.2.14
+// explicitly permits `image/tiff`, but browser ImageBitmap decoders generally
+// do not. Keep the supported class tag-defined: classic TIFF, first IFD,
+// uncompressed 8-bit chunky process-CMYK strips and top-left orientation. The
+// codec deliberately rejects other TIFF classes instead of guessing or handing
+// them to createImageBitmap and aborting the document render.
+
+import { createAuxCanvas } from '../canvas/aux-canvas.js';
+import {
+  MAX_RASTER_DIMENSION,
+  MAX_RASTER_PIXELS,
+  OoxmlDecodedImageLimitError,
+} from './pixel-budget.js';
+import { isTiff } from './tiff-contract.js';
+
+/** Stable bundle-audit marker retained only by the opt-in TIFF entry. */
+export const TIFF_IMPLEMENTATION_MARKER = 'packages/core/src/image/tiff.ts';
+
+const TYPE_BYTE = 1;
+const TYPE_SHORT = 3;
+const TYPE_LONG = 4;
+
+const TAG = {
+  width: 256,
+  height: 257,
+  bitsPerSample: 258,
+  compression: 259,
+  photometric: 262,
+  stripOffsets: 273,
+  orientation: 274,
+  samplesPerPixel: 277,
+  rowsPerStrip: 278,
+  stripByteCounts: 279,
+  planarConfiguration: 284,
+  inkSet: 332,
+  extraSamples: 338,
+} as const;
+
+interface Field {
+  type: number;
+  count: number;
+  entryOffset: number;
+}
+
+class Reader {
+  readonly view: DataView;
+
+  constructor(
+    readonly bytes: Uint8Array,
+    readonly littleEndian: boolean,
+  ) {
+    this.view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  }
+
+  contains(offset: number, length: number): boolean {
+    return Number.isSafeInteger(offset)
+      && Number.isSafeInteger(length)
+      && offset >= 0
+      && length >= 0
+      && offset <= this.view.byteLength - length;
+  }
+
+  u16(offset: number): number | null {
+    return this.contains(offset, 2) ? this.view.getUint16(offset, this.littleEndian) : null;
+  }
+
+  u32(offset: number): number | null {
+    return this.contains(offset, 4) ? this.view.getUint32(offset, this.littleEndian) : null;
+  }
+}
+
+interface Directory {
+  reader: Reader;
+  fields: Map<number, Field>;
+}
+
+function firstDirectory(bytes: Uint8Array): Directory | null {
+  if (!isTiff(bytes)) return null;
+  const reader = new Reader(bytes, bytes[0] === 0x49);
+  const ifdOffset = reader.u32(4);
+  if (ifdOffset == null) return null;
+  const count = reader.u16(ifdOffset);
+  if (count == null || !reader.contains(ifdOffset + 2, count * 12 + 4)) return null;
+
+  const fields = new Map<number, Field>();
+  for (let i = 0; i < count; i++) {
+    const entryOffset = ifdOffset + 2 + i * 12;
+    const tag = reader.u16(entryOffset);
+    const type = reader.u16(entryOffset + 2);
+    const valueCount = reader.u32(entryOffset + 4);
+    if (tag == null || type == null || valueCount == null || fields.has(tag)) return null;
+    fields.set(tag, { type, count: valueCount, entryOffset });
+  }
+  return { reader, fields };
+}
+
+function values(directory: Directory, tag: number, maxCount: number): number[] | null {
+  const field = directory.fields.get(tag);
+  if (!field || field.count < 1 || field.count > maxCount) return null;
+  const size = field.type === TYPE_BYTE ? 1 : field.type === TYPE_SHORT ? 2 : field.type === TYPE_LONG ? 4 : 0;
+  if (size === 0) return null;
+  const byteLength = field.count * size;
+  const offset = byteLength <= 4
+    ? field.entryOffset + 8
+    : directory.reader.u32(field.entryOffset + 8);
+  if (offset == null || !directory.reader.contains(offset, byteLength)) return null;
+
+  const result = new Array<number>(field.count);
+  for (let i = 0; i < field.count; i++) {
+    const itemOffset = offset + i * size;
+    const value = field.type === TYPE_BYTE
+      ? directory.reader.bytes[itemOffset]
+      : field.type === TYPE_SHORT
+        ? directory.reader.u16(itemOffset)
+        : directory.reader.u32(itemOffset);
+    if (value == null) return null;
+    result[i] = value;
+  }
+  return result;
+}
+
+function scalar(directory: Directory, tag: number, fallback?: number): number | null {
+  if (!directory.fields.has(tag)) return fallback ?? null;
+  const field = directory.fields.get(tag) as Field;
+  return field.count === 1 ? values(directory, tag, 1)?.[0] ?? null : null;
+}
+
+export interface DecodedTiff {
+  width: number;
+  height: number;
+  data: Uint8ClampedArray;
+}
+
+function cmykChannel(channel: number, black: number): number {
+  // TIFF 6.0 §16 defines ink coverage but no unique device-independent RGB
+  // conversion. This multiplicative subtractive mapping matches Word's output
+  // for the unprofiled 8-bit process-ink levels in the Office reference used to
+  // verify this compatibility path; it applies uniformly to the defined class.
+  return Math.round(((255 - channel) * (255 - black)) / 255);
+}
+
+/** Decode the supported TIFF class into top-down Canvas RGBA bytes. */
+export function decodeTiffRgba(bytes: Uint8Array): DecodedTiff | null {
+  const directory = firstDirectory(bytes);
+  if (!directory) return null;
+  const width = scalar(directory, TAG.width);
+  const height = scalar(directory, TAG.height);
+  if (width == null || height == null) return null;
+  const pixels = width * height;
+  if (
+    width <= 0
+    || height <= 0
+    || width > MAX_RASTER_DIMENSION
+    || height > MAX_RASTER_DIMENSION
+    || pixels > MAX_RASTER_PIXELS
+  ) {
+    throw new OoxmlDecodedImageLimitError('image-pixels', MAX_RASTER_PIXELS, pixels);
+  }
+
+  const compression = scalar(directory, TAG.compression, 1);
+  const photometric = scalar(directory, TAG.photometric);
+  const samples = scalar(directory, TAG.samplesPerPixel, 1);
+  const rowsPerStrip = scalar(directory, TAG.rowsPerStrip, 0xffffffff);
+  if (
+    compression !== 1
+    || photometric == null
+    || samples == null
+    || rowsPerStrip == null
+    || rowsPerStrip < 1
+    || scalar(directory, TAG.planarConfiguration, 1) !== 1
+    || scalar(directory, TAG.orientation, 1) !== 1
+    || directory.fields.has(TAG.extraSamples)
+  ) return null;
+
+  if (photometric !== 5 || samples !== 4 || scalar(directory, TAG.inkSet, 1) !== 1) return null;
+  const bits = directory.fields.has(TAG.bitsPerSample)
+    ? values(directory, TAG.bitsPerSample, samples)
+    : [1];
+  if (!bits || bits.length !== samples || bits.some((bit) => bit !== 8)) return null;
+
+  const stripCount = Math.ceil(height / rowsPerStrip);
+  const offsets = values(directory, TAG.stripOffsets, stripCount);
+  const byteCounts = values(directory, TAG.stripByteCounts, stripCount);
+  if (!offsets || !byteCounts || offsets.length !== stripCount || byteCounts.length !== stripCount) {
+    return null;
+  }
+  const bytesPerRow = width * samples;
+  const output = new Uint8ClampedArray(pixels * 4);
+  for (let strip = 0; strip < stripCount; strip++) {
+    const firstRow = strip * rowsPerStrip;
+    const rowCount = Math.min(rowsPerStrip, height - firstRow);
+    const required = rowCount * bytesPerRow;
+    if (byteCounts[strip] < required || !directory.reader.contains(offsets[strip], required)) return null;
+    for (let row = 0; row < rowCount; row++) {
+      let source = offsets[strip] + row * bytesPerRow;
+      let destination = (firstRow + row) * width * 4;
+      for (let x = 0; x < width; x++, destination += 4) {
+        const cyan = bytes[source++];
+        const magenta = bytes[source++];
+        const yellow = bytes[source++];
+        const black = bytes[source++];
+        output[destination] = cmykChannel(cyan, black);
+        output[destination + 1] = cmykChannel(magenta, black);
+        output[destination + 2] = cmykChannel(yellow, black);
+        output[destination + 3] = 255;
+      }
+    }
+  }
+  return { width, height, data: output };
+}
+
+export async function renderTiffToBitmap(bytes: Uint8Array): Promise<ImageBitmap | null> {
+  const decoded = decodeTiffRgba(bytes);
+  if (!decoded) return null;
+  const canvas = createAuxCanvas(decoded.width, decoded.height);
+  if (!canvas) return null;
+  const context = canvas.getContext('2d') as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | null;
+  if (!context) return null;
+  const imageData = context.createImageData(decoded.width, decoded.height);
+  imageData.data.set(decoded.data);
+  context.putImageData(imageData, 0, 0);
+  return createImageBitmap(canvas);
+}

--- a/packages/core/src/image/wmf.test.ts
+++ b/packages/core/src/image/wmf.test.ts
@@ -882,6 +882,49 @@ describe('decodeRasterOrMetafile', () => {
     expect(cib).toHaveBeenCalledTimes(1);
   });
 
+  it('a TIFF is skipped without the opt-in codec and decoded when supplied', async () => {
+    const bytes = new Uint8Array([0x49, 0x49, 0x2a, 0x00, 1, 2, 3, 4]);
+    const blob = new Blob([bytes as BlobPart], { type: 'image/tiff' });
+    const browserDecode = vi.fn();
+    vi.stubGlobal('createImageBitmap', browserDecode);
+
+    await expect(decodeRasterOrMetafile(blob)).resolves.toBeNull();
+    expect(browserDecode).not.toHaveBeenCalled();
+
+    const bitmap = { width: 8, height: 4, close() {} } as unknown as ImageBitmap;
+    const render = vi.fn(async (input: Uint8Array) => {
+      expect(Array.from(input)).toEqual(Array.from(bytes));
+      return bitmap;
+    });
+    await expect(decodeRasterOrMetafile(blob, { tiff: { render } })).resolves.toBe(bitmap);
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(browserDecode).not.toHaveBeenCalled();
+  });
+
+  it('rejects an oversized TIFF before invoking an injected codec', async () => {
+    const bytes = new Uint8Array(38);
+    const view = new DataView(bytes.buffer);
+    bytes.set([0x49, 0x49], 0);
+    view.setUint16(2, 42, true);
+    view.setUint32(4, 8, true);
+    view.setUint16(8, 2, true);
+    view.setUint16(10, 256, true);
+    view.setUint16(12, 4, true);
+    view.setUint32(14, 1, true);
+    view.setUint32(18, 32_767, true);
+    view.setUint16(22, 257, true);
+    view.setUint16(24, 4, true);
+    view.setUint32(26, 1, true);
+    view.setUint32(30, 32_767, true);
+    const render = vi.fn();
+
+    await expect(decodeRasterOrMetafile(
+      new Blob([bytes as BlobPart], { type: 'image/tiff' }),
+      { tiff: { render } },
+    )).rejects.toMatchObject({ code: 'ooxml-decoded-image-limit' });
+    expect(render).not.toHaveBeenCalled();
+  });
+
   it('closes and rejects an oversized decode when the header was unrecognized', async () => {
     const close = vi.fn();
     vi.stubGlobal(

--- a/packages/core/src/image/wmf.ts
+++ b/packages/core/src/image/wmf.ts
@@ -43,6 +43,7 @@ import { rasterExceedsBudget, sniffRasterDimensions } from './raster-dimensions.
 import { MAX_RASTER_PIXELS, OoxmlDecodedImageLimitError } from './pixel-budget.js';
 import { createAuxCanvas } from '../canvas/aux-canvas.js';
 import { closeImageBitmapIfSupported } from './image-bitmap-lifecycle.js';
+import { isTiff, type TiffRenderer } from './tiff-contract.js';
 
 // WMF record function codes (the subset we act on; others are skipped by size).
 const META = {
@@ -798,6 +799,8 @@ export interface DecodeRasterOptions {
    *  the HEURISTIC note on {@link playWmf}/deviceInteriorEdges). Default false =
    *  spec-clean (every edge drawn). docx opts IN when it re-points to core. */
   suppressBoundaryFrame?: boolean;
+  /** Optional TIFF codec. Omitted TIFF parts take the null-bitmap path. */
+  tiff?: TiffRenderer;
 }
 
 /**
@@ -816,6 +819,8 @@ export interface DecodeRasterOptions {
  *   - {@link isEmf} → rasterize via {@link ./emf.ts}#renderEmfToBitmap at
  *     {@link wmfRasterTarget}(widthPt, heightPt). An EMF that produces no
  *     geometry returns `null`.
+ *   - {@link isTiff} → decode the supported TIFF 6.0 class through the shared
+ *     software rasterizer because browsers generally cannot decode TIFF.
  *   - otherwise → `createImageBitmap(blob)` (PNG/JPEG/GIF/BMP/WEBP…).
  *
  * Returns `null` (never throws on an unsupported metafile) so every caller can
@@ -829,7 +834,7 @@ export async function decodeRasterOrMetafile(
   data: Blob,
   opts: DecodeRasterOptions = {},
 ): Promise<ImageBitmap | null> {
-  const { widthPt = 0, heightPt = 0, suppressBoundaryFrame = false } = opts;
+  const { widthPt = 0, heightPt = 0, suppressBoundaryFrame = false, tiff } = opts;
 
   // Sniff a header prefix, not the whole blob. `isEmf` reads bytes 40-43 (u32@40
   // == " EMF") and `isWmf` at most the 18-byte standard header, and the raster
@@ -857,16 +862,21 @@ export async function decodeRasterOrMetafile(
     );
   }
   // Decode-bomb guard: if the header declares a recognized raster (PNG/JPEG/GIF/
-  // BMP/WEBP) whose pixel dimensions exceed the shared budget, refuse it BEFORE
-  // `createImageBitmap` allocates a multi-GB surface. An unrecognized header
-  // cannot be rejected before decode, so the decoded dimensions are validated
-  // immediately afterwards and the surface is closed before it can be retained.
+  // BMP/WEBP/TIFF) whose pixel dimensions exceed the shared budget, refuse it
+  // before either a browser decoder or an injected codec can allocate a large
+  // surface. An unrecognized header is validated immediately after decode.
   const rasterDimensions = sniffRasterDimensions(head);
   if (rasterDimensions && rasterExceedsBudget(rasterDimensions)) {
     throw new OoxmlDecodedImageLimitError(
       'image-pixels',
       MAX_RASTER_PIXELS,
       rasterDimensions.width * rasterDimensions.height,
+    );
+  }
+  if (isTiff(head)) {
+    if (!tiff) return null;
+    return enforceDecodedBitmapBudget(
+      await tiff.render(new Uint8Array(await data.arrayBuffer())),
     );
   }
   return enforceDecodedBitmapBudget(await createImageBitmap(data));

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -253,6 +253,7 @@ export {
   decodeRasterOrMetafile,
   type DecodeRasterOptions,
 } from './image/wmf';
+export type { TiffRenderer } from './image/tiff-contract';
 // Raster pixel-dimension budget + header sniff (decode-bomb guard, RB1). Shared
 // caps live in `./image/pixel-budget`; `decodeRasterOrMetafile` uses the sniff to
 // refuse an over-budget PNG/JPEG/GIF/BMP/WEBP before `createImageBitmap`.

--- a/packages/core/src/types/load-options.ts
+++ b/packages/core/src/types/load-options.ts
@@ -2,6 +2,7 @@ import type { MathRenderer } from '../math/mathjax';
 import type { ChartThreeDRenderer } from '../chart/three-d-contract';
 import type { ChartRegionMapRenderer } from '../chart/region-map-contract';
 import type { ChartExRenderer } from '../chart/chart-ex-contract';
+import type { TiffRenderer } from '../image/tiff-contract';
 import type { OoxmlResourceMetrics } from './resource-metrics.js';
 
 /** A positive safe-integer byte count, or `null` to disable one public limit. */
@@ -195,4 +196,12 @@ export interface LoadOptions {
    * self-contained and includes its worker-side implementation.
    */
   chartEx?: ChartExRenderer;
+  /**
+   * Opt in to bounded TIFF 6.0 image decoding. Import `tiff` from the separate
+   * `@silurus/ooxml/tiff` entry and inject it once. The built-in codec accepts
+   * uncompressed, 8-bit, chunky process-CMYK strips; other TIFF classes fail
+   * closed. Omit it to keep the decoder out of ordinary format bundles; TIFF
+   * parts are then skipped without aborting the surrounding document render.
+   */
+  tiff?: TiffRenderer;
 }

--- a/packages/core/src/worker/renderer-module-contract.ts
+++ b/packages/core/src/worker/renderer-module-contract.ts
@@ -4,7 +4,7 @@
  * public renderer interfaces. */
 const WORKER_RENDERER_MODULE_PROTOCOL = 'ooxml-worker-renderer-module/v1' as const;
 
-export type WorkerBuiltinRendererName = 'math' | 'threeD' | 'regionMap' | 'chartEx';
+export type WorkerBuiltinRendererName = 'math' | 'threeD' | 'regionMap' | 'chartEx' | 'tiff';
 
 interface WorkerBuiltinRendererDescriptorBase {
   readonly protocol: typeof WORKER_RENDERER_MODULE_PROTOCOL;
@@ -19,7 +19,7 @@ interface WorkerMathRendererDescriptor extends WorkerBuiltinRendererDescriptorBa
 }
 
 interface WorkerChartRendererDescriptor extends WorkerBuiltinRendererDescriptorBase {
-  readonly builtin: 'threeD' | 'regionMap' | 'chartEx';
+  readonly builtin: 'threeD' | 'regionMap' | 'chartEx' | 'tiff';
 }
 
 export type WorkerRendererDescriptor =
@@ -31,6 +31,7 @@ export interface WorkerRendererDescriptors {
   readonly threeD?: WorkerRendererDescriptor;
   readonly regionMap?: WorkerRendererDescriptor;
   readonly chartEx?: WorkerRendererDescriptor;
+  readonly tiff?: WorkerRendererDescriptor;
 }
 
 export interface WorkerRendererSources {
@@ -38,6 +39,7 @@ export interface WorkerRendererSources {
   readonly threeD?: object;
   readonly regionMap?: object;
   readonly chartEx?: object;
+  readonly tiff?: object;
 }
 
 const workerRendererRegistry = new WeakMap<object, WorkerRendererDescriptor>();
@@ -48,7 +50,7 @@ function createBuiltinWorkerRendererDescriptor(
   engineAssetUrl: string,
 ): WorkerMathRendererDescriptor;
 function createBuiltinWorkerRendererDescriptor(
-  builtin: 'threeD' | 'regionMap' | 'chartEx',
+  builtin: 'threeD' | 'regionMap' | 'chartEx' | 'tiff',
 ): WorkerChartRendererDescriptor;
 function createBuiltinWorkerRendererDescriptor(
   builtin: WorkerBuiltinRendererName,
@@ -72,7 +74,7 @@ export function registerBuiltinWorkerRenderer<T extends object>(
 ): T;
 export function registerBuiltinWorkerRenderer<T extends object>(
   renderer: T,
-  builtin: 'threeD' | 'regionMap' | 'chartEx',
+  builtin: 'threeD' | 'regionMap' | 'chartEx' | 'tiff',
 ): T;
 export function registerBuiltinWorkerRenderer<T extends object>(
   renderer: T,
@@ -95,7 +97,8 @@ export function assertWorkerRendererDescriptor(
   if (descriptor.builtin !== 'math'
     && descriptor.builtin !== 'threeD'
     && descriptor.builtin !== 'regionMap'
-    && descriptor.builtin !== 'chartEx') {
+    && descriptor.builtin !== 'chartEx'
+    && descriptor.builtin !== 'tiff') {
     throw new TypeError(`Unsupported built-in worker renderer: ${String(descriptor.builtin)}`);
   }
   if (descriptor.builtin === 'math' && typeof descriptor.engineAssetUrl !== 'string') {
@@ -114,11 +117,13 @@ export function workerRendererDescriptors(
   const threeD = sources.threeD ? workerRendererRegistry.get(sources.threeD) : undefined;
   const regionMap = sources.regionMap ? workerRendererRegistry.get(sources.regionMap) : undefined;
   const chartEx = sources.chartEx ? workerRendererRegistry.get(sources.chartEx) : undefined;
+  const tiff = sources.tiff ? workerRendererRegistry.get(sources.tiff) : undefined;
   const descriptors: WorkerRendererDescriptors = {
     ...(math ? { math } : {}),
     ...(threeD ? { threeD } : {}),
     ...(regionMap ? { regionMap } : {}),
     ...(chartEx ? { chartEx } : {}),
+    ...(tiff ? { tiff } : {}),
   };
   return Object.keys(descriptors).length > 0 ? Object.freeze(descriptors) : undefined;
 }

--- a/packages/core/src/worker/renderer-module.test.ts
+++ b/packages/core/src/worker/renderer-module.test.ts
@@ -61,6 +61,7 @@ describe('worker renderer module descriptors', () => {
       threeD: registerBuiltinWorkerRenderer({}, 'threeD'),
       regionMap: registerBuiltinWorkerRenderer({}, 'regionMap'),
       chartEx: registerBuiltinWorkerRenderer({}, 'chartEx'),
+      tiff: registerBuiltinWorkerRenderer({}, 'tiff'),
     };
 
     const loaded = await loadWorkerRenderers(workerRendererDescriptors(sources));
@@ -69,6 +70,7 @@ describe('worker renderer module descriptors', () => {
     expect(typeof loaded.threeD?.render).toBe('function');
     expect(typeof loaded.regionMap?.render).toBe('function');
     expect(typeof loaded.chartEx?.render).toBe('function');
+    expect(typeof loaded.tiff?.render).toBe('function');
   });
 
   it('carries the consumer-resolved math asset URL without exposing it on the renderer', () => {

--- a/packages/core/src/worker/renderer-module.ts
+++ b/packages/core/src/worker/renderer-module.ts
@@ -2,6 +2,7 @@ import type { ChartRegionMapRenderer } from '../chart/region-map-contract.js';
 import type { ChartThreeDRenderer } from '../chart/three-d-contract.js';
 import type { ChartExRenderer } from '../chart/chart-ex-contract.js';
 import type { MathRenderer } from '../math/mathjax.js';
+import type { TiffRenderer } from '../image/tiff-contract.js';
 import {
   assertWorkerRendererDescriptor,
   type WorkerRendererDescriptor,
@@ -13,6 +14,7 @@ export interface LoadedWorkerRenderers {
   readonly threeD?: ChartThreeDRenderer;
   readonly regionMap?: ChartRegionMapRenderer;
   readonly chartEx?: ChartExRenderer;
+  readonly tiff?: TiffRenderer;
 }
 
 /** Import a renderer's named export in the calling realm (normally a render
@@ -47,6 +49,10 @@ async function loadBuiltinRenderer(descriptor: WorkerRendererDescriptor): Promis
       const renderer = await import('../chart/chart-ex-renderer.js');
       return Object.freeze({ render: renderer.renderChartExChart });
     }
+    case 'tiff': {
+      const renderer = await import('../image/tiff.js');
+      return Object.freeze({ render: renderer.renderTiffToBitmap });
+    }
   }
 }
 
@@ -71,11 +77,12 @@ function requireRendererMethods<T extends object>(
 export async function loadWorkerRenderers(
   descriptors: WorkerRendererDescriptors | undefined,
 ): Promise<LoadedWorkerRenderers> {
-  const [math, threeD, regionMap, chartEx] = await Promise.all([
+  const [math, threeD, regionMap, chartEx, tiff] = await Promise.all([
     descriptors?.math ? loadWorkerRenderer(descriptors.math) : undefined,
     descriptors?.threeD ? loadWorkerRenderer(descriptors.threeD) : undefined,
     descriptors?.regionMap ? loadWorkerRenderer(descriptors.regionMap) : undefined,
     descriptors?.chartEx ? loadWorkerRenderer(descriptors.chartEx) : undefined,
+    descriptors?.tiff ? loadWorkerRenderer(descriptors.tiff) : undefined,
   ]);
   return Object.freeze({
     ...(math ? {
@@ -97,6 +104,9 @@ export async function loadWorkerRenderers(
     } : {}),
     ...(chartEx ? {
       chartEx: requireRendererMethods<ChartExRenderer>('chartEx', chartEx, ['render']),
+    } : {}),
+    ...(tiff ? {
+      tiff: requireRendererMethods<TiffRenderer>('tiff', tiff, ['render']),
     } : {}),
   });
 }

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -1580,14 +1580,6 @@ export interface LoadOptions extends LoadOptions__emitterCollision1 {
     showTrackedChanges?: boolean;
     currentDate?: Date | number;
 }
-interface ProgressiveLayoutPartial {
-    availableUnits: number;
-    totalUnits?: number;
-    exact: boolean;
-}
-interface ProgressiveLayoutProgress {
-    committedUnits: number;
-}
 interface LoadOptions__emitterCollision1 {
     useGoogleFonts?: boolean;
     password?: string;
@@ -1601,6 +1593,7 @@ interface LoadOptions__emitterCollision1 {
     threeD?: ChartThreeDRenderer;
     regionMap?: ChartRegionMapRenderer;
     chartEx?: ChartExRenderer;
+    tiff?: TiffRenderer;
 }
 export interface MatchRunSlice {
     runIndex: number;
@@ -1895,6 +1888,14 @@ export interface PatternFill {
     fg: string;
     bg: string;
     preset: string;
+}
+interface ProgressiveLayoutPartial {
+    availableUnits: number;
+    totalUnits?: number;
+    exact: boolean;
+}
+interface ProgressiveLayoutProgress {
+    committedUnits: number;
 }
 export interface PTabRun {
     alignment: 'left' | 'center' | 'right';
@@ -2227,6 +2228,9 @@ export interface TextPath {
 export interface TextSelectionContextOptions {
     readonly maxTextCharacters?: number;
     readonly maxRunLocators?: number;
+}
+export interface TiffRenderer {
+    render(bytes: Uint8Array): Promise<ImageBitmap | null>;
 }
 export interface TileInfo {
     tx?: number;

--- a/packages/docx/src/DocxViewer.stories.ts
+++ b/packages/docx/src/DocxViewer.stories.ts
@@ -5,6 +5,7 @@ import { math } from '../../../src/math';
 import { threeD } from '../../../src/three-d';
 import { regionMap } from '../../../src/region-map';
 import { chartEx } from '../../../src/chart-ex';
+import { tiff } from '../../../src/tiff';
 
 type Args = {
   width: number;
@@ -76,6 +77,7 @@ export function buildViewerUI(
     threeD,
     regionMap,
     chartEx,
+    tiff,
     ...extra,
   });
 

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -359,6 +359,7 @@ export class DocxDocument {
   private _threeD: ChartThreeDRenderer | undefined;
   private _regionMap: ChartRegionMapRenderer | undefined;
   private _chartEx: ChartExRenderer | undefined;
+  private _tiff: import('@silurus/ooxml-core').TiffRenderer | undefined;
   private _worker: Worker;
   private _bridge: WorkerBridge<WorkerResponse | RenderWorkerResponse>;
   private readonly _rawParts = new BoundedRawPartCache({
@@ -540,6 +541,12 @@ export class DocxDocument {
         );
       }
       doc._chartEx = doc._mode === 'worker' ? undefined : opts.chartEx;
+      if (opts.tiff && doc._mode === 'worker' && !rendererDescriptors?.tiff) {
+        console.warn(
+          "[ooxml] a custom TIFF codec cannot cross the worker boundary; TIFF images will be skipped in mode: 'worker'. Use the codec from @silurus/ooxml/tiff.",
+        );
+      }
+      doc._tiff = doc._mode === 'worker' ? undefined : opts.tiff;
       if (doc._mode === 'main' && opts.useGoogleFonts && doc._document) {
         doc._googleFontFaces = await preloadGoogleFonts(
           docxFontPreloadNames(doc._document),
@@ -1649,6 +1656,7 @@ export class DocxDocument {
       threeD: this._threeD,
       regionMap: this._regionMap,
       chartEx: this._chartEx,
+      tiff: this._tiff,
     });
   }
 

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -63,6 +63,7 @@ export type {
   ChartThreeDRenderer,
   ChartRegionMapRenderer,
   ChartExRenderer,
+  TiffRenderer,
   ChartExElementStyle,
   ChartLineDashSegment,
   ChartexHistogramBinning,

--- a/packages/docx/src/paint/browser-images.ts
+++ b/packages/docx/src/paint/browser-images.ts
@@ -9,7 +9,7 @@ import {
   preferVectorBlip,
   releaseOwnedBitmap,
 } from '@silurus/ooxml-core';
-import type { Duotone } from '@silurus/ooxml-core';
+import type { Duotone, TiffRenderer } from '@silurus/ooxml-core';
 import type {
   DeepReadonly,
   ImagePaintResourceDescriptor,
@@ -78,11 +78,13 @@ export async function decodeRaster(
   heightPt = 0,
   duotone?: Duotone,
   failClosedOnDuotoneFailure = false,
+  tiff?: TiffRenderer,
 ): Promise<ImageBitmap | null> {
   const base = await getCachedBitmapByPath(imagePath, mimeType, fetchImage, {
     widthPt,
     heightPt,
     suppressBoundaryFrame: true,
+    tiff,
   });
   if (!base) return null;
   if (!colorReplaceFrom && !duotone) return base;
@@ -165,6 +167,7 @@ function imageDecodeRequests(
 export async function preloadPaintImages(
   descriptors: readonly DeepReadonly<PaintResourceDescriptor>[],
   fetchImage: DocxFetchImage | undefined,
+  tiff?: TiffRenderer,
 ): Promise<Map<string, DecodedImage>> {
   if (!fetchImage) return new Map();
   const entries = await Promise.all(imageDecodeRequests(descriptors).map(async (request) => {
@@ -185,6 +188,8 @@ export async function preloadPaintImages(
               request.widthPt,
               request.heightPt,
               request.duotone,
+              false,
+              tiff,
             );
         if (!fallback) throw vectorError;
         image = fallback;
@@ -200,6 +205,8 @@ export async function preloadPaintImages(
         request.widthPt,
         request.heightPt,
         request.duotone,
+        false,
+        tiff,
       );
     }
     return image == null

--- a/packages/docx/src/paint/canvas-document.ts
+++ b/packages/docx/src/paint/canvas-document.ts
@@ -13,7 +13,7 @@ import {
   preferVectorBlip,
 } from '@silurus/ooxml-core';
 import type { Duotone } from '@silurus/ooxml-core';
-import type { ChartThreeDRenderer, ChartRegionMapRenderer, ChartExRenderer } from '@silurus/ooxml-core';
+import type { ChartThreeDRenderer, ChartRegionMapRenderer, ChartExRenderer, TiffRenderer } from '@silurus/ooxml-core';
 import type {
   DocumentLayout,
   LayoutPage,
@@ -53,6 +53,7 @@ export interface CanvasDocumentPaintOptions<TTextRun> {
   readonly threeD?: ChartThreeDRenderer;
   readonly regionMap?: ChartRegionMapRenderer;
   readonly chartEx?: ChartExRenderer;
+  readonly tiff?: TiffRenderer;
 }
 
 /** Per-canvas cancellation token: only the newest asynchronous image preload
@@ -179,7 +180,7 @@ export async function renderSelectedDocumentPage<TTextRun>(
 
     let images;
     try {
-      images = await preloadPaintImages(options.registry.descriptors, options.fetchImage);
+      images = await preloadPaintImages(options.registry.descriptors, options.fetchImage, options.tiff);
     } catch (error) {
       if (superseded()) return;
       throw error;
@@ -209,7 +210,7 @@ export async function renderSelectedDocumentPage<TTextRun>(
             ? fill.duotone ? Promise.resolve(null) : getCachedSvgImageByPath(fill.imagePath, fetchImage)
             : decodeRaster(
                 fill.imagePath, fill.mimeType, undefined, fetchImage as DocxFetchImage,
-                raster.widthPt, raster.heightPt, fill.duotone, true,
+                raster.widthPt, raster.heightPt, fill.duotone, true, options.tiff,
               );
           let image: CanvasImageSource | null;
           if (!fill.duotone && preferVectorBlip(fill)) {

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -368,6 +368,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerWireRequest>) => {
         threeD: renderers.threeD,
         regionMap: renderers.regionMap,
         chartEx: renderers.chartEx,
+        tiff: renderers.tiff,
       });
       const runs = textRunsForSelectedPage(doc.layoutServices, req.pageIndex, {
         ...req.opts,

--- a/packages/docx/src/renderer.image.test.ts
+++ b/packages/docx/src/renderer.image.test.ts
@@ -58,6 +58,28 @@ describe('docx lazy image bytes', () => {
     expect((globalThis.createImageBitmap as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
   });
 
+  it('threads the opt-in TIFF codec through the DOCX image path', async () => {
+    const bytes = new Uint8Array([0x49, 0x49, 0x2a, 0x00, 8, 0, 0, 0]);
+    const bitmap = { width: 8, height: 4, close() {} } as unknown as ImageBitmap;
+    const render = vi.fn(async () => bitmap);
+    const fetchImage = vi.fn(async () => new Blob([bytes as BlobPart], { type: 'image/tiff' }));
+
+    await expect(decodeRaster(
+      'word/media/image1.tiff',
+      'image/tiff',
+      undefined,
+      fetchImage,
+      0,
+      0,
+      undefined,
+      false,
+      { render },
+    )).resolves.toBe(bitmap);
+
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(globalThis.createImageBitmap).not.toHaveBeenCalled();
+  });
+
   it('preloadImages keys by imagePath and decodes each distinct key exactly once', async () => {
     const fetchImage = vi.fn(
       async (path: string, mime: string) => new Blob([new Uint8Array([path.length])], { type: mime }),

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,6 +1,6 @@
 import type { DocxDocumentModel, BodyElement, DocxTextRunInfo } from './types';
 import type { LayoutServices, MathRenderer } from './layout/types.js';
-import type { ChartThreeDRenderer, ChartRegionMapRenderer, ChartExRenderer } from '@silurus/ooxml-core';
+import type { ChartThreeDRenderer, ChartRegionMapRenderer, ChartExRenderer, TiffRenderer } from '@silurus/ooxml-core';
 export type { DocxTextRunInfo } from './types';
 import { bodyMathOccurrences } from './layout/resources.js';
 import { paintResourceRegistryOf, privateResourceLookupOf } from './layout/runtime-state.js';
@@ -71,6 +71,8 @@ export interface RenderDocumentOptions {
   regionMap?: ChartRegionMapRenderer;
   /** Internal load-time optional ChartEx renderer retained by DocxDocument. */
   chartEx?: ChartExRenderer;
+  /** Internal load-time optional TIFF codec retained by DocxDocument. */
+  tiff?: TiffRenderer;
 }
 
 export function dropColorReplacedCache(
@@ -127,6 +129,7 @@ function normalizeRenderOptions(
       threeD: options.threeD,
       regionMap: options.regionMap,
       chartEx: options.chartEx,
+      tiff: options.tiff,
     },
   };
 }

--- a/packages/docx/tests/visual/fixture.html
+++ b/packages/docx/tests/visual/fixture.html
@@ -14,6 +14,7 @@
   import { DocxDocument } from '/src/index.ts';
   import { threeD } from '@ooxml-test-three-d-renderer';
   import { regionMap } from '@ooxml-test-region-map-renderer';
+  import { tiff } from '@ooxml-test-tiff-renderer';
   import { stableCanvasRender } from './stable-canvas-render.mjs';
 
   const params = new URLSearchParams(location.search);
@@ -24,7 +25,7 @@
   const canvas = document.getElementById('canvas');
 
   try {
-    const doc = await DocxDocument.load('/' + file, { threeD, regionMap });
+    const doc = await DocxDocument.load('/' + file, { threeD, regionMap, tiff });
     // Report the renderer's REAL page count so the VRT spec can assert the
     // requested page index is in range. renderPage() silently clamps an
     // out-of-range index back to page 0 (renderer.ts: `pages[pageIndex] ??

--- a/packages/docx/vite.config.ts
+++ b/packages/docx/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       '@ooxml-test-three-d-renderer': resolve(__dirname, '../../src/three-d.ts'),
       '@ooxml-test-region-map-renderer': resolve(__dirname, '../../src/region-map.ts'),
       '@ooxml-test-math-renderer': resolve(__dirname, '../../src/math.ts'),
+      '@ooxml-test-tiff-renderer': resolve(__dirname, '../../src/tiff.ts'),
     },
   },
   build: {

--- a/packages/ooxml-common/src/blip.rs
+++ b/packages/ooxml-common/src/blip.rs
@@ -75,6 +75,7 @@ pub fn mime_from_ext(path: &str) -> &'static str {
         "bmp" => "image/bmp",
         "svg" => "image/svg+xml",
         "webp" => "image/webp",
+        "tif" | "tiff" => "image/tiff",
         // Windows Metafile / Enhanced Metafile. Office embeds these for charts
         // and diagrams; the renderer rasterizes WMF via a minimal player and
         // skips EMF (a follow-up). The conventional MIME types per IANA / Windows.
@@ -368,6 +369,8 @@ mod tests {
         assert_eq!(mime_from_ext("a/b/image1.PNG"), "image/png");
         assert_eq!(mime_from_ext("x.jpeg"), "image/jpeg");
         assert_eq!(mime_from_ext("x.webp"), "image/webp");
+        assert_eq!(mime_from_ext("x.tif"), "image/tiff");
+        assert_eq!(mime_from_ext("x.TIFF"), "image/tiff");
         assert_eq!(mime_from_ext("noext"), "application/octet-stream");
     }
 

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -993,14 +993,6 @@ export type LoadOptions = LoadOptions__emitterCollision1 & {
     onLayoutPartial?: (progress: Readonly<ProgressiveLayoutPartial>) => void;
     onLayoutComplete?: (error?: unknown) => void;
 };
-interface ProgressiveLayoutPartial {
-    availableUnits: number;
-    totalUnits?: number;
-    exact: boolean;
-}
-interface ProgressiveLayoutProgress {
-    committedUnits: number;
-}
 interface LoadOptions__emitterCollision1 {
     useGoogleFonts?: boolean;
     password?: string;
@@ -1014,6 +1006,7 @@ interface LoadOptions__emitterCollision1 {
     threeD?: ChartThreeDRenderer;
     regionMap?: ChartRegionMapRenderer;
     chartEx?: ChartExRenderer;
+    tiff?: TiffRenderer;
 }
 export interface MatchRunSlice {
     runIndex: number;
@@ -1328,20 +1321,6 @@ export interface PictureElement {
     scene3d?: Scene3d;
     sp3d?: Sp3d;
 }
-export type PptxCommentAnchor = Readonly<{
-    type: 'slide';
-}> | Readonly<{
-    type: 'drawingElement';
-    elementId?: string;
-    creationId?: string;
-}> | Readonly<{
-    type: 'textRange';
-    elementId?: string;
-    start?: number;
-    length?: number;
-}> | Readonly<{
-    type: 'unknown';
-}>;
 export interface PptxComment {
     authorId?: number;
     modernAuthorId?: string;
@@ -1356,6 +1335,20 @@ export interface PptxComment {
     text: string;
     replies?: readonly Readonly<PptxCommentReply>[];
 }
+export type PptxCommentAnchor = Readonly<{
+    type: 'slide';
+}> | Readonly<{
+    type: 'drawingElement';
+    elementId?: string;
+    creationId?: string;
+}> | Readonly<{
+    type: 'textRange';
+    elementId?: string;
+    start?: number;
+    length?: number;
+}> | Readonly<{
+    type: 'unknown';
+}>;
 export interface PptxCommentReply {
     id?: string;
     authorId?: string;
@@ -1644,6 +1637,14 @@ export interface PresentationHandle {
 export interface PresentSlideOptions extends Omit<RenderSlideOptions, 'skipMediaControls'> {
     onError?: (error: Error) => void;
 }
+interface ProgressiveLayoutPartial {
+    availableUnits: number;
+    totalUnits?: number;
+    exact: boolean;
+}
+interface ProgressiveLayoutProgress {
+    committedUnits: number;
+}
 export function readPptxTextSelectionContext(root: HTMLElement, selection: Selection | null, options?: TextSelectionContextOptions): PptxTextSelectionContext | null;
 export interface Reflection {
     blur: number;
@@ -1807,6 +1808,7 @@ export type SlideRenderOptions = RenderOptions & {
     threeD?: ChartThreeDRenderer;
     regionMap?: ChartRegionMapRenderer;
     chartEx?: ChartExRenderer;
+    tiff?: TiffRenderer;
     dim?: DimOptions;
 };
 export interface SoftEdge {
@@ -1961,6 +1963,9 @@ export interface TextRunData {
 export interface TextSelectionContextOptions {
     readonly maxTextCharacters?: number;
     readonly maxRunLocators?: number;
+}
+export interface TiffRenderer {
+    render(bytes: Uint8Array): Promise<ImageBitmap | null>;
 }
 export interface TileInfo {
     tx?: number;

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -71,6 +71,7 @@ export type {
   ChartThreeDRenderer,
   ChartRegionMapRenderer,
   ChartExRenderer,
+  TiffRenderer,
   ChartExElementStyle,
   ChartLineDashSegment,
   ChartexHistogramBinning,

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -29,6 +29,7 @@ import {
   type ChartThreeDRenderer,
   type ChartRegionMapRenderer,
   type ChartExRenderer,
+  type TiffRenderer,
   type OoxmlResourceMetrics,
   workerRendererDescriptors,
 } from '@silurus/ooxml-core';
@@ -270,6 +271,7 @@ export class PptxPresentation {
   private _threeD: ChartThreeDRenderer | undefined;
   private _regionMap: ChartRegionMapRenderer | undefined;
   private _chartEx: ChartExRenderer | undefined;
+  private _tiff: TiffRenderer | undefined;
 
   private constructor(worker: Worker, mode: 'main' | 'worker', wasmUrlOverride?: string | URL) {
     this._worker = worker;
@@ -385,6 +387,12 @@ export class PptxPresentation {
         );
       }
       pres._chartEx = mode === 'worker' ? undefined : opts.chartEx;
+      if (opts.tiff && mode === 'worker' && !rendererDescriptors?.tiff) {
+        console.warn(
+          "[ooxml] a custom TIFF codec cannot cross the worker boundary; TIFF images will be skipped in mode: 'worker'. Use the codec from @silurus/ooxml/tiff.",
+        );
+      }
+      pres._tiff = mode === 'worker' ? undefined : opts.tiff;
       const progressive = opts.progressiveLayout
         ? {
             onProgress: opts.onLayoutProgress,
@@ -1039,6 +1047,7 @@ export class PptxPresentation {
             threeD: this._threeD,
             regionMap: this._regionMap,
             chartEx: this._chartEx,
+            tiff: this._tiff,
           },
           opts.onTextRun,
         );

--- a/packages/pptx/src/render-worker.ts
+++ b/packages/pptx/src/render-worker.ts
@@ -330,6 +330,7 @@ self.onmessage = async (event: MessageEvent<RenderWorkerRequest>) => {
           threeD: renderers.threeD,
           regionMap: renderers.regionMap,
           chartEx: renderers.chartEx,
+          tiff: renderers.tiff,
         }, (run) => runs.push(run));
         return { bitmap: canvas.transferToImageBitmap(), runs };
       });
@@ -357,6 +358,7 @@ self.onmessage = async (event: MessageEvent<RenderWorkerRequest>) => {
           threeD: renderers.threeD,
           regionMap: renderers.regionMap,
           chartEx: renderers.chartEx,
+          tiff: renderers.tiff,
         }, (run) => runs.push(run));
         return runs;
       });

--- a/packages/pptx/src/renderer-chart-picture-marker.test.ts
+++ b/packages/pptx/src/renderer-chart-picture-marker.test.ts
@@ -66,15 +66,17 @@ describe('PPTX chart picture-marker preload', () => {
       }],
     } as Slide;
     const fetchImage = vi.fn(async () => new Blob(['png'], { type: 'image/png' }));
+    const tiff = { render: vi.fn() };
 
     await renderSlide(canvas(), slide, 9_144_000, 6_858_000, {
-      width: 960, dpr: 1, fetchImage,
+      width: 960, dpr: 1, fetchImage, tiff,
     });
 
     expect(coreMocks.decode).toHaveBeenCalledTimes(1);
     expect(coreMocks.decode.mock.calls[0]?.slice(0, 4)).toEqual([
       'ppt/media/chart-marker.png', 'image/png', undefined, fetchImage,
     ]);
+    expect(coreMocks.decode.mock.calls[0]?.[4]).toMatchObject({ tiff });
     expect(coreMocks.renderChart).toHaveBeenCalledTimes(1);
     expect(coreMocks.resolved()).toBe(coreMocks.bitmap);
   });

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -110,6 +110,7 @@ import type {
   ChartThreeDRenderer,
   ChartRegionMapRenderer,
   ChartExRenderer,
+  TiffRenderer,
 } from '@silurus/ooxml-core';
 import type { HyperlinkTarget } from '@silurus/ooxml-core';
 import { paintDistanceAwareReflectionBlur } from './reflection-blur';
@@ -1673,6 +1674,7 @@ async function renderBackground(
   scale: number,
   superseded: () => boolean,
   fetchImage?: (path: string, mime: string) => Promise<Blob>,
+  tiff?: TiffRenderer,
 ) {
   // ECMA-376 §20.1.8.14 — image (blipFill) background. Paint an opaque white
   // base first so a partially transparent image (alphaModFix) composites over
@@ -1697,6 +1699,7 @@ async function renderBackground(
         {
           widthPt: canvasW / scale / PT_TO_EMU,
           heightPt: canvasH / scale / PT_TO_EMU,
+          tiff,
         },
       );
       if (superseded()) return;
@@ -5150,6 +5153,7 @@ export function getPosterBitmap(
   el: MediaElement,
   fetchMedia: FetchMedia,
   bitmapOwner: PosterFetchImage = posterFetchImage(fetchMedia),
+  tiff?: TiffRenderer,
 ): Promise<ImageBitmap> {
   return getCachedDecodedBitmap(
     'base',
@@ -5159,7 +5163,7 @@ export function getPosterBitmap(
       const blob = await fetchMedia(el.posterPath);
       const mimeType = el.posterMimeType || blob.type || 'application/octet-stream';
       const typed = blob.type === mimeType ? blob : new Blob([blob], { type: mimeType });
-      return { bitmap: await decodeRasterOrMetafile(typed), owned: true };
+      return { bitmap: await decodeRasterOrMetafile(typed, { tiff }), owned: true };
     },
   ).then((bitmap) => {
     if (!bitmap) throw new Error('Media poster could not be decoded');
@@ -5173,6 +5177,7 @@ async function renderPicture(
   scale: number,
   superseded: () => boolean,
   fetchImage?: (path: string, mime: string) => Promise<Blob>,
+  tiff?: TiffRenderer,
 ) {
   // No byte source → nothing to draw (the lazy pipeline always supplies one in
   // both render modes; this guards the rare misconfiguration).
@@ -5226,7 +5231,7 @@ async function renderPicture(
         // SVG vector original has no readable pixel grid (matches xlsx).
         bitmap = dataIsSvg
           ? await getCachedSvgImageByPath(el.imagePath, fetchImage)
-          : await getCachedDuotoneBitmapByPath(el.imagePath, el.mimeType, el.duotone, fetchImage, { widthPt, heightPt });
+          : await getCachedDuotoneBitmapByPath(el.imagePath, el.mimeType, el.duotone, fetchImage, { widthPt, heightPt, tiff });
       }
     } else if (dataIsSvg) {
       // SVG-only picture (here either because it has a crop, or — defensively —
@@ -5238,7 +5243,7 @@ async function renderPicture(
       // §20.1.8.23 duotone recolour on the raster blip (once, at decode time,
       // cached under a colour-suffixed key). No duotone ⇒ this is exactly the
       // former `getCachedBitmapByPath` decode.
-      bitmap = await getCachedDuotoneBitmapByPath(el.imagePath, el.mimeType, el.duotone, fetchImage, { widthPt, heightPt });
+      bitmap = await getCachedDuotoneBitmapByPath(el.imagePath, el.mimeType, el.duotone, fetchImage, { widthPt, heightPt, tiff });
     }
     // Skip a picture whose blip is an unsupported metafile (null bitmap), the
     // same way an SVG-decode failure that also fails its raster fallback would
@@ -5650,6 +5655,7 @@ async function renderMedia(
   fetchMedia?: (path: string) => Promise<Blob>,
   skipControls?: boolean,
   bitmapOwner?: PosterFetchImage,
+  tiff?: TiffRenderer,
 ) {
   const x = emuToPx(el.x, scale);
   const y = emuToPx(el.y, scale);
@@ -5661,7 +5667,7 @@ async function renderMedia(
     try {
       // Poster is cached (and prefetched by renderSlide); do not close it here —
       // it is reused across renders of the same slide.
-      poster = await getPosterBitmap(el, fetchMedia, bitmapOwner);
+      poster = await getPosterBitmap(el, fetchMedia, bitmapOwner, tiff);
     } catch (error) {
       if (isOoxmlDecodedImageLimitError(error)) throw error;
       // fall through to plain fill
@@ -6284,6 +6290,7 @@ export type SlideRenderOptions = RenderOptions & {
   threeD?: ChartThreeDRenderer;
   regionMap?: ChartRegionMapRenderer;
   chartEx?: ChartExRenderer;
+  tiff?: TiffRenderer;
   dim?: DimOptions;
 };
 
@@ -6528,6 +6535,7 @@ async function renderSlideLeased(
     scale,
     superseded,
     opts.fetchImage,
+    opts.tiff,
   );
   if (superseded()) return canvas;
 
@@ -6578,12 +6586,13 @@ async function renderSlideLeased(
         void getCachedDuotoneBitmapByPath(p.imagePath, p.mimeType, p.duotone, opts.fetchImage, {
           widthPt: warm.widthPt,
           heightPt: warm.heightPt,
+          tiff: opts.tiff,
         }).catch(() => undefined);
       }
     } else if (el.type === 'media') {
       const m = el as MediaElement;
       if (m.posterPath && opts.fetchMedia) {
-        void getPosterBitmap(m, opts.fetchMedia, bitmapOwner).catch(() => undefined);
+        void getPosterBitmap(m, opts.fetchMedia, bitmapOwner, opts.tiff).catch(() => undefined);
       }
     }
   }
@@ -6617,7 +6626,7 @@ async function renderSlideLeased(
     if (bulletPaths.size > 0 || chartFillMap.size > 0) {
       const bulletPromises: Promise<unknown>[] = [...bulletPaths].map((key) => {
           const [path, mime] = key.split(' ');
-          return getCachedBitmapByPath(path, mime, fetchImage).catch((error) => {
+          return getCachedBitmapByPath(path, mime, fetchImage, { tiff: opts.tiff }).catch((error) => {
             if (isOoxmlDecodedImageLimitError(error)) throw error;
             return undefined;
           });
@@ -6637,6 +6646,7 @@ async function renderSlideLeased(
                     widthPt: raster.widthPt,
                     heightPt: raster.heightPt,
                     failClosedOnDuotoneFailure: true,
+                    tiff: opts.tiff,
                   },
                 );
             let bitmap: CanvasImageSource | null;
@@ -6674,7 +6684,7 @@ async function renderSlideLeased(
         : undefined;
       renderShape(ctx, el, scale, themeDefaultColor, slideNumber, rc, elementTextRun, opts.fetchImage);
     } else if (el.type === 'picture') {
-      await renderPicture(ctx, el, scale, superseded, opts.fetchImage);
+      await renderPicture(ctx, el, scale, superseded, opts.fetchImage, opts.tiff);
     } else if (el.type === 'table') {
       const elementTextRun: TextRunCallback | undefined = onTextRun
         ? (run) => onTextRun({
@@ -6693,6 +6703,7 @@ async function renderSlideLeased(
         opts.fetchMedia,
         opts.skipMediaControls,
         opts.fetchImage,
+        opts.tiff,
       );
     } else if (el.type === 'chart') {
       // OOXML: 1pt = 12700 EMU. The slide renderer's `scale` is px-per-EMU,

--- a/packages/pptx/tests/visual/fixture.html
+++ b/packages/pptx/tests/visual/fixture.html
@@ -24,6 +24,7 @@
     import { PptxViewer } from '/src/index.ts';
     import { threeD } from '@ooxml-test-three-d-renderer';
     import { regionMap } from '@ooxml-test-region-map-renderer';
+    import { tiff } from '@ooxml-test-tiff-renderer';
 
     // Text rasterization must not depend on how quickly Vite serves the
     // fontsource CSS and weight-specific WOFF files. Regression baselines compare
@@ -42,6 +43,7 @@
       width,
       threeD,
       regionMap,
+      tiff,
       onError: (err) => {
         document.body.dataset.status = 'error';
         document.body.dataset.errorMessage = err.message;

--- a/packages/pptx/vite.config.ts
+++ b/packages/pptx/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       '@ooxml-test-three-d-renderer': resolve(dirname, '../../src/three-d.ts'),
       '@ooxml-test-region-map-renderer': resolve(dirname, '../../src/region-map.ts'),
       '@ooxml-test-math-renderer': resolve(dirname, '../../src/math.ts'),
+      '@ooxml-test-tiff-renderer': resolve(dirname, '../../src/tiff.ts'),
     },
   },
   server: {

--- a/packages/vscode-extension/src/advancedChartRenderers.test.ts
+++ b/packages/vscode-extension/src/advancedChartRenderers.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { advancedChartRenderers } from './webview/advancedChartRenderers';
+import { advancedChartRenderers, fullRenderers } from './webview/advancedChartRenderers';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
@@ -16,10 +16,17 @@ describe('VS Code webview advanced chart renderers', () => {
     expect(typeof advancedChartRenderers.chartEx.render).toBe('function');
     expect(typeof advancedChartRenderers.threeD.render).toBe('function');
     expect(typeof advancedChartRenderers.regionMap.render).toBe('function');
+    expect(Object.keys(fullRenderers).sort()).toEqual([
+      'chartEx',
+      'regionMap',
+      'threeD',
+      'tiff',
+    ]);
+    expect(typeof fullRenderers.tiff.render).toBe('function');
   });
 
   it('injects the same renderer set into DOCX, XLSX, and PPTX viewers', () => {
     const bootstrap = readFileSync(resolve(HERE, 'webview/bootstrap.ts'), 'utf8');
-    expect(bootstrap.match(/\.\.\.advancedChartRenderers/g)).toHaveLength(3);
+    expect(bootstrap.match(/\.\.\.fullRenderers/g)).toHaveLength(3);
   });
 });

--- a/packages/vscode-extension/src/webview/advancedChartRenderers.ts
+++ b/packages/vscode-extension/src/webview/advancedChartRenderers.ts
@@ -1,6 +1,7 @@
 import { renderChartExChart } from '@silurus/ooxml-core/internal/chart-ex-renderer';
 import { renderRegionMapChart } from '@silurus/ooxml-core/internal/region-map-renderer';
 import { renderSimpleThreeDChart } from '@silurus/ooxml-core/internal/three-d-renderer';
+import { renderTiffToBitmap } from '@silurus/ooxml-core/internal/tiff-renderer';
 
 /**
  * The extension is a ready-to-use product rather than a consumer-controlled
@@ -10,4 +11,10 @@ export const advancedChartRenderers = Object.freeze({
   chartEx: Object.freeze({ render: renderChartExChart }),
   regionMap: Object.freeze({ render: renderRegionMapChart }),
   threeD: Object.freeze({ render: renderSimpleThreeDChart }),
+});
+
+/** Every optional first-party renderer/codec enabled by the ready-to-use extension. */
+export const fullRenderers = Object.freeze({
+  ...advancedChartRenderers,
+  tiff: Object.freeze({ render: renderTiffToBitmap }),
 });

--- a/packages/vscode-extension/src/webview/bootstrap.ts
+++ b/packages/vscode-extension/src/webview/bootstrap.ts
@@ -26,7 +26,7 @@ import { svgExtents, type ZoomableViewer } from '@silurus/ooxml-core';
 import { loadAtContainerFit, loadAtNaturalScale } from './naturalScale';
 import { captureUnhandledWheelZoom } from './wheelZoomFallback';
 import { FindPopupController, type FindableViewer } from './findPopup';
-import { advancedChartRenderers } from './advancedChartRenderers';
+import { fullRenderers } from './advancedChartRenderers';
 // Side-effect import: bundles the self-contained MathJax + STIX Two Math engine
 // into the webview and sets globalThis.__ooxmlStix2. The library renders OMML
 // equations only when handed a `math` engine; its built-in engine loads lazily
@@ -188,7 +188,7 @@ window.addEventListener('message', async (event: MessageEvent) => {
 async function initXlsx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<void> {
   const viewer = new XlsxViewer(viewerContainer, {
     math,
-    ...advancedChartRenderers,
+    ...fullRenderers,
     useGoogleFonts,
     showZoomSlider: false,
     enableElementSelection: true,
@@ -227,7 +227,7 @@ async function initXlsx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<v
 async function initDocx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<void> {
   const viewer = new DocxScrollViewer(viewerContainer, {
     math,
-    ...advancedChartRenderers,
+    ...fullRenderers,
     useGoogleFonts,
     progressiveLayout: true,
     enableTextSelection: true,
@@ -256,7 +256,7 @@ async function initDocx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<v
 async function initPptx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<void> {
   const viewer = new PptxScrollViewer(viewerContainer, {
     math,
-    ...advancedChartRenderers,
+    ...fullRenderers,
     useGoogleFonts,
     progressiveLayout: true,
     enableTextSelection: true,

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -1151,6 +1151,7 @@ interface LoadOptions__emitterCollision1 {
     threeD?: ChartThreeDRenderer;
     regionMap?: ChartRegionMapRenderer;
     chartEx?: ChartExRenderer;
+    tiff?: TiffRenderer;
 }
 export interface MathAccent {
     kind: 'accent';
@@ -1840,6 +1841,9 @@ export interface TableInfo {
     band1HorizontalDxf?: number;
     band2HorizontalDxf?: number;
     columns: TableColumnInfo[];
+}
+export interface TiffRenderer {
+    render(bytes: Uint8Array): Promise<ImageBitmap | null>;
 }
 export interface TileInfo {
     tx?: number;

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -68,6 +68,7 @@ export type {
   ChartThreeDRenderer,
   ChartRegionMapRenderer,
   ChartExRenderer,
+  TiffRenderer,
   ChartExElementStyle,
   ChartLineDashSegment,
   ChartexHistogramBinning,

--- a/packages/xlsx/src/render-orchestrator.image.test.ts
+++ b/packages/xlsx/src/render-orchestrator.image.test.ts
@@ -411,6 +411,32 @@ describe('render-orchestrator image decode (lazy bytes)', () => {
     expect(createImageBitmap).toHaveBeenCalledTimes(1);
   });
 
+  it('threads the opt-in TIFF codec through the XLSX image path', async () => {
+    const bytes = new Uint8Array([0x49, 0x49, 0x2a, 0x00, 8, 0, 0, 0]);
+    const bitmap = new FakeBitmap('image/tiff') as unknown as ImageBitmap;
+    const render = vi.fn(async () => bitmap);
+    const browserDecode = vi.fn();
+    vi.stubGlobal('createImageBitmap', browserDecode);
+    const fetchImage = vi.fn(async () => new Blob([bytes as BlobPart], { type: 'image/tiff' }));
+
+    await expect(decodeImageSource(
+      'xl/media/image1.tiff',
+      'image/tiff',
+      undefined,
+      fetchImage,
+      0,
+      0,
+      null,
+      null,
+      undefined,
+      false,
+      { render },
+    )).resolves.toBe(bitmap);
+
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(browserDecode).not.toHaveBeenCalled();
+  });
+
   it('decodeImageSource forces the raster (not the SVG vector) when the picture is cropped', async () => {
     // A cropped picture (a non-null `srcRect`) with an svgBlip vector original
     // must decode the RASTER fallback: the renderer's `<a:srcRect>` crop math

--- a/packages/xlsx/src/render-orchestrator.ts
+++ b/packages/xlsx/src/render-orchestrator.ts
@@ -14,6 +14,7 @@ import {
   type ChartThreeDRenderer,
   type ChartRegionMapRenderer,
   type ChartExRenderer,
+  type TiffRenderer,
   type SrcRect,
   type Duotone,
   type OffscreenFactory,
@@ -202,6 +203,7 @@ export async function decodeImageSource(
   duotone: Duotone | null = null,
   offscreenFactory?: OffscreenFactory,
   failClosedOnDuotoneFailure = false,
+  tiff?: TiffRenderer,
 ): Promise<CanvasImageSource | null> {
   const dataIsSvg = mimeType === 'image/svg+xml';
   // SVG pixels are not exposed to the shared bitmap effect pipeline. Without
@@ -219,6 +221,7 @@ export async function decodeImageSource(
       heightPt: sized.heightPt,
       offscreenFactory,
       failClosedOnDuotoneFailure,
+      tiff,
     });
   // Shared vector-vs-raster gate (see core preferVectorBlip). When it returns
   // true, `blip.svgImagePath` is narrowed to string.
@@ -280,6 +283,7 @@ export async function prefetchImages(
     cellScale?: number;
     freezeRows?: number;
     freezeCols?: number;
+    tiff?: TiffRenderer;
   },
 ): Promise<void> {
   // This map is only the synchronous lookup for the current frame. Never keep
@@ -385,6 +389,7 @@ export async function prefetchImages(
           ref.duotone,
           opts?.offscreenFactory,
           ref.failClosedOnDuotoneFailure ?? false,
+          opts?.tiff,
         );
         // Record the resolved drawable (INCLUDING a null for an unsupported
         // metafile, so the renderer skips a falsy source without a re-fetch).
@@ -409,6 +414,7 @@ export interface RenderDeps {
   threeD?: ChartThreeDRenderer;
   regionMap?: ChartRegionMapRenderer;
   chartEx?: ChartExRenderer;
+  tiff?: TiffRenderer;
 }
 
 const autoHeightProjectionCache = new WeakMap<Worksheet, Worksheet>();
@@ -506,6 +512,7 @@ async function renderWorksheetViewportLeased(
     cellScale: opts.cellScale,
     freezeRows: opts.freezeRows,
     freezeCols: opts.freezeCols,
+    tiff: deps.tiff,
   });
 
   // ── Step 1b: Pre-rasterize equations in shapes BEFORE the canvas resize,

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -14,6 +14,7 @@ import {
   type ChartThreeDRenderer,
   type ChartRegionMapRenderer,
   type ChartExRenderer,
+  type TiffRenderer,
   OoxmlResourceLimitError,
   type OoxmlResourceMetrics,
   workerRendererDescriptors,
@@ -146,6 +147,8 @@ export class XlsxWorkbook {
   private regionMap: ChartRegionMapRenderer | undefined;
   /** Optional Microsoft ChartEx renderer. */
   private chartEx: ChartExRenderer | undefined;
+  /** Optional TIFF codec. Worker mode reconstructs the built-in implementation. */
+  private tiff: TiffRenderer | undefined;
   /** Web-font registrations are per FontFaceSet. Same-origin child windows have
    * their own set even when they share this workbook instance. */
   private googleFontNames: string[] = [];
@@ -285,6 +288,7 @@ export class XlsxWorkbook {
     this.threeD = this._mode === 'worker' ? undefined : opts.threeD;
     this.regionMap = this._mode === 'worker' ? undefined : opts.regionMap;
     this.chartEx = this._mode === 'worker' ? undefined : opts.chartEx;
+    this.tiff = this._mode === 'worker' ? undefined : opts.tiff;
     const rendererDescriptors = this._mode === 'worker'
       ? workerRendererDescriptors(opts)
       : undefined;
@@ -306,6 +310,11 @@ export class XlsxWorkbook {
     if (opts.chartEx && this._mode === 'worker' && !rendererDescriptors?.chartEx) {
       console.warn(
         "[ooxml] a custom ChartEx renderer cannot cross the worker boundary; ChartEx charts use the unsupported-chart placeholder in mode: 'worker'. Use the renderer from @silurus/ooxml/chart-ex.",
+      );
+    }
+    if (opts.tiff && this._mode === 'worker' && !rendererDescriptors?.tiff) {
+      console.warn(
+        "[ooxml] a custom TIFF codec cannot cross the worker boundary; TIFF images will be skipped in mode: 'worker'. Use the codec from @silurus/ooxml/tiff.",
       );
     }
     // In worker mode the worker preloads fonts before its first render
@@ -778,6 +787,7 @@ export class XlsxWorkbook {
           threeD: this.threeD,
           regionMap: this.regionMap,
           chartEx: this.chartEx,
+          tiff: this.tiff,
         },
         target,
         viewport,

--- a/packages/xlsx/src/worker-render-deps.ts
+++ b/packages/xlsx/src/worker-render-deps.ts
@@ -17,5 +17,6 @@ export function workerRenderDeps(
     threeD: renderers.threeD,
     regionMap: renderers.regionMap,
     chartEx: renderers.chartEx,
+    tiff: renderers.tiff,
   };
 }

--- a/packages/xlsx/tests/visual/fixture.html
+++ b/packages/xlsx/tests/visual/fixture.html
@@ -15,6 +15,7 @@
   import { XlsxWorkbook } from '/src/index.ts';
   import { threeD } from '@ooxml-test-three-d-renderer';
   import { regionMap } from '@ooxml-test-region-map-renderer';
+  import { tiff } from '@ooxml-test-tiff-renderer';
 
   const params = new URLSearchParams(location.search);
   const file   = params.get('file') ?? 'demo/sample-1.xlsx';
@@ -34,7 +35,7 @@
   canvas.style.height = height + 'px';
 
   try {
-    const wb = await XlsxWorkbook.load('/' + file, { threeD, regionMap });
+    const wb = await XlsxWorkbook.load('/' + file, { threeD, regionMap, tiff });
     document.body.dataset.sheetCount = String(wb.sheetCount);
     const idx = Math.max(0, Math.min(sheet, wb.sheetNames.length - 1));
     await wb.renderViewport(canvas, idx, { row, col, rows, cols }, { width, height, dpr: 1 });

--- a/packages/xlsx/vite.config.ts
+++ b/packages/xlsx/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       '@ooxml-test-three-d-renderer': resolve(dirname, '../../src/three-d.ts'),
       '@ooxml-test-region-map-renderer': resolve(dirname, '../../src/region-map.ts'),
       '@ooxml-test-math-renderer': resolve(dirname, '../../src/math.ts'),
+      '@ooxml-test-tiff-renderer': resolve(dirname, '../../src/tiff.ts'),
     },
   },
   server: { port: 5175, strictPort: true },

--- a/scripts/check-docx-layout-boundaries.mjs
+++ b/scripts/check-docx-layout-boundaries.mjs
@@ -142,8 +142,8 @@ const SHARED_PAINT_IMPORTS = new Map([
     ['recolorSvg', 'value'],
     ['renderChart', 'value'],
     ['withDrawingMLShapeTransform', 'value'],
-    // Optional chart renderers are paint-only capabilities threaded into the
-    // existing shared chart painter. Their erased contracts do not expose
+    // Optional renderers and image codecs are paint-only capabilities threaded
+    // into existing shared painters. Their erased contracts do not expose
     // layout acquisition or permit a renderer back-edge.
     ['ChartThreeDRenderer', 'type'],
     ['ChartRegionMapRenderer', 'type'],
@@ -151,6 +151,7 @@ const SHARED_PAINT_IMPORTS = new Map([
     ['ChartImageLookup', 'type'],
     ['Duotone', 'type'],
     ['MathRenderer', 'type'],
+    ['TiffRenderer', 'type'],
   ])],
 ]);
 

--- a/scripts/check-optional-tiff.mjs
+++ b/scripts/check-optional-tiff.mjs
@@ -1,0 +1,44 @@
+import { readFile } from 'node:fs/promises';
+import { basename, dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const distDir = resolve(process.argv[2] ?? 'dist');
+const implementationMarker = 'packages/core/src/image/tiff.ts';
+
+async function dependencyClosure(entry) {
+  const pending = [join(distDir, entry)];
+  const visited = new Set();
+  const contents = [];
+  while (pending.length > 0) {
+    const file = pending.pop();
+    if (!file || visited.has(file)) continue;
+    visited.add(file);
+    const source = await readFile(file, 'utf8');
+    contents.push({ file, source });
+    for (const match of source.matchAll(/(?:from\s*|import\s*)["'](\.\/[^"']+?\.(?:js|mjs))["']/g)) {
+      pending.push(resolve(dirname(file), match[1]));
+    }
+  }
+  return contents;
+}
+
+function assertAbsent(files, marker, entry) {
+  const hit = files.find(({ source }) => source.includes(marker));
+  if (hit) throw new Error(`${entry} unexpectedly reaches ${marker} via ${basename(hit.file)}`);
+}
+
+const rendererClosure = await dependencyClosure('tiff.mjs');
+const rendererModule = await import(pathToFileURL(join(distDir, 'tiff.mjs')).href);
+if (typeof rendererModule.tiff?.render !== 'function') {
+  throw new Error('tiff.mjs does not export a usable tiff renderer');
+}
+if (!rendererClosure.some(({ source }) => source.includes(implementationMarker))) {
+  throw new Error('tiff.mjs does not reach the TIFF implementation');
+}
+
+for (const entry of ['index.mjs', 'docx.mjs', 'xlsx.mjs', 'pptx.mjs']) {
+  const files = await dependencyClosure(entry);
+  assertAbsent(files, implementationMarker, entry);
+}
+
+console.log('optional TIFF bundle boundary verified');

--- a/site/src/lib/api-reference.test.ts
+++ b/site/src/lib/api-reference.test.ts
@@ -29,6 +29,11 @@ describe('official-site API reference', () => {
           exportName: 'regionMap',
           contract: 'ChartRegionMapRenderer',
         },
+        {
+          entry: '@silurus/ooxml/tiff',
+          exportName: 'tiff',
+          contract: 'TiffRenderer',
+        },
       ]);
   });
 
@@ -42,6 +47,8 @@ describe('official-site API reference', () => {
           .toBe('ChartRegionMapRenderer');
         expect(options.find(({ name }) => name === 'chartEx')?.type, apiClass.name)
           .toBe('ChartExRenderer');
+        expect(options.find(({ name }) => name === 'tiff')?.type, apiClass.name)
+          .toBe('TiffRenderer');
       }
     }
   });
@@ -52,6 +59,7 @@ describe('official-site API reference', () => {
       expect(guidance, format).toContain('both modes');
       expect(guidance, format).toContain('Worker mode');
       expect(guidance, format).toContain('ChartEx');
+      expect(guidance, format).toContain('TIFF');
       for (const apiClass of classes) {
         const mode = apiClass.options?.find(({ name }) => name === 'mode');
         expect(mode?.def, apiClass.name).toBe("'main'");
@@ -60,6 +68,7 @@ describe('official-site API reference', () => {
         expect(mode?.desc, apiClass.name).toContain('larger');
         expect(mode?.desc, apiClass.name).toMatch(/built-in/i);
         expect(mode?.desc, apiClass.name).toContain('ChartEx');
+        expect(mode?.desc, apiClass.name).toContain('TIFF');
       }
     }
     expect(formatRenderModeGuidance.docx).toContain('automatically use main mode');

--- a/site/src/lib/api-reference.ts
+++ b/site/src/lib/api-reference.ts
@@ -36,9 +36,9 @@ export interface OptionalRendererReference {
 }
 
 export const formatRenderModeGuidance: Readonly<Record<'docx' | 'xlsx' | 'pptx', string>> = {
-  docx: 'DOCX keeps page navigation, virtualized scrolling, selection, find, hyperlinks, equations, ChartEx, 3-D charts and Region Maps in both modes. Worker mode moves pagination and page paint away from the UI thread. Documents that require DOM OpenType vertical-glyph selection automatically use main mode; read the loaded document\'s mode to observe that fallback.',
-  xlsx: 'XLSX keeps sheet tabs, frozen panes, scrolling, selection, find, hyperlinks, equations, ChartEx, 3-D charts and Region Maps in both modes. Worker mode paints each requested sheet viewport away from the UI thread.',
-  pptx: 'PPTX keeps slide navigation, virtualized scrolling, selection, find, hyperlinks, media playback, equations, ChartEx, 3-D charts and Region Maps in both modes. Worker mode moves slide paint away from the UI thread; media controls and overlays remain interactive in the Viewer.',
+  docx: 'DOCX keeps page navigation, virtualized scrolling, selection, find, hyperlinks, equations, ChartEx, 3-D charts, Region Maps and the built-in TIFF codec in both modes. Worker mode moves pagination and page paint away from the UI thread. Documents that require DOM OpenType vertical-glyph selection automatically use main mode; read the loaded document\'s mode to observe that fallback.',
+  xlsx: 'XLSX keeps sheet tabs, frozen panes, scrolling, selection, find, hyperlinks, equations, ChartEx, 3-D charts, Region Maps and the built-in TIFF codec in both modes. Worker mode paints each requested sheet viewport away from the UI thread.',
+  pptx: 'PPTX keeps slide navigation, virtualized scrolling, selection, find, hyperlinks, media playback, equations, ChartEx, 3-D charts, Region Maps and the built-in TIFF codec in both modes. Worker mode moves slide paint away from the UI thread; media controls and overlays remain interactive in the Viewer.',
 };
 
 export const optionalRenderers: readonly OptionalRendererReference[] = [
@@ -70,6 +70,13 @@ export const optionalRenderers: readonly OptionalRendererReference[] = [
     contract: 'ChartRegionMapRenderer',
     desc: 'Renders supported country-level ChartEx maps without network access using a pinned public-domain Natural Earth asset. Cached provider identities and unsupported sub-country/view-specific layouts fail closed.',
   },
+  {
+    name: 'TIFF image codec',
+    entry: '@silurus/ooxml/tiff',
+    exportName: 'tiff',
+    contract: 'TiffRenderer',
+    desc: 'Decodes the supported TIFF 6.0 image class in DOCX, XLSX and PPTX. The current bounded codec accepts uncompressed, 8-bit, chunky process-CMYK strips; other TIFF classes fail closed without aborting the surrounding document render.',
+  },
 ];
 
 const RESOURCE_LIMITS = { name: 'resourceLimits', type: 'OoxmlResourceLimits', def: '128 MiB per entry / 256 MiB distinct total / 4,096 entries', desc: 'Shared DOCX/XLSX/PPTX package budgets. maxArchiveEntryBytes caps each package part; maxTotalInflatedBytes counts the largest amount read from every distinct part without charging repeat reads twice; maxArchiveEntries bounds central-directory entries before ZIP index allocation. Supply positive safe integers, or null to disable one configurable budget (internal hard ceilings remain). Violations reject with OoxmlResourceLimitError. These deterministic counters reduce OOM risk but do not measure or guarantee peak memory.', emphasis: 'Violations reject with OoxmlResourceLimitError.', detailsHref: '/errors#ooxml-resource-limit-error', detailsLabel: 'Error fields' };
@@ -86,8 +93,9 @@ const MATH = { name: 'math', type: 'MathRenderer', def: 'undefined', desc: 'Opt-
 const THREE_D = { name: 'threeD', type: 'ChartThreeDRenderer', def: 'undefined', desc: 'Opt-in model-space 3-D chart renderer. Import `threeD` from the separate `@silurus/ooxml/three-d` entry and inject it once. Omit it to use the canonical 2-D fallback and avoid loading or evaluating the mesh/camera implementation in main mode. The self-contained worker asset retains the worker-side implementation. It renders the view angle authored in OOXML in main and worker modes.', emphasis: 'Opt-in model-space 3-D chart renderer.' };
 const REGION_MAP = { name: 'regionMap', type: 'ChartRegionMapRenderer', def: 'undefined', desc: 'Opt-in offline ChartEx Region Map renderer using a pinned, public-domain Natural Earth country asset. Import `regionMap` from `@silurus/ooxml/region-map` and inject it once. Unsupported cached or sub-country views fail closed. The built-in renderer works in main and worker modes.', emphasis: 'Opt-in offline ChartEx Region Map renderer' };
 const CHART_EX = { name: 'chartEx', type: 'ChartExRenderer', def: 'undefined', desc: 'Opt-in renderer for Microsoft ChartEx (`cx:*`) chart families. Import `chartEx` from `@silurus/ooxml/chart-ex` and inject it once. Classic 2-D charts stay in the default format entries; ChartEx is opt-in. The built-in renderer works in main and worker modes.', emphasis: 'Classic 2-D charts stay in the default format entries; ChartEx is opt-in.' };
-const MODE = { name: 'mode', type: "'main' | 'worker'", def: "'main'", desc: "Use 'main' for the smallest worker download, the lowest single-frame overhead or custom renderer objects; parsing still runs in a Worker, while Canvas rendering runs on the main thread. Use 'worker' when document layout and paint would compete with application UI responsiveness. It requires Worker and OffscreenCanvas, downloads a larger render worker and transfers an ImageBitmap per frame. Built-in math, ChartEx, 3-D and Region Map renderers use the same options in both modes. In worker mode, use the bitmap render methods instead of methods that accept a Canvas.", emphasis: "Use 'worker' when document layout and paint would compete with application UI responsiveness." };
-const VIEWER_MODE = { name: 'mode', type: "'main' | 'worker'", def: "'main'", desc: "Use 'main' for ordinary previews, the smallest worker download or custom renderer objects. Use 'worker' when rendering larger or more complex documents would compete with scrolling, navigation or other application UI. Worker mode requires Worker and OffscreenCanvas, downloads a larger render worker and transfers an ImageBitmap per frame. Viewer navigation, zoom, virtualized scrolling, selection, find, hyperlinks and the built-in math, ChartEx, 3-D and Region Map renderers remain available in both modes.", emphasis: "Use 'worker' when rendering larger or more complex documents would compete with scrolling, navigation or other application UI." };
+const TIFF = { name: 'tiff', type: 'TiffRenderer', def: 'undefined', desc: 'Opt-in TIFF image codec shared by DOCX, XLSX and PPTX. Import `tiff` from `@silurus/ooxml/tiff` and inject it once. The bounded codec accepts uncompressed, 8-bit, chunky process-CMYK TIFF 6.0 parts. Omit it to keep the implementation out of ordinary format bundles; TIFF parts then fail closed without aborting the surrounding render. The built-in codec works in main and worker modes.', emphasis: 'Opt-in TIFF image codec shared by DOCX, XLSX and PPTX.' };
+const MODE = { name: 'mode', type: "'main' | 'worker'", def: "'main'", desc: "Use 'main' for the smallest worker download, the lowest single-frame overhead or custom renderer objects; parsing still runs in a Worker, while Canvas rendering runs on the main thread. Use 'worker' when document layout and paint would compete with application UI responsiveness. It requires Worker and OffscreenCanvas, downloads a larger render worker and transfers an ImageBitmap per frame. Built-in math, ChartEx, 3-D, Region Map and TIFF renderers use the same options in both modes. In worker mode, use the bitmap render methods instead of methods that accept a Canvas.", emphasis: "Use 'worker' when document layout and paint would compete with application UI responsiveness." };
+const VIEWER_MODE = { name: 'mode', type: "'main' | 'worker'", def: "'main'", desc: "Use 'main' for ordinary previews, the smallest worker download or custom renderer objects. Use 'worker' when rendering larger or more complex documents would compete with scrolling, navigation or other application UI. Worker mode requires Worker and OffscreenCanvas, downloads a larger render worker and transfers an ImageBitmap per frame. Viewer navigation, zoom, virtualized scrolling, selection, find, hyperlinks and the built-in math, ChartEx, 3-D, Region Map and TIFF renderers remain available in both modes.", emphasis: "Use 'worker' when rendering larger or more complex documents would compete with scrolling, navigation or other application UI." };
 const ZOOM_MIN_MAX = { name: 'zoomMin / zoomMax', type: 'number', def: '0.1 / 4', desc: 'Zoom factor bounds for setScale / fitWidth / fitPage (10%–400%).' };
 const ON_SCALE_CHANGE = { name: 'onScaleChange', type: '(scale: number) => void', desc: 'Called when the zoom factor changes (setScale / fitWidth / fitPage / zoomIn / zoomOut), with the clamped factor (1 = 100%).' };
 const ON_HYPERLINK_CLICK = { name: 'onHyperlinkClick', type: '(target: HyperlinkTarget) => void', desc: "Called when a hyperlink is clicked. `target` is `{ kind: 'external', url }` or `{ kind: 'internal', ref, slideIndex? }`. When supplied, the callback fully owns the click (the default external-open / internal-navigation is not run). External URLs are scheme-sanitized (http / https / mailto / tel only); internal targets resolve to a docx bookmark, pptx slide jump, or xlsx defined name / cell reference. XLSX switches sheets before scrolling the destination into view and uses the first cell of a range.", emphasis: 'When supplied, the callback fully owns the click (the default external-open / internal-navigation is not run).' };
@@ -252,6 +260,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         THREE_D,
         REGION_MAP,
         CHART_EX,
+        TIFF,
         VIEWER_MODE,
         ...PPTX_PROGRESSIVE_OPTIONS,
         ZOOM_MIN_MAX,
@@ -288,7 +297,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
       name: 'PptxPresentation',
       ctor: 'await PptxPresentation.load(source, options?)',
       note: 'Headless engine — parse once, render any slide into any canvas you supply (scroll views, thumbnail grids, master–detail).',
-      options: [GFONTS, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, MODE, ...PPTX_PROGRESSIVE_OPTIONS],
+      options: [GFONTS, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, TIFF, MODE, ...PPTX_PROGRESSIVE_OPTIONS],
       methods: [
         { sig: 'static load(source, options?): Promise<PptxPresentation>', desc: 'Parse a deck from a URL or ArrayBuffer. With progressiveLayout, resolve when the opening slide is paintable.' },
         { sig: 'get slideCount(): number', desc: 'Total slides.' },
@@ -346,6 +355,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         THREE_D,
         REGION_MAP,
         CHART_EX,
+        TIFF,
         DPR,
         MODE,
         ...PPTX_PROGRESSIVE_OPTIONS,
@@ -396,6 +406,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         THREE_D,
         REGION_MAP,
         CHART_EX,
+        TIFF,
         VIEWER_MODE,
         DOCX_PROGRESSIVE_LAYOUT,
         DOCX_SLICE_LAYOUT,
@@ -432,7 +443,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
       name: 'DocxDocument',
       ctor: 'await DocxDocument.load(source, options?)',
       note: 'Headless engine — render any page into any canvas you supply.',
-      options: [GFONTS, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, MODE, ...DOCX_LAYOUT_VIEW_OPTIONS, DOCX_PROGRESSIVE_LAYOUT, DOCX_SLICE_LAYOUT, DOCX_LAYOUT_PROGRESS, DOCX_LAYOUT_PARTIAL, DOCX_LAYOUT_COMPLETE],
+      options: [GFONTS, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, TIFF, MODE, ...DOCX_LAYOUT_VIEW_OPTIONS, DOCX_PROGRESSIVE_LAYOUT, DOCX_SLICE_LAYOUT, DOCX_LAYOUT_PROGRESS, DOCX_LAYOUT_PARTIAL, DOCX_LAYOUT_COMPLETE],
       methods: [
         { sig: 'static load(source, options?): Promise<DocxDocument>', desc: 'Parse a document from a URL or ArrayBuffer. With progressiveLayout, resolve when the opening pages are paintable while pagination continues in the background.' },
         { sig: 'get comments(): readonly Readonly<DocComment>[]', desc: 'Immutable detached comments and replies stored in the document.' },
@@ -489,6 +500,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         THREE_D,
         REGION_MAP,
         CHART_EX,
+        TIFF,
         DPR,
         MODE,
         DOCX_PROGRESSIVE_LAYOUT,
@@ -545,6 +557,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         THREE_D,
         REGION_MAP,
         CHART_EX,
+        TIFF,
         VIEWER_MODE,
         ON_SCALE_CHANGE,
         ON_HYPERLINK_CLICK,
@@ -618,6 +631,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         THREE_D,
         REGION_MAP,
         CHART_EX,
+        TIFF,
         VIEWER_MODE,
         ON_SCALE_CHANGE,
         ON_HYPERLINK_CLICK,
@@ -661,7 +675,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
       name: 'XlsxWorkbook',
       ctor: 'await XlsxWorkbook.load(source, options?)',
       note: 'Headless engine — parse once, render any sheet viewport into any canvas you supply.',
-      options: [GFONTS, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, MODE],
+      options: [GFONTS, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, TIFF, MODE],
       methods: [
         { sig: 'static load(source, options?): Promise<XlsxWorkbook>', desc: 'Parse a workbook from a URL or ArrayBuffer.' },
         { sig: 'get sheetNames(): string[]', desc: 'Names of all sheets.' },

--- a/site/src/lib/try.ts
+++ b/site/src/lib/try.ts
@@ -16,10 +16,11 @@ import { math } from '../../../src/math';
 import { threeD } from '../../../src/three-d';
 import { regionMap } from '../../../src/region-map';
 import { chartEx } from '../../../src/chart-ex';
+import { tiff } from '../../../src/tiff';
 
 // Opt-in OMML equation engine — enabled here so user-supplied docx/pptx with
 // equations render. (In the published library this is `@silurus/ooxml/math`.)
-const advancedChartRenderers = { threeD, regionMap, chartEx };
+const fullRenderers = { threeD, regionMap, chartEx, tiff };
 
 const VIEWER_GAP = 26;
 const MIN_SCALE = 0.5;
@@ -89,7 +90,7 @@ export async function renderFile(stage: HTMLElement, file: File): Promise<Render
       showZoomSlider: true,
       comments: true,
       math,
-      ...advancedChartRenderers,
+      ...fullRenderers,
     });
     try {
       await viewer.load(buffer);
@@ -123,7 +124,7 @@ export async function renderFile(stage: HTMLElement, file: File): Promise<Render
       // scrolls through slides that are still becoming available.
       mode: 'worker',
       progressiveLayout: true,
-      ...advancedChartRenderers,
+      ...fullRenderers,
     };
     const viewer = new PptxScrollViewer(host, viewerOptions);
     // Do not force an absolute scale here. ScrollViewer derives its initial
@@ -178,7 +179,7 @@ export async function renderFile(stage: HTMLElement, file: File): Promise<Render
     // remains responsive while later pages are still being prepared.
     mode: 'worker',
     progressiveLayout: true,
-    ...advancedChartRenderers,
+    ...fullRenderers,
   };
   const viewer = new DocxScrollViewer(host, viewerOptions);
   // As with PPTX, the viewer-owned width fit is the initial zoom contract for
@@ -243,14 +244,14 @@ export function prewarmEngines(): void {
     void PptxPresentation.load(sample('sample-1.pptx'), {
       useGoogleFonts: false,
       mode: 'main',
-      ...advancedChartRenderers,
+      ...fullRenderers,
     })
       .then((d) => d.destroy())
       .catch(() => {});
     void DocxDocument.load(sample('sample-1.docx'), {
       useGoogleFonts: false,
       mode: 'main',
-      ...advancedChartRenderers,
+      ...fullRenderers,
     })
       .then((d) => d.destroy())
       .catch(() => {});
@@ -260,7 +261,7 @@ export function prewarmEngines(): void {
     const v = new XlsxViewer(host, {
       useGoogleFonts: false,
       mode: 'main',
-      ...advancedChartRenderers,
+      ...fullRenderers,
     });
     void v.load(sample('sample-1.xlsx')).then(() => v.destroy()).catch(() => v.destroy());
   };

--- a/src/tiff.ts
+++ b/src/tiff.ts
@@ -1,0 +1,12 @@
+// Opt-in TIFF image codec entry point: `@silurus/ooxml/tiff`.
+
+import { renderTiffToBitmap } from '../packages/core/src/image/tiff.js';
+import type { TiffRenderer } from '../packages/core/src/image/tiff-contract.js';
+import { registerBuiltinWorkerRenderer } from '../packages/core/src/worker/renderer-module-contract.js';
+
+/** Optional TIFF 6.0 codec shared by DOCX, XLSX and PPTX viewers. */
+export const tiff: TiffRenderer = registerBuiltinWorkerRenderer({
+  render: renderTiffToBitmap,
+}, 'tiff');
+
+export type { TiffRenderer } from '../packages/core/src/image/tiff-contract.js';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -118,6 +118,9 @@ export default defineConfig(({ command, mode }) => ({
         // Opt-in Microsoft ChartEx family renderer. Classic 2-D charts remain
         // part of every format entry.
         'chart-ex': resolve(__dirname, 'src/chart-ex.ts'),
+        // Opt-in TIFF 6.0 software decoder. Native raster users retain only the
+        // lightweight codec contract and header guard.
+        tiff: resolve(__dirname, 'src/tiff.ts'),
         // Node-only bounded sessions and server render helpers. Kept as a
         // separate entry so browser consumers never load Node built-ins.
         node:  resolve(__dirname, 'src/node.ts'),


### PR DESCRIPTION
## Summary

- add a bounded, opt-in TIFF image codec at @silurus/ooxml/tiff
- share the codec contract and decode path across DOCX, XLSX, and PPTX in main and worker modes
- keep the TIFF implementation outside the default format bundle closures
- enable TIFF by default in the VS Code extension and the official Try Yours experience
- fail closed for unsupported TIFF classes without aborting the surrounding document render

## Specification and scope

ECMA-376 Part 1 section 15.2.14 permits image/tiff image parts. The built-in codec implements the TIFF 6.0 class verified against Office output: classic TIFF, first IFD, uncompressed 8-bit chunky process-CMYK strips, and top-left orientation. Other compression, colour, planar, alpha, orientation, and multi-image classes are rejected rather than inferred.

The unprofiled process-CMYK conversion follows the bounded Office-compatible transfer verified across the reference image's authored ink levels. TIFF 6.0 does not define a unique device-independent CMYK-to-RGB transform, so the compatibility behavior is deliberately limited to this declared class.

## Verification

- focused decoder, malformed-input, resource-budget, worker, DOCX/XLSX/PPTX wiring, VS Code, site, and bundle-boundary tests
- Rust common MIME tests: 14 passed
- related Vitest tests: 128 passed; public export/API follow-up: 15 passed
- typecheck, production build, all format public API baselines, and viewer API symmetry passed
- DOCX architecture audit: final boundary check plus 89 boundary, 17 compatibility-evidence, 26 public-API, and 2 package-build tests passed
- public self-VRT: DOCX 6 pages, XLSX 5 sheets, PPTX 9 slides, all exact
- complete local private self-VRT against the exact pre-feature main revision: 49 DOCX documents and 16 PPTX documents exact; all 139 XLSX documents produced no candidate-specific differences. Four initially detected XLSX items were reproduced by the base renderer, and base/candidate rerenders were byte-exact RGBA matches.
- the newly supported document was rendered successfully and compared with the Office-produced PDF reference
- broad suite: 760 files / 8,553 tests passed with local-only exclusions; the remaining two Skia exact-pixel assertions and two unavailable/replaced private compatibility fixtures reproduce identically on the base revision

Closes #1417