### PR TITLE
fix(pptx): match PowerPoint placeholder and table formatting

### DIFF
--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -4743,6 +4743,26 @@ mod tests {
         assert!(!r_n.strikethrough && !r_n.strike_double);
     }
 
+    /// CT_TextCharacterProperties is a sequence: the EG_TextRunProperties fill
+    /// choice precedes latin/ea/cs. PowerPoint ignores a solidFill serialized
+    /// after those font children instead of accepting the out-of-order value.
+    /// A valid fill in its schema position must continue to resolve normally.
+    #[test]
+    fn test_parse_run_ignores_out_of_order_text_fill() {
+        let valid = r#"<r xmlns="http://schemas.openxmlformats.org/drawingml/2006/main"><rPr><solidFill><schemeClr val="accent1"/></solidFill><latin typeface="Aptos"/><ea typeface=""/><cs typeface=""/></rPr><t>valid</t></r>"#;
+        let invalid = r#"<r xmlns="http://schemas.openxmlformats.org/drawingml/2006/main"><rPr><latin typeface="Aptos"/><ea typeface=""/><cs typeface=""/><solidFill><schemeClr val="accent1"/></solidFill></rPr><t>invalid</t></r>"#;
+        let theme = HashMap::from([("accent1".to_owned(), "1D6FA8".to_owned())]);
+        let rels = HashMap::new();
+
+        let valid_doc = roxmltree::Document::parse(valid).unwrap();
+        let valid_run = parse_run(valid_doc.root_element(), None, &theme, &rels).unwrap();
+        assert_eq!(valid_run.color.as_deref(), Some("1D6FA8"));
+
+        let invalid_doc = roxmltree::Document::parse(invalid).unwrap();
+        let invalid_run = parse_run(invalid_doc.root_element(), None, &theme, &rels).unwrap();
+        assert_eq!(invalid_run.color, None);
+    }
+
     /// ECMA-376 §21.1.2.3.9; ST_TextCapsType §20.1.10.64 — cap="all" /
     /// "small" are passed through;
     /// cap="none" or omitted yields None so the field stays absent in JSON.

--- a/packages/pptx/parser/src/master.rs
+++ b/packages/pptx/parser/src/master.rs
@@ -16,7 +16,8 @@ use crate::text::{
     empty_level_bullets, extract_level_bullets, extract_level_font_sizes, extract_level_indents,
     extract_lvl1_font_size, has_any_level_bullet, has_any_level_indent, has_any_level_size,
     merge_level_bullets, merge_level_indents, merge_level_sizes, read_level_bullets,
-    read_level_font_sizes, read_level_indents, LevelBullets, LevelFontSizes, LevelIndents,
+    read_level_font_sizes, read_level_indents, text_property_solid_fill, LevelBullets,
+    LevelFontSizes, LevelIndents,
 };
 use crate::theme::{
     bake_clr_map, parse_theme_part, resolve_theme_typeface, PptxSchemeResolver, PptxTheme,
@@ -874,6 +875,18 @@ pub(crate) fn parse_master_font_sizes(root: roxmltree::Node<'_, '_>) -> HashMap<
                 }
             }
         }
+    } else {
+        // CT_SlideMaster permits txStyles to be omitted. In that case current
+        // PowerPoint supplies its application-level placeholder defaults:
+        // titles at 44 pt and body/object placeholders at 28 pt. Scope these
+        // compatibility defaults to presentation placeholders only; ordinary
+        // text boxes continue through their own authored/theme cascade.
+        for ph_type in ["title", "ctrTitle"] {
+            map.entry(ph_type.to_owned()).or_insert(44.0);
+        }
+        for ph_type in ["body", "subTitle", "obj", ""] {
+            map.entry(ph_type.to_owned()).or_insert(28.0);
+        }
     }
 
     map
@@ -1201,7 +1214,7 @@ pub(crate) fn parse_master_txstyle_color(
                     .and_then(|tb| child(tb, "lstStyle"))
                     .and_then(|ls| child(ls, "lvl1pPr"))
                     .and_then(|lp| child(lp, "defRPr"))
-                    .and_then(|rp| child(rp, "solidFill"))
+                    .and_then(text_property_solid_fill)
                     .and_then(|sf| parse_color_node(sf, theme))
                 {
                     map.entry(ph_type).or_insert(color);
@@ -1217,7 +1230,7 @@ pub(crate) fn parse_master_txstyle_color(
             if let Some(color) = child(tx_styles, style_name)
                 .and_then(|sn| child(sn, "lvl1pPr"))
                 .and_then(|lp| child(lp, "defRPr"))
-                .and_then(|rp| child(rp, "solidFill"))
+                .and_then(text_property_solid_fill)
                 .and_then(|sf| parse_color_node(sf, theme))
             {
                 for ph_type in *ph_types {
@@ -1407,7 +1420,7 @@ pub(crate) fn parse_layout_placeholders(
             .and_then(|rp| child(rp, "effectLst"))
             .and_then(parse_reflection);
         let layout_color: Option<String> = layout_def_rpr
-            .and_then(|rp| child(rp, "solidFill"))
+            .and_then(text_property_solid_fill)
             .and_then(|sf| parse_color_node(sf, theme));
         let layout_alignment: Option<String> = layout_lvl1_ppr
             .and_then(|lp| attr(&lp, "algn"))
@@ -2133,6 +2146,52 @@ mod placeholder_geometry_tests {
             &mut zip,
         )
         .unwrap()
+    }
+
+    /// ECMA-376 makes p:txStyles optional on a slide master. PowerPoint still
+    /// applies its presentation placeholder defaults when that authored tier is
+    /// absent: 44 pt for title placeholders and 28 pt for body/object
+    /// placeholders. These are application defaults, not fabricated defaults
+    /// for ordinary text boxes.
+    #[test]
+    fn master_without_tx_styles_uses_powerpoint_placeholder_font_defaults() {
+        let xml = r#"<p:sldMaster
+          xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <p:cSld><p:spTree/></p:cSld>
+        </p:sldMaster>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+
+        let sizes = parse_master_font_sizes(doc.root_element());
+
+        assert_eq!(sizes.get("title"), Some(&44.0));
+        assert_eq!(sizes.get("ctrTitle"), Some(&44.0));
+        assert_eq!(sizes.get("body"), Some(&28.0));
+        assert_eq!(sizes.get("obj"), Some(&28.0));
+        assert_eq!(sizes.get("subTitle"), Some(&28.0));
+        assert_eq!(sizes.get(""), Some(&28.0));
+        assert_eq!(sizes.get("dt"), None);
+    }
+
+    #[test]
+    fn authored_master_tx_styles_override_powerpoint_placeholder_defaults() {
+        let xml = r#"<p:sldMaster
+          xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <p:cSld><p:spTree/></p:cSld>
+          <p:txStyles>
+            <p:titleStyle><a:lvl1pPr><a:defRPr sz="3600"/></a:lvl1pPr></p:titleStyle>
+            <p:bodyStyle><a:lvl1pPr><a:defRPr sz="2400"/></a:lvl1pPr></p:bodyStyle>
+            <p:otherStyle><a:lvl1pPr><a:defRPr sz="1200"/></a:lvl1pPr></p:otherStyle>
+          </p:txStyles>
+        </p:sldMaster>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+
+        let sizes = parse_master_font_sizes(doc.root_element());
+
+        assert_eq!(sizes.get("title"), Some(&36.0));
+        assert_eq!(sizes.get("body"), Some(&24.0));
+        assert_eq!(sizes.get("dt"), Some(&12.0));
     }
 
     #[test]

--- a/packages/pptx/parser/src/table_style_presets.rs
+++ b/packages/pptx/parser/src/table_style_presets.rs
@@ -165,6 +165,14 @@ fn stroke(color: &str) -> Stroke {
     }
 }
 
+fn double_stroke(color: &str) -> Stroke {
+    Stroke {
+        width: 38100,
+        cmpd: Some("dbl".to_owned()),
+        ..stroke(color)
+    }
+}
+
 // Built-in presets predate the lossless thirteen-role model. Keep their
 // declarative definitions compact while mapping each legacy shorthand onto the
 // exact CT_TablePartStyle member now used by XML-backed styles.
@@ -208,6 +216,9 @@ macro_rules! set_table_style_field {
     }};
     ($style:ident, first_row_border_b, $value:expr) => {
         $style.first_row.borders.bottom = TableLineStyle::from_stroke($value)
+    };
+    ($style:ident, last_row_border_t, $value:expr) => {
+        $style.last_row.borders.top = TableLineStyle::from_stroke($value)
     };
     ($style:ident, whole_text, $value:expr) => {
         $style.whole_tbl.text = $value
@@ -326,6 +337,7 @@ fn medium_style_1(theme: &HashMap<String, String>, accent_idx: Option<u8>) -> Ta
         .or_else(|| dk1(theme))
         .unwrap_or_else(|| "000000".into());
     let lt = lt1(theme).unwrap_or_else(|| "FFFFFF".into());
+    let dk = dk1(theme).unwrap_or_else(|| "000000".into());
     let border = Some(stroke(&a));
     let band1h_color = apply_transforms(&a, &[("tint", 20000)]);
     table_style! {
@@ -336,6 +348,22 @@ fn medium_style_1(theme: &HashMap<String, String>, accent_idx: Option<u8>) -> Ta
         whole_outer_h: border.clone(),
         whole_outer_v: border,
         whole_inside_h: Some(stroke(&a)),
+        last_row_border_t: Some(double_stroke(&a)),
+        whole_text: TableTextStyle {
+            color: Some(dk.clone()),
+            bold: Some(true),
+            ..Default::default()
+        },
+        first_row_text: TableTextStyle {
+            color: Some(lt),
+            bold: Some(true),
+            ..Default::default()
+        },
+        last_row_text: TableTextStyle {
+            color: Some(dk),
+            bold: Some(true),
+            ..Default::default()
+        },
     }
 }
 
@@ -955,5 +983,32 @@ mod tests {
         assert_eq!(style.last_row.text.bold, Some(true));
         assert_eq!(style.first_col.text.bold, Some(true));
         assert_eq!(style.last_col.text.bold, Some(true));
+    }
+
+    /// Built-in Medium Style 1 is not serialized into tableStyles.xml. Current
+    /// PowerPoint applies bold text throughout, light text on the header, and a
+    /// compound double separator above a flagged total row.
+    #[test]
+    fn medium_style_1_accent_1_carries_text_and_total_row_formatting() {
+        let theme = HashMap::from([
+            ("accent1".to_owned(), "1D6FA8".to_owned()),
+            ("lt1".to_owned(), "F9F9F9".to_owned()),
+            ("dk1".to_owned(), "10263F".to_owned()),
+        ]);
+        let style = lookup_builtin_table_style("{B301B821-A1FF-4177-AEE7-76D212191A09}", &theme)
+            .expect("known PowerPoint table style");
+
+        assert_eq!(style.whole_tbl.text.color.as_deref(), Some("10263F"));
+        assert_eq!(style.whole_tbl.text.bold, Some(true));
+        assert_eq!(style.first_row.text.color.as_deref(), Some("F9F9F9"));
+        assert_eq!(style.first_row.text.bold, Some(true));
+        assert_eq!(style.last_row.text.color.as_deref(), Some("10263F"));
+        assert_eq!(style.last_row.text.bold, Some(true));
+        let TableLineStyle::Stroke(total_separator) = &style.last_row.borders.top else {
+            panic!("last-row top separator");
+        };
+        assert_eq!(total_separator.color, "1D6FA8");
+        assert_eq!(total_separator.width, 38_100);
+        assert_eq!(total_separator.cmpd.as_deref(), Some("dbl"));
     }
 }

--- a/packages/pptx/parser/src/text.rs
+++ b/packages/pptx/parser/src/text.rs
@@ -365,6 +365,48 @@ pub(crate) enum ShapeKind {
     Sp,
 }
 
+/// Return a text-property solid fill only when it appears in the
+/// `CT_TextCharacterProperties` sequence position defined by ECMA-376
+/// §21.1.2.3.9 / dml-main.xsd. The fill choice precedes effects, highlight,
+/// underline properties and the latin/ea/cs font children. PowerPoint ignores
+/// an out-of-order fill (a pattern emitted by some non-Office producers), so a
+/// name-only descendant lookup would invent formatting Office does not apply.
+pub(crate) fn text_property_solid_fill<'a, 'input>(
+    properties: roxmltree::Node<'a, 'input>,
+) -> Option<roxmltree::Node<'a, 'input>> {
+    let sequence_rank = |name: &str| -> Option<u8> {
+        match name {
+            "ln" => Some(0),
+            "noFill" | "solidFill" | "gradFill" | "blipFill" | "pattFill" | "grpFill" => Some(1),
+            "effectLst" | "effectDag" => Some(2),
+            "highlight" => Some(3),
+            "uLnTx" | "uLn" => Some(4),
+            "uFillTx" | "uFill" => Some(5),
+            "latin" => Some(6),
+            "ea" => Some(7),
+            "cs" => Some(8),
+            "sym" => Some(9),
+            "hlinkClick" => Some(10),
+            "hlinkMouseOver" => Some(11),
+            "rtl" => Some(12),
+            "extLst" => Some(13),
+            _ => None,
+        }
+    };
+    let mut highest_preceding_rank = 0_u8;
+    for node in properties.children().filter(|node| node.is_element()) {
+        let name = node.tag_name().name();
+        let Some(rank) = sequence_rank(name) else {
+            continue;
+        };
+        if name == "solidFill" {
+            return (highest_preceding_rank <= rank).then_some(node);
+        }
+        highest_preceding_rank = highest_preceding_rank.max(rank);
+    }
+    None
+}
+
 // Carries the resolved master/layout/placeholder inheritance context (theme,
 // rels, inherited font size, default alignment/spacing, level styles) that text
 // runs need; these are inheritance inputs, not an arbitrary parameter bag.
@@ -931,7 +973,7 @@ pub(crate) fn parse_paragraph(
     let def_rpr = p_pr.and_then(|n| child(n, "defRPr"));
     let def_font_size = def_rpr.and_then(|n| attr_f64(&n, "sz")).map(|v| v / 100.0);
     let def_color = def_rpr
-        .and_then(|n| child(n, "solidFill"))
+        .and_then(text_property_solid_fill)
         .and_then(|n| parse_color_node(n, theme));
     let def_bold = def_rpr
         .and_then(|n| attr(&n, "b"))
@@ -974,7 +1016,7 @@ pub(crate) fn parse_paragraph(
                 let r_pr = child(node, "rPr");
                 let font_size = r_pr.and_then(|n| attr_f64(&n, "sz")).map(|v| v / 100.0);
                 let color = r_pr
-                    .and_then(|n| child(n, "solidFill"))
+                    .and_then(text_property_solid_fill)
                     .and_then(|n| parse_color_node(n, theme));
                 let bold = r_pr
                     .and_then(|n| attr(&n, "b"))
@@ -1330,11 +1372,11 @@ fn parse_run_with_reflection(
         .map(|v| v / 100.0);
 
     let color = r_pr
-        .and_then(|n| child(n, "solidFill"))
+        .and_then(text_property_solid_fill)
         .and_then(|n| parse_color_node(n, theme))
         .or_else(|| {
             def_rpr
-                .and_then(|n| child(n, "solidFill"))
+                .and_then(text_property_solid_fill)
                 .and_then(|n| parse_color_node(n, theme))
         });
 

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -106,6 +106,7 @@ import {
   buildWarpEnvelope,
   warpGlyphTransform,
   followPathUScale,
+  fillDoubleBorder,
 } from '@silurus/ooxml-core';
 import type {
   DecodedBitmapCacheOwner,
@@ -6496,6 +6497,30 @@ export function renderTable(
       w: Math.max(1, Math.abs(x2 - x1)),
       h: Math.max(1, Math.abs(y2 - y1)),
     }, el.rotation);
+    // ECMA-376 §20.1.8.42 `cmpd="dbl"`: table borders use the same
+    // device-pixel-safe rail/gap/rail painter as the other OOXML renderers.
+    // A fill-based painter is important for thin rules because two independently
+    // snapped canvas strokes can collapse onto one device row. Preserve dashed
+    // compound lines on the existing stroke path until their rail-wise dash
+    // phase can be represented without changing authored semantics.
+    if (
+      stroke.cmpd === 'dbl'
+      && !stroke.dashStyle
+      && !(stroke.customDash?.length)
+      && (x1 === x2 || y1 === y2)
+    ) {
+      ctx.fillStyle = ctx.strokeStyle;
+      fillDoubleBorder(
+        ctx,
+        x1,
+        y1,
+        x2,
+        y2,
+        Math.max(0.5, emuToPx(stroke.width, scale)),
+        dpr,
+      );
+      return;
+    }
     // Vertical edge (x1===x2) nudges X; horizontal edge (y1===y2) nudges Y.
     const dx = x1 === x2 ? crispOffset(x1, ctx.lineWidth, dpr) : 0;
     const dy = y1 === y2 ? crispOffset(y1, ctx.lineWidth, dpr) : 0;

--- a/packages/pptx/src/table-border-single-draw.test.ts
+++ b/packages/pptx/src/table-border-single-draw.test.ts
@@ -14,9 +14,11 @@ import type { TableCell, TableElement, TableRow, TextBody } from './types';
 // after applyStroke sets strokeStyle + lineWidth), then read the shared line.
 
 interface StrokeSeg { x1: number; y1: number; x2: number; y2: number; width: number; color: string; }
+interface FillRect { x: number; y: number; width: number; height: number; color: string; }
 
-function makeRecordingCtx(): { ctx: CanvasRenderingContext2D; strokes: StrokeSeg[] } {
+function makeRecordingCtx(): { ctx: CanvasRenderingContext2D; strokes: StrokeSeg[]; fills: FillRect[] } {
   const strokes: StrokeSeg[] = [];
+  const fills: FillRect[] = [];
   let cur = { x: 0, y: 0 };
   let pending: { x1: number; y1: number; x2: number; y2: number } | null = null;
   let lineWidth = 1;
@@ -38,7 +40,11 @@ function makeRecordingCtx(): { ctx: CanvasRenderingContext2D; strokes: StrokeSeg
     stroke() {
       if (pending) strokes.push({ ...pending, width: lineWidth, color: String(strokeStyle) });
     },
-    fill() {}, fillRect() {}, strokeRect() {}, clearRect() {}, clip() {}, rect() {},
+    fill() {},
+    fillRect(x: number, y: number, width: number, height: number) {
+      fills.push({ x, y, width, height, color: String(this.fillStyle) });
+    },
+    strokeRect() {}, clearRect() {}, clip() {}, rect() {},
     scale() {}, translate() {}, rotate() {}, setTransform() {}, transform() {}, resetTransform() {},
     setLineDash() {}, getLineDash() { return []; },
     drawImage() {}, arc() {}, arcTo() {}, ellipse() {},
@@ -54,7 +60,7 @@ function makeRecordingCtx(): { ctx: CanvasRenderingContext2D; strokes: StrokeSeg
     letterSpacing: '0px',
     globalCompositeOperation: 'source-over' as GlobalCompositeOperation,
   };
-  return { ctx: ctx as unknown as CanvasRenderingContext2D, strokes };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, strokes, fills };
 }
 
 const EMU = 12700; // 1 pt
@@ -93,6 +99,18 @@ function render(t: TableElement): StrokeSeg[] {
   const { ctx, strokes } = makeRecordingCtx();
   renderTable(ctx, t, SCALE, undefined, { themeMajorFont: null, themeMinorFont: null, dpr: 1 });
   return strokes;
+}
+
+function renderRecording(t: TableElement): { strokes: StrokeSeg[]; fills: FillRect[] } {
+  const recording = makeRecordingCtx();
+  renderTable(
+    recording.ctx,
+    t,
+    SCALE,
+    undefined,
+    { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
+  );
+  return recording;
 }
 
 function verticalAt(strokes: StrokeSeg[], x: number): StrokeSeg[] {
@@ -246,6 +264,19 @@ describe('DrawingML <a:tbl> — shared interior gridline drawn once (spec-silent
     expect(verticalAt(strokes, 60)).toHaveLength(1);  // outer right
     expect(horizontalAt(strokes, 0)).toHaveLength(1); // outer top
     expect(horizontalAt(strokes, 20)).toHaveLength(1);// outer bottom
+  });
+
+  it('paints cmpd=dbl table borders as two separated rails', () => {
+    const recording = renderRecording(tableOf([
+      [cell({ borderB: ln({ width: 3 * EMU, color: '1D6FA8', cmpd: 'dbl' }) })],
+    ], [COL]));
+
+    expect(horizontalAt(recording.strokes, 20)).toHaveLength(0);
+    const rails = recording.fills.filter((fill) => fill.color === rgba('1D6FA8'));
+    expect(rails).toEqual([
+      { x: 0, y: 19, width: 60, height: 1, color: rgba('1D6FA8') },
+      { x: 0, y: 21, width: 60, height: 1, color: rgba('1D6FA8') },
+    ]);
   });
 
   it('gridSpan: a horizontally-merged cell spans the shared vertical line region', () => {


### PR DESCRIPTION
## Summary

- apply PowerPoint placeholder font defaults when a slide master omits optional `p:txStyles`
- honor the `CT_TextCharacterProperties` child sequence so malformed late text fills do not override inherited color
- complete built-in Medium Style 1 text and total-row formatting and render solid `cmpd="dbl"` table borders

## Specification and compatibility

- ECMA-376 permits `p:txStyles` to be absent and defines the `CT_TextCharacterProperties` child sequence.
- The omitted-tier font defaults and built-in table preset details are bounded current-PowerPoint compatibility behavior, verified against Office-produced output.
- The changes are PPTX-specific because DOCX and XLSX use different placeholder and table models. Double-border painting reuses the shared core primitive.

## Verification

- `cargo test -p pptx-parser` (278 passed)
- `pnpm exec vitest run packages/pptx/src packages/core/src/draw/double-border.test.ts` (808 passed)
- `pnpm typecheck`
- private exact self-VRT against the full merge-base: four intended slides changed and each was adjudicated against Office output; the remaining 30 slides were pixel-identical; main/worker parity passed

## Adversarial review

- verified the optional master tier and text-property sequence against the local ECMA-376 schemas
- found no sample/path branches, empirical thresholds, or unbounded work; compatibility defaults are scoped to the absent tier and built-in preset family
- kept PPTX-specific parsing and preset policy in the PPTX package while reusing the shared core double-border painter
- inspected DOCX and XLSX integration points and excluded them because their placeholder and table models do not share these PPTX rules

Fixes #1435
