### PR TITLE
fix(pptx): preserve worker text rendering in production bundles

### DIFF
--- a/packages/pptx/src/render-worker.ts
+++ b/packages/pptx/src/render-worker.ts
@@ -1,5 +1,5 @@
 import init, { PptxArchive, reinit } from './wasm/pptx_parser.js';
-import { renderSlideWithEmbeddedFonts, type PptxTextRunInfo } from './renderer';
+import type { PptxTextRunInfo } from './renderer';
 import { PPTX_GOOGLE_FONTS } from './google-fonts';
 import {
   findPreflightMimeType,
@@ -74,6 +74,12 @@ const rawParts = new BoundedRawPartCache({
   maxEntries: HARD_MAX_RAW_PART_CACHE_ENTRIES,
   maxBytes: HARD_MAX_RAW_PART_CACHE_BYTES,
 });
+// Keep the renderer behind an explicit module boundary. The production worker
+// is flattened into one self-contained asset, and a static function import can
+// otherwise be hoisted past the initializers of shared DrawingML dependencies
+// that are also reached by optional renderers. Awaiting the module preserves ESM
+// initialization order before any text metrics use those shared unit constants.
+const rendererModule = import('./renderer');
 
 function reservePresentationParse(): void {
   if (presentationState !== 'empty') {
@@ -311,6 +317,7 @@ self.onmessage = async (event: MessageEvent<RenderWorkerRequest>) => {
       const { bitmap, runs } = await requireSlides().withSlide(request.slideIndex, async (slide) => {
         await slidePull.run(() => executeArchive((archive) => archive.assert_healthy()));
         await fontsLoaded;
+        const { renderSlideWithEmbeddedFonts } = await rendererModule;
         const canvas = new OffscreenCanvas(1, 1);
         const runs: PptxTextRunInfo[] = [];
         await renderSlideWithEmbeddedFonts(canvas, slide, compact.slideWidth, compact.slideHeight, {
@@ -342,6 +349,7 @@ self.onmessage = async (event: MessageEvent<RenderWorkerRequest>) => {
       const runs = await requireSlides().withSlide(request.slideIndex, async (slide) => {
         await slidePull.run(() => executeArchive((archive) => archive.assert_healthy()));
         await fontsLoaded;
+        const { renderSlideWithEmbeddedFonts } = await rendererModule;
         const canvas = new OffscreenCanvas(1, 1);
         const runs: PptxTextRunInfo[] = [];
         await renderSlideWithEmbeddedFonts(canvas, slide, compact.slideWidth, compact.slideHeight, {

--- a/scripts/build-worker-consumer-fixture.mjs
+++ b/scripts/build-worker-consumer-fixture.mjs
@@ -115,6 +115,53 @@ writeFileSync(join(outDir, 'equation.docx'), storedZip([
     </w:document>`],
 ]));
 
+// A self-authored text-only presentation exercises the production PPTX worker
+// without optional renderer descriptors. Keeping this separate from the public
+// demo catches worker-bundle initialization bugs that optional chart renderers
+// can otherwise mask by initializing shared DrawingML unit constants first.
+writeFileSync(join(outDir, 'text.pptx'), storedZip([
+  ['[Content_Types].xml', `<?xml version="1.0" encoding="UTF-8"?>
+    <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+      <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+      <Default Extension="xml" ContentType="application/xml"/>
+      <Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>
+      <Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>
+    </Types>`],
+  ['_rels/.rels', `<?xml version="1.0" encoding="UTF-8"?>
+    <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>
+    </Relationships>`],
+  ['ppt/presentation.xml', `<?xml version="1.0" encoding="UTF-8"?>
+    <p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+      xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+      <p:sldIdLst><p:sldId id="256" r:id="rIdSlide"/></p:sldIdLst>
+      <p:sldSz cx="9144000" cy="5143500"/>
+    </p:presentation>`],
+  ['ppt/_rels/presentation.xml.rels', `<?xml version="1.0" encoding="UTF-8"?>
+    <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rIdSlide" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+    </Relationships>`],
+  ['ppt/slides/slide1.xml', `<?xml version="1.0" encoding="UTF-8"?>
+    <p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+      xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+      <p:cSld><p:spTree>
+        <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+        <p:grpSpPr/>
+        <p:sp>
+          <p:nvSpPr><p:cNvPr id="2" name="Text Box"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr>
+          <p:spPr>
+            <a:xfrm><a:off x="914400" y="914400"/><a:ext cx="7315200" cy="914400"/></a:xfrm>
+            <a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:noFill/>
+          </p:spPr>
+          <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r>
+            <a:rPr lang="en-US" sz="2800" b="1"><a:latin typeface="Arial"/></a:rPr>
+            <a:t>Production worker text</a:t>
+          </a:r><a:endParaRPr lang="en-US" sz="2800"/></a:p></p:txBody>
+        </p:sp>
+      </p:spTree></p:cSld>
+    </p:sld>`],
+]));
+
 const chartExXml = `<?xml version="1.0" encoding="UTF-8"?>
   <cx:chartSpace xmlns:cx="http://schemas.microsoft.com/office/drawing/2014/chartex">
     <cx:chartData><cx:data id="0">

--- a/tests/worker-dist/consumer/index.html
+++ b/tests/worker-dist/consumer/index.html
@@ -5,6 +5,7 @@
   <canvas id="math"></canvas>
   <canvas id="xlsx"></canvas>
   <canvas id="pptx"></canvas>
+  <canvas id="pptx-text"></canvas>
   <canvas id="docx-chart-ex"></canvas>
   <canvas id="xlsx-chart-ex"></canvas>
   <canvas id="pptx-chart-ex"></canvas>

--- a/tests/worker-dist/consumer/main.js
+++ b/tests/worker-dist/consumer/main.js
@@ -54,6 +54,14 @@ try {
   paint('pptx', await pptx.renderSlideToBitmap(0, { width: 360, dpr: 1 }));
   pptx.destroy();
 
+  const textPptx = await PptxPresentation.load(
+    await bytes('/consumer/text.pptx'),
+    { mode: 'worker', useGoogleFonts: false },
+  );
+  paint('pptx-text', await textPptx.renderSlideToBitmap(0, { width: 640, dpr: 1 }));
+  window.pptxTextRuns = await textPptx.collectSlideRuns(0, 640);
+  textPptx.destroy();
+
   const chartExDocx = await DocxDocument.load(
     await bytes('/consumer/chart-ex.docx'),
     { mode: 'worker', ...renderers },

--- a/tests/worker-dist/fixture.html
+++ b/tests/worker-dist/fixture.html
@@ -5,6 +5,7 @@
   <canvas id="math"></canvas>
   <canvas id="xlsx"></canvas>
   <canvas id="pptx"></canvas>
+  <canvas id="pptx-text"></canvas>
   <canvas id="docx-chart-ex"></canvas>
   <canvas id="xlsx-chart-ex"></canvas>
   <canvas id="pptx-chart-ex"></canvas>
@@ -64,6 +65,14 @@
       );
       paint('pptx', await pptx.renderSlideToBitmap(0, { width: 360, dpr: 1 }));
       pptx.destroy();
+
+      const textPptx = await PptxPresentation.load(
+        await bytes('/consumer/text.pptx'),
+        { mode: 'worker', useGoogleFonts: false },
+      );
+      paint('pptx-text', await textPptx.renderSlideToBitmap(0, { width: 640, dpr: 1 }));
+      window.pptxTextRuns = await textPptx.collectSlideRuns(0, 640);
+      textPptx.destroy();
 
       const chartExDocx = await DocxDocument.load(
         await bytes('/consumer/chart-ex.docx'),

--- a/tests/worker-dist/production-workers.spec.ts
+++ b/tests/worker-dist/production-workers.spec.ts
@@ -4,7 +4,7 @@ async function expectWorkerBitmaps(page: import('@playwright/test').Page, url: s
   await page.goto(url);
   await expect(page.locator('body')).toHaveAttribute('data-status', 'ready', { timeout: 60_000 });
 
-  for (const id of ['docx', 'math', 'xlsx', 'pptx']) {
+  for (const id of ['docx', 'math', 'xlsx', 'pptx', 'pptx-text']) {
     const ink = await page.locator(`#${id}`).evaluate((canvas: HTMLCanvasElement) => {
       const context = canvas.getContext('2d');
       if (!context) return 0;
@@ -16,6 +16,17 @@ async function expectWorkerBitmaps(page: import('@playwright/test').Page, url: s
       return count;
     });
     expect(ink, `${id} worker bitmap should contain ink`).toBeGreaterThan(100);
+  }
+
+  const pptxTextRuns = await page.evaluate(() => (
+    window as typeof window & { pptxTextRuns?: Array<Record<string, unknown>> }
+  ).pptxTextRuns);
+  expect(pptxTextRuns).toHaveLength(1);
+  for (const field of ['inShapeX', 'inShapeY', 'w', 'h', 'fontSize']) {
+    expect(
+      Number.isFinite(pptxTextRuns?.[0]?.[field]),
+      `PPTX worker text run ${field} should be finite`,
+    ).toBe(true);
   }
 
   for (const id of ['docx-chart-ex', 'xlsx-chart-ex', 'pptx-chart-ex']) {


### PR DESCRIPTION
## Summary

- preserve the PPTX renderer's ESM initialization boundary inside the self-contained production worker
- prevent shared DrawingML unit constants from being read before initialization when no optional renderer is configured
- add a self-authored text-only PPTX regression fixture for both the published dist and a Vite consumer rebundle
- assert visible text ink and finite worker text-run geometry

## Root cause

The production worker flattens its modules into one opaque asset. After ChartEx became an optional renderer, a statically imported PPTX renderer function could be hoisted across the optional module boundary while a shared unit module remained lazily initialized. Text layout then multiplied by an uninitialized EMU-per-point value, producing `NaN` font sizes and invisible glyphs. Development modules retained normal ESM initialization order, which is why source-mode tests did not reproduce the failure.

## Verification

- confirmed the regression test fails before the fix for both direct dist and Vite consumer bundles (`pptx-text` ink: 0)
- `pnpm build`
- `./node_modules/.bin/playwright test --config tests/worker-dist/playwright.config.ts`
- `pnpm exec vitest run packages/pptx/src/render-worker-init-hang.test.ts packages/pptx/src/worker-renderer-modules.test.ts`
- `pnpm typecheck`
- `node scripts/check-production-render-workers.mjs dist`
- Electron 44.0.0 / Chromium 152.0.7977.54 on macOS arm64: main and worker bitmaps match exactly

Closes #1413
