### PR TITLE
fix(rendering): resolve v0.85 release blockers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,8 +327,13 @@ README, docs, and Storybook public-facing code examples should:
 
 Keep announcements concise and user-facing:
 
-- state the supported capability and any required migration;
-- omit implementation detail that does not change a user's decision or action;
+- write first for readers who do not know the implementation: lead with the
+  visible outcome and group low-level fixes by the user problem they solve;
+- state explicitly whether migration is required. When it is, give the minimum
+  steps and name any changed default or behavior; when it is not, say so plainly;
+- omit implementation detail that does not change a user's decision or action.
+  If a technical qualification is useful, put it in a final `Technical note`
+  section after the outcome and migration guidance;
 - keep version-sensitive bundle measurements on the stable `/bundle-size` page,
   not in release announcements;
 - do not link API reference details directly to release notes. Use a stable

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+> [!NOTE]
 > **This entire codebase — Rust parsers, TypeScript renderers, tests, and tooling — is implemented by AI coding agents, primarily [Claude](https://claude.ai) and [Codex](https://openai.com/codex/)**, through iterative prompting. No human-written application code exists in this repository.
 
 <details>

--- a/docs/docx-layout-engine-redesign.md
+++ b/docs/docx-layout-engine-redesign.md
@@ -140,8 +140,11 @@ plus legal grapheme boundaries, which also constrain emergency overlong-word
 splits. Each span carries one immutable core `CanvasFontRoute`;
 measurement, kashida/vertical probes, and paint serialize that same complete CSS
 family list. Exact registered tuples win first. Otherwise an authored family is
-an engine-scoped native CSS request with a fontTable-derived generic tail (or the
-fixed sans default), not a claim that a local face was discovered.
+an engine-scoped native CSS request with a fontTable-derived generic tail, then
+the shared bounded face-name classifier for faces absent from the table. When no
+OOXML font slot resolves at any level, the DOCX consumer policy uses a serif
+generic default, as permitted by §17.3.2.26; none of these fallback routes claims
+that a local face was discovered.
 Non-content glyphs use the same authority. Effective numbering-level run facts
 and paragraph-mark run facts remain private parser-wire metadata. The
 parser-model boundary projects numbering into a plain immutable shape input;

--- a/docs/docx-layout-engine-redesign.md
+++ b/docs/docx-layout-engine-redesign.md
@@ -143,8 +143,9 @@ family list. Exact registered tuples win first. Otherwise an authored family is
 an engine-scoped native CSS request with a fontTable-derived generic tail, then
 the shared bounded face-name classifier for faces absent from the table. When no
 OOXML font slot resolves at any level, the DOCX consumer policy uses a serif
-generic default, as permitted by §17.3.2.26; none of these fallback routes claims
-that a local face was discovered.
+generic default for Latin and complex-script slots while preserving the existing
+East Asian sans fallback, as permitted by §17.3.2.26; none of these fallback
+routes claims that a local face was discovered.
 Non-content glyphs use the same authority. Effective numbering-level run facts
 and paragraph-mark run facts remain private parser-wire metadata. The
 parser-model boundary projects numbering into a plain immutable shape input;

--- a/packages/core/src/fonts/scripts.ts
+++ b/packages/core/src/fonts/scripts.ts
@@ -109,19 +109,16 @@ export type FontGenericClass = 'serif' | 'sans' | 'mono';
 
 /**
  * Classify a font *name* into a CSS generic class (serif / sans / monospace).
- * The shared serif/sans name heuristic for the pptx and xlsx renderers, which
- * both now route through it (collapsing their two duplicated regexes into one).
- * docx is NOT yet wired in: its name classifier layers word/fontTable.xml
- * `<w:family>` priority and Arabic-companion handling on top, and its Latin-first
- * fallback ordering is still on an unmerged branch — routing docx through here is
- * a deferred follow-up (it becomes the third caller, completing the unification).
+ * The shared serif/sans name heuristic for the pptx, xlsx, and docx renderers.
+ * DOCX layers word/fontTable.xml `<w:family>` priority and its format-specific
+ * fallback-chain construction on top; only the final name-pattern decision is
+ * shared here.
  *
  * This is the NAME-pattern fallback only. A caller that has authoritative class
  * data — Word's word/fontTable.xml `<w:family>` §17.8.3.10 (roman/swiss/modern)
  * — MUST consult that first and use this only for faces absent from the table or
- * marked "auto". The token set is the union of all three renderers' prior regexes
- * (docx included, so the future docx migration loses no coverage); no new name
- * guessing is introduced.
+ * marked "auto". The token set is the union of all three renderers' prior
+ * regexes; no package-specific name guessing is introduced.
  *
  * - mono : mono / courier / consolas / 等幅 …
  * - serif: Latin serifs (Times, Cambria/Caladea, Georgia, Garamond, Century,

--- a/packages/core/src/image/crop.test.ts
+++ b/packages/core/src/image/crop.test.ts
@@ -155,5 +155,10 @@ describe('sourceRasterTargetSize', () => {
   it('rejects non-visible and non-finite crop targets', () => {
     expect(sourceRasterTargetSize(1200, 900, { l: 0.6, t: 0, r: 0.6, b: 0 })).toBeNull();
     expect(sourceRasterTargetSize(Number.NaN, 900)).toBeNull();
+    expect(sourceRasterTargetSize(
+      Number.MAX_VALUE,
+      900,
+      { l: 0.5, t: 0, r: 0.4999999999999999, b: 0 },
+    )).toBeNull();
   });
 });

--- a/packages/core/src/image/crop.test.ts
+++ b/packages/core/src/image/crop.test.ts
@@ -158,7 +158,7 @@ describe('sourceRasterTargetSize', () => {
     expect(sourceRasterTargetSize(
       Number.MAX_VALUE,
       900,
-      { l: 0.5, t: 0, r: 0.4999999999999999, b: 0 },
+      { l: 1 - Number.EPSILON, t: 0, r: 0, b: 0 },
     )).toBeNull();
   });
 });

--- a/packages/core/src/image/crop.ts
+++ b/packages/core/src/image/crop.ts
@@ -171,10 +171,11 @@ export function sourceRasterTargetSize(
   const logicalHeight = srcRect ? 1 - srcRect.t - srcRect.b : 1;
   if (!Number.isFinite(logicalWidth) || !Number.isFinite(logicalHeight)) return null;
   if (!(logicalWidth > 0) || !(logicalHeight > 0) || !srcRectHasVisibleArea(srcRect)) return null;
-  return {
-    width: Math.ceil(destinationWidthPx / logicalWidth),
-    height: Math.ceil(destinationHeightPx / logicalHeight),
-  };
+  const width = Math.ceil(destinationWidthPx / logicalWidth);
+  const height = Math.ceil(destinationHeightPx / logicalHeight);
+  return Number.isFinite(width) && Number.isFinite(height)
+    ? { width, height }
+    : null;
 }
 
 /** Raster target size (pt) for decoding an embedded image. A browser raster's

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -5672,7 +5672,16 @@ fn handle_run_in_para(
                 }
             }
             "end" => {
-                if let Some(frame) = field.stack.pop() {
+                if let Some(mut frame) = field.stack.pop() {
+                    // §17.16.18: `separate` marks the start of a stored field
+                    // result, but it is absent when no result is stored. Fields
+                    // whose value we compute locally are still complete at
+                    // `end`; retain them instead of treating the missing cached
+                    // result as a missing field.
+                    if !frame.past_separate {
+                        frame.substitute = frame.legacy_checkbox_checked.is_some()
+                            || classify_field(&frame.instruction) != "other";
+                    }
                     if frame.substitute && !frame.legacy_checkbox_nested {
                         let fmt = if has_mergeformat_switch(&frame.instruction) {
                             frame
@@ -14565,6 +14574,48 @@ mod tests {
             .expect("NUMPAGES field run");
 
         assert_eq!(field.font_size, 10.0);
+    }
+
+    /// ECMA-376 §17.16.18 permits a complex field to omit the result separator
+    /// when no cached result is stored. Recomputable fields still have complete
+    /// semantics between `begin` and `end`, so PAGE/NUMPAGES must remain visible
+    /// even when there is no `separate` fldChar or fallback text.
+    #[test]
+    fn complex_page_fields_without_cached_results_are_retained() {
+        let runs = parse_para(
+            r#"<w:r><w:fldChar w:fldCharType="begin"/></w:r>
+               <w:r><w:rPr><w:sz w:val="20"/></w:rPr><w:instrText> PAGE </w:instrText></w:r>
+               <w:r><w:fldChar w:fldCharType="end"/></w:r>
+               <w:r><w:t xml:space="preserve"> / </w:t></w:r>
+               <w:r><w:fldChar w:fldCharType="begin"/></w:r>
+               <w:r><w:instrText> NUMPAGES </w:instrText></w:r>
+               <w:r><w:fldChar w:fldCharType="end"/></w:r>
+               <w:r><w:fldChar w:fldCharType="begin"/></w:r>
+               <w:r><w:instrText> REF MissingBookmark </w:instrText></w:r>
+               <w:r><w:fldChar w:fldCharType="end"/></w:r>
+               <w:r><w:t>tail</w:t></w:r>"#,
+            &RunFmt::default(),
+            &StyleMap::parse(""),
+        );
+        let fields = runs
+            .iter()
+            .filter_map(|run| match run {
+                DocRun::Field(field) => Some(field.as_ref()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].field_type, "page");
+        assert_eq!(fields[0].instruction, "PAGE");
+        assert_eq!(fields[0].fallback_text, "");
+        assert_eq!(fields[0].font_size, 10.0);
+        assert_eq!(fields[1].field_type, "numPages");
+        assert_eq!(fields[1].instruction, "NUMPAGES");
+        assert_eq!(fields[1].fallback_text, "");
+        assert!(runs
+            .iter()
+            .any(|run| matches!(run, DocRun::Text(text) if text.text == "tail")));
     }
 
     #[test]

--- a/packages/docx/src/layout/font-service.test.ts
+++ b/packages/docx/src/layout/font-service.test.ts
@@ -236,8 +236,9 @@ describe('font layout services', () => {
         themeFontPresence,
         slot,
       } as Parameters<typeof service.resolve>[0]);
+      const generic = slot === 'eastAsia' ? 'sans-serif' : 'serif';
       expect(resolved, slot).toMatchObject({
-        source: 'generic', requestedFamily: 'serif', genericFamily: 'serif',
+        source: 'generic', requestedFamily: generic, genericFamily: generic,
       });
     }
   });

--- a/packages/docx/src/layout/font-service.test.ts
+++ b/packages/docx/src/layout/font-service.test.ts
@@ -236,7 +236,9 @@ describe('font layout services', () => {
         themeFontPresence,
         slot,
       } as Parameters<typeof service.resolve>[0]);
-      expect(resolved, slot).toMatchObject({ source: 'generic', requestedFamily: 'sans-serif' });
+      expect(resolved, slot).toMatchObject({
+        source: 'generic', requestedFamily: 'serif', genericFamily: 'serif',
+      });
     }
   });
 

--- a/packages/docx/src/layout/services-integration.test.ts
+++ b/packages/docx/src/layout/services-integration.test.ts
@@ -416,6 +416,13 @@ describe('production layout service integration', () => {
 
   it('derives generic fallback from fontTable family and pitch for each selected face', () => {
     const doc = model({
+      body: [{
+        type: 'paragraph',
+        runs: [
+          textRun('serif', { fontFamily: 'Garamond' }),
+          textRun('sans', { fontFamily: 'Arial' }),
+        ],
+      } as DocxDocumentModel['body'][number]],
       fontFamilyClasses: {
         'Roman Face': 'roman',
         'Swiss Face': 'swiss',
@@ -436,12 +443,29 @@ describe('production layout service integration', () => {
     expect(generic('Swiss Face')).toBe('sans-serif');
     expect(generic('Fixed Modern')).toBe('monospace');
     expect(generic('Variable Modern')).toBe('sans-serif');
-    expect(generic('Garamond')).toBe('sans-serif');
+    expect(generic('Garamond')).toBe('serif');
+    expect(generic('Arial')).toBe('sans-serif');
     expect(services.text.shape({
       text: 'x', fontSizePt: 10, fonts: { ascii: 'Roman Face' },
     }).spans[0]?.font.route).toMatchObject({
       familyList: expect.stringMatching(/^"Roman Face", .*"Noto Serif".*serif$/),
       scope: 'native',
+    });
+  });
+
+  it('uses a serif consumer default only when no rFonts slot resolves', () => {
+    const services = createLayoutServices(model(), { measureContext: measureContext() });
+
+    expect(services.text.shape({
+      text: 'Header 1', fontSizePt: 10, fonts: {},
+    }).spans[0]?.font).toMatchObject({
+      source: 'generic', requestedFamily: 'serif', genericFamily: 'serif',
+      route: { familyList: 'serif', scope: 'generic' },
+    });
+    expect(services.text.shape({
+      text: 'Header 1', fontSizePt: 10, fonts: { ascii: 'Arial' },
+    }).spans[0]?.font).toMatchObject({
+      source: 'native', requestedFamily: 'Arial', genericFamily: 'sans-serif',
     });
   });
 

--- a/packages/docx/src/layout/services-integration.test.ts
+++ b/packages/docx/src/layout/services-integration.test.ts
@@ -453,7 +453,7 @@ describe('production layout service integration', () => {
     });
   });
 
-  it('uses a serif consumer default only when no rFonts slot resolves', () => {
+  it('uses bounded consumer defaults only when no rFonts slot resolves', () => {
     const services = createLayoutServices(model(), { measureContext: measureContext() });
 
     expect(services.text.shape({
@@ -466,6 +466,12 @@ describe('production layout service integration', () => {
       text: 'Header 1', fontSizePt: 10, fonts: { ascii: 'Arial' },
     }).spans[0]?.font).toMatchObject({
       source: 'native', requestedFamily: 'Arial', genericFamily: 'sans-serif',
+    });
+    expect(services.text.shape({
+      text: '漢字', fontSizePt: 10, fonts: {},
+    }).spans[0]?.font).toMatchObject({
+      source: 'generic', requestedFamily: 'sans-serif', genericFamily: 'sans-serif',
+      route: { familyList: 'sans-serif', scope: 'generic' },
     });
   });
 

--- a/packages/docx/src/layout/text.ts
+++ b/packages/docx/src/layout/text.ts
@@ -1,5 +1,6 @@
 import type { LayoutDiagnostic } from './types.js';
 import {
+  classifyFontGeneric,
   graphemeClusterOffsets,
   normalizeLocalFontMetricFamily,
   type ResolvedLocalFontMetric,
@@ -368,8 +369,9 @@ export interface TextLayoutServiceInput {
   readonly genericFamilies?: Readonly<Record<string, 'serif' | 'sans-serif' | 'monospace'>>;
 }
 
-/** Generic tail for an authored DOCX face. Only fontTable family/pitch metadata
- * is evidence; absent or `auto` entries deliberately use the fixed sans tail. */
+/** Generic tail for an authored DOCX face. fontTable family/pitch metadata is
+ * authoritative; absent or `auto` entries use the shared, bounded face-name
+ * classifier that also drives the native fallback list. */
 export function classifyDocxFontGeneric(
   family: string | null | undefined,
   fontFamilyClasses: Readonly<Record<string, string>> = {},
@@ -380,7 +382,8 @@ export function classifyDocxFontGeneric(
   if (tableClass === 'roman') return 'serif';
   if (tableClass === 'swiss') return 'sans-serif';
   if (tableClass === 'modern' && fontFamilyPitches[family] === 'fixed') return 'monospace';
-  return 'sans-serif';
+  const inferred = classifyFontGeneric(family);
+  return inferred === 'mono' ? 'monospace' : inferred === 'serif' ? 'serif' : 'sans-serif';
 }
 
 const LOCAL_METRIC_SNAPSHOT = Symbol('docx.localMetricSnapshot');
@@ -548,7 +551,11 @@ export function createTextLayoutService(input: TextLayoutServiceInput): TextLayo
       ? genericFamilies[authoredFamily.trim().toLocaleLowerCase('en-US')]
         ?? request.genericFamily
         ?? 'sans-serif'
-      : request.genericFamily;
+      // ECMA-376 §17.3.2.26 deliberately leaves the consumer's supported
+      // default font unspecified when no rFonts slot resolves. This is our
+      // bounded DOCX consumer policy for that otherwise-unspecified case;
+      // every authored direct/theme face remains authoritative above.
+      : request.genericFamily ?? 'serif';
     return input.fonts.resolve({
       requestedFamily: authoredFamily,
       genericFamily,

--- a/packages/docx/src/layout/text.ts
+++ b/packages/docx/src/layout/text.ts
@@ -386,6 +386,15 @@ export function classifyDocxFontGeneric(
   return inferred === 'mono' ? 'monospace' : inferred === 'serif' ? 'serif' : 'sans-serif';
 }
 
+/** Consumer choice at the §17.3.2.26 boundary where no font slot resolves.
+ * Keep the established East Asian fallback stable; Word-produced evidence for
+ * this change covers Latin and complex-script text only. */
+function defaultGenericForSlot(
+  slot: FontScriptSlot,
+): 'serif' | 'sans-serif' {
+  return slot === 'eastAsia' ? 'sans-serif' : 'serif';
+}
+
 const LOCAL_METRIC_SNAPSHOT = Symbol('docx.localMetricSnapshot');
 type LocalMetricSnapshot = Readonly<Record<string, Readonly<ResolvedLocalFontMetric>>> & {
   readonly [LOCAL_METRIC_SNAPSHOT]: true;
@@ -552,10 +561,10 @@ export function createTextLayoutService(input: TextLayoutServiceInput): TextLayo
         ?? request.genericFamily
         ?? 'sans-serif'
       // ECMA-376 §17.3.2.26 deliberately leaves the consumer's supported
-      // default font unspecified when no rFonts slot resolves. This is our
-      // bounded DOCX consumer policy for that otherwise-unspecified case;
-      // every authored direct/theme face remains authoritative above.
-      : request.genericFamily ?? 'serif';
+      // default font unspecified when no rFonts slot resolves. This bounded
+      // consumer policy changes only the script classes covered by Word output
+      // evidence; every authored direct/theme face remains authoritative above.
+      : request.genericFamily ?? defaultGenericForSlot(request.slot);
     return input.fonts.resolve({
       requestedFamily: authoredFamily,
       genericFamily,

--- a/packages/node/src/docx-vertical-header-footer.probe.test.ts
+++ b/packages/node/src/docx-vertical-header-footer.probe.test.ts
@@ -231,8 +231,11 @@ describe.skipIf(!skia || !docxMod || !rendererMod)(
       const { layoutDocument } = rendererMod!;
       const margins =
         'w:top="2880" w:right="720" w:bottom="2880" w:left="720" w:header="360" w:footer="360" w:gutter="0"';
-      const withHF = await materializeDocxDocument(verticalHeaderFooterDocx({ hf: true, paras: 40, pgMar: margins }));
-      const noHF = await materializeDocxDocument(verticalHeaderFooterDocx({ hf: false, paras: 40, pgMar: margins }));
+      // Keep the corpus comfortably beyond a single logical page. A smaller
+      // paragraph count can fit when the selected CJK fallback has compact
+      // metrics, making this pagination invariant depend on the host fonts.
+      const withHF = await materializeDocxDocument(verticalHeaderFooterDocx({ hf: true, paras: 80, pgMar: margins }));
+      const noHF = await materializeDocxDocument(verticalHeaderFooterDocx({ hf: false, paras: 80, pgMar: margins }));
       const rImg = installImageBitmapShim(factory);
       const rOff = installOffscreenCanvasShim(factory);
       let withPages = 0;

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -3134,7 +3134,6 @@ fn produce_slide_unit_with_journal(
         let build_parsed_layout = |lx: &str, zip: &mut PptxZip| -> ParsedLayout {
             parse_layout(
                 lx,
-                &bundle.master_placeholder_types,
                 &bundle.master_font_sizes,
                 &bundle.master_font_families,
                 &bundle.master_level_font_sizes,
@@ -6211,7 +6210,6 @@ mod tests {
             &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
-            &HashMap::new(),
             &master_indents,
             &HashMap::new(),
             &HashMap::new(),
@@ -6283,7 +6281,6 @@ mod tests {
             let mut zip = PptxZip::new(cursor).unwrap();
             parse_layout(
                 layout,
-                &HashMap::new(),
                 &m_f64,
                 &m_str,
                 &m_lfs,

--- a/packages/pptx/parser/src/master.rs
+++ b/packages/pptx/parser/src/master.rs
@@ -42,7 +42,7 @@ pub(crate) struct LayoutPlaceholders {
     pub(crate) by_idx: HashMap<u32, Transform>,
     /// Effective placeholder type declared by a layout slot. A slide
     /// placeholder may omit @type while retaining @idx; the matching layout
-    /// type then precedes the CT_Placeholder schema default (`obj`).
+    /// slot supplies its authored type or the CT_Placeholder default (`obj`).
     pub(crate) by_idx_placeholder_type: HashMap<u32, String>,
     pub(crate) by_type: HashMap<String, Transform>,
     /// Fallback transforms from slide master (by ph_type), used when layout has no xfrm
@@ -259,6 +259,17 @@ impl LayoutPlaceholders {
                 }
             })
             .or_else(|| self.master_by_type.get(ph_type))
+            // ECMA-376 §19.7.9 defines placeholder size relative to the body
+            // placeholder on the master. An object/content layout slot with no
+            // own transform therefore uses the master body box; its semantic
+            // placeholder type remains the CT_Placeholder default (`obj`).
+            .or_else(|| {
+                if ph_type == "obj" {
+                    self.master_by_type.get("body")
+                } else {
+                    None
+                }
+            })
     }
 
     /// Look up the inherited default font size for a placeholder (layout then master fallback).
@@ -954,35 +965,6 @@ pub(crate) fn parse_master_font_sizes(root: roxmltree::Node<'_, '_>) -> HashMap<
     map
 }
 
-/// Effective placeholder types declared by the master, keyed by @idx. Layout
-/// placeholders may omit @type while retaining the same index; ECMA-376's
-/// placeholder inheritance then uses the master slot before applying the
-/// CT_Placeholder schema default.
-pub(crate) fn parse_master_placeholder_types(
-    root: roxmltree::Node<'_, '_>,
-) -> HashMap<u32, String> {
-    let mut map = HashMap::new();
-    if let Some(sp_tree) = child(root, "cSld").and_then(|node| child(node, "spTree")) {
-        for sp in sp_tree
-            .children()
-            .filter(|node| node.is_element() && node.tag_name().name() == "sp")
-        {
-            let Some(ph) = sp
-                .descendants()
-                .find(|node| node.is_element() && node.tag_name().name() == "ph")
-            else {
-                continue;
-            };
-            let Some(idx) = attr(&ph, "idx").and_then(|value| value.parse().ok()) else {
-                continue;
-            };
-            map.entry(idx)
-                .or_insert_with(|| attr(&ph, "type").unwrap_or_else(|| "obj".to_owned()));
-        }
-    }
-    map
-}
-
 /// Default Latin typefaces from master placeholder lstStyle/txStyles. The
 /// specific placeholder shape wins over the generic title/body/other style,
 /// matching the font-size cascade above (ECMA-376 §19.3.1.52 and
@@ -1430,7 +1412,6 @@ pub(crate) fn parse_master_transforms(root: roxmltree::Node<'_, '_>) -> HashMap<
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn parse_layout_placeholders(
     root: roxmltree::Node<'_, '_>,
-    master_placeholder_types: &HashMap<u32, String>,
     master_font_sizes: &HashMap<String, f64>,
     master_font_families: &HashMap<String, String>,
     master_level_font_sizes: &HashMap<String, LevelFontSizes>,
@@ -1620,27 +1601,18 @@ pub(crate) fn parse_layout_placeholders(
         });
 
         if let Some(ph) = ph_node {
-            // Keep an omitted type on the internal empty-key cascade so it can
-            // inherit an equally typeless master placeholder's authored
-            // lstStyle. The effective semantic type surfaced to a slide is
-            // still the CT_Placeholder default (`obj`).
+            // CT_Placeholder defaults an omitted @type to `obj`. The idx binds
+            // the slide placeholder to this layout slot, but does not permit a
+            // same-numbered master placeholder of another type to rewrite the
+            // schema value. Real PowerPoint layouts can reuse an idx for a
+            // content slot where the master uses it for date/footer metadata.
             let ph_idx: Option<u32> = attr(&ph, "idx").and_then(|v| v.parse().ok());
-            let authored_ph_type = attr(&ph, "type");
-            let inherited_ph_type = ph_idx
-                .and_then(|idx| master_placeholder_types.get(&idx))
-                .cloned();
-            let ph_type = authored_ph_type
-                .clone()
-                .or_else(|| inherited_ph_type.clone())
-                .unwrap_or_default();
-            let effective_ph_type = authored_ph_type
-                .or(inherited_ph_type)
-                .unwrap_or_else(|| "obj".to_owned());
+            let ph_type = attr(&ph, "type").unwrap_or_else(|| "obj".to_owned());
 
             if let Some(idx) = ph_idx {
                 lph.by_idx_placeholder_type
                     .entry(idx)
-                    .or_insert(effective_ph_type);
+                    .or_insert_with(|| ph_type.clone());
                 if let Some(ref t) = t_opt {
                     lph.by_idx.entry(idx).or_insert_with(|| t.clone());
                 }
@@ -1932,7 +1904,6 @@ pub(crate) fn read_show_master_sp(node: roxmltree::Node<'_, '_>) -> bool {
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn parse_layout(
     layout_xml: &str,
-    master_placeholder_types: &HashMap<u32, String>,
     master_font_sizes: &HashMap<String, f64>,
     master_font_families: &HashMap<String, String>,
     master_level_font_sizes: &HashMap<String, LevelFontSizes>,
@@ -1961,7 +1932,6 @@ pub(crate) fn parse_layout(
 
     let placeholders = parse_layout_placeholders(
         root,
-        master_placeholder_types,
         master_font_sizes,
         master_font_families,
         master_level_font_sizes,
@@ -2028,7 +1998,6 @@ pub(crate) struct ParsedMaster {
     /// (see `parse_slide`), so these frozen-against-master-theme elements are used
     /// only by the common no-override slides.
     pub(crate) master_decorative: Vec<SlideElement>,
-    pub(crate) master_placeholder_types: HashMap<u32, String>,
     pub(crate) master_font_sizes: HashMap<String, f64>,
     pub(crate) master_font_families: HashMap<String, String>,
     pub(crate) master_level_font_sizes: HashMap<String, LevelFontSizes>,
@@ -2148,9 +2117,6 @@ pub(crate) fn build_master_bundle(
         parse_background(c_sld, &theme, &mut resolve)
     });
 
-    let master_placeholder_types = master_root
-        .map(parse_master_placeholder_types)
-        .unwrap_or_default();
     let master_font_sizes = master_root.map(parse_master_font_sizes).unwrap_or_default();
     let master_font_families = master_root
         .map(|root| parse_master_font_families(root, &theme))
@@ -2204,7 +2170,6 @@ pub(crate) fn build_master_bundle(
         master_smartart_drawings,
         master_bg,
         master_decorative,
-        master_placeholder_types,
         master_font_sizes,
         master_font_families,
         master_level_font_sizes,
@@ -2240,7 +2205,6 @@ mod placeholder_geometry_tests {
 
     fn parse_layout_with_master(
         layout_shape: &str,
-        master_placeholder_types: &HashMap<u32, String>,
         master_font_sizes: &HashMap<String, f64>,
     ) -> LayoutPlaceholders {
         let xml = format!(
@@ -2254,7 +2218,6 @@ mod placeholder_geometry_tests {
         let mut zip = empty_zip();
         parse_layout_placeholders(
             doc.root_element(),
-            master_placeholder_types,
             master_font_sizes,
             &HashMap::<String, String>::new(),
             &HashMap::<String, LevelFontSizes>::new(),
@@ -2275,7 +2238,7 @@ mod placeholder_geometry_tests {
     }
 
     fn parse_layout_geometry(layout_shape: &str) -> LayoutPlaceholders {
-        parse_layout_with_master(layout_shape, &HashMap::new(), &HashMap::new())
+        parse_layout_with_master(layout_shape, &HashMap::new())
     }
 
     fn parse_slide_shape(shape: &str, placeholders: &LayoutPlaceholders) -> ShapeElement {
@@ -2355,22 +2318,34 @@ mod placeholder_geometry_tests {
     }
 
     #[test]
-    fn typeless_layout_slot_inherits_master_idx_type_and_its_text_style() {
-        let master_xml = r#"<p:sldMaster
-          xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
-          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
-          <p:cSld><p:spTree><p:sp><p:nvSpPr><p:nvPr>
-            <p:ph type="body" idx="1"/>
-          </p:nvPr></p:nvSpPr><p:spPr/></p:sp></p:spTree></p:cSld>
-        </p:sldMaster>"#;
-        let master_doc = roxmltree::Document::parse(master_xml).unwrap();
-        let master_types = parse_master_placeholder_types(master_doc.root_element());
-        let master_sizes = HashMap::from([("body".to_owned(), 28.0)]);
+    fn object_slot_without_layout_transform_uses_master_body_box() {
+        let body = Transform {
+            x: 838_200,
+            y: 1_825_625,
+            cx: 10_515_600,
+            cy: 4_351_338,
+            ..Default::default()
+        };
+        let placeholders = LayoutPlaceholders {
+            master_by_type: HashMap::from([("body".to_owned(), body.clone())]),
+            ..Default::default()
+        };
+
+        let inherited = placeholders.lookup("obj", Some(1));
+
+        assert_eq!(inherited.map(|transform| transform.x), Some(body.x));
+        assert_eq!(inherited.map(|transform| transform.y), Some(body.y));
+        assert_eq!(inherited.map(|transform| transform.cx), Some(body.cx));
+        assert_eq!(inherited.map(|transform| transform.cy), Some(body.cy));
+    }
+
+    #[test]
+    fn typeless_layout_slot_uses_schema_default_text_style() {
+        let master_sizes = HashMap::from([("body".to_owned(), 28.0), ("obj".to_owned(), 18.0)]);
         let placeholders = parse_layout_with_master(
             r#"<p:sp><p:nvSpPr><p:cNvPr id="2" name="Content"/><p:cNvSpPr/>
                  <p:nvPr><p:ph idx="1"/></p:nvPr></p:nvSpPr>
                <p:spPr/><p:txBody><a:bodyPr/><a:lstStyle/><a:p/></p:txBody></p:sp>"#,
-            &master_types,
             &master_sizes,
         );
         let shape = parse_slide_shape(
@@ -2380,8 +2355,12 @@ mod placeholder_geometry_tests {
             &placeholders,
         );
 
-        assert_eq!(shape.placeholder_type.as_deref(), Some("body"));
-        assert_eq!(shape.text_body.unwrap().default_font_size, Some(28.0));
+        // CT_Placeholder defaults an omitted @type to obj. The idx is used to
+        // match corresponding placeholders, but cannot rewrite that schema
+        // value from an unrelated master slot that happens to reuse the same
+        // idx in a two-content layout.
+        assert_eq!(shape.placeholder_type.as_deref(), Some("obj"));
+        assert_eq!(shape.text_body.unwrap().default_font_size, Some(18.0));
     }
 
     #[test]
@@ -2500,7 +2479,6 @@ mod placeholder_geometry_tests {
 
         let placeholders = parse_layout_placeholders(
             doc.root_element(),
-            &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),

--- a/site/src/announcement-content.test.ts
+++ b/site/src/announcement-content.test.ts
@@ -11,6 +11,33 @@ const siteFooter = readFileSync(new URL('./components/SiteFooter.astro', import.
 const capabilities = readFileSync(new URL('./components/Capabilities.astro', import.meta.url), 'utf8');
 const readme = readFileSync(new URL('../../README.md', import.meta.url), 'utf8');
 
+describe('v0.85 large-image and rendering announcement', () => {
+  const announcement = announcements.find((item) => item.slug === 'v085-large-images-and-rendering');
+
+  it('leads with user outcomes, gives bounded migration guidance and leaves technical detail last', () => {
+    expect(announcement).toMatchObject({
+      label: 'Upcoming release',
+      version: 'v0.85.0',
+      title: 'Larger images and steadier rendering in v0.85.0',
+    });
+    expect(announcement?.sections[0]).toMatchObject({ title: 'In short', kind: 'summary' });
+    expect(announcement?.sections.at(-1)?.title).toBe('Technical note');
+
+    const userFacingText = announcement?.sections.slice(0, -1).flatMap((section) => [
+      section.title,
+      ...section.paragraphs,
+      ...(section.bullets ?? []),
+    ]).join('\n') ?? '';
+
+    for (const outcome of ['large, high-resolution images', 'Word', 'Excel', 'PowerPoint', 'worker mode', 'zoom']) {
+      expect(userFacingText).toContain(outcome);
+    }
+    expect(userFacingText).toContain('Most applications can upgrade without code changes');
+    expect(userFacingText).toContain('TiffDecodeError');
+    expect(userFacingText).not.toMatch(/RGBA|cache eviction|header inspection|module initialization|ESM|\b(?:KB|KiB|MiB|MP|gzip)\b/i);
+  });
+});
+
 describe('v0.84.1 Word layout announcement', () => {
   const announcement = announcements.find((item) => item.slug === 'v0841-word-layout-refinements');
 
@@ -172,15 +199,18 @@ describe('v0.81 ChartEx migration guide', () => {
 
 describe('stable documentation boundaries', () => {
   it('keeps the current bundle measurements on one stable page', () => {
-    expect(bundleSizePage).toContain('Current production assets in v0.84.1');
+    expect(bundleSizePage).toContain('Current production assets for v0.85.0');
     expect(bundleSizePage).toContain('DOCX static JavaScript');
-    expect(bundleSizePage).toContain('<td>1,924 KiB</td>');
+    expect(bundleSizePage).toMatch(/<td>1,963 KiB<\/td>\s*<td>477 KiB<\/td>/);
     expect(bundleSizePage).toContain('XLSX static JavaScript');
+    expect(bundleSizePage).toMatch(/<td>1,279 KiB<\/td>\s*<td>305 KiB<\/td>/);
     expect(bundleSizePage).toContain('PPTX static JavaScript');
+    expect(bundleSizePage).toMatch(/<td>1,325 KiB<\/td>\s*<td>309 KiB<\/td>/);
     expect(bundleSizePage).toContain('<tr><th>DOCX parser WASM</th><td>1,786 KiB</td><td>741 KiB</td></tr>');
+    expect(bundleSizePage).toContain('<tr><th>PPTX parser WASM</th><td>1,649 KiB</td><td>649 KiB</td></tr>');
     expect(bundleSizePage).toContain('ChartEx');
     expect(bundleSizePage.match(/<th>TIFF image codec<\/th>/g)).toHaveLength(1);
-    expect(bundleSizePage).toContain('<td>4.0 KiB</td><td>1.6 KiB</td>');
+    expect(bundleSizePage).toContain('<td>22.2 KiB</td><td>6.7 KiB</td>');
     expect(bundleSizePage).not.toContain('3.9 KiB');
     expect(bundleSizePage).not.toContain('7.3 KiB');
     expect(bundleSizePage).not.toContain('3.1 KiB');

--- a/site/src/announcement-content.test.ts
+++ b/site/src/announcement-content.test.ts
@@ -201,13 +201,13 @@ describe('stable documentation boundaries', () => {
   it('keeps the current bundle measurements on one stable page', () => {
     expect(bundleSizePage).toContain('Current production assets for v0.85.0');
     expect(bundleSizePage).toContain('DOCX static JavaScript');
-    expect(bundleSizePage).toMatch(/<td>1,963 KiB<\/td>\s*<td>477 KiB<\/td>/);
+    expect(bundleSizePage).toMatch(/<td>1,964 KiB<\/td>\s*<td>477 KiB<\/td>/);
     expect(bundleSizePage).toContain('XLSX static JavaScript');
     expect(bundleSizePage).toMatch(/<td>1,279 KiB<\/td>\s*<td>305 KiB<\/td>/);
     expect(bundleSizePage).toContain('PPTX static JavaScript');
     expect(bundleSizePage).toMatch(/<td>1,325 KiB<\/td>\s*<td>309 KiB<\/td>/);
     expect(bundleSizePage).toContain('<tr><th>DOCX parser WASM</th><td>1,786 KiB</td><td>741 KiB</td></tr>');
-    expect(bundleSizePage).toContain('<tr><th>PPTX parser WASM</th><td>1,649 KiB</td><td>649 KiB</td></tr>');
+    expect(bundleSizePage).toContain('<tr><th>PPTX parser WASM</th><td>1,648 KiB</td><td>649 KiB</td></tr>');
     expect(bundleSizePage).toContain('ChartEx');
     expect(bundleSizePage.match(/<th>TIFF image codec<\/th>/g)).toHaveLength(1);
     expect(bundleSizePage).toContain('<td>22.2 KiB</td><td>6.7 KiB</td>');

--- a/site/src/components/BuiltInCommentViewer.astro
+++ b/site/src/components/BuiltInCommentViewer.astro
@@ -56,6 +56,7 @@ const demoId = `built-in-comment-${formats.join('-')}`;
   import { DocxScrollViewer } from '@silurus/ooxml-docx';
   import { PptxScrollViewer } from '@silurus/ooxml-pptx';
   import { XlsxViewer } from '@silurus/ooxml-xlsx';
+  import { fitVisibleCommentSurface } from '../lib/comment-demo-fit';
 
   type DemoFormat = 'docx' | 'xlsx' | 'pptx';
   type Viewer = DocxScrollViewer | PptxScrollViewer | XlsxViewer;
@@ -117,12 +118,14 @@ const demoId = `built-in-comment-${formats.join('-')}`;
           await next.load(sampleUrl(format));
           if (request !== generation) return;
           next.scrollToPage(1);
+          fitVisibleCommentSurface(next, host);
         } else if (format === 'pptx') {
           const next = new PptxScrollViewer(host, { comments: true, useGoogleFonts: true });
           viewer = next;
           await next.load(sampleUrl(format));
           if (request !== generation) return;
           next.scrollToSlide(0);
+          fitVisibleCommentSurface(next, host);
         } else {
           const next = new XlsxViewer(host, { comments: true });
           viewer = next;

--- a/site/src/lib/announcements.ts
+++ b/site/src/lib/announcements.ts
@@ -36,6 +36,49 @@ export interface Announcement {
 
 export const announcements: readonly Announcement[] = [
   {
+    slug: 'v085-large-images-and-rendering',
+    date: '2026-09-02',
+    label: 'Upcoming release',
+    version: 'v0.85.0',
+    title: 'Larger images and steadier rendering in v0.85.0',
+    summary: 'v0.85.0 opens more Office files with large images, broadens TIFF support and improves rendering stability in worker mode and during PowerPoint zoom.',
+    audience: 'Applications that display image-heavy DOCX, XLSX or PPTX files, use worker rendering, or open TIFF images. Most applications can upgrade without code changes.',
+    sections: [
+      {
+        title: 'In short',
+        kind: 'summary',
+        paragraphs: [
+          'Word, Excel and PowerPoint files with large, high-resolution images can now open more reliably. Images are prepared for the current display size when retaining their full source resolution would be excessive, and a later zoom can request a sharper result.',
+        ],
+        bullets: [
+          'Display poster-sized and camera images that previously crossed the decoded-image limit.',
+          'Support more TIFF images, including common black-and-white, grayscale, colour and Group 4 files.',
+          'Keep embedded SVGs, PowerPoint text and styled Excel sheets dependable in worker mode.',
+        ],
+      },
+      {
+        title: 'Smoother, more faithful viewing',
+        paragraphs: [
+          'PowerPoint zoom now keeps the viewed slide in place while the sharper render settles, including at the maximum zoom level. Placeholder text, built-in table styles and several chart layouts also more closely follow their Office appearance.',
+          'The same image handling is available across DOCX, XLSX and PPTX, in both regular and worker rendering modes.',
+        ],
+      },
+      {
+        title: 'Upgrading',
+        paragraphs: [
+          'Most applications can upgrade without code changes. The new image policy is automatic, and applications with a specific memory or image-quality requirement can optionally adjust imageResources.',
+          'One TIFF behavior is now explicit: when a recognized TIFF image is present but no compatible TIFF codec is configured, the viewer reports TiffDecodeError instead of silently leaving the image blank. Applications that intentionally omit TIFF support should allow that diagnostic in onError, or add the optional @silurus/ooxml/tiff module to display the image.',
+        ],
+      },
+      {
+        title: 'Technical note',
+        paragraphs: [
+          'Adaptive image sizing remains bounded by non-disableable source, dimension and per-image safety limits. imageResources controls the decoded working budget and can select strict rejection when an application prefers it; it is not a promise about total browser or GPU memory.',
+        ],
+      },
+    ],
+  },
+  {
     slug: 'v0841-word-layout-refinements',
     date: '2026-09-01',
     label: 'Release note',

--- a/site/src/lib/comment-demo-fit.test.ts
+++ b/site/src/lib/comment-demo-fit.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { commentSurfaceFitScale } from './comment-demo-fit.js';
+
+describe('comment demo initial fit', () => {
+  it('shrinks a centered page enough to reveal a right-side comment margin', () => {
+    expect(commentSurfaceFitScale({
+      currentScale: 1,
+      viewportWidth: 1000,
+      contentWidth: 1000,
+      leadingExtent: 0,
+      trailingExtent: 300,
+    })).toBeCloseTo(0.625, 10);
+  });
+
+  it('uses the same geometry for a left-side review margin', () => {
+    expect(commentSurfaceFitScale({
+      currentScale: 1.5,
+      viewportWidth: 900,
+      contentWidth: 760,
+      leadingExtent: 240,
+      trailingExtent: 0,
+    })).toBeCloseTo(1.5 * 900 / 1240, 10);
+  });
+
+  it('does not enlarge an already visible comment surface', () => {
+    expect(commentSurfaceFitScale({
+      currentScale: 0.5,
+      viewportWidth: 1200,
+      contentWidth: 600,
+      leadingExtent: 100,
+      trailingExtent: 100,
+    })).toBeNull();
+  });
+
+  it('rejects incomplete or non-finite layout measurements', () => {
+    expect(commentSurfaceFitScale({
+      currentScale: 1,
+      viewportWidth: 0,
+      contentWidth: 600,
+      leadingExtent: 100,
+      trailingExtent: 0,
+    })).toBeNull();
+    expect(commentSurfaceFitScale({
+      currentScale: 1,
+      viewportWidth: 1000,
+      contentWidth: Number.POSITIVE_INFINITY,
+      leadingExtent: 100,
+      trailingExtent: 0,
+    })).toBeNull();
+  });
+});

--- a/site/src/lib/comment-demo-fit.ts
+++ b/site/src/lib/comment-demo-fit.ts
@@ -1,0 +1,67 @@
+interface CommentSurfaceScaleInput {
+  readonly currentScale: number;
+  readonly viewportWidth: number;
+  readonly contentWidth: number;
+  readonly leadingExtent: number;
+  readonly trailingExtent: number;
+}
+
+interface CommentDemoZoomViewer {
+  getScale(): number;
+  setScale(scale: number): void;
+}
+
+/**
+ * Fit a centered document surface plus its one-sided review margin.
+ *
+ * ScrollViewer centers the authored page/slide independently of comment cards,
+ * so the larger side extent must also be reserved on the opposite side. This
+ * keeps the authored surface centered while making the adjacent margin visible.
+ */
+export function commentSurfaceFitScale(
+  input: Readonly<CommentSurfaceScaleInput>,
+): number | null {
+  const values = [
+    input.currentScale,
+    input.viewportWidth,
+    input.contentWidth,
+    input.leadingExtent,
+    input.trailingExtent,
+  ];
+  if (!values.every(Number.isFinite)) return null;
+  if (input.currentScale <= 0 || input.viewportWidth <= 0 || input.contentWidth <= 0) {
+    return null;
+  }
+  const sideExtent = Math.max(0, input.leadingExtent, input.trailingExtent);
+  const centeredSurfaceWidth = input.contentWidth + sideExtent * 2;
+  if (centeredSurfaceWidth <= input.viewportWidth) return null;
+  const scale = input.currentScale * input.viewportWidth / centeredSurfaceWidth;
+  return Number.isFinite(scale) && scale > 0 ? scale : null;
+}
+
+/** Shrink only the official comment demo's initial DOCX/PPTX view. */
+export function fitVisibleCommentSurface(
+  viewer: CommentDemoZoomViewer,
+  host: HTMLElement,
+): boolean {
+  const margin = [...host.querySelectorAll<HTMLElement>(
+    '[data-ooxml-comment-ui="margin"]',
+  )].find((candidate) => candidate.querySelector('[data-ooxml-comment-card]') !== null);
+  const wrapper = margin?.parentElement;
+  const canvas = wrapper?.querySelector<HTMLCanvasElement>(':scope > canvas');
+  const viewport = wrapper?.parentElement;
+  if (!margin || !canvas || !viewport) return false;
+
+  const content = canvas.getBoundingClientRect();
+  const review = margin.getBoundingClientRect();
+  const scale = commentSurfaceFitScale({
+    currentScale: viewer.getScale(),
+    viewportWidth: viewport.clientWidth,
+    contentWidth: content.width,
+    leadingExtent: content.left - review.left,
+    trailingExtent: review.right - content.right,
+  });
+  if (scale === null) return false;
+  viewer.setScale(scale);
+  return true;
+}

--- a/site/src/pages/bundle-size.astro
+++ b/site/src/pages/bundle-size.astro
@@ -28,7 +28,7 @@ import SiteFooter from '../components/SiteFooter.astro';
           <tbody>
             <tr>
               <th>DOCX static JavaScript</th>
-              <td>1,963 KiB</td>
+              <td>1,964 KiB</td>
               <td>477 KiB</td>
             </tr>
             <tr>
@@ -68,7 +68,7 @@ import SiteFooter from '../components/SiteFooter.astro';
           <tbody>
             <tr><th>DOCX parser WASM</th><td>1,786 KiB</td><td>741 KiB</td></tr>
             <tr><th>XLSX parser WASM</th><td>1,577 KiB</td><td>650 KiB</td></tr>
-            <tr><th>PPTX parser WASM</th><td>1,649 KiB</td><td>649 KiB</td></tr>
+            <tr><th>PPTX parser WASM</th><td>1,648 KiB</td><td>649 KiB</td></tr>
             <tr><th>MathJax runtime</th><td>3,025 KiB</td><td>1,084 KiB</td></tr>
           </tbody>
         </table>

--- a/site/src/pages/bundle-size.astro
+++ b/site/src/pages/bundle-size.astro
@@ -15,7 +15,7 @@ import SiteFooter from '../components/SiteFooter.astro';
       <div class="wrap">
         <p class="eyebrow">Current measurement</p>
         <h1>Bundle size.</h1>
-        <p>Current production assets in v0.84.1.</p>
+        <p>Current production assets for v0.85.0.</p>
       </div>
     </header>
 
@@ -28,18 +28,18 @@ import SiteFooter from '../components/SiteFooter.astro';
           <tbody>
             <tr>
               <th>DOCX static JavaScript</th>
-              <td>1,924 KiB</td>
-              <td>466 KiB</td>
+              <td>1,963 KiB</td>
+              <td>477 KiB</td>
             </tr>
             <tr>
               <th>XLSX static JavaScript</th>
-              <td>1,244 KiB</td>
-              <td>295 KiB</td>
+              <td>1,279 KiB</td>
+              <td>305 KiB</td>
             </tr>
             <tr>
               <th>PPTX static JavaScript</th>
-              <td>1,286 KiB</td>
-              <td>297 KiB</td>
+              <td>1,325 KiB</td>
+              <td>309 KiB</td>
             </tr>
           </tbody>
         </table>
@@ -55,7 +55,7 @@ import SiteFooter from '../components/SiteFooter.astro';
             <tr><th>3-D charts</th><td>100.9 KiB</td><td>28.6 KiB</td></tr>
             <tr><th>Region Map</th><td>231.5 KiB</td><td>62.6 KiB</td></tr>
             <tr><th>Math adapter</th><td>1.3 KiB</td><td>0.7 KiB</td></tr>
-            <tr><th>TIFF image codec</th><td>4.0 KiB</td><td>1.6 KiB</td></tr>
+            <tr><th>TIFF image codec</th><td>22.2 KiB</td><td>6.7 KiB</td></tr>
           </tbody>
         </table>
       </div>
@@ -68,7 +68,7 @@ import SiteFooter from '../components/SiteFooter.astro';
           <tbody>
             <tr><th>DOCX parser WASM</th><td>1,786 KiB</td><td>741 KiB</td></tr>
             <tr><th>XLSX parser WASM</th><td>1,577 KiB</td><td>650 KiB</td></tr>
-            <tr><th>PPTX parser WASM</th><td>1,638 KiB</td><td>645 KiB</td></tr>
+            <tr><th>PPTX parser WASM</th><td>1,649 KiB</td><td>649 KiB</td></tr>
             <tr><th>MathJax runtime</th><td>3,025 KiB</td><td>1,084 KiB</td></tr>
           </tbody>
         </table>


### PR DESCRIPTION
## Summary

- prepare the concise v0.85.0 announcement and refresh the stable bundle-size page
- retain DOCX page-dependent fields when a document omits cached field results
- align DOCX generic font fallback with Word while preserving authored and font-table metadata precedence
- preserve PresentationML's implicit object-placeholder type and keep geometry inheritance separate
- fit the official DOCX/PPTX comment examples so review cards are visible initially
- reject non-finite adaptive raster targets and present the existing README disclosure as a note

No public API migration is required. The announcement documents the one optional TIFF-codec diagnostic change that can affect applications which intentionally omit that codec.

## Specification and design

- ECMA-376 Part 1 §17.16.18: a complex field may end without a stored-result separator; locally recomputable fields remain meaningful
- ECMA-376 Part 1 §17.3.2.26: authored font slots and style inheritance remain authoritative; only the final supported default is consumer-defined
- ECMA-376 Part 1 §19.3.1.36 and the `CT_Placeholder` schema: omitted placeholder type defaults to `obj`
- ECMA-376 Part 1 §19.7.9: placeholder sizing is relative to the master body placeholder

The implementation contains no sample-name/path branches or empirical rendering constants. Comment-demo fitting is derived from measured viewport, page/slide, and review-margin geometry.

## Verification

- DOCX and PPTX Rust parser suites: 553 and 283 tests passed
- focused core/DOCX/site tests: 69 passed
- DOCX architecture gates: boundary scan plus 89 boundary, 17 compatibility, 26 public-API, and 2 package-build tests passed
- repository tests in a normal local environment: 8,825 passed and 24 skipped, plus both private-corpus harness tests
- typecheck and all package/site production builds passed
- exact main/worker parity passed for the complete PPTX private corpus
- `cargo fmt --check` and `git diff --check` passed

## Previous-release VRT

The self-VRT oracle is v0.84.1 at full revision `f5176cf9d0198487e0a67f2dfa333be498e59e24`, with baseline and candidate servers isolated on different ports and both sides rebuilt from their own parser sources.

- XLSX: all 139 captured sheets are pixel-identical
- DOCX: 47/50 documents are pixel-identical; all four changed pages were individually checked against Word output and the candidate matches the restored fields/font behavior
- PPTX: 15/18 documents are pixel-identical; all fourteen changed slides were individually checked against PowerPoint output and reflect the intended implicit-formatting corrections
- an unrelated PPTX regression discovered by this run was fixed; the affected presentation is now pixel-identical to v0.84.1

Office-reference fidelity and previous-renderer regression detection were adjudicated separately; no VRT threshold or baseline was weakened or updated.

## Bundle measurement

Complete synchronous import graphs were measured from production builds, with gzip level 9 applied per emitted asset. Relative to v0.84.1:

- DOCX static JavaScript: 1,924 → 1,964 KiB raw; 466 → 477 KiB gzip
- XLSX static JavaScript: 1,244 → 1,279 KiB raw; 295 → 305 KiB gzip
- PPTX static JavaScript: 1,286 → 1,325 KiB raw; 297 → 309 KiB gzip
- optional TIFF codec: 4.0 → 22.2 KiB raw; 1.6 → 6.7 KiB gzip
- PPTX parser WASM: 1,638 → 1,648 KiB raw; 645 → 649 KiB gzip

Other optional modules and runtime assets are unchanged after displayed rounding.

## Adversarial review

APPROVE. The final diff was checked for specification fidelity, unexplained heuristics, bounded Office inference, resource safety, module ownership, single responsibility, and DOCX/XLSX/PPTX cross-format wiring. The review found and removed an invalid same-index master-placeholder type inference, then narrowed the font-default policy by script when CI exposed a broader-than-evidenced CJK change. Shared font classification and image-target validation remain in core; field parsing and document layout policy remain DOCX-owned; PresentationML inheritance remains PPTX-owned; demo-only initial fitting remains site-owned. No unresolved finding remains.
