### PR TITLE
fix(rendering): restore worker SVGs and stable PPTX zoom

### DIFF
--- a/packages/core/src/image/bitmap-image-by-path.ts
+++ b/packages/core/src/image/bitmap-image-by-path.ts
@@ -49,6 +49,7 @@ import {
   OoxmlDecodedImageLimitError,
 } from './pixel-budget.js';
 import type { TiffRenderer } from './tiff-contract.js';
+import type { SvgBlobDecoder } from '../worker/svg-decode-bridge.js';
 
 type FetchImage = (path: string, mime: string) => Promise<Blob>;
 export type DecodedBitmapCacheOwner = object;
@@ -290,6 +291,8 @@ export interface CachedBitmapOptions {
   targetHeightPx?: number;
   /** Retained base-surface pixel ceiling for multi-surface effect pipelines. */
   maxRetainedPixels?: number;
+  /** Worker-only SVG decoder. Window renderers use HTMLImageElement instead. */
+  svgDecoder?: SvgBlobDecoder;
 }
 
 function normalizedRasterTarget(value: number | undefined): number | undefined {
@@ -546,7 +549,22 @@ export function getCachedBitmapByPath(
     targetWidthPx,
     targetHeightPx,
     maxRetainedPixels,
+    svgDecoder,
   } = normalized;
+  if (mimeType === 'image/svg+xml' && svgDecoder) {
+    return getCachedDecodedBitmap(
+      BASE_CACHE_NAMESPACE,
+      cachedBitmapVariantKey(imagePath, normalized),
+      fetchImage,
+      async () => ({
+        bitmap: await svgDecoder(await fetchImage(imagePath, mimeType), {
+          targetWidthPx,
+          targetHeightPx,
+        }),
+        owned: true,
+      }),
+    );
+  }
   const decode = (cacheKey: string, initial?: RasterSourceProfile) => {
     const initialBlob = initial?.initialBlob;
     if (initial) initial.initialBlob = undefined;

--- a/packages/core/src/image/svg-image-by-path.test.ts
+++ b/packages/core/src/image/svg-image-by-path.test.ts
@@ -103,6 +103,28 @@ describe('getCachedSvgImageByPath', () => {
     expect(fetchImage).toHaveBeenCalledWith('worker.svg', 'image/svg+xml');
   });
 
+  it('uses the Window decode bridge at the requested display size in a worker', async () => {
+    vi.stubGlobal('Image', undefined);
+    vi.stubGlobal('createImageBitmap', vi.fn(async () => {
+      throw new Error('Chromium workers cannot decode this SVG Blob');
+    }));
+    const bitmap = { width: 640, height: 360, close() {} } as unknown as ImageBitmap;
+    const workerDecoder = vi.fn(async () => bitmap);
+    const fetchImage = vi.fn(async () => new Blob(['<svg/>'], { type: 'image/svg+xml' }));
+
+    const result = await getCachedSvgImageByPath('worker-bridged.svg', fetchImage, {
+      targetWidthPx: 640,
+      targetHeightPx: 360,
+      workerDecoder,
+    });
+
+    expect(result).toBe(bitmap);
+    expect(workerDecoder).toHaveBeenCalledWith(expect.any(Blob), {
+      targetWidthPx: 640,
+      targetHeightPx: 360,
+    });
+  });
+
   it('admits at most two concurrent SVG fetch/decode operations per document', async () => {
     vi.stubGlobal('URL', { createObjectURL: () => 'blob:x', revokeObjectURL: () => {} });
     class FakeImg { onload: (() => void) | null = null; onerror: (() => void) | null = null;

--- a/packages/core/src/image/svg-image-by-path.ts
+++ b/packages/core/src/image/svg-image-by-path.ts
@@ -11,9 +11,16 @@
 
 import { getCachedBitmapByPath } from './bitmap-image-by-path.js';
 import { withDecodedImageSlot } from './decode-gate.js';
+import type { SvgBlobDecoder } from '../worker/svg-decode-bridge.js';
 
 type FetchImage = (path: string, mimeType: string) => Promise<Blob>;
 export type SvgImageSource = HTMLImageElement | ImageBitmap;
+
+export interface SvgImageDecodeOptions {
+  readonly targetWidthPx?: number;
+  readonly targetHeightPx?: number;
+  readonly workerDecoder?: SvgBlobDecoder;
+}
 
 interface SvgCacheEntry {
   promise: Promise<SvgImageSource>;
@@ -40,13 +47,18 @@ function docCacheFor(fetchImage: FetchImage): DocCache {
 export function getCachedSvgImageByPath(
   svgImagePath: string,
   fetchImage: FetchImage,
+  options: SvgImageDecodeOptions = {},
 ): Promise<SvgImageSource> {
   // Dedicated Workers and Node have no HTMLImageElement. Route SVG bytes
   // through the same decoded owner as raster blips; browser/Node
   // createImageBitmap support (or the injected Node factory) determines
   // decodability, and the shared decoder validates the resulting dimensions.
   if (typeof Image === 'undefined') {
-    return getCachedBitmapByPath(svgImagePath, 'image/svg+xml', fetchImage).then((bitmap) => {
+    return getCachedBitmapByPath(svgImagePath, 'image/svg+xml', fetchImage, {
+      targetWidthPx: options.targetWidthPx,
+      targetHeightPx: options.targetHeightPx,
+      svgDecoder: options.workerDecoder,
+    }).then((bitmap) => {
       if (!bitmap) throw new Error(`svg decode failed: ${svgImagePath}`);
       return bitmap;
     });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -210,7 +210,9 @@ export {
   getCachedSvgImageByPath,
   dropSvgImageCache,
   type SvgImageSource,
+  type SvgImageDecodeOptions,
 } from './image/svg-image-by-path';
+export type { SvgBlobDecoder, SvgDecodeTarget } from './worker/svg-decode-bridge';
 // Shared per-document decoded-raster owner: one weighted LRU, decode gate and
 // render-pass lease covers base blips, media posters, and derived effects across
 // all three renderers. `fetchImage` remains the compatibility owner by default,

--- a/packages/core/src/worker/index.ts
+++ b/packages/core/src/worker/index.ts
@@ -96,6 +96,18 @@ export {
 } from './resource-policy.generated.js';
 export { disposeRejectedLoad } from './rejected-load.js';
 export {
+  WorkerSvgDecodeClient,
+  boundedSvgRasterSize,
+  decodeSvgBlobOnMainThread,
+  isWorkerSvgDecodeRequest,
+  isWorkerSvgDecodeResponse,
+  respondToWorkerSvgDecodeRequest,
+  type SvgBlobDecoder,
+  type SvgDecodeTarget,
+  type WorkerSvgDecodeRequest,
+  type WorkerSvgDecodeResponse,
+} from './svg-decode-bridge.js';
+export {
   BoundedPullSession,
   DEFAULT_PULL_CANCEL_GRACE_MS,
   PULL_SESSION_PROTOCOL,

--- a/packages/core/src/worker/svg-decode-bridge.test.ts
+++ b/packages/core/src/worker/svg-decode-bridge.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  WorkerSvgDecodeClient,
+  boundedSvgRasterSize,
+  decodeSvgBlobOnMainThread,
+  type WorkerSvgDecodeRequest,
+} from './svg-decode-bridge';
+
+describe('WorkerSvgDecodeClient', () => {
+  it('correlates a transferred SVG decode without losing the display target', async () => {
+    const sent: WorkerSvgDecodeRequest[] = [];
+    const client = new WorkerSvgDecodeClient((message) => sent.push(message as WorkerSvgDecodeRequest));
+    const pending = client.decode(new Blob(['<svg/>']), {
+      targetWidthPx: 512,
+      targetHeightPx: 256,
+    });
+    await vi.waitFor(() => expect(sent).toHaveLength(1));
+    expect(sent[0]).toMatchObject({
+      kind: 'ooxmlDecodeSvg',
+      decodeId: 1,
+      targetWidthPx: 512,
+      targetHeightPx: 256,
+    });
+    const bitmap = { width: 512, height: 256, close: vi.fn() } as unknown as ImageBitmap;
+    expect(client.accept({ kind: 'ooxmlSvgDecoded', decodeId: 1, bitmap })).toBe(true);
+    await expect(pending).resolves.toBe(bitmap);
+  });
+
+  it('bounds extreme vector targets by axis and aggregate pixel budgets', () => {
+    const size = boundedSvgRasterSize(500_000, 500_000);
+    expect(size.width).toBe(size.height);
+    expect(size.width * size.height).toBeLessThanOrEqual(1 << 25);
+    expect(size.width).toBeLessThanOrEqual(32_767);
+  });
+
+  it('keeps bounded dimensions finite when a finite target product overflows', () => {
+    const size = boundedSvgRasterSize(Number.MAX_VALUE, Number.MAX_VALUE);
+    expect(Number.isSafeInteger(size.width)).toBe(true);
+    expect(Number.isSafeInteger(size.height)).toBe(true);
+    expect(size.width * size.height).toBeLessThanOrEqual(1 << 25);
+  });
+});
+
+describe('decodeSvgBlobOnMainThread', () => {
+  it('rasterizes a viewBox-only SVG into the requested bounded surface before transfer', async () => {
+    const drawImage = vi.fn();
+    const bitmap = { width: 400, height: 240, close: vi.fn() } as unknown as ImageBitmap;
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test-svg');
+    vi.stubGlobal('Image', class {
+      width = 0;
+      height = 0;
+      naturalWidth = 0;
+      naturalHeight = 0;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      decode = vi.fn(async () => undefined);
+      set src(_value: string) { queueMicrotask(() => this.onload?.()); }
+    });
+    vi.stubGlobal('OffscreenCanvas', class {
+      constructor(readonly width: number, readonly height: number) {}
+      getContext() { return { drawImage }; }
+      transferToImageBitmap() { return bitmap; }
+    });
+
+    try {
+      await expect(decodeSvgBlobOnMainThread(
+        new Blob(['<svg viewBox="0 0 10 6"/>'], { type: 'image/svg+xml' }),
+        { targetWidthPx: 400, targetHeightPx: 240 },
+      )).resolves.toBe(bitmap);
+      expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 400, 240);
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:test-svg');
+    } finally {
+      vi.restoreAllMocks();
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/packages/core/src/worker/svg-decode-bridge.ts
+++ b/packages/core/src/worker/svg-decode-bridge.ts
@@ -1,0 +1,209 @@
+import {
+  MAX_RASTER_DIMENSION,
+  MAX_RASTER_PIXELS,
+  OoxmlDecodedImageLimitError,
+} from '../image/pixel-budget.js';
+import { closeImageBitmapIfSupported } from '../image/image-bitmap-lifecycle.js';
+
+export interface SvgDecodeTarget {
+  readonly targetWidthPx?: number;
+  readonly targetHeightPx?: number;
+}
+
+export type SvgBlobDecoder = (
+  blob: Blob,
+  target?: SvgDecodeTarget,
+) => Promise<ImageBitmap>;
+
+export interface WorkerSvgDecodeRequest extends SvgDecodeTarget {
+  readonly kind: 'ooxmlDecodeSvg';
+  readonly decodeId: number;
+  readonly bytes: ArrayBuffer;
+}
+
+export type WorkerSvgDecodeResponse =
+  | { readonly kind: 'ooxmlSvgDecoded'; readonly decodeId: number; readonly bitmap: ImageBitmap }
+  | { readonly kind: 'ooxmlSvgDecodeFailed'; readonly decodeId: number; readonly message: string };
+
+type WorkerPost = (message: unknown, transfer?: Transferable[]) => void;
+
+function finitePositive(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.ceil(value)
+    : undefined;
+}
+
+/** Bound a requested SVG raster surface to the same per-image hard quota used
+ * by ordinary decoded OOXML images. Both axes scale together, preserving the
+ * authored vector aspect ratio when a host asks for an oversized target. */
+export function boundedSvgRasterSize(width: number, height: number): { width: number; height: number } {
+  if (!Number.isFinite(width) || !Number.isFinite(height) || !(width > 0) || !(height > 0)) {
+    throw new Error(`invalid SVG raster size: ${width}x${height}`);
+  }
+  // Divide the square roots separately: `width * height` can overflow to
+  // Infinity for finite hostile inputs, which would collapse the scale to zero
+  // and produce NaN dimensions after multiplication.
+  const pixelScale = Math.sqrt(MAX_RASTER_PIXELS) / Math.sqrt(width) / Math.sqrt(height);
+  const scale = Math.min(
+    1,
+    MAX_RASTER_DIMENSION / width,
+    MAX_RASTER_DIMENSION / height,
+    pixelScale,
+  );
+  return {
+    width: Math.min(MAX_RASTER_DIMENSION, Math.max(1, Math.floor(width * scale))),
+    height: Math.min(MAX_RASTER_DIMENSION, Math.max(1, Math.floor(height * scale))),
+  };
+}
+
+/** Decode SVG with the Window's standards-compliant image pipeline, then
+ * transfer a bounded, display-sized ImageBitmap back to the render worker.
+ * Dedicated workers cannot rely on `createImageBitmap(svgBlob)` in Chromium. */
+export async function decodeSvgBlobOnMainThread(
+  blob: Blob,
+  target: SvgDecodeTarget = {},
+): Promise<ImageBitmap> {
+  if (typeof Image === 'undefined') throw new Error('SVG host decode requires HTMLImageElement');
+  const url = URL.createObjectURL(blob);
+  try {
+    const image = new Image();
+    // SVG parts commonly declare only a viewBox. An HTMLImageElement can draw
+    // those directly, but createImageBitmap rejects a zero-intrinsic-size image
+    // in Chromium unless its replaced-element dimensions are established first.
+    const targetWidth = finitePositive(target.targetWidthPx);
+    const targetHeight = finitePositive(target.targetHeightPx);
+    if (targetWidth) image.width = targetWidth;
+    if (targetHeight) image.height = targetHeight;
+    await new Promise<void>((resolve, reject) => {
+      image.onload = () => {
+        if (typeof image.decode === 'function') image.decode().then(resolve).catch(resolve);
+        else resolve();
+      };
+      image.onerror = () => reject(new Error('SVG host decode failed'));
+      image.src = url;
+    });
+    const requestedWidth = targetWidth ?? image.naturalWidth;
+    const requestedHeight = targetHeight ?? image.naturalHeight;
+    const size = boundedSvgRasterSize(requestedWidth || 300, requestedHeight || 150);
+    // Rasterize explicitly instead of createImageBitmap(image): Chromium can
+    // return a transparent bitmap for a viewBox-only SVG even after the image
+    // loaded successfully. Worker render mode already requires OffscreenCanvas;
+    // transferToImageBitmap moves that backing store without retaining a second
+    // full-size surface on Window.
+    let bitmap: ImageBitmap;
+    if (typeof OffscreenCanvas !== 'undefined') {
+      const canvas = new OffscreenCanvas(size.width, size.height);
+      const context = canvas.getContext('2d');
+      if (!context) throw new Error('SVG host raster target has no 2-D context');
+      context.drawImage(image, 0, 0, size.width, size.height);
+      bitmap = canvas.transferToImageBitmap();
+    } else {
+      const canvas = document.createElement('canvas');
+      canvas.width = size.width;
+      canvas.height = size.height;
+      const context = canvas.getContext('2d');
+      if (!context) throw new Error('SVG host raster target has no 2-D context');
+      context.drawImage(image, 0, 0, size.width, size.height);
+      bitmap = await createImageBitmap(canvas);
+    }
+    const pixels = bitmap.width * bitmap.height;
+    if (
+      bitmap.width > MAX_RASTER_DIMENSION
+      || bitmap.height > MAX_RASTER_DIMENSION
+      || pixels > MAX_RASTER_PIXELS
+    ) {
+      closeImageBitmapIfSupported(bitmap);
+      throw new OoxmlDecodedImageLimitError('image-pixels', MAX_RASTER_PIXELS, pixels);
+    }
+    return bitmap;
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+export function isWorkerSvgDecodeRequest(value: unknown): value is WorkerSvgDecodeRequest {
+  return !!value && typeof value === 'object'
+    && (value as { kind?: unknown }).kind === 'ooxmlDecodeSvg';
+}
+
+export function isWorkerSvgDecodeResponse(value: unknown): value is WorkerSvgDecodeResponse {
+  if (!value || typeof value !== 'object') return false;
+  const kind = (value as { kind?: unknown }).kind;
+  return kind === 'ooxmlSvgDecoded' || kind === 'ooxmlSvgDecodeFailed';
+}
+
+/** Main-thread half of the SVG decode bridge. Returns true when `message` was
+ * consumed. The async response owns the transferred bitmap; a failed post
+ * closes it locally so teardown races cannot leak GPU memory. */
+export function respondToWorkerSvgDecodeRequest(
+  post: WorkerPost,
+  message: unknown,
+): boolean {
+  if (!isWorkerSvgDecodeRequest(message)) return false;
+  void decodeSvgBlobOnMainThread(
+    new Blob([message.bytes], { type: 'image/svg+xml' }),
+    message,
+  ).then((bitmap) => {
+    try {
+      post({ kind: 'ooxmlSvgDecoded', decodeId: message.decodeId, bitmap }, [bitmap]);
+    } catch {
+      closeImageBitmapIfSupported(bitmap);
+    }
+  }).catch((error: unknown) => {
+    try {
+      post({
+        kind: 'ooxmlSvgDecodeFailed',
+        decodeId: message.decodeId,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    } catch {
+      // The worker has already terminated; no remote waiter remains.
+    }
+  });
+  return true;
+}
+
+/** Worker-thread half. It transfers SVG bytes to Window only on a cache miss,
+ * correlates the returned ImageBitmap, and exposes a decoder compatible with
+ * the shared per-document decoded-bitmap cache. */
+export class WorkerSvgDecodeClient {
+  private nextId = 1;
+  private readonly pending = new Map<
+    number,
+    { resolve: (bitmap: ImageBitmap) => void; reject: (error: Error) => void }
+  >();
+
+  constructor(private readonly post: WorkerPost) {}
+
+  readonly decode: SvgBlobDecoder = async (blob, target = {}) => {
+    const decodeId = this.nextId++;
+    const bytes = await blob.arrayBuffer();
+    return await new Promise<ImageBitmap>((resolve, reject) => {
+      this.pending.set(decodeId, { resolve, reject });
+      try {
+        this.post({ kind: 'ooxmlDecodeSvg', decodeId, bytes, ...target }, [bytes]);
+      } catch (error) {
+        this.pending.delete(decodeId);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  };
+
+  accept(message: unknown): boolean {
+    if (!isWorkerSvgDecodeResponse(message)) return false;
+    const waiter = this.pending.get(message.decodeId);
+    if (!waiter) {
+      if (message.kind === 'ooxmlSvgDecoded') closeImageBitmapIfSupported(message.bitmap);
+      return true;
+    }
+    this.pending.delete(message.decodeId);
+    if (message.kind === 'ooxmlSvgDecoded') waiter.resolve(message.bitmap);
+    else waiter.reject(new Error(message.message));
+    return true;
+  }
+
+  dispose(error = new Error('SVG decode worker disposed')): void {
+    for (const waiter of this.pending.values()) waiter.reject(error);
+    this.pending.clear();
+  }
+}

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -31,6 +31,7 @@ import {
   OoxmlResourceMetricsSession,
   readLatestOoxmlResourceMetrics,
   PULL_SESSION_PROTOCOL,
+  respondToWorkerSvgDecodeRequest,
   type NormalizedOoxmlResourcePolicy,
   type WorkerRendererDescriptors,
 } from '@silurus/ooxml-core/worker';
@@ -849,6 +850,12 @@ export class DocxDocument {
    * load this document has already moved past.
    */
   private _onWorkerLayoutPush(res: WorkerResponse | RenderWorkerResponse): void {
+    if (respondToWorkerSvgDecodeRequest(
+      (message, transfer) => (
+        this._worker.postMessage as (value: unknown, transfer?: Transferable[]) => void
+      )(message, transfer),
+      res,
+    )) return;
     if (!('forId' in res) || res.forId !== this._parseRequestId) return;
     // Any push proves the worker is alive and working, which is the only thing
     // the watchdog is asking about.

--- a/packages/docx/src/paint/browser-images.ts
+++ b/packages/docx/src/paint/browser-images.ts
@@ -206,18 +206,26 @@ export async function preloadPaintImages(
   fetchImage: DocxFetchImage | undefined,
   tiff?: TiffRenderer,
   devicePixelsPerPoint?: number,
+  svgDecoder?: import('@silurus/ooxml-core').SvgBlobDecoder,
 ): Promise<Map<string, DecodedImage>> {
   if (!fetchImage) return new Map();
+  const decodeSvg = (path: string, request: ImageDecodeRequest) => svgDecoder
+    ? getCachedSvgImageByPath(path, fetchImage, {
+        targetWidthPx: request.targetWidthPx,
+        targetHeightPx: request.targetHeightPx,
+        workerDecoder: svgDecoder,
+      })
+    : getCachedSvgImageByPath(path, fetchImage);
   const entries = await Promise.all(imageDecodeRequests(descriptors, devicePixelsPerPoint).map(async (request) => {
     const dataIsSvg = request.mimeType === 'image/svg+xml';
     const blip = { svgImagePath: request.svgImagePath, srcRect: request.hasCrop || null };
     let image: DecodedImage | null;
     if (preferVectorBlip(blip)) {
       try {
-        image = await getCachedSvgImageByPath(blip.svgImagePath, fetchImage);
+        image = await decodeSvg(blip.svgImagePath, request);
       } catch (vectorError) {
         const fallback = dataIsSvg
-          ? await getCachedSvgImageByPath(request.imagePath, fetchImage)
+          ? await decodeSvg(request.imagePath, request)
           : await decodeRaster(
               request.imagePath,
               request.mimeType,
@@ -236,7 +244,7 @@ export async function preloadPaintImages(
         image = fallback;
       }
     } else if (dataIsSvg) {
-      image = await getCachedSvgImageByPath(request.imagePath, fetchImage);
+      image = await decodeSvg(request.imagePath, request);
     } else {
       image = await decodeRaster(
         request.imagePath,

--- a/packages/docx/src/paint/canvas-document.ts
+++ b/packages/docx/src/paint/canvas-document.ts
@@ -45,6 +45,7 @@ export interface CanvasDocumentPaintOptions<TTextRun> {
   readonly dpr?: number;
   readonly defaultTextColor?: string;
   readonly fetchImage?: DocxFetchImage;
+  readonly svgDecoder?: import('@silurus/ooxml-core').SvgBlobDecoder;
   readonly parseError: boolean;
   readonly registry: PaintResourceRegistry;
   readonly privateResources?: PrivatePaintResourceLookup;
@@ -185,6 +186,7 @@ export async function renderSelectedDocumentPage<TTextRun>(
         options.fetchImage,
         options.tiff,
         scale * effectiveDpr,
+        options.svgDecoder,
       );
     } catch (error) {
       if (superseded()) return;
@@ -212,7 +214,11 @@ export async function renderSelectedDocumentPage<TTextRun>(
         }
         try {
           const decodeFallback = () => fill.mimeType === 'image/svg+xml'
-            ? fill.duotone ? Promise.resolve(null) : getCachedSvgImageByPath(fill.imagePath, fetchImage)
+            ? fill.duotone ? Promise.resolve(null) : options.svgDecoder
+              ? getCachedSvgImageByPath(fill.imagePath, fetchImage, {
+                  workerDecoder: options.svgDecoder,
+                })
+              : getCachedSvgImageByPath(fill.imagePath, fetchImage)
             : decodeRaster(
                 fill.imagePath, fill.mimeType, undefined, fetchImage as DocxFetchImage,
                 raster.widthPt, raster.heightPt, fill.duotone, true, options.tiff,
@@ -220,7 +226,11 @@ export async function renderSelectedDocumentPage<TTextRun>(
           let image: CanvasImageSource | null;
           if (!fill.duotone && preferVectorBlip(fill)) {
             try {
-              image = await getCachedSvgImageByPath(fill.svgImagePath, fetchImage);
+              image = await (options.svgDecoder
+                ? getCachedSvgImageByPath(fill.svgImagePath, fetchImage, {
+                    workerDecoder: options.svgDecoder,
+                  })
+                : getCachedSvgImageByPath(fill.svgImagePath, fetchImage));
             } catch {
               image = await decodeFallback();
             }

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -26,8 +26,11 @@ import {
   resourcePolicyForWasm,
   serializeWorkerError,
   loadWorkerRenderers,
+  isWorkerSvgDecodeResponse,
+  WorkerSvgDecodeClient,
   type LoadedWorkerRenderers,
   type PullSessionResponse,
+  type WorkerSvgDecodeResponse,
 } from '@silurus/ooxml-core/worker';
 import { prepareMathRuns, renderLayoutSourceToCanvas } from './renderer';
 import { createLayoutServices } from './layout-runtime.js';
@@ -104,11 +107,15 @@ const rawParts = new BoundedRawPartCache({
   maxBytes: HARD_MAX_RAW_PART_CACHE_BYTES,
 });
 
+const rawPost = (
+  msg: unknown,
+  transfer?: Transferable[],
+) => (self.postMessage as (m: unknown, t?: Transferable[]) => void)(msg, transfer);
 const post = (
   msg: RenderWorkerResponse | PullSessionResponse<ArrayBuffer, number>,
   transfer?: Transferable[],
-) =>
-  (self.postMessage as (m: unknown, t?: Transferable[]) => void)(msg, transfer);
+) => rawPost(msg, transfer);
+const svgDecodeClient = new WorkerSvgDecodeClient(rawPost);
 
 /** In-worker image-byte loader (twin of pptx's render-worker `getImage`). The
  *  renderer's `fetchImage` routes here in worker mode, so image bytes are
@@ -123,8 +130,12 @@ function getImage(path: string, mimeType: string): Promise<Blob> {
   });
 }
 
-self.onmessage = async (e: MessageEvent<RenderWorkerWireRequest>) => {
+self.onmessage = async (e: MessageEvent<RenderWorkerWireRequest | WorkerSvgDecodeResponse>) => {
   const req = e.data;
+  if (isWorkerSvgDecodeResponse(req)) {
+    svgDecodeClient.accept(req);
+    return;
+  }
   if (isDocumentPullCommand(req)) {
     try {
       if (!fallbackPull) throw new Error('DOCX vertical fallback session is not open');
@@ -363,6 +374,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerWireRequest>) => {
       await renderLayoutSourceToCanvas(source, canvas, req.pageIndex, {
         ...req.opts,
         fetchImage: getImage,
+        svgDecoder: svgDecodeClient.decode,
         layoutServices: doc.layoutServices,
         defaultCurrentDateMs: doc.defaultCurrentDateMs,
         threeD: renderers.threeD,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,6 +1,6 @@
 import type { DocxDocumentModel, BodyElement, DocxTextRunInfo } from './types';
 import type { LayoutServices, MathRenderer } from './layout/types.js';
-import type { ChartThreeDRenderer, ChartRegionMapRenderer, ChartExRenderer, TiffRenderer } from '@silurus/ooxml-core';
+import type { ChartThreeDRenderer, ChartRegionMapRenderer, ChartExRenderer, TiffRenderer, SvgBlobDecoder } from '@silurus/ooxml-core';
 export type { DocxTextRunInfo } from './types';
 import { bodyMathOccurrences } from './layout/resources.js';
 import { paintResourceRegistryOf, privateResourceLookupOf } from './layout/runtime-state.js';
@@ -49,6 +49,8 @@ export interface RenderDocumentOptions {
    * omitted, images are skipped (no byte source).
    */
   fetchImage?: (path: string, mimeType: string) => Promise<Blob>;
+  /** Internal worker-to-Window SVG decoder. */
+  svgDecoder?: SvgBlobDecoder;
   /** Called for each rendered text segment. Used to build a transparent text selection overlay. */
   onTextRun?: (run: DocxTextRunInfo) => void;
   /** ECMA-376 §17.16.5.16 DATE / §17.16.5.72 TIME — the "current" instant that a
@@ -119,6 +121,7 @@ function normalizeRenderOptions(
       dpr: options.dpr,
       defaultTextColor: options.defaultTextColor,
       fetchImage: options.fetchImage,
+      svgDecoder: options.svgDecoder,
       parseError: source.fatalParse !== null,
       registry: paintResourceRegistryOf(services),
       privateResources: privateResourceLookupOf<CanvasImageSource>(services),

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -41,7 +41,8 @@
     "wasm": "cd parser && wasm-pack build --target web --out-dir ../src/wasm && node ../../../scripts/append-wasm-reinit.mjs ../src/wasm/pptx_parser.js",
     "vrt": "VRT_MODE=regression playwright test --config playwright.config.ts",
     "vrt:snapshot": "VRT_SNAPSHOT=1 playwright test --config playwright.config.ts",
-    "vrt:private": "VRT_PRIVATE_CORPUS=1 VRT_MODE=regression playwright test --config playwright.config.ts --grep 'private corpus self regression'",
+    "vrt:private": "VRT_PRIVATE_CORPUS=1 VRT_MODE=regression playwright test --config playwright.config.ts --grep 'private corpus (self regression|worker parity)'",
+    "vrt:private:worker": "VRT_PRIVATE_WORKER_PARITY=1 playwright test --config playwright.config.ts --grep 'private corpus worker parity'",
     "vrt:private:snapshot": "VRT_PRIVATE_CORPUS=1 VRT_SNAPSHOT=1 playwright test --config playwright.config.ts --grep 'private corpus self regression'",
     "vrt:fidelity": "VRT_MODE=fidelity playwright test --config playwright.config.ts",
     "vrt:worker": "playwright test --config playwright.config.ts worker-equivalence"

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -45,6 +45,7 @@ import {
   readLatestOoxmlResourceMetrics,
   parseResourceLimitError,
   PULL_SESSION_PROTOCOL,
+  respondToWorkerSvgDecodeRequest,
   type NormalizedOoxmlResourcePolicy,
   type PullSessionResponse,
   type WorkerRendererDescriptors,
@@ -692,6 +693,12 @@ export class PptxPresentation {
   private _onWorkerLayoutPush(
     response: PptxWorkerResponse | RenderWorkerResponse | PullSessionResponse<ArrayBuffer, number>,
   ): void {
+    if (respondToWorkerSvgDecodeRequest(
+      (message, transfer) => (
+        this._worker.postMessage as (value: unknown, transfer?: Transferable[]) => void
+      )(message, transfer),
+      response,
+    )) return;
     if (
       !('kind' in response) ||
       response.kind !== 'presentationLayoutPartial' ||

--- a/packages/pptx/src/render-worker.ts
+++ b/packages/pptx/src/render-worker.ts
@@ -26,7 +26,10 @@ import {
   resourcePolicyForWasm,
   serializeWorkerError,
   loadWorkerRenderers,
+  isWorkerSvgDecodeResponse,
+  WorkerSvgDecodeClient,
   type LoadedWorkerRenderers,
+  type WorkerSvgDecodeResponse,
 } from '@silurus/ooxml-core/worker';
 import { BoundedRawPartCache } from '@silurus/ooxml-core/internal/bounded-raw-part-cache';
 import type {
@@ -90,8 +93,10 @@ function reservePresentationParse(): void {
   presentationState = 'opening';
 }
 
-const post = (message: RenderWorkerResponse, transfer?: Transferable[]) =>
+const rawPost = (message: unknown, transfer?: Transferable[]) =>
   (self.postMessage as (value: unknown, transfer?: Transferable[]) => void)(message, transfer);
+const post = (message: RenderWorkerResponse, transfer?: Transferable[]) => rawPost(message, transfer);
+const svgDecodeClient = new WorkerSvgDecodeClient(rawPost);
 
 function requirePreflight(): PresentationPreflight {
   if (preflight) return preflight;
@@ -277,8 +282,12 @@ function executeArchiveFromNew(
   });
 }
 
-self.onmessage = async (event: MessageEvent<RenderWorkerRequest>) => {
+self.onmessage = async (event: MessageEvent<RenderWorkerRequest | WorkerSvgDecodeResponse>) => {
   const request = event.data;
+  if (isWorkerSvgDecodeResponse(request)) {
+    svgDecodeClient.accept(request);
+    return;
+  }
   if (request.kind === 'init') {
     host.setWasmInput(decodeDataUrl(request.wasmUrl) ?? request.wasmUrl);
     return;
@@ -331,6 +340,7 @@ self.onmessage = async (event: MessageEvent<RenderWorkerRequest>) => {
           embeddedFontAuthoredFamilies,
           fetchMedia: getMedia,
           fetchImage: getImage,
+          svgDecoder: svgDecodeClient.decode,
           skipMediaControls: request.skipMediaControls,
           dim: request.dim,
           math: renderers.math,
@@ -362,6 +372,7 @@ self.onmessage = async (event: MessageEvent<RenderWorkerRequest>) => {
           embeddedFontAuthoredFamilies,
           fetchMedia: getMedia,
           fetchImage: getImage,
+          svgDecoder: svgDecodeClient.decode,
           math: renderers.math,
           threeD: renderers.threeD,
           regionMap: renderers.regionMap,

--- a/packages/pptx/src/renderer-chart-picture-marker.test.ts
+++ b/packages/pptx/src/renderer-chart-picture-marker.test.ts
@@ -76,7 +76,11 @@ describe('PPTX chart picture-marker preload', () => {
     expect(coreMocks.decode.mock.calls[0]?.slice(0, 4)).toEqual([
       'ppt/media/chart-marker.png', 'image/png', undefined, fetchImage,
     ]);
-    expect(coreMocks.decode.mock.calls[0]?.[4]).toMatchObject({ tiff });
+    expect(coreMocks.decode.mock.calls[0]?.[4]).toMatchObject({
+      tiff,
+      targetWidthPx: 420,
+      targetHeightPx: 315,
+    });
     expect(coreMocks.renderChart).toHaveBeenCalledTimes(1);
     expect(coreMocks.resolved()).toBe(coreMocks.bitmap);
   });
@@ -111,7 +115,15 @@ describe('PPTX chart picture-marker preload', () => {
     await renderSlide(canvas(), slide, 9_144_000, 6_858_000, {
       width: 960, dpr: 1, fetchImage,
     });
-    expect(coreMocks.decodeSvg).toHaveBeenCalledWith('ppt/media/chart-marker.svg', fetchImage);
+    expect(coreMocks.decodeSvg).toHaveBeenCalledWith(
+      'ppt/media/chart-marker.svg',
+      fetchImage,
+      {
+        targetWidthPx: 420,
+        targetHeightPx: 315,
+        workerDecoder: undefined,
+      },
+    );
     expect(coreMocks.decode).toHaveBeenCalled();
     expect(coreMocks.decode.mock.calls.at(-1)?.[4]).toMatchObject({
       failClosedOnDuotoneFailure: true,

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -80,7 +80,6 @@ import {
   getCachedDuotoneBitmapByPath,
   chartImageFillKey,
   collectChartMarkerImageFills,
-  collectChartMarkerImageFillsForCharts,
   acquireBitmapCacheLease,
   peekCachedBitmapByPath,
   dropDecodedBitmapCache,
@@ -109,6 +108,7 @@ import type {
   ChartRegionMapRenderer,
   ChartExRenderer,
   TiffRenderer,
+  SvgBlobDecoder,
 } from '@silurus/ooxml-core';
 import type { HyperlinkTarget } from '@silurus/ooxml-core';
 import { paintDistanceAwareReflectionBlur } from './reflection-blur';
@@ -1690,6 +1690,7 @@ async function renderBackground(
   fetchImage?: (path: string, mime: string) => Promise<Blob>,
   tiff?: TiffRenderer,
   dpr = 1,
+  svgDecoder?: SvgBlobDecoder,
 ) {
   // ECMA-376 §20.1.8.14 — image (blipFill) background. Paint an opaque white
   // base first so a partially transparent image (alphaModFix) composites over
@@ -1725,6 +1726,7 @@ async function renderBackground(
           heightPt: canvasH / scale / PT_TO_EMU,
           ...(!fill.tile ? (rasterTargetOptions(dw, dh, dpr, fill.srcRect) ?? {}) : {}),
           tiff,
+          svgDecoder,
         },
       );
       if (superseded()) return;
@@ -5191,12 +5193,13 @@ export function getPosterBitmap(
   bitmapOwner: PosterFetchImage = posterFetchImage(fetchMedia),
   tiff?: TiffRenderer,
   target?: { targetWidthPx: number; targetHeightPx: number },
+  svgDecoder?: SvgBlobDecoder,
 ): Promise<ImageBitmap> {
   return getCachedBitmapByPath(
     el.posterPath,
     el.posterMimeType || 'application/octet-stream',
     bitmapOwner,
-    { tiff, ...(target ?? {}) },
+    { tiff, svgDecoder, ...(target ?? {}) },
   ).then((bitmap) => {
     if (!bitmap) throw new Error('Media poster could not be decoded');
     return bitmap;
@@ -5211,6 +5214,7 @@ async function renderPicture(
   fetchImage?: (path: string, mime: string) => Promise<Blob>,
   tiff?: TiffRenderer,
   dpr = 1,
+  svgDecoder?: SvgBlobDecoder,
 ) {
   // No byte source → nothing to draw (the lazy pipeline always supplies one in
   // both render modes; this guards the rare misconfiguration).
@@ -5248,6 +5252,7 @@ async function renderPicture(
       dpr,
       el.srcRect,
     );
+    const svgOptions = { ...(target ?? {}), workerDecoder: svgDecoder };
     // `null` is reachable when the raster path resolves to an unsupported
     // metafile (a true EMF, or a WMF with no geometry); guarded below.
     let bitmap: ImageBitmap | HTMLImageElement | null;
@@ -5263,12 +5268,12 @@ async function renderPicture(
       // when only the SVG exists the `dataIsSvg` branch below still draws it
       // (uncropped is the overwhelmingly common case for icons).
       try {
-        bitmap = await getCachedSvgImageByPath(el.svgImagePath, fetchImage);
+        bitmap = await getCachedSvgImageByPath(el.svgImagePath, fetchImage, svgOptions);
       } catch {
         // §20.1.8.23 duotone recolour applies only to the raster fallback — an
         // SVG vector original has no readable pixel grid (matches xlsx).
         bitmap = dataIsSvg
-          ? await getCachedSvgImageByPath(el.imagePath, fetchImage)
+          ? await getCachedSvgImageByPath(el.imagePath, fetchImage, svgOptions)
           : await getCachedDuotoneBitmapByPath(el.imagePath, el.mimeType, el.duotone, fetchImage, {
               widthPt,
               heightPt,
@@ -5281,7 +5286,7 @@ async function renderPicture(
       // because no svgImagePath was surfaced): decode through the SVG path since
       // createImageBitmap can't. A duotone on a vector picture is a rare edge
       // case left un-recoloured (no readable pixel grid), matching xlsx.
-      bitmap = await getCachedSvgImageByPath(el.imagePath, fetchImage);
+      bitmap = await getCachedSvgImageByPath(el.imagePath, fetchImage, svgOptions);
     } else {
       // §20.1.8.23 duotone recolour on the raster blip (once, at decode time,
       // cached under a colour-suffixed key). No duotone ⇒ this is exactly the
@@ -5706,6 +5711,7 @@ async function renderMedia(
   bitmapOwner?: PosterFetchImage,
   tiff?: TiffRenderer,
   dpr = 1,
+  svgDecoder?: SvgBlobDecoder,
 ) {
   const x = emuToPx(el.x, scale);
   const y = emuToPx(el.y, scale);
@@ -5718,7 +5724,7 @@ async function renderMedia(
       // Poster is cached (and prefetched by renderSlide); do not close it here —
       // it is reused across renders of the same slide.
       const target = rasterTargetOptions(w, h, dpr);
-      poster = await getPosterBitmap(el, fetchMedia, bitmapOwner, tiff, target);
+      poster = await getPosterBitmap(el, fetchMedia, bitmapOwner, tiff, target, svgDecoder);
     } catch (error) {
       if (isOoxmlDecodedImageLimitError(error)) throw error;
       // fall through to plain fill
@@ -6351,6 +6357,7 @@ export type SlideRenderOptions = RenderOptions & {
 type InternalSlideRenderOptions = SlideRenderOptions & {
   embeddedFontAliases?: ReadonlyMap<string, string>;
   embeddedFontAuthoredFamilies?: ReadonlyMap<string, string>;
+  svgDecoder?: SvgBlobDecoder;
 };
 
 /**
@@ -6588,6 +6595,7 @@ async function renderSlideLeased(
     opts.fetchImage,
     opts.tiff,
     effectiveDpr,
+    opts.svgDecoder,
   );
   if (superseded()) return canvas;
 
@@ -6616,10 +6624,19 @@ async function renderSlideLeased(
       // failure, so the raster stays cold only in that rare case.)
       const p = el as PictureElement;
       const pDataIsSvg = p.mimeType === 'image/svg+xml';
+      const svgOptions = {
+        ...(rasterTargetOptions(
+          emuToPx(p.width, scale),
+          emuToPx(p.height, scale),
+          effectiveDpr,
+          p.srcRect,
+        ) ?? {}),
+        workerDecoder: opts.svgDecoder,
+      };
       if (preferVectorBlip(p)) {
-        void getCachedSvgImageByPath(p.svgImagePath, opts.fetchImage).catch(() => undefined);
+        void getCachedSvgImageByPath(p.svgImagePath, opts.fetchImage, svgOptions).catch(() => undefined);
       } else if (pDataIsSvg) {
-        void getCachedSvgImageByPath(p.imagePath, opts.fetchImage).catch(() => undefined);
+        void getCachedSvgImageByPath(p.imagePath, opts.fetchImage, svgOptions).catch(() => undefined);
       } else {
         // Pass the picture's pt size so a metafile blip warms at the same raster
         // size the draw loop requests. A cropped metafile warms at its full
@@ -6644,6 +6661,7 @@ async function renderSlideLeased(
             p.srcRect,
           ) ?? {}),
           tiff: opts.tiff,
+          svgDecoder: opts.svgDecoder,
         }).catch(() => undefined);
       }
     } else if (el.type === 'media') {
@@ -6659,6 +6677,7 @@ async function renderSlideLeased(
             emuToPx(m.height, scale),
             effectiveDpr,
           ),
+          opts.svgDecoder,
         ).catch(() => undefined);
       }
     }
@@ -6674,14 +6693,33 @@ async function renderSlideLeased(
   if (opts.fetchImage) {
     const fetchImage = opts.fetchImage;
     const bulletPaths = new Set<string>();
-    const chartFillMap = new Map<string, ReturnType<typeof collectChartMarkerImageFills>[number]>();
-    for (const fill of collectChartMarkerImageFillsForCharts(
-      slide.elements
-        .filter((element): element is ChartElement => element.type === 'chart')
-        .map(element => element.chart),
-    )) {
-      const key = chartImageFillKey(fill);
-      if (!chartFillMap.has(key)) chartFillMap.set(key, fill);
+    const chartFillMap = new Map<string, {
+      fill: ReturnType<typeof collectChartMarkerImageFills>[number];
+      widthPt: number;
+      heightPt: number;
+      targetWidthPx: number;
+      targetHeightPx: number;
+    }>();
+    for (const element of slide.elements) {
+      if (element.type !== 'chart') continue;
+      const widthPx = emuToPx(element.width, scale);
+      const heightPx = emuToPx(element.height, scale);
+      for (const fill of collectChartMarkerImageFills(element.chart)) {
+        const target = rasterTargetOptions(widthPx, heightPx, effectiveDpr, fill.srcRect);
+        if (!target) continue;
+        const key = chartImageFillKey(fill);
+        const prior = chartFillMap.get(key);
+        chartFillMap.set(key, {
+          fill,
+          // A chart picture can paint a marker, plot area, wall, or floor. Its
+          // authored chart frame is the smallest format-derived upper bound
+          // common to all consumers, without assuming a marker size.
+          widthPt: Math.max(prior?.widthPt ?? 0, element.width / PT_TO_EMU),
+          heightPt: Math.max(prior?.heightPt ?? 0, element.height / PT_TO_EMU),
+          targetWidthPx: Math.max(prior?.targetWidthPx ?? 0, target.targetWidthPx),
+          targetHeightPx: Math.max(prior?.targetHeightPx ?? 0, target.targetHeightPx),
+        });
+      }
     }
     for (const el of slide.elements) {
       if (el.type !== 'shape' || !el.textBody) continue;
@@ -6692,50 +6730,58 @@ async function renderSlideLeased(
     }
     if (bulletPaths.size > 0 || chartFillMap.size > 0) {
       const bulletPromises: Promise<unknown>[] = [...bulletPaths].map((key) => {
-          const [path, mime] = key.split(' ');
-          return getCachedBitmapByPath(path, mime, fetchImage, {
-            tiff: opts.tiff,
-            ...(rasterTargetOptions(canvasW, canvasH, effectiveDpr) ?? {}),
-          }).catch((error) => {
-            if (isOoxmlDecodedImageLimitError(error)) throw error;
-            return undefined;
-          });
+        const [path, mime] = key.split(' ');
+        return getCachedBitmapByPath(path, mime, fetchImage, {
+          tiff: opts.tiff,
+          ...(rasterTargetOptions(canvasW, canvasH, effectiveDpr) ?? {}),
+        }).catch((error) => {
+          if (isOoxmlDecodedImageLimitError(error)) throw error;
+          return undefined;
         });
-      const chartPromises: Promise<unknown>[] = [...chartFillMap].map(async ([key, fill]) => {
-          try {
-            const raster = metafileRasterSize(fill.mimeType, fill.srcRect, 72, 72);
-            if (!raster) {
-              chartMarkerImages.set(key, null);
-              return;
-            }
-            const decodeFallback = () => fill.mimeType === 'image/svg+xml'
-              ? fill.duotone ? Promise.resolve(null) : getCachedSvgImageByPath(fill.imagePath, fetchImage)
-              : getCachedDuotoneBitmapByPath(
-                  fill.imagePath, fill.mimeType, fill.duotone, fetchImage,
-                  {
-                    widthPt: raster.widthPt,
-                    heightPt: raster.heightPt,
-                    ...(rasterTargetOptions(96, 96, effectiveDpr, fill.srcRect) ?? {}),
-                    failClosedOnDuotoneFailure: true,
-                    tiff: opts.tiff,
-                  },
-                );
-            let bitmap: CanvasImageSource | null;
-            if (!fill.duotone && preferVectorBlip(fill)) {
-              try {
-                bitmap = await getCachedSvgImageByPath(fill.svgImagePath, fetchImage);
-              } catch {
-                bitmap = await decodeFallback();
-              }
-            } else {
+      });
+      const chartPromises: Promise<unknown>[] = [...chartFillMap].map(async ([key, entry]) => {
+        const { fill, widthPt, heightPt, targetWidthPx, targetHeightPx } = entry;
+        const target = { targetWidthPx, targetHeightPx };
+        try {
+          const raster = metafileRasterSize(fill.mimeType, fill.srcRect, widthPt, heightPt);
+          if (!raster) {
+            chartMarkerImages.set(key, null);
+            return;
+          }
+          const decodeFallback = () => fill.mimeType === 'image/svg+xml'
+            ? fill.duotone ? Promise.resolve(null) : getCachedSvgImageByPath(fill.imagePath, fetchImage, {
+                ...target,
+                workerDecoder: opts.svgDecoder,
+              })
+            : getCachedDuotoneBitmapByPath(
+                fill.imagePath, fill.mimeType, fill.duotone, fetchImage,
+                {
+                  widthPt: raster.widthPt,
+                  heightPt: raster.heightPt,
+                  ...target,
+                  failClosedOnDuotoneFailure: true,
+                  tiff: opts.tiff,
+                },
+              );
+          let bitmap: CanvasImageSource | null;
+          if (!fill.duotone && preferVectorBlip(fill)) {
+            try {
+              bitmap = await getCachedSvgImageByPath(fill.svgImagePath, fetchImage, {
+                ...target,
+                workerDecoder: opts.svgDecoder,
+              });
+            } catch {
               bitmap = await decodeFallback();
             }
-            chartMarkerImages.set(key, bitmap);
-          } catch (error) {
-            if (isOoxmlDecodedImageLimitError(error)) throw error;
-            chartMarkerImages.set(key, null);
+          } else {
+            bitmap = await decodeFallback();
           }
-        });
+          chartMarkerImages.set(key, bitmap);
+        } catch (error) {
+          if (isOoxmlDecodedImageLimitError(error)) throw error;
+          chartMarkerImages.set(key, null);
+        }
+      });
       await Promise.all([...bulletPromises, ...chartPromises]);
       if (superseded()) return canvas;
     }
@@ -6755,7 +6801,16 @@ async function renderSlideLeased(
         : undefined;
       renderShape(ctx, el, scale, themeDefaultColor, slideNumber, rc, elementTextRun, opts.fetchImage);
     } else if (el.type === 'picture') {
-      await renderPicture(ctx, el, scale, superseded, opts.fetchImage, opts.tiff, effectiveDpr);
+      await renderPicture(
+        ctx,
+        el,
+        scale,
+        superseded,
+        opts.fetchImage,
+        opts.tiff,
+        effectiveDpr,
+        opts.svgDecoder,
+      );
     } else if (el.type === 'table') {
       const elementTextRun: TextRunCallback | undefined = onTextRun
         ? (run) => onTextRun({
@@ -6776,6 +6831,7 @@ async function renderSlideLeased(
         opts.fetchImage,
         opts.tiff,
         effectiveDpr,
+        opts.svgDecoder,
       );
     } else if (el.type === 'chart') {
       // OOXML: 1pt = 12700 EMU. The slide renderer's `scale` is px-per-EMU,

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -3044,7 +3044,7 @@ describe('PptxScrollViewer — flicker-free zoom (T8)', () => {
     }
   });
 
-  it('CSS preview: text layer gets a transform: scale(ratio) matching newScale / renderedScale', async () => {
+  it('CSS preview: text layer scales from its committed box so transformed overlays cannot inflate the scroll extent', async () => {
     const { v, scrollHost, engine } = setup(20, { enableTextSelection: true });
     engine.feedTextRuns = [
       {
@@ -3071,6 +3071,14 @@ describe('PptxScrollViewer — flicker-free zoom (T8)', () => {
     v.setScale(v.scaleForTest() * 2);
     expect(textLayer.style.transform).toBe('scale(2)');
     expect(textLayer.style.transformOrigin).toBe('0 0');
+    // The wrapper has already grown to 400x240. A width/height:100% overlay
+    // transformed by 2 would expose an 800x480 overflow box. When the worker
+    // settle clears that transform, the scroll range shrinks and the browser
+    // clamps scrollLeft/scrollTop toward the top-left. Keep the committed
+    // 200x120 overlay box during the preview so its transformed extent is
+    // exactly the new slide box.
+    expect(textLayer.style.width).toBe('200px');
+    expect(textLayer.style.height).toBe('120px');
     v.destroy();
   });
 

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -1163,8 +1163,7 @@ export class PptxScrollViewer implements ZoomableViewer {
       slot.textLayer.innerHTML = '';
       // Drop any preview transform so a pooled slot re-used for another slide does
       // not inherit a stale scale() before its overlay is rebuilt.
-      slot.textLayer.style.transform = '';
-      slot.textLayer.style.transformOrigin = '';
+      this._clearTextLayerPreview(slot.textLayer);
     }
     slot.highlightLayer.innerHTML = '';
     slot.highlightLayer.style.transform = '';
@@ -1711,8 +1710,7 @@ export class PptxScrollViewer implements ZoomableViewer {
       // overlay is sized to the slot's CSS box (Math.round of the uniform slide
       // width/height at the current scale), NOT the dpr-scaled backing store.
       if (slot.textLayer) {
-        slot.textLayer.style.transform = '';
-        slot.textLayer.style.transformOrigin = '';
+        this._clearTextLayerPreview(slot.textLayer);
         if (wantOverlay) {
           buildPptxTextLayer(
             slot.textLayer,
@@ -2044,6 +2042,13 @@ export class PptxScrollViewer implements ZoomableViewer {
     if (slot.textLayer && slot.renderedScale > 0) {
       const ratio = this._scale / slot.renderedScale;
       slot.textLayer.style.transformOrigin = '0 0';
+      // `_positionSlot` has already grown the wrapper to the new scale. Keep the
+      // overlay's layout box at the dimensions of the bitmap it was built for,
+      // then transform that committed box to the preview size. Leaving it at
+      // 100% here would scale the new wrapper-sized box a second time, briefly
+      // inflating the scroll extent until the crisp render settles.
+      slot.textLayer.style.width = `${this._slideWidthPx() / ratio}px`;
+      slot.textLayer.style.height = `${this._slideHeightPx() / ratio}px`;
       slot.textLayer.style.transform = `scale(${ratio})`;
     }
     if (slot.renderedScale > 0) {
@@ -2064,6 +2069,13 @@ export class PptxScrollViewer implements ZoomableViewer {
     if (slot.commentMarkerLayer) slot.commentMarkerLayer.style.visibility = 'hidden';
     if (slot.commentMargin) slot.commentMargin.style.visibility = 'hidden';
     if (slot.commentDecorationLayer) slot.commentDecorationLayer.style.visibility = 'hidden';
+  }
+
+  private _clearTextLayerPreview(layer: HTMLDivElement): void {
+    layer.style.transform = '';
+    layer.style.transformOrigin = '';
+    layer.style.width = '100%';
+    layer.style.height = '100%';
   }
 
   /** (Re)schedule the debounced settle re-render (design §7 mechanism 2). Resets
@@ -2179,8 +2191,7 @@ export class PptxScrollViewer implements ZoomableViewer {
         // Rebuild the overlay at the full resolution and CLEAR the preview
         // transform (the crisp render no longer needs the scale()).
         if (slot.textLayer) {
-          slot.textLayer.style.transform = '';
-          slot.textLayer.style.transformOrigin = '';
+          this._clearTextLayerPreview(slot.textLayer);
           if (wantOverlay) {
             // buildPptxTextLayer takes NUMBERS: pass the CSS box (uniform slide
             // width/height at the current scale), NOT the retina backing store.
@@ -2259,8 +2270,7 @@ export class PptxScrollViewer implements ZoomableViewer {
         oldHandle?.destroy();
 
         if (slot.textLayer) {
-          slot.textLayer.style.transform = '';
-          slot.textLayer.style.transformOrigin = '';
+          this._clearTextLayerPreview(slot.textLayer);
           if (wantOverlay) {
             buildPptxTextLayer(
               slot.textLayer,

--- a/packages/pptx/tests/visual/scroll-zoom-settle-fixture.html
+++ b/packages/pptx/tests/visual/scroll-zoom-settle-fixture.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <style>
+    * { box-sizing: border-box; }
+    html, body { margin: 0; width: 100%; height: 100%; }
+    #host { width: 900px; height: 620px; }
+  </style>
+</head>
+<body>
+  <div id="host"></div>
+  <script type="module">
+    import { PptxScrollViewer } from '/src/index.ts';
+
+    const frame = () => new Promise((resolve) => requestAnimationFrame(() => resolve()));
+    try {
+      const response = await fetch('/demo/sample-1.pptx');
+      if (!response.ok) throw new Error(`fetch demo/sample-1.pptx -> ${response.status}`);
+      const viewer = new PptxScrollViewer(document.getElementById('host'), {
+        mode: 'worker',
+        enableTextSelection: true,
+        enableZoom: true,
+        overscan: 1,
+        gap: 16,
+      });
+      await viewer.load(await response.arrayBuffer());
+      viewer.scrollToSlide(4);
+      await frame();
+      await frame();
+
+      viewer.setScale(viewer.getScale() * 2);
+      await frame();
+      const scrollHost = document.querySelector('#host > div > div');
+      const measure = () => ({
+        left: scrollHost.scrollLeft,
+        top: scrollHost.scrollTop,
+        width: scrollHost.scrollWidth,
+        height: scrollHost.scrollHeight,
+      });
+      const preview = measure();
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      await frame();
+      await frame();
+      document.body.dataset.result = JSON.stringify({ preview, settled: measure() });
+      document.body.dataset.status = 'ready';
+      window.addEventListener('pagehide', () => viewer.destroy(), { once: true });
+    } catch (error) {
+      document.body.dataset.status = 'error';
+      document.body.dataset.errorMessage = error instanceof Error ? error.message : String(error);
+    }
+  </script>
+</body>
+</html>

--- a/packages/pptx/tests/visual/scroll-zoom-settle.spec.ts
+++ b/packages/pptx/tests/visual/scroll-zoom-settle.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test';
+
+test('PptxScrollViewer keeps its scroll anchor when a worker zoom preview settles', async ({ page }) => {
+  test.setTimeout(120_000);
+  await page.goto('/tests/visual/scroll-zoom-settle-fixture.html');
+  await page.waitForFunction(
+    () => document.body.dataset.status === 'ready' || document.body.dataset.status === 'error',
+    undefined,
+    { timeout: 90_000 },
+  );
+  if (await page.evaluate(() => document.body.dataset.status) === 'error') {
+    throw new Error(await page.evaluate(() => document.body.dataset.errorMessage ?? ''));
+  }
+  const result = JSON.parse(await page.evaluate(() => document.body.dataset.result ?? '{}')) as {
+    preview: { left: number; top: number; width: number; height: number };
+    settled: { left: number; top: number; width: number; height: number };
+  };
+
+  // The preview and crisp render represent the same scaled document geometry.
+  // A text overlay based on the already-expanded wrapper used to make the
+  // preview extent larger; clearing its transform then shrank the range and the
+  // browser clamped both axes toward the top-left.
+  expect(Math.abs(result.settled.left - result.preview.left)).toBeLessThanOrEqual(1);
+  expect(Math.abs(result.settled.top - result.preview.top)).toBeLessThanOrEqual(1);
+  expect(Math.abs(result.settled.width - result.preview.width)).toBeLessThanOrEqual(1);
+  expect(Math.abs(result.settled.height - result.preview.height)).toBeLessThanOrEqual(1);
+});

--- a/packages/pptx/tests/visual/worker-equivalence.spec.ts
+++ b/packages/pptx/tests/visual/worker-equivalence.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { mkdirSync, readdirSync, writeFileSync } from 'fs';
 import { PNG } from 'pngjs';
 import pixelmatch from 'pixelmatch';
 
@@ -44,6 +45,78 @@ for (const slide of SLIDES) {
     expect(pct).toBeLessThanOrEqual(MAX_DIFF_PCT[slide]);
   });
 }
+
+const PRIVATE_CORPUS = (
+  process.env.VRT_PRIVATE_CORPUS === '1'
+  || process.env.VRT_PRIVATE_WORKER_PARITY === '1'
+)
+  ? readdirSync('public/private')
+      .filter((file) => file.endsWith('.pptx') && !file.startsWith('~$'))
+      .sort((left, right) => left.localeCompare(right, undefined, { numeric: true }))
+  : [];
+
+test.describe('private corpus worker parity', () => {
+  for (const file of PRIVATE_CORPUS) {
+    test(file, async ({ page }) => {
+      test.setTimeout(600_000);
+      const stem = file.slice(0, -'.pptx'.length);
+      await page.goto(`/tests/visual/worker-fixture.html?pptx=${encodeURIComponent(`private/${stem}`)}&slide=0`);
+      await page.waitForFunction(
+        () => document.body.dataset.status === 'ready' || document.body.dataset.status === 'error',
+        undefined,
+        { timeout: 120_000 },
+      );
+      const status = await page.evaluate(() => document.body.dataset.status);
+      if (status === 'error') {
+        throw new Error(await page.evaluate(() => document.body.dataset.errorMessage ?? ''));
+      }
+      const slideCount = Number(await page.evaluate(() => document.body.dataset.slideCount));
+      expect(slideCount).toBeGreaterThan(0);
+      const differences: string[] = [];
+      for (let slideIndex = 0; slideIndex < slideCount; slideIndex++) {
+        if (slideIndex > 0) {
+          await page.evaluate(async (index) => {
+            const render = (globalThis as unknown as {
+              renderPptxWorkerVrtSlide(slideIndex: number): Promise<void>;
+            }).renderPptxWorkerVrtSlide;
+            await render(index);
+          }, slideIndex);
+        }
+        const [mainUrl, workerUrl] = await page.evaluate(() => [
+          (document.getElementById('main-canvas') as HTMLCanvasElement).toDataURL('image/png'),
+          (document.getElementById('worker-canvas') as HTMLCanvasElement).toDataURL('image/png'),
+        ]);
+        const main = PNG.sync.read(Buffer.from(mainUrl.split(',')[1], 'base64'));
+        const worker = PNG.sync.read(Buffer.from(workerUrl.split(',')[1], 'base64'));
+        if (main.width !== worker.width || main.height !== worker.height) {
+          differences.push(`${stem} slide-${slideIndex + 1}: dimensions differ`);
+          continue;
+        }
+        const diff = pixelmatch(
+          main.data,
+          worker.data,
+          undefined,
+          main.width,
+          main.height,
+          { threshold: 0.1 },
+        );
+        const pct = (diff / (main.width * main.height)) * 100;
+        // Main draws SVGs as vectors while the worker receives a bounded
+        // display-sized bitmap, so edge antialiasing is not byte-identical.
+        // Keep the same narrow tolerance as the public worker-parity suite;
+        // dropped content changes materially more than this raster edge noise.
+        if (pct > 0.1) {
+          const output = `tests/visual/screenshots/worker-parity/${stem}`;
+          mkdirSync(output, { recursive: true });
+          writeFileSync(`${output}/slide-${slideIndex + 1}-main.png`, PNG.sync.write(main));
+          writeFileSync(`${output}/slide-${slideIndex + 1}-worker.png`, PNG.sync.write(worker));
+          differences.push(`${stem} slide-${slideIndex + 1}: worker/main diff ${pct.toFixed(3)}%`);
+        }
+      }
+      expect(differences, differences.join('\n')).toEqual([]);
+    });
+  }
+});
 
 // IX-nav (M2): the internal-navigation map is derived in BOTH modes — main from
 // the parsed slides, worker from the `partNames` that ride through the meta. A

--- a/packages/pptx/tests/visual/worker-fixture.html
+++ b/packages/pptx/tests/visual/worker-fixture.html
@@ -34,10 +34,14 @@
 
       const renderers = { math, threeD, regionMap };
       const main = await PptxPresentation.load(buf.slice(0), { useGoogleFonts: true, ...renderers });
-      paint('main-canvas', await main.renderSlideToBitmap(slide, { width, dpr }));
-
       const wk = await PptxPresentation.load(buf.slice(0), { mode: 'worker', useGoogleFonts: true, ...renderers });
-      paint('worker-canvas', await wk.renderSlideToBitmap(slide, { width, dpr }));
+      const renderBoth = async (slideIndex) => {
+        paint('main-canvas', await main.renderSlideToBitmap(slideIndex, { width, dpr }));
+        paint('worker-canvas', await wk.renderSlideToBitmap(slideIndex, { width, dpr }));
+      };
+      await renderBoth(slide);
+      window.renderPptxWorkerVrtSlide = renderBoth;
+      document.body.dataset.slideCount = String(main.slideCount);
 
       // IX-nav: the slide part-name → index map must be identical in main and
       // worker mode (worker rides `partNames` through the meta). Probe every
@@ -53,8 +57,10 @@
       document.body.dataset.navMain = JSON.stringify(probe(main));
       document.body.dataset.navWorker = JSON.stringify(probe(wk));
 
-      main.destroy();
-      wk.destroy();
+      window.addEventListener('pagehide', () => {
+        main.destroy();
+        wk.destroy();
+      }, { once: true });
 
       document.body.dataset.status = 'ready';
     } catch (err) {

--- a/packages/xlsx/src/render-orchestrator.ts
+++ b/packages/xlsx/src/render-orchestrator.ts
@@ -19,6 +19,7 @@ import {
   type SrcRect,
   type Duotone,
   type OffscreenFactory,
+  type SvgBlobDecoder,
   chartImageFillKey,
   collectChartMarkerImageFills,
   collectChartMarkerImageFillsForCharts,
@@ -229,6 +230,7 @@ export async function decodeImageSource(
   failClosedOnDuotoneFailure = false,
   tiff?: TiffRenderer,
   target?: Readonly<{ targetWidthPx: number; targetHeightPx: number }>,
+  svgDecoder?: SvgBlobDecoder,
 ): Promise<CanvasImageSource | null> {
   const dataIsSvg = mimeType === 'image/svg+xml';
   // SVG pixels are not exposed to the shared bitmap effect pipeline. Without
@@ -260,15 +262,20 @@ export async function decodeImageSource(
     // duotone applies only to the raster fallback — an SVG vector original has no
     // readable pixel grid (matches docx/pptx).
     try {
-      return await getCachedSvgImageByPath(blip.svgImagePath, fetchImage);
+      return await getCachedSvgImageByPath(blip.svgImagePath, fetchImage, {
+        ...target,
+        workerDecoder: svgDecoder,
+      });
     } catch {
-      return dataIsSvg ? getCachedSvgImageByPath(imagePath, fetchImage) : decodeRaster();
+      return dataIsSvg
+        ? getCachedSvgImageByPath(imagePath, fetchImage, { ...target, workerDecoder: svgDecoder })
+        : decodeRaster();
     }
   }
   if (dataIsSvg) {
     // svg-only picture with no separate `svgImagePath` field (defensive): the
     // raster decoder (createImageBitmap) can't rasterize SVG.
-    return getCachedSvgImageByPath(imagePath, fetchImage);
+    return getCachedSvgImageByPath(imagePath, fetchImage, { ...target, workerDecoder: svgDecoder });
   }
   return decodeRaster();
 }
@@ -311,6 +318,7 @@ export async function prefetchImages(
     freezeCols?: number;
     tiff?: TiffRenderer;
     effectiveDpr?: number;
+    svgDecoder?: SvgBlobDecoder;
   },
 ): Promise<void> {
   // This map is only the synchronous lookup for the current frame. Never keep
@@ -485,6 +493,7 @@ export async function prefetchImages(
           ref.targetWidthPx && ref.targetHeightPx
             ? { targetWidthPx: ref.targetWidthPx, targetHeightPx: ref.targetHeightPx }
             : undefined,
+          opts?.svgDecoder,
         );
         // Record the resolved drawable (INCLUDING a null for an unsupported
         // metafile, so the renderer skips a falsy source without a re-fetch).
@@ -558,10 +567,11 @@ export async function renderWorksheetViewport(
   target: HTMLCanvasElement | OffscreenCanvas,
   viewport: ViewportRange,
   opts: RenderViewportOptions = {},
+  svgDecoder?: SvgBlobDecoder,
 ): Promise<void> {
   const releaseLease = opts.fetchImage ? acquireBitmapCacheLease(opts.fetchImage) : undefined;
   try {
-    await renderWorksheetViewportLeased(deps, target, viewport, opts);
+    await renderWorksheetViewportLeased(deps, target, viewport, opts, svgDecoder);
   } finally {
     releaseLease?.();
   }
@@ -574,6 +584,7 @@ async function renderWorksheetViewportLeased(
   target: HTMLCanvasElement | OffscreenCanvas,
   viewport: ViewportRange,
   opts: RenderViewportOptions = {},
+  svgDecoder?: SvgBlobDecoder,
 ): Promise<void> {
   const styles = deps.styles;
   const measurementCtx = target.getContext('2d') as CanvasRenderingContext2D | null;
@@ -612,6 +623,7 @@ async function renderWorksheetViewportLeased(
     freezeCols: opts.freezeCols,
     tiff: deps.tiff,
     effectiveDpr,
+    svgDecoder,
   });
 
   // ── Step 1b: Pre-rasterize equations in shapes BEFORE the canvas resize,

--- a/packages/xlsx/src/render-worker.ts
+++ b/packages/xlsx/src/render-worker.ts
@@ -25,9 +25,12 @@ import {
   resourcePolicyForWasm,
   serializeWorkerError,
   loadWorkerRenderers,
+  isWorkerSvgDecodeResponse,
+  WorkerSvgDecodeClient,
   type LoadedWorkerRenderers,
   type PullSessionCommand,
   type PullSessionResponse,
+  type WorkerSvgDecodeResponse,
 } from '@silurus/ooxml-core/worker';
 import { renderWorksheetViewport } from './render-orchestrator.js';
 import { workerRenderDeps } from './worker-render-deps.js';
@@ -112,8 +115,11 @@ const worksheetPull = new WorksheetPullWorker(
   },
 );
 
-const post = (msg: RenderWorkerResponse | PullSessionResponse<ArrayBuffer, number>, transfer?: Transferable[]) =>
+const rawPost = (msg: unknown, transfer?: Transferable[]) =>
   (self.postMessage as (m: unknown, t?: Transferable[]) => void)(msg, transfer);
+const post = (msg: RenderWorkerResponse | PullSessionResponse<ArrayBuffer, number>, transfer?: Transferable[]) =>
+  rawPost(msg, transfer);
+const svgDecodeClient = new WorkerSvgDecodeClient(rawPost);
 
 /** In-worker image-byte loader (twin of the docx render-worker `getImage`). The
  *  orchestrator's `fetchImage` routes here in worker mode, so image bytes are
@@ -128,8 +134,14 @@ function getImage(path: string, mimeType: string): Promise<Blob> {
   });
 }
 
-self.onmessage = async (e: MessageEvent<RenderWorkerRequest | PullSessionCommand<number>>) => {
+self.onmessage = async (e: MessageEvent<
+  RenderWorkerRequest | PullSessionCommand<number> | WorkerSvgDecodeResponse
+>) => {
   const req = e.data;
+  if (isWorkerSvgDecodeResponse(req)) {
+    svgDecodeClient.accept(req);
+    return;
+  }
   if (isWorksheetPullCommand(req)) {
     await worksheetPull.dispatchSafely(req, post);
     return;
@@ -254,6 +266,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest | PullSessionCommand
         // Supply the in-worker byte loader so embedded images decode straight
         // from the retained archive (no main-thread round-trip).
         { ...renderOpts, fetchImage: getImage },
+        svgDecodeClient.decode,
       );
       const bitmap = canvas.transferToImageBitmap();
       post({ type: 'viewportRendered', id, bitmap }, [bitmap]);

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -31,6 +31,7 @@ import {
   type PullSessionResponse,
   HARD_MAX_RAW_PART_CACHE_BYTES,
   HARD_MAX_RAW_PART_CACHE_ENTRIES,
+  respondToWorkerSvgDecodeRequest,
 } from '@silurus/ooxml-core/worker';
 import { BoundedRawPartCache } from '@silurus/ooxml-core/internal/bounded-raw-part-cache';
 import type { ParsedWorkbook, Worksheet, ViewportRange, RenderViewportOptions, XlsxRenderViewportOptions, WorkerRequest, WorkerResponse, Cell, SheetVisibility, XlsxComment } from './types.js';
@@ -184,6 +185,14 @@ export class XlsxWorkbook {
       // historical rejection behavior.
       toError: (res) =>
         'type' in res && res.type === 'error' ? deserializeWorkerError(res) : undefined,
+      onUnsolicited: (res) => {
+        respondToWorkerSvgDecodeRequest(
+          (message, transfer) => (
+            this.worker.postMessage as (value: unknown, transfer?: Transferable[]) => void
+          )(message, transfer),
+          res,
+        );
+      },
     });
     // Default: the parser WASM emitted next to this bundle, resolved relative to
     // the document URL. `wasmUrl` overrides it (CDN / self-hosted copy); a


### PR DESCRIPTION
## Summary
- decode DrawingML SVG images through a bounded Window-to-worker bridge when dedicated workers cannot decode SVG blobs reliably
- reuse the core decoded-image cache, ownership, concurrency, and memory limits across DOCX, XLSX, and PPTX; derive raster targets from authored display geometry
- keep PPTX text-overlay geometry stable while a zoom preview settles so browser scroll extents do not shrink and clamp toward the top-left
- add a complete local PPTX main/worker corpus parity sweep plus a real-browser zoom-settle regression test

## Specification and design
- preserves the existing ECMA-376 Part 1 section 20.1.8.13 / CT_Blip image model and extension-list flow
- adds no parser or sample-specific behavior; the bridge is a runtime decode capability shared by all three formats
- retains the existing decoded-image pixel, byte, concurrency, cache-weight, and lifecycle controls

## Verification
- focused Vitest: 200 passed
- TypeScript build: passed
- DOCX architecture audit: final boundary check, 89 boundary tests, 17 compatibility tests, 26 public-API tests, and 2 package-build tests passed
- browser parity: DOCX 3/3, XLSX 2/2, public PPTX plus zoom-settle 5/5
- complete local PPTX worker/main corpus: 16/16 presentations, every slide passed
- the saved previous-renderer main-mode image for the reported class remains pixel-identical to current main mode, confirming the historical VRT blind spot was worker coverage rather than baseline drift

## Local full-suite note
The full run completed 8,595 passing tests with four local-only failures. Two private DOCX probes fail identically on the clean merge-base. Two Skia pixel tests passed when rerun standalone and failed only under the full concurrent run. No reference images were updated. The strict private self-VRT also correctly refused to run because the current local corpus contains an input absent from its saved previous-renderer manifest; worker parity is therefore exposed as an independent fail-closed command.