### PR TITLE
chore(release): 0.85.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ the corresponding minor release.
 
 ## Unreleased
 
+## 0.85.3 — 2026-09-04
+
+Compatible patch release improving progressive Word opening, PowerPoint text
+alignment, underline continuity, and worker-mode first paint.
+
+- **progressive Word opening:** safe provisional page prefixes are published
+  while header and footer pagination converges, so later pages keep arriving
+  without requiring the reader to scroll. The authoritative final layout still
+  replaces provisional pagination atomically.
+- **stable worker first paint:** DOCX and PPTX scroll-viewer loads wait for the
+  current opening page or slide bitmap, preventing a transient browser-default
+  canvas from becoming visible before the real content.
+- **PowerPoint text placement:** `spAutoFit` text uses resolved browser font
+  metrics when a saved shape height is stale, preserving top alignment for
+  large-format slides without changing fixed-size or explicitly spaced text.
+- **continuous Word underlines:** adjacent underlined runs whose shared boundary
+  differs only by floating-point roundoff paint as one continuous underline,
+  while authored gaps remain visible.
+- **compatibility:** no existing option or method is removed or renamed, and no
+  application changes are required.
+
 ## 0.85.2 — 2026-09-03
 
 Patch release restoring smooth progressive viewing in worker mode and fixing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.85.2"
+version = "0.85.3"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.85.2",
+  "version": "0.85.3",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.85.2",
+  "version": "0.85.3",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.85.2",
+  "version": "0.85.3",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.85.2",
+  "version": "0.85.3",
   "description": "Internal workspace adapter for DOCX / XLSX / PPTX Markdown projection",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.85.2"
+version = "0.85.3"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.85.2",
+  "version": "0.85.3",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.85.2",
+  "version": "0.85.3",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity local viewer for Office files (.docx / .xlsx / .pptx), powered by Rust/WASM and Canvas. Optional MCP integration can share requested context with an AI agent.",
-  "version": "0.85.2",
+  "version": "0.85.3",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.85.2",
+  "version": "0.85.3",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.85.2",
+  "version": "0.85.3",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",

--- a/site/src/announcement-content.test.ts
+++ b/site/src/announcement-content.test.ts
@@ -200,13 +200,13 @@ describe('v0.81 ChartEx migration guide', () => {
 
 describe('stable documentation boundaries', () => {
   it('keeps the current bundle measurements on one stable page', () => {
-    expect(bundleSizePage).toContain('Current production assets for v0.85.2');
+    expect(bundleSizePage).toContain('Current production assets for v0.85.3');
     expect(bundleSizePage).toContain('DOCX static JavaScript');
     expect(bundleSizePage).toMatch(/<td>1,967 KiB<\/td>\s*<td>479 KiB<\/td>/);
     expect(bundleSizePage).toContain('XLSX static JavaScript');
     expect(bundleSizePage).toMatch(/<td>1,283 KiB<\/td>\s*<td>306 KiB<\/td>/);
     expect(bundleSizePage).toContain('PPTX static JavaScript');
-    expect(bundleSizePage).toMatch(/<td>1,329 KiB<\/td>\s*<td>311 KiB<\/td>/);
+    expect(bundleSizePage).toMatch(/<td>1,330 KiB<\/td>\s*<td>311 KiB<\/td>/);
     expect(bundleSizePage).toContain('<tr><th>DOCX parser WASM</th><td>1,786 KiB</td><td>741 KiB</td></tr>');
     expect(bundleSizePage).toContain('<tr><th>PPTX parser WASM</th><td>1,650 KiB</td><td>649 KiB</td></tr>');
     expect(bundleSizePage).toContain('ChartEx');

--- a/site/src/pages/bundle-size.astro
+++ b/site/src/pages/bundle-size.astro
@@ -15,7 +15,7 @@ import SiteFooter from '../components/SiteFooter.astro';
       <div class="wrap">
         <p class="eyebrow">Current measurement</p>
         <h1>Bundle size.</h1>
-        <p>Current production assets for v0.85.2.</p>
+        <p>Current production assets for v0.85.3.</p>
       </div>
     </header>
 
@@ -38,7 +38,7 @@ import SiteFooter from '../components/SiteFooter.astro';
             </tr>
             <tr>
               <th>PPTX static JavaScript</th>
-              <td>1,329 KiB</td>
+              <td>1,330 KiB</td>
               <td>311 KiB</td>
             </tr>
           </tbody>


### PR DESCRIPTION
## Outcome

Prepares the compatible 0.85.3 patch release with smoother progressive Word
opening, correct PowerPoint spAutoFit top alignment, continuous Word
underlines, and a stable first visible paint in DOCX and PPTX worker scroll
viewers.

No migration is required. Existing options and methods remain available.

## Release updates

- bumps all npm, VS Code extension, site, and MCP package versions to 0.85.3
- adds the 0.85.3 changelog entry
- refreshes measured production bundle sizes
- reviews the README, public API documentation, and capability summary against
  the current implementation
- regenerates all three README screenshots; they remain byte-identical

## Verification

- focused regressions: 372 passed
- full workspace suite: 8,866 passed and 26 skipped; the sandbox-blocked
  loopback cases passed when their complete 12-test files were rerun outside
  the network sandbox
- DOCX architecture gates: final boundary check, 89 boundary tests, 17
  compatibility-evidence tests, 26 public-API audit tests, and package-boundary
  tests passed
- package and site production builds, full typecheck, Cargo check, declaration
  baselines, viewer API symmetry, and optional-module boundaries passed
- production browser verification: 24 multi-browser smoke tests, 6 site runtime
  tests, and 2 packaged worker tests passed
- README screenshot smoke: 3 passed
- private self-VRT against the immutable v0.85.2 renderer: DOCX 47/50 documents
  exact, with all three changed pages individually Office-adjudicated as
  intended continuous-underline improvements; PPTX 18/19 documents exact, with
  both changed slides in the purpose-built validation deck matching the
  PowerPoint PDF; PPTX main/worker parity 19/19
- mandatory adversarial review: APPROVE
