### PR TITLE
fix(viewer): restore progressive DOCX and PPTX autofit

### DIFF
--- a/packages/docx/src/layout/body-paginator.ts
+++ b/packages/docx/src/layout/body-paginator.ts
@@ -2377,30 +2377,20 @@ export function* paginateBodySteps(
   const owners = ownerMap(input);
   let nextPublicationPages = 1;
   let publicationFailed = false;
-  let publicationUnsafe = false;
   const passObserver: BodyPaginationPassObserver | undefined = observer
     ? {
         shouldPublish: (committedPages) => (
-          !publicationFailed && !publicationUnsafe && committedPages >= nextPublicationPages
+          !publicationFailed && committedPages >= nextPublicationPages
         ),
         publish: (pass, processedEntries) => {
           try {
-            // The seed pass starts without header/footer body reserves. If a
-            // story already overflows its margin allowance, publishing any of
-            // those pages would expose geometry that reserve convergence must
-            // later replace. Stop previewing this document instead of showing
-            // content briefly on the wrong page.
-            if (headerFooterReserves(pass, owners).some(
-              (reserve) => reserve.top > 0 || reserve.bottom > 0,
-            )) {
-              publicationUnsafe = true;
-              return;
-            }
             const composed = composeBodyPaginationResult(pass, input, owners, options, false);
             // The newest committed page still owns the live transition edge:
             // section-region and page-final composition can change when the
             // following page becomes committed. Keep one page as the checkpoint
-            // guard and publish only the stable prefix before it.
+            // guard and publish only the prefix before it. This publication is
+            // deliberately provisional: header/footer and pagination-field
+            // convergence may replace it, and consumers receive `exact:false`.
             const publishable = Object.freeze({
               ...composed,
               pages: Object.freeze(composed.pages.slice(0, -1)),

--- a/packages/docx/src/layout/progressive.test.ts
+++ b/packages/docx/src/layout/progressive.test.ts
@@ -174,10 +174,10 @@ describe('preview pages match the final layout', () => {
     }
   }, 300_000);
 
-  it('does not expose seed pages before header/footer reserve convergence', async () => {
+  it('keeps publishing provisional pages while header/footer reserves converge', async () => {
     const previews: ProgressiveLayoutPreview[] = [];
     const testCase = open('header-footer', 200, { headerFooterFontSize: 64 });
-    await layoutDocumentProgressively(
+    const final = await layoutDocumentProgressively(
       testCase.source.bodyLayoutInput,
       testCase.services,
       testCase.options,
@@ -186,7 +186,19 @@ describe('preview pages match the final layout', () => {
       },
     );
 
-    expect(previews).toEqual([]);
+    expect(previews.length).toBeGreaterThan(0);
+    expect(previews.at(-1)!.layout.pages.length).toBeLessThan(final.pages.length);
+    const counts = previews.map((preview) => preview.layout.pages.length);
+    expect(counts).toEqual([...counts].sort((left, right) => left - right));
+    expect(new Set(counts).size).toBe(counts.length);
+    // The seed deliberately uses zero header/footer body reserves. At least one
+    // preview must therefore differ from the authoritative converged geometry:
+    // consumers may paint it immediately, but must replace it when a newer
+    // generation arrives instead of treating it as exact layout.
+    expect(previews.some((preview) => preview.layout.pages.some((page, pageIndex) => (
+      pageFingerprint(page as LayoutPage)
+        !== pageFingerprint(final.pages[pageIndex] as LayoutPage)
+    )))).toBe(true);
   }, 300_000);
 
   it('keeps a keepNext chain beyond the checkpoint in the canonical lookahead', async () => {

--- a/packages/docx/src/layout/progressive.ts
+++ b/packages/docx/src/layout/progressive.ts
@@ -13,7 +13,9 @@
  * Publications remain provisional because later anchor/header/footer/field
  * convergence can repaginate the document. They are nevertheless based on the
  * complete source input, so unbounded `keepNext` lookahead is no longer cut off
- * at an artificial preview boundary.
+ * at an artificial preview boundary. Header/footer reserve and pagination-field
+ * convergence can replace a preview; the public publication contract marks
+ * these snapshots `exact:false` until the authoritative final layout arrives.
  *
  * ## What is guaranteed
  *

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -4136,6 +4136,9 @@ export function renderTextBody(
     alignment: string;
     isLastLine: boolean;
     para: Paragraph;
+    /** This spAutoFit line replaces an authored-font design floor with metrics
+     * from the font Canvas actually resolved. */
+    useResolvedFontMetrics: boolean;
   }
 
   // buildLayout runs Pass 1 at a given font scale (1.0 = normal; <1 = normAutoFit shrink)
@@ -4317,6 +4320,11 @@ export function renderTextBody(
       // authored `<a:spcPct>`; §21.1.2.2.5 / §21.1.2.2.11 define percentage
       // spacing from the line's largest text size.
       let designSingle = 0;
+      // spAutoFit is recalculated by the consuming application. Measure the
+      // fonts Canvas actually resolved (including browser substitutions) so
+      // that a shape saved with another machine's font metrics is not laid out
+      // again with those stale design metrics.
+      let resolvedFontLine = 0;
       for (const seg of line.segments) {
         // For an equation, the line must be at least as tall as its own font
         // size (so a short label like "y"/"p"/"z" gets the normal font-ascent
@@ -4331,6 +4339,14 @@ export function renderTextBody(
         if (!seg.math) {
           const ds = intendedSingleLinePx(seg.fontFamily, seg.sizePx);
           if (ds > designSingle) designSingle = ds;
+          if (isSpAutoFit) {
+            ctx.font = seg.font;
+            const metrics = ctx.measureText(seg.text || 'M');
+            const fontAscent = metrics.fontBoundingBoxAscent ?? 0;
+            const fontDescent = metrics.fontBoundingBoxDescent ?? 0;
+            const resolved = fontAscent + fontDescent;
+            if (resolved > resolvedFontLine) resolvedFontLine = resolved;
+          }
         }
       }
       if (maxSizePx === 0) maxSizePx = paraDefaultFontSizePx;
@@ -4356,7 +4372,12 @@ export function renderTextBody(
       // design-metric floor; glyph painting may keep that floor below without
       // enlarging the table structure.
       const naturalSingle = maxSizePx * 1.2;
-      const implicitSingle = Math.max(naturalSingle, designSingle);
+      const useResolvedFontMetrics = isSpAutoFit
+        && designSingle > naturalSingle
+        && resolvedFontLine > 0;
+      const implicitSingle = useResolvedFontMetrics
+        ? Math.max(naturalSingle, resolvedFontLine)
+        : Math.max(naturalSingle, designSingle);
       let lineHeight: number;
       if (para.spaceLine) {
         if (para.spaceLine.type === 'pct') {
@@ -4366,7 +4387,7 @@ export function renderTextBody(
           lineHeight = para.spaceLine.val * PT_TO_EMU * scale;
         }
       } else {
-        lineHeight = measureOnly
+        lineHeight = measureOnly && !isSpAutoFit
           ? (measureNaturalLineSpacing ? naturalSingle : maxSizePx)
           : implicitSingle;
       }
@@ -4414,6 +4435,7 @@ export function renderTextBody(
         alignment: para.alignment,
         isLastLine: isLast,
         para,
+        useResolvedFontMetrics,
       });
       totalHeight += linePx + topGap;
     }
@@ -4540,7 +4562,7 @@ export function renderTextBody(
   let entriesInCol = 0;
 
   for (const entry of allLines) {
-    const { line, linePx, lineHeight, topGapPx, textXOffset, bulletLabel, bulletFont, bulletColor, bulletImage, alignment, isLastLine } = entry;
+    const { line, linePx, lineHeight, topGapPx, textXOffset, bulletLabel, bulletFont, bulletColor, bulletImage, alignment, isLastLine, useResolvedFontMetrics } = entry;
     // Balanced column advance: when the current column has reached its share
     // of paragraphs, jump to the next one. PowerPoint never breaks a single
     // line across columns and never spills past the last column — anything
@@ -4610,12 +4632,14 @@ export function renderTextBody(
       }
     }
 
-    // Measure line for alignment AND baseline ascent in one pass.
-    // actualBoundingBoxAscent gives the real font ascent for the rendered glyphs,
-    // replacing the 0.8×lineHeight heuristic that over-estimates for CJK and
-    // tall fonts, causing text to sit too low within the line box.
+    // Measure line width and the metrics of the fonts Canvas actually resolved.
+    // spAutoFit is a live recalculation, so its baseline must use the same
+    // resolved metrics as the line-height pass above. Ordinary text retains the
+    // established PowerPoint-compatible baseline.
     let lineWidth = 0;
-    let maxAscent = lineHeight * 0.8; // fallback when no segments
+    let maxAscent = 0;
+    let resolvedFontAscent = 0;
+    let resolvedFontHeight = 0;
     for (const seg of line.segments) {
       if (seg.isTab) {
         lineWidth += seg.tabWidthPx ?? 0;
@@ -4634,8 +4658,22 @@ export function renderTextBody(
       if (m.actualBoundingBoxAscent > 0) {
         maxAscent = Math.max(maxAscent, m.actualBoundingBoxAscent);
       }
+      if (useResolvedFontMetrics) {
+        const fontAscent = m.fontBoundingBoxAscent ?? 0;
+        const fontHeight = fontAscent + (m.fontBoundingBoxDescent ?? 0);
+        if (fontHeight > resolvedFontHeight) {
+          resolvedFontHeight = fontHeight;
+          resolvedFontAscent = fontAscent;
+        }
+      }
     }
-    const baseline = cursorY + maxAscent;
+    const baselineOffset = useResolvedFontMetrics && resolvedFontHeight > 0
+      ? Math.max(
+          maxAscent,
+          resolvedFontAscent + Math.max(0, lineHeight - resolvedFontHeight) / 2,
+        )
+      : Math.max(lineHeight * 0.8, maxAscent);
+    const baseline = cursorY + baselineOffset;
 
     // Reading-frame marker placement under an RTL base (issue #930, same class as
     // the docx #830 / pptx #913 leading-edge mirroring). PowerPoint seats a list

--- a/packages/pptx/src/sp-autofit-top-anchor.test.ts
+++ b/packages/pptx/src/sp-autofit-top-anchor.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import { intendedSingleLinePx, type TextRunData } from '@silurus/ooxml-core';
+import { renderTextBody } from './renderer.js';
+import type { Paragraph, TextBody } from './types.js';
+
+const SCALE = 1 / 12700; // 1 point => 1 canvas unit
+
+function recordingContext(ascent: number, descent: number, exposeFontMetrics = true) {
+  const draws: Array<{ text: string; y: number }> = [];
+  let font = '';
+  let fillStyle = '';
+  let direction: CanvasDirection = 'ltr';
+  const ctx = {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    get fillStyle() { return fillStyle; },
+    set fillStyle(value: string) { fillStyle = value; },
+    get direction() { return direction; },
+    set direction(value: CanvasDirection) { direction = value; },
+    measureText: (text: string) => ({
+      width: [...text].length * 20,
+      actualBoundingBoxAscent: ascent,
+      actualBoundingBoxDescent: descent,
+      ...(exposeFontMetrics
+        ? { fontBoundingBoxAscent: ascent, fontBoundingBoxDescent: descent }
+        : {}),
+    }),
+    fillText: (text: string, _x: number, y: number) => draws.push({ text, y }),
+    fillRect: () => {},
+    drawImage: () => {},
+    save: () => {},
+    restore: () => {},
+    translate: () => {},
+    rotate: () => {},
+    scale: () => {},
+    beginPath: () => {},
+    moveTo: () => {},
+    lineTo: () => {},
+    stroke: () => {},
+    clip: () => {},
+    rect: () => {},
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, draws };
+}
+
+function body(fontFamily: string, fontFamilyEa: string, fontSize: number): TextBody {
+  const run: TextRunData = {
+    type: 'text',
+    text: '見出し',
+    bold: true,
+    italic: null,
+    underline: false,
+    strikethrough: false,
+    fontSize,
+    color: '000000',
+    fontFamily,
+    fontFamilyEa,
+  };
+  const paragraph: Paragraph = {
+    alignment: 'l',
+    marL: 0,
+    marR: 0,
+    indent: 0,
+    spaceBefore: null,
+    spaceAfter: null,
+    spaceLine: null,
+    lvl: 0,
+    bullet: { type: 'none' },
+    defFontSize: null,
+    defColor: null,
+    defBold: null,
+    defItalic: null,
+    defFontFamily: null,
+    tabStops: [],
+    eaLnBrk: true,
+    runs: [run],
+  } as Paragraph;
+  return {
+    verticalAnchor: 't',
+    paragraphs: [paragraph],
+    defaultFontSize: fontSize,
+    defaultBold: null,
+    defaultItalic: null,
+    lIns: 0,
+    rIns: 0,
+    tIns: 0,
+    bIns: 0,
+    wrap: 'none',
+    vert: 'horz',
+    autoFit: 'sp',
+  } as TextBody;
+}
+
+describe('pptx spAutoFit top anchoring', () => {
+  it.each([
+    ['theme-resolved heading face', 'Meiryo', 'Meiryo', 32, 46],
+    ['explicit Meiryo face', 'Meiryo', 'Meiryo', 36, 50.9],
+  ])('uses the measured glyph ascent for %s instead of pushing the first line down', (
+    _label,
+    latin,
+    eastAsian,
+    fontSize,
+    storedHeight,
+  ) => {
+    // The resolved browser font can have a shorter font box than Meiryo's
+    // 1.596em saved-design line. spAutoFit must recalculate from those live
+    // metrics instead of reusing the document font's stale design-height floor.
+    const ascent = fontSize * 0.98;
+    const descent = fontSize * 0.37;
+    const { ctx, draws } = recordingContext(ascent, descent);
+    renderTextBody(
+      ctx,
+      body(latin as string, eastAsian as string, fontSize as number),
+      0,
+      0,
+      400,
+      storedHeight as number,
+      SCALE,
+    );
+
+    expect(draws).toHaveLength(1);
+    expect(draws[0]!.y).toBeCloseTo(ascent, 5);
+
+    const neededHeight = renderTextBody(
+      ctx,
+      body(latin as string, eastAsian as string, fontSize as number),
+      0,
+      0,
+      400,
+      storedHeight as number,
+      SCALE,
+      null,
+      0,
+      false,
+      false,
+      '#000000',
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+    expect(neededHeight).toBeCloseTo(ascent + descent, 5);
+  });
+
+  it('falls back to the authored font design box when Canvas has no font metrics', () => {
+    const fontSize = 32;
+    const { ctx, draws } = recordingContext(fontSize * 0.82, fontSize * 0.18, false);
+    const textBody = body('Meiryo', 'Meiryo', fontSize);
+    renderTextBody(ctx, textBody, 0, 0, 400, 46, SCALE);
+    const designedLineHeight = intendedSingleLinePx('Meiryo', fontSize);
+
+    expect(draws[0]!.y).toBeCloseTo(designedLineHeight * 0.8, 5);
+    expect(renderTextBody(
+      ctx, textBody, 0, 0, 400, 46, SCALE,
+      null, 0, false, false, '#000000', undefined, undefined, undefined, true,
+    )).toBeCloseTo(designedLineHeight, 5);
+  });
+
+  it('does not apply live spAutoFit metrics to fixed text', () => {
+    const fontSize = 32;
+    const { ctx, draws } = recordingContext(fontSize * 0.98, fontSize * 0.37);
+    const textBody = { ...body('Meiryo', 'Meiryo', fontSize), autoFit: 'none' as const };
+    renderTextBody(ctx, textBody, 0, 0, 400, 46, SCALE);
+
+    expect(draws[0]!.y).toBeCloseTo(intendedSingleLinePx('Meiryo', fontSize) * 0.8, 5);
+  });
+
+  it('keeps the established natural line box for spAutoFit fonts without a taller design floor', () => {
+    const fontSize = 32;
+    const { ctx, draws } = recordingContext(fontSize * 0.98, fontSize * 0.37);
+    const textBody = body('Arial', 'Arial', fontSize);
+    renderTextBody(ctx, textBody, 0, 0, 400, 46, SCALE);
+
+    expect(intendedSingleLinePx('Arial', fontSize)).toBeLessThan(fontSize * 1.2);
+    expect(draws[0]!.y).toBeCloseTo(fontSize * 0.98, 5);
+  });
+});


### PR DESCRIPTION
## Summary

- restore provisional DOCX page-prefix publications while header/footer and pagination-field convergence continues
- keep those publications explicitly non-authoritative until the final layout atomically replaces them
- recalculate PPTX `spAutoFit` implicit line height and baseline from Canvas-resolved font metrics when a taller authored-font design floor would otherwise be stale
- preserve fixed text, explicit line spacing, ordinary natural line boxes, and the existing fallback when Canvas font-box metrics are unavailable

## Root causes

The DOCX seed pass had acquired a document-wide publication gate when any header/footer reserve was detected. That prevented the viewer from receiving any opening pages for common long documents even though the progressive API already distinguishes provisional (`exact: false`) and authoritative publications.

The PPTX renderer reused an authored-font design-metric floor after browser font resolution for `spAutoFit` text. In short text boxes, the layout line could therefore be taller than the font Canvas actually painted, leaving excess space above a top-anchored glyph. The fix is scoped to the stale-floor boundary instead of changing all auto-fit text.

The anchor behavior remains specification-based: an omitted `bodyPr@anchor` is top-aligned (ECMA-376 Part 1 §21.1.2.1.1), and `spAutoFit` resizes the shape to contain its text (§21.1.2.1.4).

## Verification

- full test suite: 8,866 passed, 24 skipped
- TypeScript project build/typecheck
- focused DOCX progressive-layout and PPTX auto-fit boundary/counterexample tests
- DOCX layout boundary, compatibility, public API, and package-build architecture gates
- private release-base self-VRT: DOCX 50/50 exact pixel matches
- private release-base self-VRT and worker parity: PPTX 36/36 matches
- local public-site verification confirmed opening pages are published incrementally before final pagination completes

## Adversarial review

- no file-name, page-size, font-size, or sample-specific branches
- no new public mode or compatibility flag; the existing provisional publication contract remains the authority boundary
- live font measurement is bounded to the existing per-line layout pass and only affects the relevant `spAutoFit` design-floor case
- parser theme-font resolution, main-thread rendering, worker rendering, failure fallback, fixed text, and non-target auto-fit paths were checked
- DOCX final geometry is unchanged against the release base; the PPTX private corpus contains no instance of the newly covered boundary, so the fix itself is proven by synthetic specification/metric boundary tests while the VRT establishes non-regression

Closes #1458
Closes #1459
