### PR TITLE
fix(chart): honor radar plot area layout

### DIFF
--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -14648,6 +14648,32 @@ describe('authored minor tick marks are painted between major ticks', () => {
 });
 
 describe('radar value-axis planning', () => {
+  it('honors the authored inner plot-area layout', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'radar', radarStyle: 'standard',
+      categories: ['A', 'B', 'C', 'D'],
+      series: [series({ values: [8, 6, 2, 1] })],
+      plotAreaBg: 'ABCDEF',
+      plotAreaManualLayout: {
+        layoutTarget: 'inner',
+        xMode: 'edge', yMode: 'edge',
+        x: 0.2,
+        y: 0.25,
+        w: 0.5,
+        h: 0.4,
+      },
+    }), RECT, 1);
+
+    expect(rec.rects.find(rect => rect.fs === '#ABCDEF')).toEqual({
+      x: RECT.w * 0.2,
+      y: RECT.h * 0.25,
+      w: RECT.w * 0.5,
+      h: RECT.h * 0.4,
+      fs: '#ABCDEF',
+    });
+  });
+
   it('honors an explicit minimum and paints minor gridlines without minor ticks', () => {
     const rec = segRecordingCtx();
     renderChart(rec.ctx, baseModel({

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -11656,6 +11656,7 @@ function renderRadarChart(
     legendSideReserveFrac: 0.22,
     legendReserve: leg,
     radialGapFrac: 0.02,
+    honorPlotAreaManualLayout: true,
   });
   const titleFontPx = frame.title.fontPx;
   drawChartTitleForLayout(ctx, chart, x, y, w, h, y + frame.title.topPad, titleFontPx);


### PR DESCRIPTION
## Summary
- apply authored plot-area manual layout to radar chart frames
- preserve the automatic radial frame when no manual geometry is authored
- cover inner-target radar geometry with a renderer regression test

## Specification
- ECMA-376 section 21.2.2.88 (manualLayout)
- layoutTarget=inner describes the inner plot rectangle without axes or labels

## Verification
- pnpm exec vitest run packages/core/src/chart packages/xlsx/src/chart-sheet-render.test.ts (1,367 tests)
- pnpm exec tsc --build --pretty false
- previous-renderer private self-VRT across all workbook sheets
- targeted local-only viewport comparison against Excel-produced PDF output