### PR TITLE
fix(pptx): decode oversized images for display

### DIFF
--- a/docs/ooxml-resource-default-calibration.md
+++ b/docs/ooxml-resource-default-calibration.md
@@ -77,11 +77,27 @@ rejections. Setting a field to `null` disables only that public admission limit;
 internal non-configurable safety ceilings still apply.
 
 Decoded browser images use separate shared hard guards rather than additional
-public tuning parameters: 32 megapixels / 128 MiB RGBA for one raster, 128 MiB
-of decoded ownership per document cache or active render pass, and two
-simultaneous decodes per document. These values are deliberately conservative
-implementation ceilings. They prevent measured image amplification from being
-silently omitted or left to an uncontrolled allocation, but are not added to the
-archive counters and do not model canvas, GPU, decoder, or process overhead.
+public tuning parameters. A retained raster surface remains bounded to 32 Mi
+pixels / 128 MiB RGBA, decoded ownership remains bounded to 128 MiB per document
+cache or active render pass, and each document has at most two simultaneous
+decodes. When a PPTX source exceeds the retained-surface limits, target-aware
+paint paths derive the required full-source resolution from the effective canvas
+size, DPR, and DrawingML `srcRect`, then request a high-quality resized
+`ImageBitmap`; resolution-banded cache keys prevent a larger zoom from silently
+reusing an undersized decode. Sources already within the retained limits keep
+the browser's established native-decode path, preserving existing sampling.
+
+The encoded source grid has a separate 128 Mi-pixel ceiling (four times the
+retained-surface pixel budget). This admits high-resolution authored sources
+without retaining their full RGBA grid, while keeping a conventional full-frame
+decoder intermediate below 512 MiB and continuing to reject pathological image
+headers before decode. The HTML image APIs guarantee the resized output size,
+not a portable peak-decoder-memory bound, so the source ceiling remains active
+even for a tiny display target. A source without a bounded target retains the
+older 32 Mi-pixel admission behavior.
+
+These image values prevent measured amplification from being silently omitted
+or left to an unbounded retained allocation, but are not added to the archive
+counters and do not model canvas, GPU, decoder, or process overhead.
 Browser-managed SVG/vector storage is count-bounded separately; it cannot be
 reliably expressed as decoded RGBA bytes or explicitly closed by the library.

--- a/packages/core/src/image/bitmap-image-by-path.test.ts
+++ b/packages/core/src/image/bitmap-image-by-path.test.ts
@@ -32,9 +32,9 @@ function buildMinimalWmf(): Uint8Array {
 }
 
 /**
- * The path-keyed decoded-bitmap cache (sibling of getCachedSvgImageByPath):
- * pulls bytes via the injected `fetchImage(path, mime)` and caches the decode by
- * zip path, namespaced per document by the `fetchImage` closure identity.
+ * The decoded-bitmap cache (sibling of getCachedSvgImageByPath) pulls bytes via
+ * the injected `fetchImage(path, mime)` and caches by zip path plus any raster
+ * resolution band, namespaced per document by the closure identity.
  */
 describe('getCachedBitmapByPath', () => {
   beforeEach(() => {
@@ -59,6 +59,41 @@ describe('getCachedBitmapByPath', () => {
     expect(fetchImage).toHaveBeenCalledTimes(1);
     expect(fetchImage).toHaveBeenCalledWith(path, 'image/png');
     expect(globalThis.createImageBitmap as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+  });
+
+  it('keys display-sized raster variants by stable resolution bands', async () => {
+    const png = new Uint8Array(26);
+    png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    png.set([0, 0, 0, 13, 0x49, 0x48, 0x44, 0x52], 8);
+    const view = new DataView(png.buffer);
+    view.setUint32(16, 12_000);
+    view.setUint32(20, 9_000);
+    const fetchImage = vi.fn(async () => new Blob([png as BlobPart], { type: 'image/png' }));
+    const cib = vi.fn(async (_blob: Blob, options?: ImageBitmapOptions) => ({
+      width: options?.resizeWidth ?? 12_000,
+      height: options?.resizeHeight ?? 9_000,
+      close() {},
+    }) as unknown as ImageBitmap);
+    vi.stubGlobal('createImageBitmap', cib);
+
+    const path = 'ppt/media/poster-resolution-bands.png';
+    const a = await getCachedBitmapByPath(path, 'image/png', fetchImage, {
+      targetWidthPx: 1000,
+      targetHeightPx: 750,
+    });
+    const sameBand = await getCachedBitmapByPath(path, 'image/png', fetchImage, {
+      targetWidthPx: 1010,
+      targetHeightPx: 758,
+    });
+    const larger = await getCachedBitmapByPath(path, 'image/png', fetchImage, {
+      targetWidthPx: 1400,
+      targetHeightPx: 1050,
+    });
+
+    expect(a).toBe(sameBand);
+    expect(larger).not.toBe(a);
+    expect(fetchImage).toHaveBeenCalledTimes(2);
+    expect(cib).toHaveBeenCalledTimes(2);
   });
 
   it('namespaces the cache by fetchImage — two documents sharing a zip path decode independently', async () => {

--- a/packages/core/src/image/bitmap-image-by-path.ts
+++ b/packages/core/src/image/bitmap-image-by-path.ts
@@ -1,7 +1,8 @@
 // Decoded-bitmap cache for raster / metafile blips shared by the docx, pptx and
 // xlsx renderers, for the lazy byte-on-demand image pipeline. The sibling of
-// `svg-image-by-path.ts`: same path-keyed, per-document (per-`fetchImage`)
-// shape, but the drawable here is an `ImageBitmap` (GPU-backed) decoded via the
+// `svg-image-by-path.ts`: same per-document (per-`fetchImage`) shape, keyed by
+// path plus any raster resolution band, but the drawable here is an
+// `ImageBitmap` (GPU-backed) decoded via the
 // shared `decodeRasterOrMetafile` rather than an `<img>`. Decoding an inlined
 // base64 image to an ImageBitmap is expensive, and the same picture is otherwise
 // re-decoded on every render (each scroll / resize / interaction / page revisit);
@@ -233,11 +234,11 @@ export function deferBitmapCloseWhileLeased(
   promise.then((b) => closeBitmapOnce(b)).catch(() => {});
 }
 
-/** Options for {@link getCachedBitmapByPath}. `widthPt`/`heightPt` are the
- *  picture's intended draw size in points and only affect metafile raster
- *  sharpness (a raster blip ignores them), so the path alone keys the cache.
- *  `suppressBoundaryFrame` is the docx-only WMF window/device-boundary edge
- *  suppression (spec-clean default OFF; pptx/xlsx leave it unset). */
+/** Options for {@link getCachedBitmapByPath}. `widthPt`/`heightPt` size a
+ * metafile raster; `targetWidthPx`/`targetHeightPx` select a display-resolution
+ * variant for ordinary rasters. `suppressBoundaryFrame` is the docx-only WMF
+ * window/device-boundary edge suppression (spec-clean default OFF;
+ * pptx/xlsx leave it unset). */
 export interface CachedBitmapOptions {
   /** Intended draw width in points; sizes any metafile raster target. */
   widthPt?: number;
@@ -248,6 +249,42 @@ export interface CachedBitmapOptions {
   suppressBoundaryFrame?: boolean;
   /** Optional TIFF codec retained by the owning document. */
   tiff?: TiffRenderer;
+  /** Desired width of the full raster source in device pixels. Requests are
+   * quantized into stable bands so nearby zoom levels reuse one decode. */
+  targetWidthPx?: number;
+  /** Desired height of the full raster source in device pixels. */
+  targetHeightPx?: number;
+}
+
+const SMALL_RASTER_TARGET_MAX = 64;
+const RASTER_TARGET_QUANTUM = 64;
+
+function rasterTargetBand(value: number | undefined): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || !(value > 0)) return undefined;
+  const rounded = Math.ceil(value);
+  if (rounded <= SMALL_RASTER_TARGET_MAX) {
+    return 2 ** Math.ceil(Math.log2(rounded));
+  }
+  return Math.ceil(rounded / RASTER_TARGET_QUANTUM) * RASTER_TARGET_QUANTUM;
+}
+
+function normalizedBitmapOptions(opts: CachedBitmapOptions): CachedBitmapOptions {
+  return {
+    ...opts,
+    targetWidthPx: rasterTargetBand(opts.targetWidthPx),
+    targetHeightPx: rasterTargetBand(opts.targetHeightPx),
+  };
+}
+
+/** Stable base key shared by the base and derived decoded-surface caches. */
+export function cachedBitmapVariantKey(
+  imagePath: string,
+  opts: CachedBitmapOptions = {},
+): string {
+  const width = rasterTargetBand(opts.targetWidthPx);
+  const height = rasterTargetBand(opts.targetHeightPx);
+  const pathKey = `${imagePath.length}:${imagePath}`;
+  return width && height ? `raster:${pathKey}:${width}x${height}` : `native:${pathKey}`;
 }
 
 interface ProducedBitmap {
@@ -395,10 +432,18 @@ export function getCachedBitmapByPath(
   fetchImage: FetchImage,
   opts: CachedBitmapOptions = {},
 ): Promise<ImageBitmap | null> {
-  const { widthPt = 0, heightPt = 0, suppressBoundaryFrame = false, tiff } = opts;
+  const normalized = normalizedBitmapOptions(opts);
+  const {
+    widthPt = 0,
+    heightPt = 0,
+    suppressBoundaryFrame = false,
+    tiff,
+    targetWidthPx,
+    targetHeightPx,
+  } = normalized;
   return getCachedDecodedBitmap(
     BASE_CACHE_NAMESPACE,
-    imagePath,
+    cachedBitmapVariantKey(imagePath, normalized),
     fetchImage,
     async () => {
       const blob = await fetchImage(imagePath, mimeType);
@@ -407,6 +452,8 @@ export function getCachedBitmapByPath(
         heightPt,
         suppressBoundaryFrame,
         tiff,
+        targetWidthPx,
+        targetHeightPx,
       });
       return { bitmap, owned: true };
     },
@@ -424,7 +471,8 @@ export function peekCachedBitmapByPath(
   imagePath: string,
   fetchImage: FetchImage,
 ): ImageBitmap | null | undefined {
-  return bitmapCacheByFetch.get(fetchImage)?.entries.get(`${BASE_CACHE_PREFIX}${imagePath}`)?.bitmap;
+  return bitmapCacheByFetch.get(fetchImage)?.entries
+    .get(`${BASE_CACHE_PREFIX}${cachedBitmapVariantKey(imagePath)}`)?.bitmap;
 }
 
 /**

--- a/packages/core/src/image/crop.test.ts
+++ b/packages/core/src/image/crop.test.ts
@@ -4,6 +4,7 @@ import {
   drawImageCropped,
   imageNaturalSize,
   metafileRasterSize,
+  sourceRasterTargetSize,
   srcRectHasVisibleArea,
 } from './crop';
 
@@ -133,5 +134,26 @@ describe('metafileRasterSize', () => {
     const narrow = metafileRasterSize('image/wmf', { l: 0.499, t: 0, r: 0.5, b: 0 }, 80, 50);
     expect(narrow?.widthPt).toBeCloseTo(80 / 0.001, 6);
     expect(narrow?.heightPt).toBe(50);
+  });
+});
+
+describe('sourceRasterTargetSize', () => {
+  it('uses the destination device-pixel box for an uncropped raster', () => {
+    expect(sourceRasterTargetSize(1200, 900)).toEqual({ width: 1200, height: 900 });
+  });
+
+  it('requests enough full-source pixels for a cropped slice to fill the destination', () => {
+    expect(sourceRasterTargetSize(1200, 900, { l: 0.25, t: 0.1, r: 0.25, b: 0.1 }))
+      .toEqual({ width: 2400, height: 1125 });
+  });
+
+  it('accounts for negative crop outsets without over-decoding transparent margins', () => {
+    expect(sourceRasterTargetSize(1200, 900, { l: -0.1, t: 0, r: -0.1, b: 0 }))
+      .toEqual({ width: 1000, height: 900 });
+  });
+
+  it('rejects non-visible and non-finite crop targets', () => {
+    expect(sourceRasterTargetSize(1200, 900, { l: 0.6, t: 0, r: 0.6, b: 0 })).toBeNull();
+    expect(sourceRasterTargetSize(Number.NaN, 900)).toBeNull();
   });
 });

--- a/packages/core/src/image/crop.ts
+++ b/packages/core/src/image/crop.ts
@@ -150,6 +150,32 @@ export function drawImageCropped(
   }
 }
 
+/**
+ * Required full-source raster resolution for a destination measured in device
+ * pixels. A positive `<a:srcRect>` crop magnifies a source slice to fill the
+ * destination, so the full decoded source needs proportionally more pixels;
+ * negative insets create transparent outsets and therefore need fewer.
+ *
+ * The result is a decode request, not an allocation promise. The decoder keeps
+ * the source aspect ratio and applies the shared decoded-surface ceiling.
+ */
+export function sourceRasterTargetSize(
+  destinationWidthPx: number,
+  destinationHeightPx: number,
+  srcRect?: SrcRect | null,
+): { width: number; height: number } | null {
+  if (!Number.isFinite(destinationWidthPx) || !Number.isFinite(destinationHeightPx)) return null;
+  if (!(destinationWidthPx > 0) || !(destinationHeightPx > 0)) return null;
+  const logicalWidth = srcRect ? 1 - srcRect.l - srcRect.r : 1;
+  const logicalHeight = srcRect ? 1 - srcRect.t - srcRect.b : 1;
+  if (!Number.isFinite(logicalWidth) || !Number.isFinite(logicalHeight)) return null;
+  if (!(logicalWidth > 0) || !(logicalHeight > 0) || !srcRectHasVisibleArea(srcRect)) return null;
+  return {
+    width: Math.ceil(destinationWidthPx / logicalWidth),
+    height: Math.ceil(destinationHeightPx / logicalHeight),
+  };
+}
+
 /** Raster target size (pt) for decoding an embedded image. A raster blip decodes
  *  at its native pixel grid, so its display box passes through. A metafile
  *  (WMF/EMF) with an `<a:srcRect>` crop must be rasterized at its FULL picture

--- a/packages/core/src/image/duotone-bitmap-by-path.ts
+++ b/packages/core/src/image/duotone-bitmap-by-path.ts
@@ -5,6 +5,7 @@
 
 import {
   dropCachedDerivedBitmapNamespace,
+  cachedBitmapVariantKey,
   getCachedBitmapByPath,
   getCachedDerivedBitmap,
   type CachedBitmapOptions,
@@ -69,7 +70,10 @@ export async function getCachedDuotoneBitmapByPath(
   if (!duotone || !base) return base;
   // Strict and compatibility callers must not share a derived cache entry: a
   // compatibility pass-through must never make a later strict lookup succeed.
-  const key = `${duotoneCacheKey(imagePath, duotone)}${failClosedOnDuotoneFailure ? '|strict' : ''}`;
+  const key = `${duotoneCacheKey(
+    cachedBitmapVariantKey(imagePath, bitmapOpts),
+    duotone,
+  )}${failClosedOnDuotoneFailure ? '|strict' : ''}`;
   return getCachedDerivedBitmap(
     DUOTONE_CACHE_NAMESPACE,
     key,

--- a/packages/core/src/image/pixel-budget.ts
+++ b/packages/core/src/image/pixel-budget.ts
@@ -1,10 +1,9 @@
 // ── Shared raster pixel-dimension budget (DoS / decode-bomb guard) ───────────
 //
-// One source of truth for the caps that bound how large a decoded raster surface
-// may be, used both by the metafile-embedded DIB decoder (`./dib.ts`) and by the
-// pre-`createImageBitmap` header sniff (`./raster-dimensions.ts`). Keeping the
-// two paths on the SAME numbers means a raster that is refused as a standalone
-// blip is also refused when embedded in a WMF/EMF, and vice versa.
+// One source of truth for the caps that bound encoded raster inputs and retained
+// decoded surfaces. Metafile-embedded DIBs cannot request decoder-side resizing,
+// so they use the retained-surface limits directly; standalone browser rasters
+// may use the larger source limits only when decoded to a bounded display target.
 
 /**
  * Implementation hard ceiling for one raster axis. This rejects obviously huge
@@ -13,6 +12,14 @@
  * failure remains possible below this ceiling.
  */
 export const MAX_RASTER_DIMENSION = 32767;
+
+/**
+ * Hard ceiling for one axis of an encoded raster passed to a resizing decoder.
+ * This is separate from {@link MAX_RASTER_DIMENSION}: an authored source may be
+ * wider than a browser canvas while its retained, display-sized result is not.
+ * 65535 also matches the largest dimension representable by baseline JPEG SOF.
+ */
+export const MAX_RASTER_SOURCE_DIMENSION = 65535;
 
 /**
  * Pixel budget for one decoded raster: 32 MP (2^25 px). A decoded surface is
@@ -24,13 +31,27 @@ export const MAX_RASTER_DIMENSION = 32767;
  */
 export const MAX_RASTER_PIXELS = 1 << 25; // 33_554_432 px = 32 MP / 128 MiB RGBA
 
+/**
+ * Hard ceiling for the encoded raster's declared source grid. Display-sized
+ * decoding may safely retain far fewer pixels than the source contains, but a
+ * decoder is still allowed to do implementation-specific intermediate work.
+ * Keep obviously hostile headers away from it even when a tiny output was
+ * requested. The source ceiling is four times the retained-surface ceiling,
+ * bounding a conventional 4-byte full-frame intermediate to 512 MiB while
+ * leaving useful headroom for high-resolution authored assets.
+ */
+export const MAX_RASTER_SOURCE_PIXELS = 1 << 27;
+
 /** Maximum decoded RGBA ownership retained or leased per document. */
 export const MAX_DECODED_IMAGE_BYTES = MAX_RASTER_PIXELS * 4;
 
 /** Keep simultaneous browser decoders bounded even before exact pixels exist. */
 export const MAX_CONCURRENT_IMAGE_DECODES = 2;
 
-export type OoxmlDecodedImageLimitMetric = 'image-pixels' | 'active-decoded-bytes';
+export type OoxmlDecodedImageLimitMetric =
+  | 'image-dimension'
+  | 'image-pixels'
+  | 'active-decoded-bytes';
 
 /** Catchable hard-quota crossing for decoded image surfaces. */
 export class OoxmlDecodedImageLimitError extends RangeError {

--- a/packages/core/src/image/raster-dimensions.test.ts
+++ b/packages/core/src/image/raster-dimensions.test.ts
@@ -2,9 +2,15 @@ import { describe, it, expect } from 'vitest';
 import {
   sniffRasterDimensions,
   rasterExceedsBudget,
+  sourceRasterExceedsBudget,
   rasterHeaderExceedsBudget,
 } from './raster-dimensions.js';
-import { MAX_RASTER_DIMENSION, MAX_RASTER_PIXELS } from './pixel-budget.js';
+import {
+  MAX_RASTER_DIMENSION,
+  MAX_RASTER_PIXELS,
+  MAX_RASTER_SOURCE_DIMENSION,
+  MAX_RASTER_SOURCE_PIXELS,
+} from './pixel-budget.js';
 
 // ── Raster header dimension sniff + budget (RB1 decode-bomb guard) ───────────
 //
@@ -349,5 +355,32 @@ describe('rasterHeaderExceedsBudget — end-to-end neutralization of decode bomb
   it('does NOT flag an unrecognized header (fail-open — the caller decodes normally)', () => {
     expect(rasterHeaderExceedsBudget(new Uint8Array([0xde, 0xad, 0xbe, 0xef]))).toBe(false);
     expect(rasterHeaderExceedsBudget(new TextEncoder().encode('<svg/>'))).toBe(false);
+  });
+});
+
+describe('sourceRasterExceedsBudget — encoded-source hard ceiling', () => {
+  it('admits the reported 109,571,670-pixel poster class for bounded display decode', () => {
+    const dimensions = { width: 12_090, height: 9_063 };
+    expect(dimensions.width * dimensions.height).toBe(109_571_670);
+    expect(dimensions.width * dimensions.height).toBeGreaterThan(MAX_RASTER_PIXELS);
+    expect(sourceRasterExceedsBudget(dimensions)).toBe(false);
+  });
+
+  it('rejects source grids beyond the separate 128-Mi-pixel hard ceiling', () => {
+    expect(sourceRasterExceedsBudget({ width: 30_000, height: 30_000 })).toBe(true);
+    expect(30_000 * 30_000).toBeGreaterThan(MAX_RASTER_SOURCE_PIXELS);
+  });
+
+  it('allows a source axis above the retained-canvas limit when resizing can bound it', () => {
+    expect(40_000).toBeGreaterThan(MAX_RASTER_DIMENSION);
+    expect(40_000).toBeLessThan(MAX_RASTER_SOURCE_DIMENSION);
+    expect(sourceRasterExceedsBudget({ width: 40_000, height: 2_000 })).toBe(false);
+  });
+
+  it('rejects a source axis beyond the separate encoded-source limit', () => {
+    expect(sourceRasterExceedsBudget({
+      width: MAX_RASTER_SOURCE_DIMENSION + 1,
+      height: 1,
+    })).toBe(true);
   });
 });

--- a/packages/core/src/image/raster-dimensions.ts
+++ b/packages/core/src/image/raster-dimensions.ts
@@ -16,7 +16,12 @@
 // to its normal path. Recognizing "too big" is a safe superset: an unrecognized
 // header simply isn't blocked here.
 
-import { MAX_RASTER_DIMENSION, MAX_RASTER_PIXELS } from './pixel-budget.js';
+import {
+  MAX_RASTER_DIMENSION,
+  MAX_RASTER_PIXELS,
+  MAX_RASTER_SOURCE_DIMENSION,
+  MAX_RASTER_SOURCE_PIXELS,
+} from './pixel-budget.js';
 import { sniffTiffDimensions } from './tiff-contract.js';
 
 /** Read a big-endian u16 at `o` (bounds already checked by the caller). */
@@ -253,6 +258,21 @@ export function rasterExceedsBudget(dims: RasterDimensions): boolean {
   // width, height ≤ MAX_RASTER_DIMENSION (≤ 32767), so the product is ≤ ~1.07e9,
   // exact in a double — a plain comparison suffices.
   return width * height > MAX_RASTER_PIXELS;
+}
+
+/**
+ * Whether an encoded raster's declared source grid is too large to hand to a
+ * browser or injected decoder, even when the retained output will be resized.
+ * This is deliberately separate from {@link rasterExceedsBudget}: the latter
+ * bounds a decoded surface retained by the renderer, while this ceiling bounds
+ * decoder input complexity and possible implementation-specific temporaries.
+ */
+export function sourceRasterExceedsBudget(dims: RasterDimensions): boolean {
+  const { width, height } = dims;
+  if (!Number.isFinite(width) || !Number.isFinite(height)) return true;
+  if (width <= 0 || height <= 0) return true;
+  if (width > MAX_RASTER_SOURCE_DIMENSION || height > MAX_RASTER_SOURCE_DIMENSION) return true;
+  return width * height > MAX_RASTER_SOURCE_PIXELS;
 }
 
 /**

--- a/packages/core/src/image/wmf.test.ts
+++ b/packages/core/src/image/wmf.test.ts
@@ -882,6 +882,189 @@ describe('decodeRasterOrMetafile', () => {
     expect(cib).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps an in-budget raster on the native decode path when a target is supplied', async () => {
+    const fake = { width: 1920, height: 1080, close() {} } as unknown as ImageBitmap;
+    const cib = vi.fn(async () => fake);
+    vi.stubGlobal('createImageBitmap', cib);
+    const png = new Uint8Array(26);
+    png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    png.set([0, 0, 0, 13, 0x49, 0x48, 0x44, 0x52], 8);
+    const view = new DataView(png.buffer);
+    view.setUint32(16, 1920);
+    view.setUint32(20, 1080);
+    const blob = new Blob([png as BlobPart], { type: 'image/png' });
+
+    await expect(decodeRasterOrMetafile(blob, {
+      targetWidthPx: 960,
+      targetHeightPx: 540,
+    })).resolves.toBe(fake);
+    expect(cib).toHaveBeenCalledWith(blob);
+  });
+
+  it('downsamples a legitimate over-32MP raster to the requested display resolution', async () => {
+    const sourceWidth = 12_000;
+    const sourceHeight = 9_000; // 108 MP: legitimate poster / camera output.
+    const png = new Uint8Array(26);
+    png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    png.set([0, 0, 0, 13, 0x49, 0x48, 0x44, 0x52], 8);
+    const put = (o: number, v: number) => {
+      png[o] = (v >>> 24) & 0xff;
+      png[o + 1] = (v >>> 16) & 0xff;
+      png[o + 2] = (v >>> 8) & 0xff;
+      png[o + 3] = v & 0xff;
+    };
+    put(16, sourceWidth);
+    put(20, sourceHeight);
+    const blob = new Blob([png as BlobPart], { type: 'image/png' });
+    const resized = { width: 1_200, height: 900, close() {} } as unknown as ImageBitmap;
+    const cib = vi.fn(async () => resized);
+    vi.stubGlobal('createImageBitmap', cib);
+
+    await expect(decodeRasterOrMetafile(blob, {
+      targetWidthPx: 1_200,
+      targetHeightPx: 900,
+    })).resolves.toBe(resized);
+    expect(cib).toHaveBeenCalledWith(blob, {
+      resizeWidth: 1_200,
+      resizeQuality: 'high',
+    });
+  });
+
+  it('downsamples a panoramic source wider than the retained-canvas axis limit', async () => {
+    const png = new Uint8Array(26);
+    png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    png.set([0, 0, 0, 13, 0x49, 0x48, 0x44, 0x52], 8);
+    const view = new DataView(png.buffer);
+    view.setUint32(16, 40_000);
+    view.setUint32(20, 2_000);
+    const blob = new Blob([png as BlobPart], { type: 'image/png' });
+    const resized = { width: 4_000, height: 200, close() {} } as unknown as ImageBitmap;
+    const cib = vi.fn(async () => resized);
+    vi.stubGlobal('createImageBitmap', cib);
+
+    await expect(decodeRasterOrMetafile(blob, {
+      targetWidthPx: 4_000,
+      targetHeightPx: 200,
+    })).resolves.toBe(resized);
+    expect(cib).toHaveBeenCalledWith(blob, {
+      resizeWidth: 4_000,
+      resizeQuality: 'high',
+    });
+  });
+
+  it('uses the largest safe surface when the display request asks for native resolution', async () => {
+    const sourceWidth = 12_000;
+    const sourceHeight = 9_000;
+    const png = new Uint8Array(26);
+    png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    png.set([0, 0, 0, 13, 0x49, 0x48, 0x44, 0x52], 8);
+    const view = new DataView(png.buffer);
+    view.setUint32(16, sourceWidth);
+    view.setUint32(20, sourceHeight);
+    const blob = new Blob([png as BlobPart], { type: 'image/png' });
+    const safeScale = Math.sqrt((1 << 25) / (sourceWidth * sourceHeight));
+    const resizeWidth = Math.floor(sourceWidth * safeScale);
+    const resized = {
+      width: resizeWidth,
+      height: Math.floor(sourceHeight * safeScale),
+      close() {},
+    } as unknown as ImageBitmap;
+    const cib = vi.fn(async () => resized);
+    vi.stubGlobal('createImageBitmap', cib);
+
+    await expect(decodeRasterOrMetafile(blob, {
+      targetWidthPx: sourceWidth,
+      targetHeightPx: sourceHeight,
+    })).resolves.toBe(resized);
+    expect(cib).toHaveBeenCalledWith(blob, {
+      resizeWidth,
+      resizeQuality: 'high',
+    });
+  });
+
+  it('still rejects an over-32MP raster when no bounded display target is known', async () => {
+    const png = new Uint8Array(26);
+    png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    png.set([0, 0, 0, 13, 0x49, 0x48, 0x44, 0x52], 8);
+    const view = new DataView(png.buffer);
+    view.setUint32(16, 12_000);
+    view.setUint32(20, 9_000);
+    const cib = vi.fn();
+    vi.stubGlobal('createImageBitmap', cib);
+
+    await expect(decodeRasterOrMetafile(new Blob([png as BlobPart], { type: 'image/png' })))
+      .rejects.toMatchObject({
+        code: 'ooxml-decoded-image-limit',
+        metric: 'image-pixels',
+        observed: 12_000 * 9_000,
+      });
+    expect(cib).not.toHaveBeenCalled();
+  });
+
+  it('keeps the encoded-source hard ceiling even when a tiny display target is requested', async () => {
+    const bomb = new Uint8Array(26);
+    bomb.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    bomb.set([0, 0, 0, 13, 0x49, 0x48, 0x44, 0x52], 8);
+    const view = new DataView(bomb.buffer);
+    view.setUint32(16, 30_000);
+    view.setUint32(20, 30_000);
+    const cib = vi.fn();
+    vi.stubGlobal('createImageBitmap', cib);
+
+    await expect(decodeRasterOrMetafile(
+      new Blob([bomb as BlobPart], { type: 'image/png' }),
+      { targetWidthPx: 300, targetHeightPx: 300 },
+    )).rejects.toMatchObject({
+      code: 'ooxml-decoded-image-limit',
+      metric: 'image-pixels',
+      observed: 30_000 * 30_000,
+    });
+    expect(cib).not.toHaveBeenCalled();
+  });
+
+  it('reports a source-axis crossing as a dimension limit with truthful values', async () => {
+    const bomb = new Uint8Array(26);
+    bomb.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    bomb.set([0, 0, 0, 13, 0x49, 0x48, 0x44, 0x52], 8);
+    const view = new DataView(bomb.buffer);
+    view.setUint32(16, 70_000);
+    view.setUint32(20, 1);
+    const cib = vi.fn();
+    vi.stubGlobal('createImageBitmap', cib);
+
+    await expect(decodeRasterOrMetafile(
+      new Blob([bomb as BlobPart], { type: 'image/png' }),
+      { targetWidthPx: 700, targetHeightPx: 1 },
+    )).rejects.toMatchObject({
+      code: 'ooxml-decoded-image-limit',
+      metric: 'image-dimension',
+      limit: 65_535,
+      observed: 70_000,
+    });
+    expect(cib).not.toHaveBeenCalled();
+  });
+
+  it('reports a retained-axis crossing separately when no downsample target is supplied', async () => {
+    const panoramic = new Uint8Array(26);
+    panoramic.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    panoramic.set([0, 0, 0, 13, 0x49, 0x48, 0x44, 0x52], 8);
+    const view = new DataView(panoramic.buffer);
+    view.setUint32(16, 40_000);
+    view.setUint32(20, 1);
+    const cib = vi.fn();
+    vi.stubGlobal('createImageBitmap', cib);
+
+    await expect(decodeRasterOrMetafile(
+      new Blob([panoramic as BlobPart], { type: 'image/png' }),
+    )).rejects.toMatchObject({
+      code: 'ooxml-decoded-image-limit',
+      metric: 'image-dimension',
+      limit: 32_767,
+      observed: 40_000,
+    });
+    expect(cib).not.toHaveBeenCalled();
+  });
+
   it('a TIFF is skipped without the opt-in codec and decoded when supplied', async () => {
     const bytes = new Uint8Array([0x49, 0x49, 0x2a, 0x00, 1, 2, 3, 4]);
     const blob = new Blob([bytes as BlobPart], { type: 'image/tiff' });
@@ -911,16 +1094,16 @@ describe('decodeRasterOrMetafile', () => {
     view.setUint16(10, 256, true);
     view.setUint16(12, 4, true);
     view.setUint32(14, 1, true);
-    view.setUint32(18, 32_767, true);
+    view.setUint32(18, 12_000, true);
     view.setUint16(22, 257, true);
     view.setUint16(24, 4, true);
     view.setUint32(26, 1, true);
-    view.setUint32(30, 32_767, true);
+    view.setUint32(30, 9_000, true);
     const render = vi.fn();
 
     await expect(decodeRasterOrMetafile(
       new Blob([bytes as BlobPart], { type: 'image/tiff' }),
-      { tiff: { render } },
+      { tiff: { render }, targetWidthPx: 320, targetHeightPx: 200 },
     )).rejects.toMatchObject({ code: 'ooxml-decoded-image-limit' });
     expect(render).not.toHaveBeenCalled();
   });

--- a/packages/core/src/image/wmf.ts
+++ b/packages/core/src/image/wmf.ts
@@ -39,8 +39,19 @@
 
 import { decodePackedDib, blitDibToCtx } from './dib.js';
 import { renderEmfToBitmap } from './emf.js';
-import { rasterExceedsBudget, sniffRasterDimensions } from './raster-dimensions.js';
-import { MAX_RASTER_PIXELS, OoxmlDecodedImageLimitError } from './pixel-budget.js';
+import {
+  rasterExceedsBudget,
+  sniffRasterDimensions,
+  sourceRasterExceedsBudget,
+  type RasterDimensions,
+} from './raster-dimensions.js';
+import {
+  MAX_RASTER_DIMENSION,
+  MAX_RASTER_PIXELS,
+  MAX_RASTER_SOURCE_DIMENSION,
+  MAX_RASTER_SOURCE_PIXELS,
+  OoxmlDecodedImageLimitError,
+} from './pixel-budget.js';
 import { createAuxCanvas } from '../canvas/aux-canvas.js';
 import { closeImageBitmapIfSupported } from './image-bitmap-lifecycle.js';
 import { isTiff, type TiffRenderer } from './tiff-contract.js';
@@ -801,6 +812,66 @@ export interface DecodeRasterOptions {
   suppressBoundaryFrame?: boolean;
   /** Optional TIFF codec. Omitted TIFF parts take the null-bitmap path. */
   tiff?: TiffRenderer;
+  /** Desired width of the full source grid in retained device pixels. The
+   * decoder preserves source aspect ratio and never upscales. */
+  targetWidthPx?: number;
+  /** Desired height of the full source grid in retained device pixels. */
+  targetHeightPx?: number;
+}
+
+function decodeResizeOptions(
+  source: RasterDimensions,
+  targetWidthPx: number | undefined,
+  targetHeightPx: number | undefined,
+): ImageBitmapOptions | null {
+  // Preserve the browser's established native-decode + drawImage sampling for
+  // ordinary, already-safe sources. Target-sized decoding is the admission path
+  // for a source that cannot be retained natively, not a fidelity rewrite for
+  // every existing picture.
+  if (!rasterExceedsBudget(source)) return null;
+  if (typeof targetWidthPx !== 'number' || typeof targetHeightPx !== 'number') return null;
+  if (!Number.isFinite(targetWidthPx) || !Number.isFinite(targetHeightPx)) return null;
+  if (!(targetWidthPx > 0) || !(targetHeightPx > 0)) return null;
+  const requestedScale = Math.min(1, Math.max(
+    targetWidthPx / source.width,
+    targetHeightPx / source.height,
+  ));
+  let scale = requestedScale;
+  scale = Math.min(
+    scale,
+    MAX_RASTER_DIMENSION / source.width,
+    MAX_RASTER_DIMENSION / source.height,
+    Math.sqrt(MAX_RASTER_PIXELS / (source.width * source.height)),
+  );
+  if (!(scale < 1)) return null;
+  const resizeWidth = Math.max(1, Math.floor(source.width * scale));
+  // Specify one axis only. The HTML algorithm derives the other from the
+  // oriented source rectangle, preserving JPEG EXIF rotation/aspect instead of
+  // forcing coded-header W×H onto a 90°-oriented image.
+  return { resizeWidth, resizeQuality: 'high' };
+}
+
+function rasterLimitError(
+  dimensions: RasterDimensions,
+  dimensionLimit: number,
+  pixelLimit: number,
+): OoxmlDecodedImageLimitError {
+  const observedDimension = Math.max(dimensions.width, dimensions.height);
+  if (!Number.isFinite(observedDimension) || observedDimension > dimensionLimit) {
+    return new OoxmlDecodedImageLimitError(
+      'image-dimension',
+      dimensionLimit,
+      Number.isFinite(observedDimension) ? observedDimension : Number.MAX_SAFE_INTEGER,
+    );
+  }
+  const observedPixels = dimensions.width * dimensions.height;
+  return new OoxmlDecodedImageLimitError(
+    'image-pixels',
+    pixelLimit,
+    Number.isSafeInteger(observedPixels) && observedPixels >= 0
+      ? observedPixels
+      : Number.MAX_SAFE_INTEGER,
+  );
 }
 
 /**
@@ -821,7 +892,8 @@ export interface DecodeRasterOptions {
  *     geometry returns `null`.
  *   - {@link isTiff} → decode the supported TIFF 6.0 class through the shared
  *     software rasterizer because browsers generally cannot decode TIFF.
- *   - otherwise → `createImageBitmap(blob)` (PNG/JPEG/GIF/BMP/WEBP…).
+ *   - otherwise → `createImageBitmap(blob)`, with a bounded display-sized
+ *     decode when an over-budget source has a target (PNG/JPEG/GIF/BMP/WEBP…).
  *
  * Returns `null` (never throws on an unsupported metafile) so every caller can
  * treat the result like the existing "missing image" / null-bitmap path and
@@ -834,7 +906,14 @@ export async function decodeRasterOrMetafile(
   data: Blob,
   opts: DecodeRasterOptions = {},
 ): Promise<ImageBitmap | null> {
-  const { widthPt = 0, heightPt = 0, suppressBoundaryFrame = false, tiff } = opts;
+  const {
+    widthPt = 0,
+    heightPt = 0,
+    suppressBoundaryFrame = false,
+    tiff,
+    targetWidthPx,
+    targetHeightPx,
+  } = opts;
 
   // Sniff a header prefix, not the whole blob. `isEmf` reads bytes 40-43 (u32@40
   // == " EMF") and `isWmf` at most the 18-byte standard header, and the raster
@@ -866,20 +945,35 @@ export async function decodeRasterOrMetafile(
   // before either a browser decoder or an injected codec can allocate a large
   // surface. An unrecognized header is validated immediately after decode.
   const rasterDimensions = sniffRasterDimensions(head);
-  if (rasterDimensions && rasterExceedsBudget(rasterDimensions)) {
-    throw new OoxmlDecodedImageLimitError(
-      'image-pixels',
-      MAX_RASTER_PIXELS,
-      rasterDimensions.width * rasterDimensions.height,
+  if (rasterDimensions && sourceRasterExceedsBudget(rasterDimensions)) {
+    throw rasterLimitError(
+      rasterDimensions,
+      MAX_RASTER_SOURCE_DIMENSION,
+      MAX_RASTER_SOURCE_PIXELS,
     );
   }
-  if (isTiff(head)) {
+  const resizeOptions = rasterDimensions
+    ? decodeResizeOptions(rasterDimensions, targetWidthPx, targetHeightPx)
+    : null;
+  const tiffInput = isTiff(head);
+  if (rasterDimensions && rasterExceedsBudget(rasterDimensions) && (!resizeOptions || tiffInput)) {
+    throw rasterLimitError(
+      rasterDimensions,
+      MAX_RASTER_DIMENSION,
+      MAX_RASTER_PIXELS,
+    );
+  }
+  if (tiffInput) {
     if (!tiff) return null;
     return enforceDecodedBitmapBudget(
       await tiff.render(new Uint8Array(await data.arrayBuffer())),
     );
   }
-  return enforceDecodedBitmapBudget(await createImageBitmap(data));
+  return enforceDecodedBitmapBudget(
+    resizeOptions
+      ? await createImageBitmap(data, resizeOptions)
+      : await createImageBitmap(data),
+  );
 }
 
 /** Validate at the decoder boundary so direct callers and the shared cache have
@@ -892,11 +986,10 @@ function enforceDecodedBitmapBudget(bitmap: ImageBitmap | null): ImageBitmap | n
   const height = Number(bitmap.height);
   if (!rasterExceedsBudget({ width, height })) return bitmap;
 
-  const pixels = width * height;
   closeImageBitmapIfSupported(bitmap);
-  throw new OoxmlDecodedImageLimitError(
-    'image-pixels',
+  throw rasterLimitError(
+    { width, height },
+    MAX_RASTER_DIMENSION,
     MAX_RASTER_PIXELS,
-    Number.isSafeInteger(pixels) && pixels >= 0 ? pixels : Number.MAX_SAFE_INTEGER,
   );
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -261,7 +261,9 @@ export {
   MAX_CONCURRENT_IMAGE_DECODES,
   MAX_DECODED_IMAGE_BYTES,
   MAX_RASTER_DIMENSION,
+  MAX_RASTER_SOURCE_DIMENSION,
   MAX_RASTER_PIXELS,
+  MAX_RASTER_SOURCE_PIXELS,
   OoxmlDecodedImageLimitError,
   isOoxmlDecodedImageLimitError,
   type OoxmlDecodedImageLimitMetric,
@@ -269,6 +271,7 @@ export {
 export {
   sniffRasterDimensions,
   rasterExceedsBudget,
+  sourceRasterExceedsBudget,
   rasterHeaderExceedsBudget,
   type RasterDimensions,
 } from './image/raster-dimensions';
@@ -279,6 +282,7 @@ export {
   drawImageCropped,
   imageNaturalSize,
   metafileRasterSize,
+  sourceRasterTargetSize,
   type SrcRect,
 } from './image/crop';
 // Shared DrawingML duotone image effect (§20.1.8.23): recolour a decoded image

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -1747,7 +1747,7 @@ export class OoxmlDecodedImageLimitError extends RangeError {
     readonly code: 'ooxml-decoded-image-limit';
     constructor(metric: OoxmlDecodedImageLimitMetric, limit: number, observed: number);
 }
-export type OoxmlDecodedImageLimitMetric = 'image-pixels' | 'active-decoded-bytes';
+export type OoxmlDecodedImageLimitMetric = 'image-dimension' | 'image-pixels' | 'active-decoded-bytes';
 export class OoxmlError extends Error {
     readonly code: OoxmlErrorCode;
     constructor(code: OoxmlErrorCode, message: string);

--- a/packages/node/src/render.test.ts
+++ b/packages/node/src/render.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { installOffscreenCanvasShim, installImageBitmapShim } from './render';
 import type { NodeCanvasFactory } from './render';
 import { loadSkiaForTests } from './test-imports';
@@ -18,6 +18,36 @@ const factory: NodeCanvasFactory = {
 };
 
 const g = globalThis as unknown as { OffscreenCanvas?: unknown };
+
+describe('installImageBitmapShim display-sized decode', () => {
+  it('forwards the target to the codec and resizes a native-sized fallback surface', async () => {
+    const drawImage = vi.fn();
+    const resizedSurface = {
+      width: 1280,
+      height: 960,
+      getContext: () => ({ measureText: () => ({ width: 0 }), drawImage }),
+    };
+    const sourceImage = { width: 12_090, height: 9_063 };
+    const loadImage = vi.fn(async () => sourceImage);
+    const fallbackFactory: NodeCanvasFactory = {
+      createCanvas: vi.fn(() => resizedSurface),
+      loadImage,
+    };
+    const restore = installImageBitmapShim(fallbackFactory);
+    try {
+      const bitmap = await createImageBitmap(new Blob(['encoded']), {
+        resizeWidth: 1280,
+        resizeHeight: 960,
+        resizeQuality: 'high',
+      });
+      expect(loadImage).toHaveBeenCalledWith(expect.any(ArrayBuffer), { width: 1280 });
+      expect(drawImage).toHaveBeenCalledWith(sourceImage, 0, 0, 1280, 960);
+      expect(bitmap).toBe(resizedSurface);
+    } finally {
+      restore();
+    }
+  });
+});
 
 describe.skipIf(!skia)('installOffscreenCanvasShim', () => {
   afterEach(() => {

--- a/packages/node/src/render.ts
+++ b/packages/node/src/render.ts
@@ -27,6 +27,9 @@ export interface NodeTextMetricsLike {
 /** DOM-free structural seam for the Node canvas 2D context. */
 export interface NodeCanvasContext2D {
   measureText(text: string): NodeTextMetricsLike;
+  /** Optional here for lightweight metric-only adapters; required by the
+   * image shim when it must materialize a resized fallback surface. */
+  drawImage?(image: NodeImageLike, dx: number, dy: number, dw: number, dh: number): void;
 }
 
 /** A subset of the Node-canvas API that the renderers actually need. The
@@ -49,8 +52,13 @@ export interface NodeImageLike {
 export interface NodeCanvasFactory {
   /** Create a blank canvas of the given pixel size. */
   createCanvas(width: number, height: number): NodeCanvasLike;
-  /** Decode a buffer (PNG/JPEG/etc.) into something the canvas can `drawImage`. */
-  loadImage(buffer: ArrayBuffer | Uint8Array): Promise<NodeImageLike>;
+  /** Decode a buffer (PNG/JPEG/etc.) into something the canvas can `drawImage`.
+   * Implementations should honor `target` in the decoder when possible; the
+   * shim falls back to a target-sized canvas when they return native pixels. */
+  loadImage(
+    buffer: ArrayBuffer | Uint8Array,
+    target?: Readonly<{ width?: number; height?: number }>,
+  ): Promise<NodeImageLike>;
 }
 
 /**
@@ -123,7 +131,10 @@ export function installImageBitmapShim(factory: NodeCanvasFactory): () => void {
   // recoloured offscreen surface back into an "ImageBitmap"). Widen the param so
   // the canvas branch is a real member and needs no double-cast.
   type CanvasLike = { getContext(id: '2d'): unknown };
-  g.createImageBitmap = async (source: Blob | ArrayBuffer | Uint8Array | CanvasLike) => {
+  g.createImageBitmap = async (
+    source: Blob | ArrayBuffer | Uint8Array | CanvasLike,
+    options?: ImageBitmapOptions,
+  ) => {
     // A canvas-like source is already a drawable image source in node-canvas —
     // return it directly. The surface IS the skia Canvas the factory made, so no
     // byte round-trip is needed (and skia has no `createImageBitmap(canvas)`).
@@ -138,7 +149,30 @@ export function installImageBitmapShim(factory: NodeCanvasFactory): () => void {
     } else {
       throw new Error('createImageBitmap shim: unsupported source type');
     }
-    return factory.loadImage(buf);
+    const resizeWidth = options?.resizeWidth;
+    const resizeHeight = options?.resizeHeight;
+    const target = typeof resizeWidth === 'number' && resizeWidth > 0
+      ? { width: resizeWidth }
+      : typeof resizeHeight === 'number' && resizeHeight > 0
+        ? { height: resizeHeight }
+        : undefined;
+    const image = await factory.loadImage(buf, target);
+    if (!target) return image;
+    if (target.width !== undefined && image.width === target.width) return image;
+    if (target.height !== undefined && image.height === target.height) return image;
+    const scale = target.width !== undefined
+      ? target.width / image.width
+      : typeof target.height === 'number'
+        ? target.height / image.height
+        : 1;
+    const width = Math.max(1, Math.round(image.width * scale));
+    const height = Math.max(1, Math.round(image.height * scale));
+    const surface = factory.createCanvas(width, height);
+    const context = surface.getContext('2d');
+    if (typeof context.drawImage !== 'function') return image;
+    context.drawImage(image, 0, 0, width, height);
+    (image as NodeImageLike & { close?: () => void }).close?.();
+    return surface;
   };
   return () => { g.createImageBitmap = prev as typeof globalThis.createImageBitmap; };
 }

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -1153,7 +1153,7 @@ export class OoxmlDecodedImageLimitError extends RangeError {
     readonly code: 'ooxml-decoded-image-limit';
     constructor(metric: OoxmlDecodedImageLimitMetric, limit: number, observed: number);
 }
-export type OoxmlDecodedImageLimitMetric = 'image-pixels' | 'active-decoded-bytes';
+export type OoxmlDecodedImageLimitMetric = 'image-dimension' | 'image-pixels' | 'active-decoded-bytes';
 export class OoxmlError extends Error {
     readonly code: OoxmlErrorCode;
     constructor(code: OoxmlErrorCode, message: string);

--- a/packages/pptx/src/poster-decode-bomb.test.ts
+++ b/packages/pptx/src/poster-decode-bomb.test.ts
@@ -91,6 +91,28 @@ describe('getPosterBitmap — RB1 poster decode-bomb guard', () => {
     expect(createImageBitmapSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('downsamples the reported 109,571,670-pixel poster class to its display target', async () => {
+    const large = pngHeader(12_090, 9_063);
+    expect(12_090 * 9_063).toBe(109_571_670);
+    const fetchMedia = vi.fn(
+      async (_path: string) => new Blob([large as BlobPart], { type: 'image/png' }),
+    );
+    const resized = { width: 1280, height: 960, close() {} } as unknown as ImageBitmap;
+    createImageBitmapSpy.mockResolvedValueOnce(resized);
+
+    await expect(getPosterBitmap(
+      mediaEl(),
+      fetchMedia,
+      undefined,
+      undefined,
+      { targetWidthPx: 1280, targetHeightPx: 960 },
+    )).resolves.toBe(resized);
+    expect(createImageBitmapSpy).toHaveBeenCalledWith(expect.any(Blob), {
+      resizeWidth: 1280,
+      resizeQuality: 'high',
+    });
+  });
+
   it('leaves an unrecognized (non-raster) poster header to decode normally (fail-open)', async () => {
     // e.g. an SVG poster: not a recognized raster ⇒ not blocked by the sniff.
     const svg = '<svg xmlns="http://www.w3.org/2000/svg"/>';

--- a/packages/pptx/src/renderer-picture-raster-target.test.ts
+++ b/packages/pptx/src/renderer-picture-raster-target.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Slide } from './types.js';
+
+const coreMocks = vi.hoisted(() => ({
+  bitmap: { width: 1920, height: 720, close() {} } as unknown as ImageBitmap,
+  decode: vi.fn(),
+}));
+
+vi.mock('@silurus/ooxml-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@silurus/ooxml-core')>();
+  coreMocks.decode.mockResolvedValue(coreMocks.bitmap);
+  return {
+    ...actual,
+    getCachedDuotoneBitmapByPath: coreMocks.decode,
+  };
+});
+
+import { renderSlide } from './renderer.js';
+
+function canvas(): HTMLCanvasElement {
+  const state: Record<string, unknown> = {
+    fillStyle: '', strokeStyle: '', globalAlpha: 1, lineWidth: 1,
+  };
+  const context = new Proxy(state, {
+    get(target, property: string) {
+      if (property in target) return target[property];
+      return () => undefined;
+    },
+    set(target, property: string, value) {
+      target[property] = value;
+      return true;
+    },
+  }) as unknown as CanvasRenderingContext2D;
+  return {
+    width: 0, height: 0, style: {}, offsetWidth: 960,
+    getContext: () => context,
+  } as unknown as HTMLCanvasElement;
+}
+
+describe('PPTX display-sized picture decode', () => {
+  it('derives full-source device pixels from the frame, effective DPR, and srcRect crop', async () => {
+    const slide = {
+      index: 0,
+      slideNumber: 1,
+      background: null,
+      elements: [{
+        type: 'picture',
+        x: 0,
+        y: 0,
+        width: 4_572_000, // half of the 10-inch slide => 480 CSS px
+        height: 3_429_000, // half slide height => 360 CSS px
+        rotation: 0,
+        flipH: false,
+        flipV: false,
+        imagePath: 'ppt/media/108mp-poster.jpg',
+        mimeType: 'image/jpeg',
+        srcRect: { l: 0.25, t: 0, r: 0.25, b: 0 },
+      }],
+    } as Slide;
+    const fetchImage = vi.fn(async () => new Blob(['jpeg'], { type: 'image/jpeg' }));
+
+    await renderSlide(canvas(), slide, 9_144_000, 6_858_000, {
+      width: 960,
+      dpr: 2,
+      fetchImage,
+    });
+
+    expect(coreMocks.decode).toHaveBeenCalled();
+    for (const call of coreMocks.decode.mock.calls) {
+      expect(call[4]).toMatchObject({
+        // 480 CSS px × DPR 2, then / 50% visible source width.
+        targetWidthPx: 1920,
+        targetHeightPx: 720,
+      });
+    }
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -77,8 +77,6 @@ import {
   graphemeClusterOffsets,
   getCachedSvgImageByPath,
   getCachedBitmapByPath,
-  getCachedDecodedBitmap,
-  getCachedDerivedBitmap,
   getCachedDuotoneBitmapByPath,
   chartImageFillKey,
   collectChartMarkerImageFills,
@@ -86,10 +84,10 @@ import {
   acquireBitmapCacheLease,
   peekCachedBitmapByPath,
   dropDecodedBitmapCache,
-  decodeRasterOrMetafile,
   preferVectorBlip,
   drawImageCropped,
   metafileRasterSize,
+  sourceRasterTargetSize,
   isOoxmlDecodedImageLimitError,
   highlightBox,
   symbolFontToUnicode,
@@ -227,6 +225,22 @@ export type TextRunCallback = (run: PptxTextRunInfo) => void;
  */
 function emuToPx(emu: number, scale: number): number {
   return emu * scale;
+}
+
+function rasterTargetOptions(
+  widthCssPx: number,
+  heightCssPx: number,
+  dpr: number,
+  srcRect?: PictureElement['srcRect'],
+): { targetWidthPx: number; targetHeightPx: number } | undefined {
+  const target = sourceRasterTargetSize(
+    Math.abs(widthCssPx * dpr),
+    Math.abs(heightCssPx * dpr),
+    srcRect,
+  );
+  return target
+    ? { targetWidthPx: target.width, targetHeightPx: target.height }
+    : undefined;
 }
 
 const hexToRgba = hexToRgbaCore;
@@ -1675,6 +1689,7 @@ async function renderBackground(
   superseded: () => boolean,
   fetchImage?: (path: string, mime: string) => Promise<Blob>,
   tiff?: TiffRenderer,
+  dpr = 1,
 ) {
   // ECMA-376 §20.1.8.14 — image (blipFill) background. Paint an opaque white
   // base first so a partially transparent image (alphaModFix) composites over
@@ -1699,6 +1714,7 @@ async function renderBackground(
         {
           widthPt: canvasW / scale / PT_TO_EMU,
           heightPt: canvasH / scale / PT_TO_EMU,
+          ...(!fill.tile ? (rasterTargetOptions(canvasW, canvasH, dpr, fill.srcRect) ?? {}) : {}),
           tiff,
         },
       );
@@ -5154,17 +5170,13 @@ export function getPosterBitmap(
   fetchMedia: FetchMedia,
   bitmapOwner: PosterFetchImage = posterFetchImage(fetchMedia),
   tiff?: TiffRenderer,
+  target?: { targetWidthPx: number; targetHeightPx: number },
 ): Promise<ImageBitmap> {
-  return getCachedDecodedBitmap(
-    'base',
+  return getCachedBitmapByPath(
     el.posterPath,
+    el.posterMimeType || 'application/octet-stream',
     bitmapOwner,
-    async () => {
-      const blob = await fetchMedia(el.posterPath);
-      const mimeType = el.posterMimeType || blob.type || 'application/octet-stream';
-      const typed = blob.type === mimeType ? blob : new Blob([blob], { type: mimeType });
-      return { bitmap: await decodeRasterOrMetafile(typed, { tiff }), owned: true };
-    },
+    { tiff, ...(target ?? {}) },
   ).then((bitmap) => {
     if (!bitmap) throw new Error('Media poster could not be decoded');
     return bitmap;
@@ -5178,6 +5190,7 @@ async function renderPicture(
   superseded: () => boolean,
   fetchImage?: (path: string, mime: string) => Promise<Blob>,
   tiff?: TiffRenderer,
+  dpr = 1,
 ) {
   // No byte source → nothing to draw (the lazy pipeline always supplies one in
   // both render modes; this guards the rare misconfiguration).
@@ -5210,6 +5223,12 @@ async function renderPicture(
     );
     if (!rasterSize) return;
     const { widthPt, heightPt } = rasterSize;
+    const target = rasterTargetOptions(
+      emuToPx(el.width, scale),
+      emuToPx(el.height, scale),
+      dpr,
+      el.srcRect,
+    );
     // `null` is reachable when the raster path resolves to an unsupported
     // metafile (a true EMF, or a WMF with no geometry); guarded below.
     let bitmap: ImageBitmap | HTMLImageElement | null;
@@ -5231,7 +5250,12 @@ async function renderPicture(
         // SVG vector original has no readable pixel grid (matches xlsx).
         bitmap = dataIsSvg
           ? await getCachedSvgImageByPath(el.imagePath, fetchImage)
-          : await getCachedDuotoneBitmapByPath(el.imagePath, el.mimeType, el.duotone, fetchImage, { widthPt, heightPt, tiff });
+          : await getCachedDuotoneBitmapByPath(el.imagePath, el.mimeType, el.duotone, fetchImage, {
+              widthPt,
+              heightPt,
+              ...(target ?? {}),
+              tiff,
+            });
       }
     } else if (dataIsSvg) {
       // SVG-only picture (here either because it has a crop, or — defensively —
@@ -5243,7 +5267,13 @@ async function renderPicture(
       // §20.1.8.23 duotone recolour on the raster blip (once, at decode time,
       // cached under a colour-suffixed key). No duotone ⇒ this is exactly the
       // former `getCachedBitmapByPath` decode.
-      bitmap = await getCachedDuotoneBitmapByPath(el.imagePath, el.mimeType, el.duotone, fetchImage, { widthPt, heightPt, tiff });
+      bitmap = await getCachedDuotoneBitmapByPath(
+        el.imagePath,
+        el.mimeType,
+        el.duotone,
+        fetchImage,
+        { widthPt, heightPt, ...(target ?? {}), tiff },
+      );
     }
     // Skip a picture whose blip is an unsupported metafile (null bitmap), the
     // same way an SVG-decode failure that also fails its raster fallback would
@@ -5656,6 +5686,7 @@ async function renderMedia(
   skipControls?: boolean,
   bitmapOwner?: PosterFetchImage,
   tiff?: TiffRenderer,
+  dpr = 1,
 ) {
   const x = emuToPx(el.x, scale);
   const y = emuToPx(el.y, scale);
@@ -5667,7 +5698,8 @@ async function renderMedia(
     try {
       // Poster is cached (and prefetched by renderSlide); do not close it here —
       // it is reused across renders of the same slide.
-      poster = await getPosterBitmap(el, fetchMedia, bitmapOwner, tiff);
+      const target = rasterTargetOptions(w, h, dpr);
+      poster = await getPosterBitmap(el, fetchMedia, bitmapOwner, tiff, target);
     } catch (error) {
       if (isOoxmlDecodedImageLimitError(error)) throw error;
       // fall through to plain fill
@@ -6536,6 +6568,7 @@ async function renderSlideLeased(
     superseded,
     opts.fetchImage,
     opts.tiff,
+    effectiveDpr,
   );
   if (superseded()) return canvas;
 
@@ -6586,13 +6619,29 @@ async function renderSlideLeased(
         void getCachedDuotoneBitmapByPath(p.imagePath, p.mimeType, p.duotone, opts.fetchImage, {
           widthPt: warm.widthPt,
           heightPt: warm.heightPt,
+          ...(rasterTargetOptions(
+            emuToPx(p.width, scale),
+            emuToPx(p.height, scale),
+            effectiveDpr,
+            p.srcRect,
+          ) ?? {}),
           tiff: opts.tiff,
         }).catch(() => undefined);
       }
     } else if (el.type === 'media') {
       const m = el as MediaElement;
       if (m.posterPath && opts.fetchMedia) {
-        void getPosterBitmap(m, opts.fetchMedia, bitmapOwner, opts.tiff).catch(() => undefined);
+        void getPosterBitmap(
+          m,
+          opts.fetchMedia,
+          bitmapOwner,
+          opts.tiff,
+          rasterTargetOptions(
+            emuToPx(m.width, scale),
+            emuToPx(m.height, scale),
+            effectiveDpr,
+          ),
+        ).catch(() => undefined);
       }
     }
   }
@@ -6684,7 +6733,7 @@ async function renderSlideLeased(
         : undefined;
       renderShape(ctx, el, scale, themeDefaultColor, slideNumber, rc, elementTextRun, opts.fetchImage);
     } else if (el.type === 'picture') {
-      await renderPicture(ctx, el, scale, superseded, opts.fetchImage, opts.tiff);
+      await renderPicture(ctx, el, scale, superseded, opts.fetchImage, opts.tiff, effectiveDpr);
     } else if (el.type === 'table') {
       const elementTextRun: TextRunCallback | undefined = onTextRun
         ? (run) => onTextRun({
@@ -6704,6 +6753,7 @@ async function renderSlideLeased(
         opts.skipMediaControls,
         opts.fetchImage,
         opts.tiff,
+        effectiveDpr,
       );
     } else if (el.type === 'chart') {
       // OOXML: 1pt = 12700 EMU. The slide renderer's `scale` is px-per-EMU,

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -1290,7 +1290,7 @@ export class OoxmlDecodedImageLimitError extends RangeError {
     readonly code: 'ooxml-decoded-image-limit';
     constructor(metric: OoxmlDecodedImageLimitMetric, limit: number, observed: number);
 }
-export type OoxmlDecodedImageLimitMetric = 'image-pixels' | 'active-decoded-bytes';
+export type OoxmlDecodedImageLimitMetric = 'image-dimension' | 'image-pixels' | 'active-decoded-bytes';
 export class OoxmlError extends Error {
     readonly code: OoxmlErrorCode;
     constructor(code: OoxmlErrorCode, message: string);

--- a/site/src/components/ResourceGovernance.astro
+++ b/site/src/components/ResourceGovernance.astro
@@ -23,10 +23,13 @@
       </div>
     </div>
     <p class="rg-caveat">
-      Raster decode is also guarded uniformly: 32 MP per image, 128 MiB of decoded
-      ownership per document cache or render pass, and two concurrent decodes. These are
-      deterministic admission guards—not exact JavaScript, WASM, canvas or GPU accounting—so
-      they limit measured decode work but cannot guarantee that every device avoids OOM.
+      Raster decode is also guarded uniformly: 32 MP per retained surface, 128 MiB of decoded
+      ownership per document cache or render pass, and two concurrent decodes. Target-aware
+      PPTX paint paths downsample sources above the retained-surface limits to the actual canvas/DPR requirement;
+      the encoded source grid retains a separate 128 Mi-pixel hard ceiling so a tiny display request
+      cannot bypass decode-bomb protection. These are deterministic admission guards—not exact
+      JavaScript, WASM, canvas or GPU accounting—so they limit measured decode work but cannot
+      guarantee that every device avoids OOM.
       Browser-managed SVG/vector storage has no portable decoded-byte metric; its cache is
       count-bounded and owned object URLs are revoked, but it is outside the RGBA counter.
     </p>

--- a/site/src/pages/errors.astro
+++ b/site/src/pages/errors.astro
@@ -193,7 +193,7 @@ try {
     <section id="decoded-image-limit-error" class="error-section error-detail">
       <p class="error-kicker">Raster image safety</p>
       <h2><code>OoxmlDecodedImageLimitError</code></h2>
-      <p><code>error.code</code> is <code>ooxml-decoded-image-limit</code>. Inspect <code>metric</code>, <code>limit</code> and <code>observed</code>. The metric is <code>image-pixels</code> or <code>active-decoded-bytes</code>.</p>
+      <p><code>error.code</code> is <code>ooxml-decoded-image-limit</code>. Inspect <code>metric</code>, <code>limit</code> and <code>observed</code>. The metric is <code>image-dimension</code>, <code>image-pixels</code> or <code>active-decoded-bytes</code>. For target-aware PPTX painting, the image metrics can describe either the retained output-surface ceiling or the separate encoded-source hard ceiling; <code>limit</code> identifies which boundary was crossed.</p>
       <p class="note"><strong>This limit is not configurable.</strong> It prevents dangerous decoded surfaces before or during image work. A browser or device may still impose a lower image or Canvas limit, so ordinary decode failures can occur below this ceiling.</p>
     </section>
 


### PR DESCRIPTION
## Summary

- separate encoded source-image admission from retained decoded-surface limits
- decode over-budget PPTX pictures, stretch backgrounds, and media posters at a target derived from the frame, effective DPR, and DrawingML crop
- preserve native decoding for already-safe images and retain a hard source-grid ceiling for decode-bomb protection
- add resolution-banded caching, Node target-decode support, truthful dimension-limit diagnostics, and resource-governance documentation

## Verification

- focused core image, PPTX renderer/poster, and Node shim tests
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm check:public-api:built
- pnpm --dir site build:ci
- private PPTX self-VRT against the exact merge base: 16 documents / 154 slides, pixel-identical