### PR TITLE
chore(release): 0.85.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ the corresponding minor release.
 
 ## Unreleased
 
+## 0.85.2 — 2026-09-03
+
+Patch release restoring smooth progressive viewing in worker mode and fixing
+large-image decoding, PowerPoint placeholder alignment, and provisional Word
+pagination.
+
+- **responsive progressive viewing:** Try Yours continues loading later pages
+  while idle, updates page totals as pages arrive, and starts image decoding
+  without waiting for whole-document raster inspection.
+- **large-image reliability and clarity:** decoded raster dimensions now match
+  the two-axis resource plan, avoiding false decoded-image-limit failures for
+  poster-sized slides while preserving native image detail when it fits the
+  configured budget.
+- **PowerPoint text placement:** placeholder text boxes inherit their vertical
+  anchor from the matching layout placeholder, preventing top-aligned text from
+  appearing at the bottom of large slides.
+- **stable Word pagination:** documents whose header or footer reserve is still
+  converging no longer publish a transient page assignment that can briefly
+  place the next page's content on the previous page.
+- **Try Yours defaults:** comments are hidden in the public file preview.
+- **compatibility:** no existing option or method is removed or renamed, and no
+  application changes are required. The optional image resolution policy can be
+  set to `display`; its default remains `native-if-fit`.
+
 ## 0.85.1 — 2026-09-02
 
 Compatible patch release restoring fitted viewing after zoom and preventing a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.85.1"
+version = "0.85.2"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.85.1",
+  "version": "0.85.2",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.85.1",
+  "version": "0.85.2",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.85.1",
+  "version": "0.85.2",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.85.1",
+  "version": "0.85.2",
   "description": "Internal workspace adapter for DOCX / XLSX / PPTX Markdown projection",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.85.1"
+version = "0.85.2"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.85.1",
+  "version": "0.85.2",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.85.1",
+  "version": "0.85.2",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity local viewer for Office files (.docx / .xlsx / .pptx), powered by Rust/WASM and Canvas. Optional MCP integration can share requested context with an AI agent.",
-  "version": "0.85.1",
+  "version": "0.85.2",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.85.1",
+  "version": "0.85.2",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.85.1",
+  "version": "0.85.2",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",

--- a/site/src/announcement-content.test.ts
+++ b/site/src/announcement-content.test.ts
@@ -200,15 +200,15 @@ describe('v0.81 ChartEx migration guide', () => {
 
 describe('stable documentation boundaries', () => {
   it('keeps the current bundle measurements on one stable page', () => {
-    expect(bundleSizePage).toContain('Current production assets for v0.85.1');
+    expect(bundleSizePage).toContain('Current production assets for v0.85.2');
     expect(bundleSizePage).toContain('DOCX static JavaScript');
-    expect(bundleSizePage).toMatch(/<td>1,966 KiB<\/td>\s*<td>478 KiB<\/td>/);
+    expect(bundleSizePage).toMatch(/<td>1,967 KiB<\/td>\s*<td>479 KiB<\/td>/);
     expect(bundleSizePage).toContain('XLSX static JavaScript');
-    expect(bundleSizePage).toMatch(/<td>1,281 KiB<\/td>\s*<td>306 KiB<\/td>/);
+    expect(bundleSizePage).toMatch(/<td>1,283 KiB<\/td>\s*<td>306 KiB<\/td>/);
     expect(bundleSizePage).toContain('PPTX static JavaScript');
-    expect(bundleSizePage).toMatch(/<td>1,327 KiB<\/td>\s*<td>310 KiB<\/td>/);
+    expect(bundleSizePage).toMatch(/<td>1,329 KiB<\/td>\s*<td>311 KiB<\/td>/);
     expect(bundleSizePage).toContain('<tr><th>DOCX parser WASM</th><td>1,786 KiB</td><td>741 KiB</td></tr>');
-    expect(bundleSizePage).toContain('<tr><th>PPTX parser WASM</th><td>1,648 KiB</td><td>649 KiB</td></tr>');
+    expect(bundleSizePage).toContain('<tr><th>PPTX parser WASM</th><td>1,650 KiB</td><td>649 KiB</td></tr>');
     expect(bundleSizePage).toContain('ChartEx');
     expect(bundleSizePage.match(/<th>TIFF image codec<\/th>/g)).toHaveLength(1);
     expect(bundleSizePage).toContain('<td>22.2 KiB</td><td>6.7 KiB</td>');

--- a/site/src/pages/bundle-size.astro
+++ b/site/src/pages/bundle-size.astro
@@ -15,7 +15,7 @@ import SiteFooter from '../components/SiteFooter.astro';
       <div class="wrap">
         <p class="eyebrow">Current measurement</p>
         <h1>Bundle size.</h1>
-        <p>Current production assets for v0.85.1.</p>
+        <p>Current production assets for v0.85.2.</p>
       </div>
     </header>
 
@@ -28,18 +28,18 @@ import SiteFooter from '../components/SiteFooter.astro';
           <tbody>
             <tr>
               <th>DOCX static JavaScript</th>
-              <td>1,966 KiB</td>
-              <td>478 KiB</td>
+              <td>1,967 KiB</td>
+              <td>479 KiB</td>
             </tr>
             <tr>
               <th>XLSX static JavaScript</th>
-              <td>1,281 KiB</td>
+              <td>1,283 KiB</td>
               <td>306 KiB</td>
             </tr>
             <tr>
               <th>PPTX static JavaScript</th>
-              <td>1,327 KiB</td>
-              <td>310 KiB</td>
+              <td>1,329 KiB</td>
+              <td>311 KiB</td>
             </tr>
           </tbody>
         </table>
@@ -68,7 +68,7 @@ import SiteFooter from '../components/SiteFooter.astro';
           <tbody>
             <tr><th>DOCX parser WASM</th><td>1,786 KiB</td><td>741 KiB</td></tr>
             <tr><th>XLSX parser WASM</th><td>1,577 KiB</td><td>650 KiB</td></tr>
-            <tr><th>PPTX parser WASM</th><td>1,648 KiB</td><td>649 KiB</td></tr>
+            <tr><th>PPTX parser WASM</th><td>1,650 KiB</td><td>649 KiB</td></tr>
             <tr><th>MathJax runtime</th><td>3,025 KiB</td><td>1,084 KiB</td></tr>
           </tbody>
         </table>


### PR DESCRIPTION
## Outcome

Prepares the 0.85.2 patch release with smoother worker-mode progress, reliable bounded image decoding for large Office artwork, correct PowerPoint placeholder vertical alignment, and stable provisional Word pagination. Try Yours also hides comments by default.

No migration is required. Existing options and methods remain available. Applications that explicitly prefer display-sized image decoding may set the new image resolution policy to `display`; the default is `native-if-fit`.

## Release updates

- bumps all npm, VS Code extension, site, and MCP package versions to 0.85.2
- adds the 0.85.2 changelog entry
- refreshes measured production bundle sizes
- reviews the README and public API documentation against the current implementation
- regenerates all three README screenshots; they remain byte-identical

## Verification

- source-change CI: audit, Rust, typecheck/build/unit suite, and multi-browser smoke all passed
- full unit suite: 8,862 passed, 24 skipped
- package production build and declaration bundle passed
- site production build passed
- full typecheck passed
- MCP Cargo check passed
- release documentation tests: 19 passed
- README screenshot smoke: 3 passed
- private VRT: PPTX 36/36 exact; DOCX 49/50 exact with one Office-adjudicated fidelity improvement; XLSX renderer output exact aside from date-sensitive cells
- mandatory adversarial review: APPROVE