### PR TITLE
fix(viewers): preserve logical geometry under canvas clamping

### DIFF
--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -513,6 +513,10 @@ describe('DocxScrollViewer — opt-in comment cards', () => {
     );
     await vi.waitFor(() => expect(engine.renderCalls).toHaveLength(1));
     expect((viewer as unknown as { _commentMarginExtent(): number })._commentMarginExtent()).toBe(0);
+    const scrollHost = container.children[0]!.children[0]!;
+    const page = scrollHost.children.find((child) => child !== scrollHost.children[0])!;
+    const margin = page.children.find((child) => child.style.cssText.includes('overflow-y:auto'))!;
+    expect(margin.style.display).toBe('none');
     viewer.destroy();
   });
 

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -986,6 +986,9 @@ export class DocxScrollViewer implements ZoomableViewer {
 
   private _syncCommentMarginGeometry(margin: HTMLDivElement | null): void {
     if (!margin) return;
+    // Empty absolutely positioned review cards otherwise enlarge scrollWidth
+    // even though no displayable comment contributes a declared margin extent.
+    margin.style.display = this._hasCommentMargin() ? '' : 'none';
     const zoom = this._commentZoom();
     const offset = `calc(100% + ${COMMENT_MARGIN_GAP_PX * zoom}px)`;
     margin.style.left = this._commentSide() === 'right' ? offset : '';
@@ -2585,6 +2588,7 @@ export class DocxScrollViewer implements ZoomableViewer {
 
   private _redrawSlotComments(page: number, slot: PageSlot): void {
     if (!this._doc || !slot.commentTintLayer) return;
+    this._syncCommentMarginGeometry(slot.commentMargin);
     const commentUi = this._commentUi;
     if (!commentUi) {
       slot.commentTintLayer.replaceChildren();

--- a/packages/pptx/src/presentation-handle-media-errors.test.ts
+++ b/packages/pptx/src/presentation-handle-media-errors.test.ts
@@ -77,6 +77,9 @@ function makeCanvas(ctx = makeContext()) {
     }),
     setPointerCapture: vi.fn(),
     releasePointerCapture: vi.fn(),
+    dispatch(type: string, event: Event) {
+      for (const listener of listeners.get(type) ?? []) listener(event);
+    },
   };
 }
 
@@ -132,7 +135,7 @@ function installDom(media = makeMedia()) {
 function options(overrides: Partial<PresentOptions> = {}): PresentOptions {
   return {
     width: 960,
-    dpr: 1,
+    height: 540,
     slideWidthEmu: 9_144_000,
     fetchMedia: vi.fn(async () => new Blob(['media'], { type: 'audio/mpeg' })),
     fetchImage: vi.fn(),
@@ -150,6 +153,43 @@ afterEach(() => {
 });
 
 describe('presentation media failure reporting', () => {
+  it('keeps overlay drawing and hit testing in logical slide coordinates when the backing store is clamped', async () => {
+    const { media } = installDom();
+    const canvasContext = makeContext();
+    const canvas = makeCanvas(canvasContext);
+    canvas.width = 1_000;
+    canvas.height = 500;
+    canvas.getBoundingClientRect.mockReturnValue({
+      left: 0,
+      top: 0,
+      width: 2_000,
+      height: 1_000,
+    });
+    const rightSideMedia = {
+      ...mediaElement('video'),
+      x: 7_315_200,
+      y: 1_828_800,
+    };
+
+    const handle = await createPresentationHandle(
+      canvas as unknown as HTMLCanvasElement,
+      [rightSideMedia],
+      options({ width: 2_000, height: 1_000 }),
+    );
+
+    // Requested DPR would have been 2, but the allocated buffer represents
+    // only 0.5 physical pixels per logical pixel after clamping.
+    expect(canvasContext.setTransform).toHaveBeenCalledWith(0.5, 0, 0, 0.5, 0, 0);
+    canvas.dispatch('pointerdown', {
+      clientX: 1_700,
+      clientY: 450,
+      pointerId: 1,
+      preventDefault: vi.fn(),
+    } as unknown as PointerEvent);
+    expect(media.play).toHaveBeenCalledTimes(1);
+    handle.destroy();
+  });
+
   it('rejects initial fetchMedia failures without also calling onError', async () => {
     installDom();
     const onError = vi.fn();

--- a/packages/pptx/src/presentation-handle.ts
+++ b/packages/pptx/src/presentation-handle.ts
@@ -32,10 +32,10 @@ export interface PresentationHandle {
 }
 
 export interface PresentOptions {
-  /** Display width in CSS pixels (same value used to render the base slide). */
+  /** Logical slide width in CSS pixels (same value used to render the base slide). */
   width: number;
-  /** Device pixel ratio used when sizing the canvas backing store. */
-  dpr: number;
+  /** Logical slide height in CSS pixels (independent of backing-store clamping). */
+  height: number;
   /** Slide width in EMU (from Presentation.slideWidth). */
   slideWidthEmu: number;
   /** Retrieve the raw media bytes for the given zip path. */
@@ -183,10 +183,19 @@ export async function createPresentationHandle(
   let hoveredState: MediaState | null = null;
 
   const drawFrame = () => {
-    ctx.setTransform(opts.dpr, 0, 0, opts.dpr, 0, 0);
-    const cssW = canvas.width / opts.dpr;
-    const cssH = canvas.height / opts.dpr;
-    ctx.drawImage(base, 0, 0, canvas.width, canvas.height, 0, 0, cssW, cssH);
+    // The backing store may be smaller than `logical size × requested DPR`
+    // after the shared canvas-area guard clamps an extreme zoom. Derive the
+    // effective raster scale from the dimensions that were actually allocated;
+    // the requested DPR is no longer an authoritative coordinate transform.
+    ctx.setTransform(
+      canvas.width / opts.width,
+      0,
+      0,
+      canvas.height / opts.height,
+      0,
+      0,
+    );
+    ctx.drawImage(base, 0, 0, canvas.width, canvas.height, 0, 0, opts.width, opts.height);
 
     for (const s of states) {
       const media = s.media;
@@ -244,11 +253,9 @@ export async function createPresentationHandle(
 
   const toLocal = (clientX: number, clientY: number) => {
     const bb = canvas.getBoundingClientRect();
-    const cssW = canvas.width / opts.dpr;
-    const cssH = canvas.height / opts.dpr;
     return {
-      x: ((clientX - bb.left) / bb.width) * cssW,
-      y: ((clientY - bb.top) / bb.height) * cssH,
+      x: ((clientX - bb.left) / bb.width) * opts.width,
+      y: ((clientY - bb.top) / bb.height) * opts.height,
     };
   };
 

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -1317,43 +1317,54 @@ export class PptxPresentation {
       if (!this._preflight) {
         throw new Error('Presentation not loaded');
       }
-    const dpr = opts.dpr ?? defaultDpr();
-    const width = opts.width ?? (canvas.offsetWidth || 960);
+      const dpr = opts.dpr ?? defaultDpr();
+      const width = opts.width ?? (canvas.offsetWidth || 960);
+      // `width` is the logical CSS-pixel contract. The renderer may clamp the
+      // physical backing store when `width × dpr` exceeds the canvas-area budget;
+      // that reduced bitmap resolution must never shrink the on-screen slide.
+      // Keep logical layout and physical raster size as separate quantities.
+      const logicalHeight = this.slideWidth > 0
+        ? (width * this.slideHeight) / this.slideWidth
+        : 0;
+      canvas.style.width = `${Math.round(width)}px`;
+      canvas.style.height = `${Math.round(logicalHeight)}px`;
+      if (!canvas.style.display) canvas.style.display = 'block';
 
-    const drawBase =
-      this._mode === 'worker'
-        ? async () => {
-            // Whole slide rendered off-thread; the handle snapshots this paint
-            // into its own base copy, so the bitmap can be closed right after.
-            // IX6 — the run geometry rides back beside the bitmap, so a media
-            // slide is as selectable/searchable in worker mode as in main mode.
-            const bmp = await this.renderSlideToBitmap(slideIndex, { width, dpr, skipMediaControls: true, dim: opts.dim, onTextRun: opts.onTextRun });
-            canvas.width = bmp.width;
-            canvas.height = bmp.height;
-            // Set only the CSS width and let height follow the intrinsic aspect
-            // ratio — mirrors the main renderer (renderer.ts), which avoids an
-            // explicit style.height that could fight the ratio.
-            canvas.style.width = `${Math.round(bmp.width / dpr)}px`;
-            if (!canvas.style.display) canvas.style.display = 'block';
-            const ctx = canvas.getContext('2d');
-            if (!ctx) throw new Error('2D context not available');
-            ctx.drawImage(bmp, 0, 0);
-            bmp.close();
-          }
-        : () =>
-            this.renderSlide(canvas, slideIndex, {
-              width,
-              dpr,
-              skipMediaControls: true,
-              dim: opts.dim,
-              onTextRun: opts.onTextRun,
-            });
+      const drawBase =
+        this._mode === 'worker'
+          ? async () => {
+              // Whole slide rendered off-thread; the handle snapshots this paint
+              // into its own base copy, so the bitmap can be closed right after.
+              // IX6 — the run geometry rides back beside the bitmap, so a media
+              // slide is as selectable/searchable in worker mode as in main mode.
+              const bmp = await this.renderSlideToBitmap(slideIndex, {
+                width,
+                dpr,
+                skipMediaControls: true,
+                dim: opts.dim,
+                onTextRun: opts.onTextRun,
+              });
+              canvas.width = bmp.width;
+              canvas.height = bmp.height;
+              const ctx = canvas.getContext('2d');
+              if (!ctx) throw new Error('2D context not available');
+              ctx.drawImage(bmp, 0, 0);
+              bmp.close();
+            }
+          : () =>
+              this.renderSlide(canvas, slideIndex, {
+                width,
+                dpr,
+                skipMediaControls: true,
+                dim: opts.dim,
+                onTextRun: opts.onTextRun,
+              });
 
-    const mediaElements = this._preflight.slides[slideIndex]?.mediaElements ?? [];
+      const mediaElements = this._preflight.slides[slideIndex]?.mediaElements ?? [];
 
       return await createPresentationHandle(canvas, mediaElements, {
         width,
-        dpr,
+        height: logicalHeight,
         slideWidthEmu: this.slideWidth,
         fetchMedia: this._fetchMedia,
         fetchImage: this._fetchImage,

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -332,6 +332,10 @@ describe('PptxScrollViewer — opt-in comment cards', () => {
       { comments: { connectors: {} } },
     );
     expect((viewer as unknown as { _commentMarginExtent(): number })._commentMarginExtent()).toBe(0);
+    const scrollHost = container.children[0]!.children[0]!;
+    const slide = scrollHost.children.find((child) => child !== scrollHost.children[0])!;
+    const margin = slide.children.find((child) => child.style.cssText.includes('overflow-y:auto'))!;
+    expect(margin.style.display).toBe('none');
     viewer.destroy();
   });
 

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -753,6 +753,10 @@ export class PptxScrollViewer implements ZoomableViewer {
 
   private _syncCommentMarginGeometry(margin: HTMLDivElement | null): void {
     if (!margin) return;
+    // An absolutely positioned margin still contributes to native overflow even
+    // when it contains no cards. Keep it out of layout until an authoritative
+    // comment scan says the review surface exists.
+    margin.style.display = this._hasCommentMargin() ? '' : 'none';
     const zoom = this._commentZoom();
     const offset = `calc(100% + ${COMMENT_MARGIN_GAP_PX * zoom}px)`;
     margin.style.left = this._commentSide() === 'right' ? offset : '';
@@ -1690,8 +1694,11 @@ export class PptxScrollViewer implements ZoomableViewer {
         return;
       }
       const size = {
-        cssWidth: Math.round(bmp.width / dpr),
-        cssHeight: Math.round(bmp.height / dpr),
+        // The worker bitmap may be physically downscaled by the shared canvas
+        // area guard. Preserve the requested logical slide box instead of
+        // deriving CSS geometry from that reduced backing store.
+        cssWidth: Math.round(widthPx),
+        cssHeight: Math.round(this._slideHeightPx()),
       };
       // Interactive media later paints through `presentSlide()` on the same
       // pooled canvas, so that canvas must remain a 2D canvas. A browser canvas
@@ -2544,6 +2551,7 @@ export class PptxScrollViewer implements ZoomableViewer {
 
   private _redrawSlotComments(slide: number, slot: SlideSlot): void {
     if (!this._pres || !slot.commentMarkerLayer) return;
+    this._syncCommentMarginGeometry(slot.commentMargin);
     const commentUi = this._commentUi;
     if (!commentUi) {
       slot.commentMarkerLayer.replaceChildren();

--- a/packages/pptx/tests/visual/scroll-zoom-settle-fixture.html
+++ b/packages/pptx/tests/visual/scroll-zoom-settle-fixture.html
@@ -17,29 +17,89 @@
     try {
       const response = await fetch('/demo/sample-1.pptx');
       if (!response.ok) throw new Error(`fetch demo/sample-1.pptx -> ${response.status}`);
-      const viewer = new PptxScrollViewer(document.getElementById('host'), {
+      const maximumZoom = new URLSearchParams(location.search).has('maximum');
+      const options = {
         mode: 'worker',
         enableTextSelection: true,
         enableZoom: true,
-        overscan: 1,
+        enableMediaPlayback: maximumZoom,
+        mediaOverscan: 1,
+        comments: maximumZoom,
+        progressiveLayout: maximumZoom,
+        overscan: maximumZoom ? 0 : 1,
         gap: 16,
-      });
+      };
+      const viewer = new PptxScrollViewer(document.getElementById('host'), options);
       await viewer.load(await response.arrayBuffer());
+      if (maximumZoom) {
+        await viewer.waitUntilLayoutComplete();
+        options.overscan = viewer.slideCount;
+        viewer.relayout();
+      }
       viewer.scrollToSlide(4);
       await frame();
       await frame();
 
-      viewer.setScale(viewer.getScale() * 2);
+      if (maximumZoom) {
+        const scrollHost = document.querySelector('#host > div > div');
+        const rect = scrollHost.getBoundingClientRect();
+        while (viewer.getScale() < 4) {
+          scrollHost.dispatchEvent(new WheelEvent('wheel', {
+            bubbles: true,
+            cancelable: true,
+            clientX: rect.left + rect.width / 2,
+            clientY: rect.top + rect.height / 2,
+            ctrlKey: true,
+            deltaY: -100,
+            deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+          }));
+        }
+      } else {
+        viewer.setScale(viewer.getScale() * 2);
+      }
       await frame();
       const scrollHost = document.querySelector('#host > div > div');
-      const measure = () => ({
-        left: scrollHost.scrollLeft,
-        top: scrollHost.scrollTop,
-        width: scrollHost.scrollWidth,
-        height: scrollHost.scrollHeight,
-      });
+      const measure = () => {
+        const viewport = scrollHost.getBoundingClientRect();
+        const centerY = viewport.top + viewport.height / 2;
+        const slide = [...scrollHost.children].find((element) => {
+          if (!element.hasAttribute('data-slide-index')) return false;
+          const rect = element.getBoundingClientRect();
+          return rect.top <= centerY && rect.bottom >= centerY;
+        });
+        const canvas = slide?.querySelector('canvas');
+        const slideRect = slide?.getBoundingClientRect();
+        const canvasRect = canvas?.getBoundingClientRect();
+        return {
+          left: scrollHost.scrollLeft,
+          top: scrollHost.scrollTop,
+          width: scrollHost.scrollWidth,
+          height: scrollHost.scrollHeight,
+          slideWidth: slideRect?.width ?? 0,
+          slideHeight: slideRect?.height ?? 0,
+          canvasWidth: canvasRect?.width ?? 0,
+          canvasHeight: canvasRect?.height ?? 0,
+          canvasBufferWidth: canvas?.width ?? 0,
+          canvasBufferHeight: canvas?.height ?? 0,
+          scale: viewer.getScale(),
+        };
+      };
       const preview = measure();
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      const previewSlide = [...scrollHost.children].find((element) => {
+        if (!element.hasAttribute('data-slide-index')) return false;
+        const viewport = scrollHost.getBoundingClientRect();
+        const rect = element.getBoundingClientRect();
+        const centerY = viewport.top + viewport.height / 2;
+        return rect.top <= centerY && rect.bottom >= centerY;
+      });
+      const previewCanvas = previewSlide?.querySelector('canvas');
+      if (maximumZoom) {
+        const settleDeadline = performance.now() + 15_000;
+        while (previewCanvas?.isConnected && performance.now() < settleDeadline) await frame();
+        if (previewCanvas?.isConnected) throw new Error('timed out waiting for settled canvas swap');
+      } else {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
       await frame();
       await frame();
       document.body.dataset.result = JSON.stringify({ preview, settled: measure() });

--- a/packages/pptx/tests/visual/scroll-zoom-settle.spec.ts
+++ b/packages/pptx/tests/visual/scroll-zoom-settle.spec.ts
@@ -25,3 +25,59 @@ test('PptxScrollViewer keeps its scroll anchor when a worker zoom preview settle
   expect(Math.abs(result.settled.width - result.preview.width)).toBeLessThanOrEqual(1);
   expect(Math.abs(result.settled.height - result.preview.height)).toBeLessThanOrEqual(1);
 });
+
+test('PptxScrollViewer keeps its scroll anchor when the Try Yours configuration settles at maximum zoom', async ({ page }) => {
+  test.setTimeout(120_000);
+  await page.goto('/tests/visual/scroll-zoom-settle-fixture.html?maximum');
+  await page.waitForFunction(
+    () => document.body.dataset.status === 'ready' || document.body.dataset.status === 'error',
+    undefined,
+    { timeout: 90_000 },
+  );
+  if (await page.evaluate(() => document.body.dataset.status) === 'error') {
+    throw new Error(await page.evaluate(() => document.body.dataset.errorMessage ?? ''));
+  }
+  const result = JSON.parse(await page.evaluate(() => document.body.dataset.result ?? '{}')) as {
+    preview: { left: number; top: number; width: number; height: number };
+    settled: { left: number; top: number; width: number; height: number };
+  };
+
+  expect(Math.abs(result.settled.left - result.preview.left)).toBeLessThanOrEqual(1);
+  expect(Math.abs(result.settled.top - result.preview.top)).toBeLessThanOrEqual(1);
+  expect(Math.abs(result.settled.width - result.preview.width)).toBeLessThanOrEqual(1);
+  expect(Math.abs(result.settled.height - result.preview.height)).toBeLessThanOrEqual(1);
+});
+
+test.describe('Retina Try Yours maximum zoom', () => {
+  test.use({ deviceScaleFactor: 2 });
+
+  test('keeps the scroll anchor after the high-resolution settle', async ({ page }) => {
+    test.setTimeout(120_000);
+    await page.goto('/tests/visual/scroll-zoom-settle-fixture.html?maximum');
+    await page.waitForFunction(
+      () => document.body.dataset.status === 'ready' || document.body.dataset.status === 'error',
+      undefined,
+      { timeout: 90_000 },
+    );
+    if (await page.evaluate(() => document.body.dataset.status) === 'error') {
+      throw new Error(await page.evaluate(() => document.body.dataset.errorMessage ?? ''));
+    }
+    const result = JSON.parse(await page.evaluate(() => document.body.dataset.result ?? '{}')) as {
+      preview: { left: number; top: number; width: number; height: number };
+      settled: {
+        left: number; top: number; width: number; height: number;
+        slideWidth: number; slideHeight: number; canvasWidth: number; canvasHeight: number;
+        canvasBufferWidth: number; canvasBufferHeight: number; scale: number;
+      };
+    };
+    expect(Math.abs(result.settled.left - result.preview.left)).toBeLessThanOrEqual(1);
+    expect(Math.abs(result.settled.top - result.preview.top)).toBeLessThanOrEqual(1);
+    expect(Math.abs(result.settled.width - result.preview.width)).toBeLessThanOrEqual(1);
+    expect(Math.abs(result.settled.height - result.preview.height)).toBeLessThanOrEqual(1);
+    expect(Math.abs(result.settled.canvasWidth - result.settled.slideWidth)).toBeLessThanOrEqual(1);
+    expect(Math.abs(result.settled.canvasHeight - result.settled.slideHeight)).toBeLessThanOrEqual(1);
+    expect(result.settled.scale).toBe(4);
+    expect(result.settled.canvasBufferWidth).toBeLessThan(result.settled.canvasWidth * 2);
+    expect(result.settled.canvasBufferHeight).toBeLessThan(result.settled.canvasHeight * 2);
+  });
+});


### PR DESCRIPTION
## Summary

- keep PPTX slide CSS dimensions independent from a clamped worker bitmap backing store
- use the effective logical-to-physical transform for interactive media drawing and pointer hit testing
- remove empty DOCX/PPTX comment card surfaces from native overflow
- add DPR 2 maximum-zoom, scroll-settle, media-coordinate, and empty-margin regression coverage

## Root cause

At extreme zoom on high-DPI displays, the shared canvas guard correctly reduced the physical backing resolution. PPTX then incorrectly derived the logical CSS box and interactive media coordinates from that reduced bitmap using the originally requested DPR. The canvas therefore collapsed into the upper-left of the unchanged slide wrapper.

## Verification

- focused DOCX/PPTX unit tests: 270 passed
- PPTX maximum-zoom browser regressions, including DPR 2 clamp path: passed
- TypeScript build and DOCX/PPTX production package builds: passed
- lint and diff checks: passed
- merge-base private self-VRT: zero pixel differences across the complete PPTX and DOCX corpora
- PPTX main/worker parity: passed across the complete private corpus

The full unit suite also exposed two pre-existing private DOCX probe failures that reproduce unchanged on the merge base; all other 8,620 tests passed.