### PR TITLE
fix(chart): size radar plots within inner layouts

### DIFF
--- a/packages/core/src/chart/layout.ts
+++ b/packages/core/src/chart/layout.ts
@@ -128,6 +128,7 @@ export interface ChartFrame {
   legendBands: ChartLegendBands;
   axisTitles: ChartAxisTitleBands;
   plotRect: ChartPlotRect;
+  plotAreaManualLayoutApplied: boolean;
   center: { cx: number; cy: number };
 }
 
@@ -686,6 +687,7 @@ export function computeChartFrame(
     ph = h - pad.t - pad.b;
   }
 
+  let plotAreaManualLayoutApplied = false;
   const pml = params.honorPlotAreaManualLayout ? chart.plotAreaManualLayout : null;
   if (pml) {
     const inset = pml.layoutTarget === 'inner'
@@ -709,6 +711,7 @@ export function computeChartFrame(
       py0 = resolved.y + inset.t;
       pw = resolved.w - inset.l - inset.r;
       ph = resolved.h - inset.t - inset.b;
+      plotAreaManualLayoutApplied = true;
     }
   }
 
@@ -718,6 +721,7 @@ export function computeChartFrame(
     legendBands,
     axisTitles,
     plotRect: { px0, py0, pw, ph },
+    plotAreaManualLayoutApplied,
     center: { cx: px0 + pw / 2, cy: py0 + ph / 2 },
   };
 }

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -14846,6 +14846,58 @@ describe('radar value-axis planning', () => {
     });
   });
 
+  it('inscribes maximum radar values in an authored inner plot area', () => {
+    const rec = strokedPolylineCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'radar', radarStyle: 'standard',
+      categories: ['A', 'B', 'C', 'D'],
+      series: [series({ values: [8, 8, 8, 8], lineColor: '123456' })],
+      valMin: 0,
+      valMax: 8,
+      valAxisMajorUnit: 8,
+      valAxisMajorGridlines: false,
+      plotAreaManualLayout: {
+        layoutTarget: 'inner',
+        xMode: 'edge', yMode: 'edge',
+        x: 0.2,
+        y: 0.25,
+        w: 0.5,
+        h: 0.4,
+      },
+    }), RECT, 1);
+
+    expect(rec.strokes.find(stroke => stroke.ss === '#123456')?.points).toEqual([
+      { x: 288, y: 90 },
+      { x: 360, y: 162 },
+      { x: 288, y: 234 },
+      { x: 216, y: 162 },
+    ]);
+  });
+
+  it('keeps the automatic radar radius when an inner layout size is absent or invalid', () => {
+    const points = (layout: 'none' | 'position-only' | 'invalid-size') => {
+      const rec = strokedPolylineCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType: 'radar', radarStyle: 'standard',
+        categories: ['A', 'B', 'C', 'D'],
+        series: [series({ values: [8, 8, 8, 8], lineColor: '123456' })],
+        valMin: 0,
+        valMax: 8,
+        valAxisMajorUnit: 8,
+        valAxisMajorGridlines: false,
+        plotAreaManualLayout: layout === 'position-only'
+          ? { layoutTarget: 'inner', x: 0, y: 0 }
+          : layout === 'invalid-size'
+            ? { layoutTarget: 'inner', x: 0, y: 0, w: -1, h: 0.4 }
+            : undefined,
+      }), RECT, 1);
+      return rec.strokes.find(stroke => stroke.ss === '#123456')?.points;
+    };
+
+    expect(points('position-only')).toEqual(points('none'));
+    expect(points('invalid-size')).toEqual(points('none'));
+  });
+
   it('honors an explicit minimum and paints minor gridlines without minor ticks', () => {
     const rec = segRecordingCtx();
     renderChart(rec.ctx, baseModel({

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -11667,7 +11667,20 @@ function renderRadarChart(
   );
   const cx2 = frame.center.cx;
   const cy2 = frame.center.cy;
-  const rd  = Math.min(pw, ph) * 0.38;
+  // An explicitly sized `layoutTarget="inner"` rectangle defines the data
+  // region itself (ECMA-376 §21.2.2.88), so the outer radar ring is the
+  // largest circle inscribed in it. Automatic, position-only, and outer
+  // layouts keep the existing label reserve.
+  const manualLayout = chart.plotAreaManualLayout;
+  const hasExplicitInnerSize = manualLayout?.layoutTarget === 'inner'
+    && manualLayout.w != null
+    && manualLayout.h != null
+    && Number.isFinite(manualLayout.w)
+    && Number.isFinite(manualLayout.h)
+    && frame.plotAreaManualLayoutApplied;
+  const rd = hasExplicitInnerSize
+    ? Math.min(pw, ph) / 2
+    : Math.min(pw, ph) * 0.38;
 
   let dataMin = Infinity;
   let dataMax = -Infinity;


### PR DESCRIPTION
## Summary
- inscribe radar rings in explicitly sized inner plot-area layouts
- retain the existing automatic radius for outer, position-only, and invalid layouts
- expose whether a manual plot-area layout was actually applied so invalid geometry cannot trigger the inner-layout behavior

## Specification and adversarial review
- ECMA-376 §21.2.2.88 defines `layoutTarget=inner` as the plot area excluding axis labels; the radius is therefore the geometric circle inscribed in that applied rectangle
- no sample-specific branches, thresholds, or empirical scale factors were added
- the change is O(1) arithmetic with no allocation, cache, worker, or resource-lifetime impact
- the implementation remains in the shared chart core used by DOCX, XLSX, and PPTX; parser/model and host wiring require no format-specific changes

## Verification
- `pnpm exec vitest run packages/core/src/chart packages/xlsx/src/chart-sheet-render.test.ts` (35 files, 1381 tests)
- `pnpm exec tsc --build --pretty false`
- `git diff --check`
- private all-sheet self-VRT matched the previous renderer exactly in the standard viewport
- a targeted previous-renderer comparison changed only the two authored radar plot regions; separate Office-produced PDF comparison confirmed the intended polygon dimensions