### PR TITLE
fix(pptx): align top-anchored spAutoFit text

### DIFF
--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -4668,10 +4668,17 @@ export function renderTextBody(
       }
     }
     const baselineOffset = useResolvedFontMetrics && resolvedFontHeight > 0
-      ? Math.max(
-          maxAscent,
-          resolvedFontAscent + Math.max(0, lineHeight - resolvedFontHeight) / 2,
-        )
+      ? anchor === 't' && maxAscent > 0
+        // PowerPoint's spAutoFit recalculation seats the visible ink at the
+        // top inset for a top-anchored body. fontBoundingBoxAscent includes
+        // leading above that ink; using it here leaves the exact downward gap
+        // spAutoFit is meant to remove. Keep the font box for line advance and
+        // required height, but use the actual glyph ascent for this origin.
+        ? maxAscent
+        : Math.max(
+            maxAscent,
+            resolvedFontAscent + Math.max(0, lineHeight - resolvedFontHeight) / 2,
+          )
       : Math.max(lineHeight * 0.8, maxAscent);
     const baseline = cursorY + baselineOffset;
 

--- a/packages/pptx/src/sp-autofit-top-anchor.test.ts
+++ b/packages/pptx/src/sp-autofit-top-anchor.test.ts
@@ -5,7 +5,13 @@ import type { Paragraph, TextBody } from './types.js';
 
 const SCALE = 1 / 12700; // 1 point => 1 canvas unit
 
-function recordingContext(ascent: number, descent: number, exposeFontMetrics = true) {
+function recordingContext(
+  actualAscent: number,
+  actualDescent: number,
+  exposeFontMetrics = true,
+  fontAscent = actualAscent,
+  fontDescent = actualDescent,
+) {
   const draws: Array<{ text: string; y: number }> = [];
   let font = '';
   let fillStyle = '';
@@ -19,10 +25,10 @@ function recordingContext(ascent: number, descent: number, exposeFontMetrics = t
     set direction(value: CanvasDirection) { direction = value; },
     measureText: (text: string) => ({
       width: [...text].length * 20,
-      actualBoundingBoxAscent: ascent,
-      actualBoundingBoxDescent: descent,
+      actualBoundingBoxAscent: actualAscent,
+      actualBoundingBoxDescent: actualDescent,
       ...(exposeFontMetrics
-        ? { fontBoundingBoxAscent: ascent, fontBoundingBoxDescent: descent }
+        ? { fontBoundingBoxAscent: fontAscent, fontBoundingBoxDescent: fontDescent }
         : {}),
     }),
     fillText: (text: string, _x: number, y: number) => draws.push({ text, y }),
@@ -105,9 +111,17 @@ describe('pptx spAutoFit top anchoring', () => {
     // The resolved browser font can have a shorter font box than Meiryo's
     // 1.596em saved-design line. spAutoFit must recalculate from those live
     // metrics instead of reusing the document font's stale design-height floor.
-    const ascent = fontSize * 0.98;
-    const descent = fontSize * 0.37;
-    const { ctx, draws } = recordingContext(ascent, descent);
+    const actualAscent = fontSize * 0.78;
+    const actualDescent = fontSize * 0.18;
+    const fontAscent = fontSize * 0.98;
+    const fontDescent = fontSize * 0.37;
+    const { ctx, draws } = recordingContext(
+      actualAscent,
+      actualDescent,
+      true,
+      fontAscent,
+      fontDescent,
+    );
     renderTextBody(
       ctx,
       body(latin as string, eastAsian as string, fontSize as number),
@@ -119,7 +133,10 @@ describe('pptx spAutoFit top anchoring', () => {
     );
 
     expect(draws).toHaveLength(1);
-    expect(draws[0]!.y).toBeCloseTo(ascent, 5);
+    // PowerPoint PDF output places the visible glyph top at the top inset.
+    // Canvas therefore needs the actual glyph ascent for the first baseline,
+    // not the larger font-box ascent that includes leading above the ink.
+    expect(draws[0]!.y).toBeCloseTo(actualAscent, 5);
 
     const neededHeight = renderTextBody(
       ctx,
@@ -139,7 +156,39 @@ describe('pptx spAutoFit top anchoring', () => {
       undefined,
       true,
     );
-    expect(neededHeight).toBeCloseTo(ascent + descent, 5);
+    expect(neededHeight).toBeCloseTo(fontAscent + fontDescent, 5);
+  });
+
+  it.each(['ctr', 'b'] as const)(
+    'keeps the font-box baseline for explicitly %s-anchored spAutoFit text',
+    (verticalAnchor) => {
+      const fontSize = 32;
+      const actualAscent = fontSize * 0.78;
+      const fontAscent = fontSize * 0.98;
+      const fontDescent = fontSize * 0.37;
+      const { ctx, draws } = recordingContext(
+        actualAscent,
+        fontSize * 0.18,
+        true,
+        fontAscent,
+        fontDescent,
+      );
+      const textBody = { ...body('Meiryo', 'Meiryo', fontSize), verticalAnchor };
+      renderTextBody(ctx, textBody, 0, 0, 400, fontAscent + fontDescent, SCALE);
+
+      expect(draws[0]!.y).toBeCloseTo(fontAscent, 5);
+    },
+  );
+
+  it('falls back to the font-box baseline when Canvas exposes no glyph ascent', () => {
+    const fontSize = 32;
+    const fontAscent = fontSize * 0.98;
+    const fontDescent = fontSize * 0.37;
+    const { ctx, draws } = recordingContext(0, 0, true, fontAscent, fontDescent);
+
+    renderTextBody(ctx, body('Meiryo', 'Meiryo', fontSize), 0, 0, 400, 46, SCALE);
+
+    expect(draws[0]!.y).toBeCloseTo(fontAscent, 5);
   });
 
   it('falls back to the authored font design box when Canvas has no font metrics', () => {


### PR DESCRIPTION
## Outcome

Top-anchored `spAutoFit` text now follows PowerPoint when resolved font metrics differ from the metrics saved into a tight text box. No migration is required.

## Implementation

- Keep `fontBoundingBoxAscent/Descent` for live line height and required-height recalculation.
- Use `actualBoundingBoxAscent` for the drawing baseline only when live-metric `spAutoFit` is top-anchored, removing font leading above the visible ink.
- Preserve the existing font-box baseline for center/bottom anchors and fall back safely when Canvas exposes no usable glyph ascent.

## Verification

- `pnpm test` — 8,871 passed, 25 skipped
- `pnpm typecheck`
- focused spAutoFit and percentage-line-spacing tests — 13 passed
- complete private PPTX self-VRT against the 0.85.2 release: all unaffected documents were pixel-identical; only the two targeted slides changed
- both targeted changes were adjudicated against PowerPoint-produced PDF output (14px → 3px vs 3px, and 15px → 3px vs 4px top gap)
- worker/main parity passed, including both target slides

## Adversarial review

The change is limited to the DrawingML `bodyPr` + `spAutoFit` + top-anchor path. It adds no sample, path, font-name, font-size, or empirical threshold branches; performs no additional text measurement; and leaves fixed text, natural line boxes, non-top anchors, and missing-metric fallbacks under explicit counterexample tests.

Closes #1459