### PR TITLE
fix(viewer): await current opening paint

### DIFF
--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -1695,6 +1695,55 @@ describe('DocxScrollViewer — self-load path (T7 story)', () => {
     expect(engine.renderCalls.length).toBeGreaterThan(0);
     v.destroy();
   });
+
+  it('worker load waits for the current first paint when progressive layout supersedes the initial render', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(
+      1,
+      [{ widthPt: 100, heightPt: 200 }],
+      'worker',
+      true,
+    );
+    engine.setLayoutComplete(false);
+    const doc = engine.asDoc();
+    vi.spyOn(DocxDocument, 'load').mockResolvedValue(doc);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      mode: 'worker',
+      progressiveLayout: true,
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+
+    let loadSettled = false;
+    const load = v.load('sample.docx').then(() => {
+      loadSettled = true;
+    });
+    await vi.waitFor(() => expect(engine.bitmapCalls).toHaveLength(1));
+    const initial = engine.bitmapCalls[0]!;
+
+    // A progressive publication invalidates the bitmap that load() originally
+    // collected. Its replacement is the first paint users will actually see.
+    publishDocxLayout(doc, { pageCount: 1, exact: false, complete: false });
+    initial.resolve();
+    await vi.waitFor(() => expect(engine.bitmapCalls).toHaveLength(2));
+
+    // load() must remain pending while the current-epoch replacement is pending;
+    // otherwise hosts that reveal the viewer after load() expose a blank canvas.
+    expect(loadSettled).toBe(false);
+
+    const current = engine.bitmapCalls[1]!;
+    current.resolve();
+    await load;
+
+    const slot = scrollHost.children.find((child) =>
+      child.children.some((nested) => nested.tag === 'canvas')) as FakeEl | undefined;
+    const canvas = slot?.children.find((child) => child.tag === 'canvas') as FakeEl | undefined;
+    expect(canvas?._bitmapCtx?.lastBitmap).toBe(engine.createdBitmaps[1]);
+    v.destroy();
+  });
 });
 
 describe('DocxScrollViewer — text selection (T5)', () => {

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -1731,8 +1731,23 @@ export class DocxScrollViewer implements ZoomableViewer {
         !this._destroyed
       ) {
         // live.renderedPage === i already (set by _renderSlot on mount); the fresh
-        // dispatch runs at the CURRENT epoch/scale via _pageWidthPx(i).
-        void this._renderSlotBitmap(i, live, this._pageWidthPx(i), this._dpr(), this._scale);
+        // dispatch runs at the CURRENT epoch/scale via _pageWidthPx(i). Keep the
+        // replacement in this Promise chain: load() awaits the render originally
+        // mounted for the opening window, and must therefore follow superseding
+        // epochs until the render that can actually commit has finished. Callers
+        // that intentionally fire-and-forget this method still do so at their
+        // outer call site.
+        const nextDispatcher = live.dispatcher;
+        await this._renderSlotBitmap(
+          i,
+          live,
+          this._pageWidthPx(i),
+          this._dpr(),
+          this._scale,
+          nextDispatcher,
+          nextDispatcher.begin(),
+          reportErrors,
+        );
       }
     }
   }

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -1446,6 +1446,48 @@ describe('PptxScrollViewer — self-load path (T7 story)', () => {
     expect(engine.renderCalls.length).toBeGreaterThan(0);
     v.destroy();
   });
+
+  it('worker load waits for the current first paint when the render epoch changes', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(
+      1,
+      SLIDE_W_EMU,
+      SLIDE_H_EMU,
+      'worker',
+      true,
+    );
+    vi.spyOn(PptxPresentation, 'load').mockResolvedValue(engine.asPres());
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      mode: 'worker',
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+
+    let loadSettled = false;
+    const load = v.load('sample.pptx').then(() => {
+      loadSettled = true;
+    });
+    await vi.waitFor(() => expect(engine.bitmapCalls).toHaveLength(1));
+    const initial = engine.bitmapCalls[0]!;
+
+    v.setScale(v.scaleForTest() * 2);
+    initial.resolve();
+    await vi.waitFor(() => expect(engine.bitmapCalls).toHaveLength(2));
+    expect(loadSettled).toBe(false);
+
+    const current = engine.bitmapCalls[1]!;
+    current.resolve();
+    await load;
+
+    const slot = scrollHost.children.find((child) =>
+      child.children.some((nested) => nested.tag === 'canvas')) as FakeEl | undefined;
+    const canvas = slot?.children.find((child) => child.tag === 'canvas') as FakeEl | undefined;
+    expect(canvas?._bitmapCtx?.lastBitmap).toBe(engine.createdBitmaps[1]);
+    v.destroy();
+  });
 });
 
 describe('PptxScrollViewer — interactive media lifecycle', () => {

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -1786,8 +1786,23 @@ export class PptxScrollViewer implements ZoomableViewer {
         !(this._opts.enableMediaPlayback && live.mediaInteractive)
       ) {
         // live.renderedSlide === i already (set by _renderSlot on mount); the fresh
-        // dispatch runs at the CURRENT epoch/scale via _slideWidthPx().
-        void this._renderSlotBitmap(i, live, this._slideWidthPx(), this._dpr(), this._scale);
+        // dispatch runs at the CURRENT epoch/scale via _slideWidthPx(). Keep the
+        // replacement in this Promise chain so load() cannot resolve after a
+        // superseded opening render but before the bitmap that can actually
+        // commit. Fire-and-forget callers retain that behavior at their outer
+        // call site.
+        const nextDispatcher = live.dispatcher;
+        await this._renderSlotBitmap(
+          i,
+          live,
+          this._slideWidthPx(),
+          this._dpr(),
+          this._scale,
+          ++live.renderGeneration,
+          nextDispatcher,
+          nextDispatcher.begin(),
+          reportErrors,
+        );
       }
     }
   }


### PR DESCRIPTION
## Outcome

Worker-mode DOCX and PPTX scroll viewers now keep `load()` pending until the opening render that is still eligible to commit has finished. Hosts that reveal the viewer after awaiting `load()` no longer expose the canvas element's default blank size when an initial bitmap is superseded.

Progressive layout remains progressive: this waits only for the opening mounted render chain, not whole-document pagination. No migration is required.

## Root cause and fix

The viewers already discarded stale bitmaps and dispatched a current-epoch replacement. That replacement was fire-and-forget, however, so the promise collected by `load()` ended with the stale request.

The redispatch now remains in the same promise chain. Existing bitmap cleanup, coalescing, bounded failure behavior, and background error routing are preserved. Deterministic tests cover both the DOCX progressive-publication race and the equivalent PPTX render-epoch race.

Fixes #1467

## Verification

- DOCX scroll viewer: 129 tests passed
- PPTX scroll viewer: 137 tests passed
- Full workspace Vitest run: 8,865 tests passed; six loopback-binding tests blocked by the restricted sandbox passed when rerun with loopback access
- DOCX architecture boundary, compatibility, public-API, and package-build gates passed
- TypeScript build and `git diff --check` passed
- Browser observation confirmed the local Try Yours page remained hidden while the default canvas existed and first became visible only after the correctly sized bitmap was committed

## Adversarial review

APPROVE. The change alters promise ownership only: it introduces no sample-specific condition, rendering heuristic, additional render dispatch, whole-document wait, OOXML behavior, parser/layout mutation, paint-time work, public API change, or cross-package dependency. DOCX and PPTX sibling implementations and stale/error paths were inspected together.
