### PR TITLE
fix(docx): keep contiguous underlines level

### DIFF
--- a/packages/docx/src/layout/line-compatibility.ts
+++ b/packages/docx/src/layout/line-compatibility.ts
@@ -191,7 +191,7 @@ export const WORD_CONTIGUOUS_UNDERLINE_GEOMETRY = defineCompatibilityRule({
   id: 'word-contiguous-underline-geometry',
   evidence: {
     kind: 'regression-test',
-    reference: 'packages/docx/src/layout/paragraph.test.ts#uses one safe baseline for a solid underline spanning adjacent source runs',
+    reference: 'packages/docx/src/layout/paragraph.test.ts#keeps a solid underline continuous across floating-precision retained run seams',
   },
   description: 'Adjacent compatible underlined source runs share one safe baseline and continuous authored cadence while style, color, and thickness boundaries remain distinct.',
 });

--- a/packages/docx/src/layout/paragraph.test.ts
+++ b/packages/docx/src/layout/paragraph.test.ts
@@ -1929,6 +1929,62 @@ describe('planLine visual geometry', () => {
     ]);
   });
 
+  it('keeps a solid underline continuous across floating-precision retained run seams', () => {
+    const seamPt = 300;
+    const driftedSeamPt = seamPt + Number.EPSILON * seamPt * 2;
+    const underline = (fromXPt: number, toXPt: number, yPt: number) => ({
+      kind: 'underline' as const,
+      from: { xPt: fromXPt, yPt }, to: { xPt: toXPt, yPt },
+      color: '#ff3333', widthPt: 1, style: 'solid' as const,
+    });
+    const first = {
+      ...measuredText('left  ', 0, seamPt),
+      decorations: [underline(0, seamPt, 16)],
+    };
+    const second = {
+      ...measuredText('right', 6, 20),
+      decorations: [underline(driftedSeamPt, 320, 17)],
+    };
+
+    const line = planLine({
+      paragraphXPt: 0, availableWidthPt: 400, alignment: 'left', baseRtl: false,
+      isFirstLine: true, isLastLine: true, stretchLastLine: false,
+      line: {
+        range: { start: 0, end: 11 }, topPt: 5, baselinePt: 15, advancePt: 14,
+        xOffsetPt: 0, availableWidthPt: 400, endsWithBreak: false,
+        segments: [first, second],
+      },
+    });
+
+    expect(line.placements).toMatchObject([
+      { kind: 'text', decorations: [{ from: { xPt: 0, yPt: 17 }, to: { xPt: 320, yPt: 17 } }] },
+      { kind: 'text', decorations: [] },
+    ]);
+  });
+
+  it('keeps a one-point underline gap across adjacent runs', () => {
+    const underline = (fromXPt: number, toXPt: number) => ({
+      kind: 'underline' as const,
+      from: { xPt: fromXPt, yPt: 16 }, to: { xPt: toXPt, yPt: 16 },
+      color: '#000000', widthPt: 1, style: 'solid' as const,
+    });
+    const first = { ...measuredText('aa', 0, 20), decorations: [underline(0, 20)] };
+    const second = { ...measuredText('bb', 2, 20), decorations: [underline(21, 40)] };
+
+    const line = planLine({
+      paragraphXPt: 0, availableWidthPt: 100, alignment: 'left', baseRtl: false,
+      isFirstLine: true, isLastLine: true, stretchLastLine: false,
+      line: {
+        range: { start: 0, end: 4 }, topPt: 5, baselinePt: 15, advancePt: 14,
+        xOffsetPt: 0, availableWidthPt: 100, endsWithBreak: false,
+        segments: [first, second],
+      },
+    });
+
+    expect(line.placements.map((placement) =>
+      placement.kind === 'text' ? placement.decorations?.length : 0)).toEqual([1, 1]);
+  });
+
   it('retains one wave cadence across adjacent underlined source runs', () => {
     const wave = (fromXPt: number, toXPt: number) => ({
       kind: 'underline' as const,

--- a/packages/docx/src/layout/paragraph.ts
+++ b/packages/docx/src/layout/paragraph.ts
@@ -595,6 +595,16 @@ function sameDashPattern(
   return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
+/** Decoration endpoints reconstruct the same retained run seam through
+ * independent justification sums. Their combined binary64 roundoff is bounded
+ * by the precision of both operands; this is not a visible layout tolerance. */
+function sameCoordinateWithinFloatingPrecision(left: number, right: number): boolean {
+  if (left === right) return true;
+  const combinedPrecision = Number.EPSILON
+    * Math.max(1, Math.abs(left) + Math.abs(right));
+  return Math.abs(left - right) <= combinedPrecision;
+}
+
 function sameContinuousDecoration(
   left: TextDecorationLayout,
   right: TextDecorationLayout,
@@ -605,7 +615,7 @@ function sameContinuousDecoration(
     && left.style === right.style
     && left.color === right.color
     && left.widthPt === right.widthPt
-    && left.to.xPt === right.from.xPt
+    && sameCoordinateWithinFloatingPrecision(left.to.xPt, right.from.xPt)
     && sameDashPattern(left.dashPatternPt, right.dashPatternPt);
 }
 

--- a/packages/docx/src/layout/paragraph.ts
+++ b/packages/docx/src/layout/paragraph.ts
@@ -600,9 +600,9 @@ function sameDashPattern(
  * by the precision of both operands; this is not a visible layout tolerance. */
 function sameCoordinateWithinFloatingPrecision(left: number, right: number): boolean {
   if (left === right) return true;
-  const combinedPrecision = Number.EPSILON
+  const roundoffBound = Number.EPSILON
     * Math.max(1, Math.abs(left) + Math.abs(right));
-  return Math.abs(left - right) <= combinedPrecision;
+  return Math.abs(left - right) <= roundoffBound;
 }
 
 function sameContinuousDecoration(


### PR DESCRIPTION
## Summary

- keep compatible adjacent DOCX underlines continuous when independently accumulated layout coordinates differ only by binary64 rounding
- retain the safer shared baseline across the joined decoration
- preserve genuine coordinate gaps and existing style, color, thickness, and dash boundaries

Closes #1462

## Verification

- focused paragraph layout and compatibility tests
- full DOCX test suite: 3,422 passed, 1 skipped
- full workspace test suite: 8,869 passed, 24 skipped
- TypeScript project build
- local before/after rendering against the reported document and Office reference

## Adversarial review

- Specification fidelity: the change preserves the authored `w:u` semantics from ECMA-376 §17.3.2.40 and only corrects numerical seam comparison in retained DOCX layout.
- Heuristics: the bound is derived from `Number.EPSILON` and the two operands, not a visible layout tolerance; a one-point-gap regression test remains split.
- Performance/resources: constant-time arithmetic in the existing comparison path, with no new allocations or retained resources.
- Boundaries/cross-format: the affected coalescing path is DOCX-specific; shared underline painting and XLSX/PPTX rendering remain unchanged.