### PR TITLE
fix(xlsx): preserve worker draw module initialization

### DIFF
--- a/packages/xlsx/src/render-worker.ts
+++ b/packages/xlsx/src/render-worker.ts
@@ -33,9 +33,7 @@ import {
   type PullSessionResponse,
   type WorkerSvgDecodeResponse,
 } from '@silurus/ooxml-core/worker';
-import { renderWorksheetViewport } from './render-orchestrator.js';
 import { workerRenderDeps } from './worker-render-deps.js';
-import { inheritSheetRenderCache, markAutoRowHeightsPrepared } from './renderer.js';
 import { XLSX_GOOGLE_FONTS, xlsxFontPreloadNames } from './google-fonts.js';
 import { resolveSharedStringRows } from './shared-strings.js';
 import {
@@ -82,6 +80,14 @@ const rawParts = new BoundedRawPartCache({
   maxEntries: HARD_MAX_RAW_PART_CACHE_ENTRIES,
   maxBytes: HARD_MAX_RAW_PART_CACHE_BYTES,
 });
+// Keep the renderer and its orchestrator behind explicit module boundaries. The
+// production worker is flattened into one self-contained asset, and a static
+// function import can otherwise be hoisted past the initializers of shared draw
+// dependencies that are also reached by optional renderers. Awaiting the modules
+// preserves ESM initialization order, so the shared border dash tables and
+// pattern-fill caches exist before the first bordered or filled cell is stroked.
+const rendererModule = import('./renderer.js');
+const orchestratorModule = import('./render-orchestrator.js');
 const worksheetPull = new WorksheetPullWorker(
   () => host.archive,
   (sheetIndex, worksheet, measured, resourceUsage) => {
@@ -237,6 +243,8 @@ self.onmessage = async (e: MessageEvent<
     if (req.type === 'renderViewport') {
       if (!workbook) throw new Error('Workbook not loaded');
       await fontsLoaded;
+      const { inheritSheetRenderCache, markAutoRowHeightsPrepared } = await rendererModule;
+      const { renderWorksheetViewport } = await orchestratorModule;
       const ws = sheetCache.get(req.sheetIndex);
       if (!ws) throw new Error('Worksheet is not loaded through its pull session');
       // Apply view-only size mutations to a render-local projection. Multiple

--- a/scripts/build-worker-consumer-fixture.mjs
+++ b/scripts/build-worker-consumer-fixture.mjs
@@ -162,6 +162,66 @@ writeFileSync(join(outDir, 'text.pptx'), storedZip([
     </p:sld>`],
 ]));
 
+// A self-authored bordered workbook exercises the production XLSX worker without
+// optional renderer descriptors. Every border edge goes through the shared
+// border dash lookup, so a worker bundle that strands the shared draw module's
+// initializer throws on the first bordered cell. The public demo and the
+// chart-ex workbook cannot catch that: one has no borders, and the other pulls
+// in an optional renderer that initializes the shared draw module as a side
+// effect. `thin` is deliberate — it is the style Excel emits most, and it is
+// absent from the dash table (it is solid), so it reaches the lookup's miss path.
+writeFileSync(join(outDir, 'bordered.xlsx'), storedZip([
+  ['[Content_Types].xml', `<?xml version="1.0" encoding="UTF-8"?>
+    <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+      <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+      <Default Extension="xml" ContentType="application/xml"/>
+      <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+      <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+      <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
+    </Types>`],
+  ['_rels/.rels', `<?xml version="1.0" encoding="UTF-8"?>
+    <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+    </Relationships>`],
+  ['xl/workbook.xml', `<?xml version="1.0" encoding="UTF-8"?>
+    <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+      xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+      <sheets><sheet name="Bordered" sheetId="1" r:id="rIdSheet"/></sheets>
+    </workbook>`],
+  ['xl/_rels/workbook.xml.rels', `<?xml version="1.0" encoding="UTF-8"?>
+    <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rIdSheet" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+    </Relationships>`],
+  ['xl/styles.xml', `<?xml version="1.0" encoding="UTF-8"?>
+    <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+      <fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>
+      <fills count="1"><fill><patternFill patternType="none"/></fill></fills>
+      <borders count="2">
+        <border/>
+        <border>
+          <left style="thin"><color rgb="FF000000"/></left>
+          <right style="thin"><color rgb="FF000000"/></right>
+          <top style="thin"><color rgb="FF000000"/></top>
+          <bottom style="thin"><color rgb="FF000000"/></bottom>
+          <diagonal/>
+        </border>
+      </borders>
+      <cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
+      <cellXfs count="2">
+        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>
+        <xf numFmtId="0" fontId="0" fillId="0" borderId="1" xfId="0" applyBorder="1"/>
+      </cellXfs>
+    </styleSheet>`],
+  ['xl/worksheets/sheet1.xml', `<?xml version="1.0" encoding="UTF-8"?>
+    <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+      <dimension ref="A1:B2"/>
+      <sheetData>
+        <row r="1"><c r="A1" s="1"><v>1</v></c><c r="B1" s="1"><v>2</v></c></row>
+        <row r="2"><c r="A2" s="1"><v>3</v></c><c r="B2" s="1"><v>4</v></c></row>
+      </sheetData>
+    </worksheet>`],
+]));
+
 const chartExXml = `<?xml version="1.0" encoding="UTF-8"?>
   <cx:chartSpace xmlns:cx="http://schemas.microsoft.com/office/drawing/2014/chartex">
     <cx:chartData><cx:data id="0">

--- a/tests/worker-dist/consumer/index.html
+++ b/tests/worker-dist/consumer/index.html
@@ -6,6 +6,7 @@
   <canvas id="xlsx"></canvas>
   <canvas id="pptx"></canvas>
   <canvas id="pptx-text"></canvas>
+  <canvas id="xlsx-bordered"></canvas>
   <canvas id="docx-chart-ex"></canvas>
   <canvas id="xlsx-chart-ex"></canvas>
   <canvas id="pptx-chart-ex"></canvas>

--- a/tests/worker-dist/consumer/main.js
+++ b/tests/worker-dist/consumer/main.js
@@ -62,6 +62,17 @@ try {
   window.pptxTextRuns = await textPptx.collectSlideRuns(0, 640);
   textPptx.destroy();
 
+  const borderedXlsx = await XlsxWorkbook.load(
+    await bytes('/consumer/bordered.xlsx'),
+    { mode: 'worker', useGoogleFonts: false },
+  );
+  paint('xlsx-bordered', await borderedXlsx.renderViewportToBitmap(
+    0,
+    { row: 0, col: 0, rows: 8, cols: 4 },
+    { width: 320, height: 200, dpr: 1 },
+  ));
+  borderedXlsx.destroy();
+
   const chartExDocx = await DocxDocument.load(
     await bytes('/consumer/chart-ex.docx'),
     { mode: 'worker', ...renderers },

--- a/tests/worker-dist/fixture.html
+++ b/tests/worker-dist/fixture.html
@@ -6,6 +6,7 @@
   <canvas id="xlsx"></canvas>
   <canvas id="pptx"></canvas>
   <canvas id="pptx-text"></canvas>
+  <canvas id="xlsx-bordered"></canvas>
   <canvas id="docx-chart-ex"></canvas>
   <canvas id="xlsx-chart-ex"></canvas>
   <canvas id="pptx-chart-ex"></canvas>
@@ -73,6 +74,17 @@
       paint('pptx-text', await textPptx.renderSlideToBitmap(0, { width: 640, dpr: 1 }));
       window.pptxTextRuns = await textPptx.collectSlideRuns(0, 640);
       textPptx.destroy();
+
+      const borderedXlsx = await XlsxWorkbook.load(
+        await bytes('/consumer/bordered.xlsx'),
+        { mode: 'worker', useGoogleFonts: false },
+      );
+      paint('xlsx-bordered', await borderedXlsx.renderViewportToBitmap(
+        0,
+        { row: 0, col: 0, rows: 8, cols: 4 },
+        { width: 320, height: 200, dpr: 1 },
+      ));
+      borderedXlsx.destroy();
 
       const chartExDocx = await DocxDocument.load(
         await bytes('/consumer/chart-ex.docx'),

--- a/tests/worker-dist/production-workers.spec.ts
+++ b/tests/worker-dist/production-workers.spec.ts
@@ -4,7 +4,7 @@ async function expectWorkerBitmaps(page: import('@playwright/test').Page, url: s
   await page.goto(url);
   await expect(page.locator('body')).toHaveAttribute('data-status', 'ready', { timeout: 60_000 });
 
-  for (const id of ['docx', 'math', 'xlsx', 'pptx', 'pptx-text']) {
+  for (const id of ['docx', 'math', 'xlsx', 'pptx', 'pptx-text', 'xlsx-bordered']) {
     const ink = await page.locator(`#${id}`).evaluate((canvas: HTMLCanvasElement) => {
       const context = canvas.getContext('2d');
       if (!context) return 0;


### PR DESCRIPTION
fixes #1441

The self-contained production XLSX worker flattens the renderer across optional renderer module boundaries. Its statically imported render entry points were hoisted past the initializer of the shared draw module, so the shared border dash table was still undefined when the first bordered cell was stroked. Rendering then threw
`Cannot read properties of undefined (reading 'thin')` and the canvas kept the previously rendered sheet.

`thin` surfaced in the message because it is the border style Excel emits most and it is deliberately absent from the dash table (it is solid), so it reaches the lookup's miss path. The same stranded initializer also defers the shared pattern-fill cache, so pattern fills were exposed to the same failure. Main-thread rendering was unaffected: there the table compiles to an eager top-level binding.

Load the renderer and its orchestrator through explicit module promises so ESM dependency initialization completes before the first viewport render. This mirrors the PPTX worker fix in e80e60dd; the XLSX worker still held static imports, so the hazard was untouched there.

Existing coverage could not catch this: every XLSX case in the production-worker fixtures supplies optional renderers, and pulling one in initializes the shared draw module as a side effect. Add a self-authored bordered workbook loaded with no optional renderer descriptors to the production-worker and Vite-consumer fixtures, and assert painted ink. Without the fix the load rejects and the fixture reports an error status before the ink assertion runs.

Verified against a private bordered workbook whose styled sheets failed to render in worker mode: 7 of 11 sheets threw before the change and all 11 render after it, with pixel coverage matching the main-thread control. The new bordered fixture reproduces the throw on the released bundle and renders cleanly once initialization is restored. Also verified with tsc --build (remaining errors are only the ungenerated local WASM bindings) and ast-grep scan.