### PR TITLE
fix(xlsx): preserve degraded container diagnostics

### DIFF
--- a/packages/node/src/xlsx-workbook-session.test.ts
+++ b/packages/node/src/xlsx-workbook-session.test.ts
@@ -23,6 +23,23 @@ afterAll(async () => {
 });
 
 describe('Node bounded XLSX workbook session', () => {
+  it('keeps the degraded-container diagnostic when archive usage is unavailable', async () => {
+    const workbook = await openXlsxWorkbook(new Uint8Array([0x50, 0x4b, 0x03, 0x04]));
+    try {
+      expect(workbook.resourceUsage).toBeUndefined();
+      expect(workbook.workbookIndex.workbook.parseError)
+        .toContain('(zip container): ZIP central directory preflight failed');
+
+      let terminalError: string | undefined;
+      for await (const chunk of workbook.worksheetRows(0)) {
+        if (chunk.kind === 'finished') terminalError = chunk.worksheet.parseError;
+      }
+      expect(terminalError).toContain('(zip container): ZIP central directory preflight failed');
+    } finally {
+      await workbook.close();
+    }
+  });
+
   it('opens one workbook and streams worksheets sequentially from the retained archive', async () => {
     const free = vi.spyOn(archivePrototype(), 'free');
     try {

--- a/packages/xlsx/src/internal/archive-bootstrap.test.ts
+++ b/packages/xlsx/src/internal/archive-bootstrap.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readXlsxArchiveBootstrap } from './archive-bootstrap.js';
+
+const usageBytes = new TextEncoder().encode(JSON.stringify({
+  archiveEntryCount: 1,
+  declaredInflatedBytes: 2,
+  largestInflatedEntryBytes: 2,
+  distinctInflatedBytes: 2,
+  operationInflatedBytes: 2,
+}));
+
+describe('readXlsxArchiveBootstrap', () => {
+  it('preserves a parsed degraded workbook when archive usage is unavailable', () => {
+    const workbook = { workbook: { parseError: '(zip container): invalid archive' } };
+    const calls: string[] = [];
+
+    const result = readXlsxArchiveBootstrap(
+      () => {
+        calls.push('parse');
+        return workbook;
+      },
+      () => {
+        calls.push('usage');
+        throw 'xlsx resource usage is unavailable';
+      },
+    );
+
+    expect(result).toEqual({ workbook, usage: undefined });
+    expect(calls).toEqual(['parse', 'usage']);
+  });
+
+  it('returns decoded usage for a healthy archive', () => {
+    const workbook = new Uint8Array([1, 2, 3]);
+
+    expect(readXlsxArchiveBootstrap(() => workbook, () => usageBytes)).toEqual({
+      workbook,
+      usage: {
+        archiveEntryCount: 1,
+        declaredInflatedBytes: 2,
+        largestInflatedEntryBytes: 2,
+        distinctInflatedBytes: 2,
+        operationInflatedBytes: 2,
+      },
+    });
+  });
+
+  it('does not downgrade parse or unrelated usage failures', () => {
+    const parseError = new Error('parse failed');
+    const readUsage = vi.fn(() => usageBytes);
+    expect(() => readXlsxArchiveBootstrap(
+      () => { throw parseError; },
+      readUsage,
+    )).toThrow(parseError);
+    expect(readUsage).not.toHaveBeenCalled();
+
+    const usageError = new TypeError('usage checkpoint is malformed');
+    expect(() => readXlsxArchiveBootstrap(
+      () => ({ workbook: {} }),
+      () => { throw usageError; },
+    )).toThrow(usageError);
+  });
+});

--- a/packages/xlsx/src/internal/archive-bootstrap.ts
+++ b/packages/xlsx/src/internal/archive-bootstrap.ts
@@ -1,0 +1,34 @@
+import type { OoxmlResourceUsageSnapshot } from '@silurus/ooxml-core';
+import { decodeOoxmlResourceUsage } from '@silurus/ooxml-core/worker';
+
+const ARCHIVE_USAGE_UNAVAILABLE = 'xlsx resource usage is unavailable';
+
+export interface XlsxArchiveBootstrap<TWorkbook> {
+  readonly workbook: TWorkbook;
+  readonly usage: OoxmlResourceUsageSnapshot | undefined;
+}
+
+/**
+ * Read the workbook projection first, then attach archive accounting when the
+ * retained ZIP opened successfully. A corrupt container intentionally produces
+ * a degraded workbook without an archive usage ledger; that missing diagnostic
+ * must not replace the already-materialized container failure.
+ */
+export function readXlsxArchiveBootstrap<TWorkbook>(
+  readWorkbook: () => TWorkbook,
+  readUsage: () => Uint8Array,
+): XlsxArchiveBootstrap<TWorkbook> {
+  const workbook = readWorkbook();
+  try {
+    return {
+      workbook,
+      usage: decodeOoxmlResourceUsage(readUsage()),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message === ARCHIVE_USAGE_UNAVAILABLE) {
+      return { workbook, usage: undefined };
+    }
+    throw error;
+  }
+}

--- a/packages/xlsx/src/internal/node-acquisition.ts
+++ b/packages/xlsx/src/internal/node-acquisition.ts
@@ -1,6 +1,5 @@
 import type { OoxmlResourceUsageSnapshot } from '@silurus/ooxml-core';
 import {
-  decodeOoxmlResourceUsage,
   normalizeLoadResourceOptions,
   OoxmlResourceMetricsSession,
   parseResourceLimitError,
@@ -12,6 +11,7 @@ import {
   type WasmModuleRuntime,
 } from '@silurus/ooxml-core/internal/wasm-runtime-generation';
 import type { ParsedWorkbook } from '../types.js';
+import { readXlsxArchiveBootstrap } from './archive-bootstrap.js';
 // @ts-ignore wasm-pack generated module has no declaration entry
 import * as xlsxWasm from '../wasm/xlsx_parser.js';
 
@@ -101,10 +101,10 @@ export async function acquireXlsxNodeSession(
     );
     throwIfAborted(options.signal);
     const archive = handle.proxy;
-    const workbookIndex = JSON.parse(
-      new TextDecoder().decode(archive.parse()),
-    ) as ParsedWorkbook;
-    const usage = decodeUsage(archive.resource_usage());
+    const { workbook: workbookIndex, usage } = readXlsxArchiveBootstrap(
+      () => JSON.parse(new TextDecoder().decode(archive.parse())) as ParsedWorkbook,
+      () => archive.resource_usage(),
+    );
     metrics.observeUsage(usage);
     metrics.checkpoint('workbook index ready');
     return {
@@ -119,15 +119,6 @@ export async function acquireXlsxNodeSession(
     const normalized = parseResourceLimitError(error) ?? error;
     metrics.fail(normalized);
     throw normalized;
-  }
-}
-
-function decodeUsage(bytes: Uint8Array): OoxmlResourceUsageSnapshot | undefined {
-  try {
-    return decodeOoxmlResourceUsage(bytes);
-  } catch (error) {
-    if (String(error).includes('worksheet cursor usage is unavailable')) return undefined;
-    throw error;
   }
 }
 

--- a/packages/xlsx/src/render-worker.ts
+++ b/packages/xlsx/src/render-worker.ts
@@ -45,6 +45,7 @@ import {
 import type { ParsedWorkbook, Worksheet } from './types.js';
 import { WorksheetViewProjectionCache } from './worker-protocol.js';
 import { GridGeometry } from './internal/grid-geometry.js';
+import { readXlsxArchiveBootstrap } from './internal/archive-bootstrap.js';
 import type { RenderWorkerRequest, RenderWorkerResponse } from './worker-protocol.js';
 import { isWorksheetPullCommand, WorksheetPullWorker } from './worksheet-pull-worker.js';
 
@@ -208,16 +209,20 @@ self.onmessage = async (e: MessageEvent<
       // prior handle first — the re-parse dispose. `parse()` returns UTF-8 JSON
       // bytes (Result<Vec<u8>, JsValue>); decode + parse the workbook index here
       // (consumed in-worker, then a light copy is sent to the proxy as an object).
-      workbook = host.run(() => {
-        const archive = new XlsxArchive(
-          new Uint8Array(req.data),
-          maxEntry,
-          maxTotal,
-          maxEntries,
-        );
-        host.setArchive(archive);
-        return JSON.parse(new TextDecoder().decode(archive.parse())) as ParsedWorkbook;
-      });
+      const bootstrap = readXlsxArchiveBootstrap(
+        () => host.run(() => {
+          const archive = new XlsxArchive(
+            new Uint8Array(req.data),
+            maxEntry,
+            maxTotal,
+            maxEntries,
+          );
+          host.setArchive(archive);
+          return JSON.parse(new TextDecoder().decode(archive.parse())) as ParsedWorkbook;
+        }),
+        () => host.run(() => host.archive!.resource_usage()),
+      );
+      workbook = bootstrap.workbook;
       if (req.useGoogleFonts) {
         // Mirror XlsxWorkbook._load exactly: queue Google Fonts substitutes for
         // every styled font name, plus the generic Arabic fallbacks. Fonts must
@@ -225,10 +230,7 @@ self.onmessage = async (e: MessageEvent<
         // and await it in the renderViewport handler.
         fontsLoaded = preloadGoogleFonts(xlsxFontPreloadNames(workbook), XLSX_GOOGLE_FONTS);
       }
-      const usage = host.run(() => decodeOoxmlResourceUsage(
-        host.archive!.resource_usage(),
-      ));
-      post({ type: 'parsed', id, workbook, usage });
+      post({ type: 'parsed', id, workbook, usage: bootstrap.usage });
       return;
     }
     if (req.type === 'renderViewport') {

--- a/packages/xlsx/src/worker.ts
+++ b/packages/xlsx/src/worker.ts
@@ -10,6 +10,7 @@ import {
   type PullSessionCommand,
 } from '@silurus/ooxml-core/worker';
 import type { WorkerRequest, WorkerResponse } from './types.js';
+import { readXlsxArchiveBootstrap } from './internal/archive-bootstrap.js';
 import { isWorksheetPullCommand, WorksheetPullWorker } from './worksheet-pull-worker.js';
 
 // RB6: a `panic = "abort"` build traps (not unwinds) on a Rust panic / OOM /
@@ -102,15 +103,15 @@ self.onmessage = async (e: MessageEvent<WorkerRequest | PullSessionCommand<numbe
       // JsValue>). wasm-bindgen hands back a fresh Uint8Array that owns its
       // buffer, so forward it to main as a transferable — no clone, no decode
       // here. The single decode + JSON.parse happens on main.
-      const json = host.run(() => {
-        const archive = new XlsxArchive(bytes, maxEntry, maxTotal, maxEntries);
-        host.setArchive(archive);
-        return archive.parse();
-      });
+      const { workbook: json, usage } = readXlsxArchiveBootstrap(
+        () => host.run(() => {
+          const archive = new XlsxArchive(bytes, maxEntry, maxTotal, maxEntries);
+          host.setArchive(archive);
+          return archive.parse();
+        }),
+        () => host.run(() => host.archive!.resource_usage()),
+      );
       const workbookJson = json.buffer as ArrayBuffer;
-      const usage = host.run(() => decodeOoxmlResourceUsage(
-        host.archive!.resource_usage(),
-      ));
       const res: WorkerResponse = { type: 'parsed', id, workbookJson, usage };
       (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(res, [
         workbookJson,


### PR DESCRIPTION
## Summary

- preserve the degraded XLSX workbook when the ZIP archive has no resource-usage ledger
- share the same bootstrap ordering across Node, the parse worker, and the render worker
- keep unexpected usage decoding, parser, trap, and structured resource-limit failures unchanged

## Root cause

XlsxArchive.parse() intentionally serializes a degraded workbook when container preflight fails. Each acquisition path then called resource_usage() unconditionally. The failed archive has no usage ledger, so that second call replaced the useful container diagnostic with xlsx resource usage is unavailable.

## Verification

- focused archive-bootstrap tests
- real-WASM Node degraded-container session regression test
- focused XLSX resource-policy, worksheet-pull, and workbook compatibility tests
- XLSX typecheck
- full TypeScript project build
- full Vitest run: 8,598 passed; two unrelated effect-crop pixel tests failed only under full parallel load and passed 6/6 when rerun in isolation
- git diff --check

Fixes #1430
