### PR TITLE
chore(release): 0.85.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ the corresponding minor release.
 
 ## Unreleased
 
+## 0.85.1 — 2026-09-02
+
+Compatible patch release restoring fitted viewing after zoom and preventing a
+floating-point edge case from rejecting Word tables that fit on the page.
+
+- **fitted zoom:** after zooming into poster-sized PPTX slides or DOCX pages,
+  zooming out can return to the original fit-to-viewport scale even when that
+  scale is below the configured manual zoom minimum.
+- **mixed Word page sizes:** fit-to-width uses the widest page in the document,
+  and progressive rendering refits when a wider page becomes available, without
+  leaving an avoidable horizontal scrollbar.
+- **Word table stability:** tolerate single-ULP arithmetic drift when a table
+  fragment exactly meets a page boundary, avoiding a false non-convergence
+  error while retaining strict handling for genuine overflow.
+- **compatibility:** no existing option or method is removed or renamed, and no
+  application changes are required.
+
 ## 0.85.0 — 2026-09-02
 
 Compatible minor release making image-heavy Office files more reliable while

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.85.0"
+version = "0.85.1"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/README.md
+++ b/README.md
@@ -311,10 +311,11 @@ await viewer.load('/deck.pptx');
 ```
 
 The container must have a bounded height (e.g. `height: 100vh` or a flex child)
-so the viewer can size its scroll host to it. Base zoom fits the first page/slide
-width to the container width and re-fits on resize; a `0`-width container defers
-layout until it has width. Call `destroy()` to tear down (a self-loaded engine is
-destroyed with it; a borrowed one is not — see below).
+so the viewer can size its scroll host to it. Base zoom fits the widest available
+DOCX page, or the PPTX slide width, to the container and re-fits on resize. A
+progressively loaded DOCX re-fits if a wider page appears; a `0`-width container
+defers layout until it has width. Call `destroy()` to tear down (a self-loaded
+engine is destroyed with it; a borrowed one is not — see below).
 
 Pass `refitOnResize: false` when the viewport must not determine the document's
 physical display size. An explicit pre-load `setScale(1)` then keeps the same
@@ -343,7 +344,9 @@ sheet sits inside a uniform desk margin; pass `0` for a flush edge.
 bare-wheel still scrolls natively. Zoom is flicker-free — a rapid gesture shows a
 CSS preview and settles into a crisp re-render when it pauses. Bounds are the
 absolute scale factors `zoomMin` / `zoomMax` (default `0.1` / `4`), and
-`setScale(scale)` sets it programmatically. Pass `enableZoom: false` to disable.
+`setScale(scale)` sets it programmatically. When fitting needs a scale below
+`zoomMin`, that fitted scale becomes the effective minimum so users can zoom in
+and still return to the original fit. Pass `enableZoom: false` to disable.
 
 **Text selection and find.** Pass `enableTextSelection: true` to overlay a
 transparent, selectable text layer per page/slide for native copy. It works in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.85.0",
+  "version": "0.85.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.85.0",
+  "version": "0.85.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.85.0",
+  "version": "0.85.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.85.0",
+  "version": "0.85.1",
   "description": "Internal workspace adapter for DOCX / XLSX / PPTX Markdown projection",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.85.0"
+version = "0.85.1"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.85.0",
+  "version": "0.85.1",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.85.0",
+  "version": "0.85.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity local viewer for Office files (.docx / .xlsx / .pptx), powered by Rust/WASM and Canvas. Optional MCP integration can share requested context with an AI agent.",
-  "version": "0.85.0",
+  "version": "0.85.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.85.0",
+  "version": "0.85.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.85.0",
+  "version": "0.85.1",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",

--- a/site/src/announcement-content.test.ts
+++ b/site/src/announcement-content.test.ts
@@ -200,7 +200,7 @@ describe('v0.81 ChartEx migration guide', () => {
 
 describe('stable documentation boundaries', () => {
   it('keeps the current bundle measurements on one stable page', () => {
-    expect(bundleSizePage).toContain('Current production assets for v0.85.0');
+    expect(bundleSizePage).toContain('Current production assets for v0.85.1');
     expect(bundleSizePage).toContain('DOCX static JavaScript');
     expect(bundleSizePage).toMatch(/<td>1,966 KiB<\/td>\s*<td>478 KiB<\/td>/);
     expect(bundleSizePage).toContain('XLSX static JavaScript');

--- a/site/src/pages/bundle-size.astro
+++ b/site/src/pages/bundle-size.astro
@@ -15,7 +15,7 @@ import SiteFooter from '../components/SiteFooter.astro';
       <div class="wrap">
         <p class="eyebrow">Current measurement</p>
         <h1>Bundle size.</h1>
-        <p>Current production assets for v0.85.0.</p>
+        <p>Current production assets for v0.85.1.</p>
       </div>
     </header>
 


### PR DESCRIPTION
## Summary

- prepare the compatible v0.85.1 patch release
- restore the opening fit-to-viewport scale after users zoom into poster-sized PPTX slides or DOCX pages
- fit continuous DOCX viewing to the widest available page and re-fit when progressive layout reveals a wider page
- prevent single-ULP arithmetic drift from rejecting a Word table fragment that exactly fits its page boundary
- synchronize package, VS Code extension, site, and MCP server versions
- refresh release notes, stable bundle metadata, and continuous-viewer documentation

No public API migration is required.

## Verification

- full unit suite in a normal local environment: 8,841 passed and 24 skipped
- private-corpus VRT harness tests: 2 passed
- focused release and viewer/layout tests: 328 passed
- TypeScript project build and all package-specific typechecks passed
- production package and site builds passed
- README screenshot smoke tests: 3 passed; regenerated images are pixel-identical
- DOCX, XLSX, and PPTX public API baselines and viewer symmetry passed
- production worker, WASM separation, and optional ChartEx/3-D/Region Map/TIFF boundaries passed
- `cargo check -p ooxml-mcp-server` and `git diff --check` passed

## Bundle measurement

Production assets were rebuilt and measured from each complete synchronous format graph, applying gzip level 9 per emitted asset. Displayed values are unchanged from v0.85.0:

- DOCX static JavaScript: 1,966 KiB raw / 478 KiB gzip
- XLSX static JavaScript: 1,281 KiB raw / 306 KiB gzip
- PPTX static JavaScript: 1,327 KiB raw / 310 KiB gzip
- optional modules and runtime assets are also unchanged after displayed rounding

## Adversarial review

APPROVE. The fitted zoom floor is derived only from the configured minimum and current width-fit base; there are no sample-specific branches, empirical constants, or new OOXML compatibility heuristics. DOCX uses the same widest presented-page population for scale and spacer geometry, including progressive updates, without adding work beyond the existing per-page relayout scan. PPTX and DOCX continuous viewers are covered; XLSX and single-canvas viewers have different initial-scale behavior and are intentionally unchanged. The Word table fix only tolerates one floating-point ULP when two arithmetic paths reconstruct the same page boundary; genuine overflow remains rejected and ECMA-376 §17.4 row-breaking behavior is unchanged.
