### PR TITLE
fix(pptx): match PowerPoint multiline text flow

### DIFF
--- a/packages/pptx/src/cjk-latin-word-wrap.test.ts
+++ b/packages/pptx/src/cjk-latin-word-wrap.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { TextRunData } from '@silurus/ooxml-core';
+import { layoutParagraph } from './renderer.js';
+import type { Paragraph } from './types.js';
+
+function mockCtx(): CanvasRenderingContext2D {
+  let font = '';
+  return {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    measureText: (text: string) => ({ width: [...text].length * 10 }),
+    fillRect() {},
+    fillText() {},
+    fillStyle: '',
+    strokeStyle: '',
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function run(text: string, fontFamily = 'Arial'): TextRunData {
+  return {
+    type: 'text',
+    text,
+    bold: null,
+    italic: null,
+    underline: false,
+    strikethrough: false,
+    fontSize: 20,
+    color: '000000',
+    fontFamily,
+    fontFamilyEa: 'Meiryo',
+  };
+}
+
+function paragraph(runs: TextRunData[]): Paragraph {
+  return {
+    alignment: 'l',
+    marL: 0,
+    marR: 0,
+    indent: 0,
+    spaceBefore: null,
+    spaceAfter: null,
+    spaceLine: null,
+    lvl: 0,
+    bullet: { type: 'none' },
+    defFontSize: null,
+    defColor: null,
+    defBold: null,
+    defItalic: null,
+    defFontFamily: null,
+    tabStops: [],
+    eaLnBrk: true,
+    runs,
+  } as Paragraph;
+}
+
+function lines(runs: TextRunData[], width = 70): string[] {
+  return layoutParagraph(
+    mockCtx(), paragraph(runs), width, 20, '000000', 1, 0,
+  ).map((line) => line.segments.map((segment) => segment.text).join(''));
+}
+
+describe('pptx CJK/Latin word wrapping (#1474)', () => {
+  it('moves a Latin word intact after CJK text in the same DrawingML run', () => {
+    expect(lines([run('日本語Power')])).toEqual(['日本語', 'Power']);
+  });
+
+  it('moves a Latin word intact after CJK text across a formatting-run boundary', () => {
+    expect(lines([run('日本語'), run('Power', 'Courier New')]))
+      .toEqual(['日本語', 'Power']);
+  });
+
+  it('does not invent a break across a formatting seam inside a Latin word', () => {
+    expect(lines([run('YoY+'), run('11.9%', 'Courier New')]))
+      .toEqual(['YoY+11.9%']);
+  });
+});

--- a/packages/pptx/src/percentage-line-spacing.test.ts
+++ b/packages/pptx/src/percentage-line-spacing.test.ts
@@ -6,12 +6,12 @@ import type { TextRun } from '@silurus/ooxml-core';
 /**
  * DrawingML percentage line spacing is authored explicitly by `a:lnSpc >
  * a:spcPct` (ECMA-376 §21.1.2.2.5 / §21.1.2.2.11). It is based on the
- * largest text size on the line. A document-font design-height floor used for
- * implicit single spacing must therefore not override an explicit percentage.
+ * largest text size on the line. The same natural single-line base is used
+ * when `a:lnSpc` is omitted; a font's design box is not the baseline pitch.
  *
  * The regression was visible with Meiryo UI: its 1.596-em design-height floor
- * expanded an authored 100% line pitch, while PowerPoint kept the same pitch as
- * another face at the same point size.
+ * expanded the pitch, while PowerPoint kept the same 120%-of-point-size natural
+ * pitch as Arial for fixed and spAutoFit shapes.
  */
 
 const SCALE = 1 / 12700; // 1 pt => 1 px
@@ -147,10 +147,12 @@ describe('pptx DrawingML percentage line spacing', () => {
       .toBeCloseTo(baselinePitch('Arial', pct100, bullet), 5);
   });
 
-  it('keeps the Meiryo design-height floor for implicit single spacing', () => {
-    expect(baselinePitch('Meiryo UI', null))
-      .toBeGreaterThan(baselinePitch('Arial', null));
-  });
+  it.each(['Meiryo UI', 'Arial'])(
+    'uses the natural 120%% pitch for omitted line spacing in %s',
+    (fontFamily) => {
+      expect(baselinePitch(fontFamily, null)).toBeCloseTo(20 * 1.2, 5);
+    },
+  );
 
   it('keeps absolute point line spacing independent of the font design height', () => {
     const pts18: Paragraph['spaceLine'] = { type: 'pts', val: 18 };

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -102,7 +102,6 @@ import {
   symbolFontToUnicode,
   isSymbolFontFamily,
   drawUnderline,
-  intendedSingleLinePx,
   hasTextWarp,
   buildWarpEnvelope,
   warpGlyphTransform,
@@ -648,15 +647,6 @@ type LayoutSegment = {
   isTab?: true;
   /** Reading-frame gap resolved against a:tabLst immediately before paint. */
   tabWidthPx?: number;
-  /**
-   * Raw (normalized) font-family requested for this segment's glyphs, kept
-   * alongside the composed CSS `font` string so the line-height pass can floor
-   * the single-line box to the DOCUMENT font's design line height via core's
-   * `intendedSingleLinePx` (ECMA-376 §17.3.1.33 single spacing). Only the
-   * tabled substituted faces (Meiryo / Sakkal Majalla) raise the floor; every
-   * other family returns 0 and leaves PowerPoint's flat 1.2×em untouched.
-   */
-  fontFamily?: string;
   sizePx: number;
   /**
    * Actual glyph size used for paint and width measurement. PowerPoint renders
@@ -1386,8 +1376,6 @@ export function layoutParagraph(
       reflection?: import('@silurus/ooxml-core').Reflection;
       outline?: import('@silurus/ooxml-core').TextOutline;
       highlight?: string;
-      /** Raw normalized family for the design-line-height floor (see LayoutSegment). */
-      fontFamily?: string;
       /** Resolved hyperlink target (IX1) — passed through to the overlay span. */
       hyperlink?: HyperlinkTarget;
       sourceRunId?: number;
@@ -1409,7 +1397,6 @@ export function layoutParagraph(
     const reflection = extras?.reflection;
     const outline = extras?.outline;
     const highlight = extras?.highlight;
-    const fontFamily = extras?.fontFamily;
     const hyperlink = extras?.hyperlink;
     const drawSizePx = extras?.drawSizePx ?? sizePx;
     // Shadow / outline use object identity for merging — adjacent runs share
@@ -1431,7 +1418,6 @@ export function layoutParagraph(
       a.reflection === reflection &&
       a.outline === outline &&
       (a.highlight ?? '') === (highlight ?? '') &&
-      (a.fontFamily ?? '') === (fontFamily ?? '') &&
       (a.drawSizePx ?? a.sizePx) === drawSizePx &&
       hyperlinkKey(a.hyperlink) === hyperlinkKey(hyperlink) &&
       (lsPx === 0 || a.sourceRunId === sourceRunId);
@@ -1463,7 +1449,7 @@ export function layoutParagraph(
         && sourceRunId != null && last.sourceRunId === sourceRunId
         ? lsPx
         : 0;
-      currentLine.segments.push({ text, font, fontFamily, sizePx, drawSizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, sourceRunId, leadingLetterSpacingPx: leadingLetterSpacingPx || undefined, baseline, shadow, reflection, outline, highlight, hyperlink });
+      currentLine.segments.push({ text, font, sizePx, drawSizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, sourceRunId, leadingLetterSpacingPx: leadingLetterSpacingPx || undefined, baseline, shadow, reflection, outline, highlight, hyperlink });
     }
   };
 
@@ -1505,7 +1491,6 @@ export function layoutParagraph(
       reflection: seg.reflection,
       outline: seg.outline,
       highlight: seg.highlight,
-      fontFamily: seg.fontFamily,
       sourceRunId: seg.sourceRunId,
       drawSizePx: seg.drawSizePx,
     });
@@ -1620,10 +1605,6 @@ export function layoutParagraph(
       shadow: run.shadow,
       reflection: run.reflection,
       outline: run.outline,
-      // Raw latin/primary family for the design-line-height floor. CJK per-char
-      // pushes below override this to `familyEa` when they draw with `fontEa`,
-      // so a Meiryo set only as the East Asian typeface is still floored.
-      fontFamily: family,
       // §21.1.2.3.4 — highlight is a resolved hex (6-char opaque or 8-char
       // RRGGBBAA); hexToRgba handles both, matching how text/underline colours
       // are converted for canvas.
@@ -1660,7 +1641,6 @@ export function layoutParagraph(
             text: '',
             isTab: true,
             font,
-            fontFamily: family,
             sizePx,
             color,
             underline: false,
@@ -1748,7 +1728,7 @@ export function layoutParagraph(
         // forbidden-set element (w:noLineBreaksBefore/After are WordprocessingML-only).
         // docx's analogous CJK path (renderer.ts, fitCJKPrefix) is intentionally
         // separate: substring binary-search fit + cross-run 追い出し. Do not unify them.
-        const measured: (MeasuredChar & { font: string; family: string })[] = [];
+        const measured: (MeasuredChar & { font: string })[] = [];
         let westernWord = '';
         const flushWesternWord = (): void => {
           if (westernWord === '') return;
@@ -1757,7 +1737,6 @@ export function layoutParagraph(
             ch: westernWord,
             w: measureTextAdvance(ctx, westernWord, lsPx),
             font,
-            family,
           });
           westernWord = '';
         };
@@ -1769,11 +1748,8 @@ export function layoutParagraph(
           }
           flushWesternWord();
           const chFont = familyEa != null ? fontEa : font;
-          // Floor to the family actually rendering this glyph: `familyEa` for
-          // CJK when an East Asian typeface was declared, else the latin family.
-          const chFamily = familyEa != null ? familyEa : family;
           ctx.font = chFont;
-          measured.push({ ch, w: measureTextAdvance(ctx, ch, 0), font: chFont, family: chFamily });
+          measured.push({ ch, w: measureTextAdvance(ctx, ch, 0), font: chFont });
         }
         flushWesternWord();
         if (para.eaLnBrk === false) {
@@ -1789,7 +1765,7 @@ export function layoutParagraph(
             + (leadingBoundary && measured.length > 0 ? lsPx : 0);
           if (lineW > 0 && !fitsW(tokenW)) newLine();
           for (const m of measured) {
-            push(m.ch, m.font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, { ...segExtras, fontFamily: m.family });
+            push(m.ch, m.font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
           }
           continue;
         }
@@ -1822,7 +1798,7 @@ export function layoutParagraph(
           }
           for (let i = 0; i < n; i++) {
             const m = rest[i];
-            push(m.ch, m.font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, { ...segExtras, fontFamily: m.family });
+            push(m.ch, m.font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
           }
           rest = rest.slice(n);
           if (rest.length > 0) newLine();
@@ -1880,8 +1856,7 @@ export function layoutParagraph(
           const flush = (): void => {
             if (runText === '') return;
             const pFont = runEa ? (fontEa as string) : font;
-            const pFamily = runEa ? (familyEa as string) : family;
-            push(runText, pFont, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, { ...segExtras, fontFamily: pFamily });
+            push(runText, pFont, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
             runText = '';
           };
           for (const ch of piece) {
@@ -4353,20 +4328,10 @@ export function renderTextBody(
       // defaults like `defRPr sz="30000"` (300pt prompt-text marker) would
       // inflate lineHeight and push real 24pt runs far below the anchor.
       let maxSizePx = 0;
-      // Design single-line-height FLOOR for IMPLICIT single spacing, shared
-      // with docx via core's `intendedSingleLinePx`. For a substituted face
-      // whose Windows design line height is taller than the 1.2×em fallback
-      // (Meiryo 1.596×em, Sakkal Majalla 1.3965×em), the floor keeps fixed
-      // shapes from collapsing. spAutoFit is recalculated from the resolved
-      // browser face below, so its omitted `<a:lnSpc>` path does not inherit
-      // that authored-face floor. Neither path may override an explicitly
-      // authored `<a:spcPct>`; §21.1.2.2.5 / §21.1.2.2.11 define percentage
-      // spacing from the line's largest text size.
-      let designSingle = 0;
-      // spAutoFit is recalculated by the consuming application. Measure the
-      // fonts Canvas actually resolved (including browser substitutions) so
-      // that a shape saved with another machine's font metrics is not laid out
-      // again with those stale design metrics.
+      // Measure the fonts Canvas actually resolved (including browser
+      // substitutions). A tall live font box is retained for containment under
+      // spAutoFit, but PowerPoint does not repeat that box as the implicit
+      // baseline pitch when `<a:lnSpc>` is omitted.
       let resolvedFontLine = 0;
       for (const seg of line.segments) {
         // For an equation, the line must be at least as tall as its own font
@@ -4378,10 +4343,7 @@ export function renderTextBody(
           ? Math.max(seg.sizePx, (seg.math.ascent + seg.math.descent) / 1.2)
           : seg.sizePx;
         if (effSize > maxSizePx) maxSizePx = effSize;
-        // Equations carry no text family; only text segments contribute a floor.
         if (!seg.math) {
-          const ds = intendedSingleLinePx(seg.fontFamily, seg.sizePx);
-          if (ds > designSingle) designSingle = ds;
           if (isSpAutoFit) {
             ctx.font = seg.font;
             const metrics = ctx.measureText(seg.text || 'M');
@@ -4407,23 +4369,21 @@ export function renderTextBody(
       }
 
       // PowerPoint's natural single-line pitch is 120% of the authored text size.
+      // An Office-produced boundary deck confirms that this is independent of
+      // the chosen font and of spAutoFit: Meiryo and Arial, fixed and spAutoFit
+      // shapes all keep the same omitted-lnSpc pitch at a given point size.
       // An explicit percentage is instead based directly on that authored size
       // (ECMA-376 §21.1.2.2.5/.11). Table measurement therefore retains the
       // natural 120% box only when line spacing is omitted in an auto-height
       // row. A positive a:tr@h remains a minimum and uses the glyph-size box for
-      // overflow measurement. Both exclude a substituted font's larger
-      // design-metric floor; glyph painting may keep that floor below without
-      // enlarging the table structure.
+      // overflow measurement. Neither path substitutes the font's design box
+      // for PowerPoint's natural baseline pitch.
       const naturalSingle = maxSizePx * 1.2;
-      const useResolvedFontMetrics = isSpAutoFit
-        && designSingle > naturalSingle
-        && resolvedFontLine > 0;
+      const useResolvedFontMetrics = isSpAutoFit && resolvedFontLine > naturalSingle;
       // A live resolved font box describes containment, not baseline advance.
       // Keeping the two values separate prevents a tall Meiryo design box from
       // being repeated between every pair of lines under spAutoFit (#1473).
-      const implicitSingle = isSpAutoFit && resolvedFontLine > 0
-        ? naturalSingle
-        : Math.max(naturalSingle, designSingle);
+      const implicitSingle = naturalSingle;
       let lineHeight: number;
       if (para.spaceLine) {
         if (para.spaceLine.type === 'pct') {

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1728,8 +1728,12 @@ export function layoutParagraph(
       // whole. A CJK token with no SEA is unchanged.
       const routeCjk = hasCJK && (!containsSeaScript(token) || para.eaLnBrk === false);
       if (routeCjk) {
-        // Measure each grapheme with its per-char font (latin/ea boundary stays
-        // clean), then place chars according to a:pPr@eaLnBrk (ECMA-376
+        // Measure each CJK grapheme with its EA font, but keep every contiguous
+        // non-CJK span as ONE word unit. A mixed run such as `日本語Power`
+        // may wrap at the CJK/Latin boundary, never between the Latin letters.
+        // This is the same word-vs-CJK distinction used by the XLSX wrapper;
+        // previously this path treated every Latin letter as a CJK break unit.
+        // Place the resulting units according to a:pPr@eaLnBrk (ECMA-376
         // §21.1.2.2.7, "East Asian Line Break"):
         //   • eaLnBrk=true (default) → East Asian text MAY break at character
         //     boundaries, so we wrap char-by-char with kinsoku (§17.15.1.58–.60):
@@ -1745,15 +1749,33 @@ export function layoutParagraph(
         // docx's analogous CJK path (renderer.ts, fitCJKPrefix) is intentionally
         // separate: substring binary-search fit + cross-run 追い出し. Do not unify them.
         const measured: (MeasuredChar & { font: string; family: string })[] = [];
+        let westernWord = '';
+        const flushWesternWord = (): void => {
+          if (westernWord === '') return;
+          ctx.font = font;
+          measured.push({
+            ch: westernWord,
+            w: measureTextAdvance(ctx, westernWord, lsPx),
+            font,
+            family,
+          });
+          westernWord = '';
+        };
         for (const ch of token) {
-          const isEa = isCjkBreakChar(ch.codePointAt(0) ?? 0) && familyEa != null;
-          const chFont = isEa ? fontEa : font;
+          const isCjk = isCjkBreakChar(ch.codePointAt(0) ?? 0);
+          if (!isCjk) {
+            westernWord += ch;
+            continue;
+          }
+          flushWesternWord();
+          const chFont = familyEa != null ? fontEa : font;
           // Floor to the family actually rendering this glyph: `familyEa` for
           // CJK when an East Asian typeface was declared, else the latin family.
-          const chFamily = isEa ? (familyEa as string) : family;
+          const chFamily = familyEa != null ? familyEa : family;
           ctx.font = chFont;
           measured.push({ ch, w: measureTextAdvance(ctx, ch, 0), font: chFont, family: chFamily });
         }
+        flushWesternWord();
         if (para.eaLnBrk === false) {
           // Keep the East Asian word whole. If the current line already has
           // content and the token would overflow, wrap once before placing it;
@@ -1913,7 +1935,17 @@ export function layoutParagraph(
         // unbroken sequence of non-whitespace text (e.g. "YoY+11.9%" split
         // across mixed-size runs). Office never breaks mid-sequence in that
         // case; it lets the shape overflow and relies on spAutoFit / lIns to
-        // size the bbox correctly. Match that behavior.
+        // size the bbox correctly. A CJK/Latin script boundary is different:
+        // it is a real soft-wrap opportunity even without ASCII whitespace, so
+        // move the incoming Latin word intact rather than overflowing it.
+        const previousText = currentLine.segments.at(-1)?.text ?? '';
+        const previousCp = [...previousText].at(-1)?.codePointAt(0);
+        const firstCp = token.codePointAt(0);
+        const cjkBoundary = previousCp !== undefined
+          && firstCp !== undefined
+          && isCjkBreakChar(previousCp) !== isCjkBreakChar(firstCp)
+          && !isUax14NoBreakPair(previousCp, firstCp);
+        if (cjkBoundary && lineW > 0) newLine();
         push(token, font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
       } else {
         // UAX #14 segment-boundary glue: LB13 keeps a non-starter with the word
@@ -4142,10 +4174,19 @@ export function renderTextBody(
   }
 
   // buildLayout runs Pass 1 at a given font scale (1.0 = normal; <1 = normAutoFit shrink)
-  const buildLayout = (fontScale: number): { allLines: LineEntry[], totalHeight: number } => {
+  const buildLayout = (fontScale: number): {
+    allLines: LineEntry[];
+    totalHeight: number;
+    requiredHeight: number;
+  } => {
   const bodyDefaultFontSizePx = (body.defaultFontSize ?? 18) * PT_TO_EMU * scale * fontScale;
   const allLines: LineEntry[] = [];
   let totalHeight = 0;
+  // Visual bounds may be taller than the baseline advance. This is especially
+  // important for spAutoFit: the live Canvas font box must enlarge the SHAPE
+  // enough to contain the last line, but must not silently become the pitch of
+  // every preceding line when a:lnSpc is omitted (#1473).
+  let requiredHeight = 0;
 
   // AutoNum counters per list level
   const autoNumCounters = new Map<number, number>();
@@ -4315,8 +4356,10 @@ export function renderTextBody(
       // Design single-line-height FLOOR for IMPLICIT single spacing, shared
       // with docx via core's `intendedSingleLinePx`. For a substituted face
       // whose Windows design line height is taller than the 1.2×em fallback
-      // (Meiryo 1.596×em, Sakkal Majalla 1.3965×em), the floor keeps omitted
-      // `<a:lnSpc>` from collapsing. It must not override an explicitly
+      // (Meiryo 1.596×em, Sakkal Majalla 1.3965×em), the floor keeps fixed
+      // shapes from collapsing. spAutoFit is recalculated from the resolved
+      // browser face below, so its omitted `<a:lnSpc>` path does not inherit
+      // that authored-face floor. Neither path may override an explicitly
       // authored `<a:spcPct>`; §21.1.2.2.5 / §21.1.2.2.11 define percentage
       // spacing from the line's largest text size.
       let designSingle = 0;
@@ -4363,7 +4406,7 @@ export function renderTextBody(
         maxSizePx = bulletImage.sizePx;
       }
 
-      // PowerPoint's natural single-line box is 120% of the authored text size.
+      // PowerPoint's natural single-line pitch is 120% of the authored text size.
       // An explicit percentage is instead based directly on that authored size
       // (ECMA-376 §21.1.2.2.5/.11). Table measurement therefore retains the
       // natural 120% box only when line spacing is omitted in an auto-height
@@ -4375,8 +4418,11 @@ export function renderTextBody(
       const useResolvedFontMetrics = isSpAutoFit
         && designSingle > naturalSingle
         && resolvedFontLine > 0;
-      const implicitSingle = useResolvedFontMetrics
-        ? Math.max(naturalSingle, resolvedFontLine)
+      // A live resolved font box describes containment, not baseline advance.
+      // Keeping the two values separate prevents a tall Meiryo design box from
+      // being repeated between every pair of lines under spAutoFit (#1473).
+      const implicitSingle = isSpAutoFit && resolvedFontLine > 0
+        ? naturalSingle
         : Math.max(naturalSingle, designSingle);
       let lineHeight: number;
       if (para.spaceLine) {
@@ -4437,14 +4483,23 @@ export function renderTextBody(
         para,
         useResolvedFontMetrics,
       });
+      const lineTop = totalHeight + topGap;
       totalHeight += linePx + topGap;
+      const requiredLineHeight = useResolvedFontMetrics
+        ? Math.max(lineHeight, resolvedFontLine)
+        : lineHeight;
+      requiredHeight = Math.max(
+        requiredHeight,
+        totalHeight,
+        lineTop + requiredLineHeight + (isLast ? spaceAfterPx : 0),
+      );
     }
   }
 
-  return { allLines, totalHeight };
+  return { allLines, totalHeight, requiredHeight };
   }; // end buildLayout
 
-  let { allLines, totalHeight } = buildLayout(1.0);
+  let { allLines, totalHeight, requiredHeight } = buildLayout(1.0);
 
   // ── normAutoFit ──────────────────────────────────────────────────────────
   // PowerPoint stores the font-shrink ratio it computed at edit time in
@@ -4454,16 +4509,16 @@ export function renderTextBody(
   // was stored do we fall back to fitting the text by search.
   if (body.autoFit === 'norm') {
     if (body.fontScale != null && body.fontScale > 0) {
-      if (body.fontScale < 1.0) ({ allLines, totalHeight } = buildLayout(body.fontScale));
+      if (body.fontScale < 1.0) ({ allLines, totalHeight, requiredHeight } = buildLayout(body.fontScale));
     } else {
       const maxContentH = bh - tPad - bPad;
-      if (totalHeight > maxContentH && maxContentH > 0) {
+      if (requiredHeight > maxContentH && maxContentH > 0) {
         let lo = 0.1, hi = 1.0;
         for (let i = 0; i < 6; i++) {
           const mid = (lo + hi) / 2;
-          if (buildLayout(mid).totalHeight <= maxContentH) lo = mid; else hi = mid;
+          if (buildLayout(mid).requiredHeight <= maxContentH) lo = mid; else hi = mid;
         }
-        ({ allLines, totalHeight } = buildLayout(lo));
+        ({ allLines, totalHeight, requiredHeight } = buildLayout(lo));
       }
     }
   }
@@ -4472,7 +4527,7 @@ export function renderTextBody(
   // Used by renderTable to grow rows to fit their tallest cell (ECMA-376
   // §21.1.3.18: a:tr@h is a minimum). Returns padding + laid-out text height.
   if (measureOnly) {
-    return tPad + totalHeight + bPad;
+    return tPad + requiredHeight + bPad;
   }
 
   // ── anchor="b" with bh=0: auto-height growing upward from by ────────────
@@ -4481,13 +4536,13 @@ export function renderTextBody(
   let effectiveBy = by;
   let effectiveBh: number;
   if (bh === 0 && anchor === 'b') {
-    effectiveBh = tPad + totalHeight + bPad;
+    effectiveBh = tPad + requiredHeight + bPad;
     effectiveBy = by - effectiveBh;
   } else {
     // ── Effective height (spAutoFit: shape expands to fit text) ─────────────
     const isSpAutoFit = body.autoFit === 'sp';
     effectiveBh = isSpAutoFit
-      ? Math.max(bh, tPad + totalHeight + bPad)
+      ? Math.max(bh, tPad + requiredHeight + bPad)
       : bh;
   }
 
@@ -4495,9 +4550,9 @@ export function renderTextBody(
   let cursorY: number;
   const contentH = Math.max(0, effectiveBh - tPad - bPad);
   if (anchor === 'ctr') {
-    cursorY = effectiveBy + tPad + (contentH - totalHeight) / 2;
+    cursorY = effectiveBy + tPad + (contentH - requiredHeight) / 2;
   } else if (anchor === 'b') {
-    cursorY = effectiveBy + effectiveBh - bPad - totalHeight;
+    cursorY = effectiveBy + effectiveBh - bPad - requiredHeight;
   } else {
     cursorY = effectiveBy + tPad;
   }
@@ -4554,7 +4609,7 @@ export function renderTextBody(
   const trailingSpaceAfter = lastEntry
     ? Math.max(0, lastEntry.linePx - lastEntry.lineHeight)
     : 0;
-  const occupiedHeight = totalHeight - trailingSpaceAfter;
+  const occupiedHeight = requiredHeight - trailingSpaceAfter;
   const fitsInOneCol = bh === 0 || occupiedHeight <= colHeightCapacity + 0.5;
   const useMultiCol = numCol > 1 && !fitsInOneCol;
   const linesPerCol = useMultiCol ? Math.ceil(allLines.length / numCol) : allLines.length;

--- a/packages/pptx/src/sp-autofit-top-anchor.test.ts
+++ b/packages/pptx/src/sp-autofit-top-anchor.test.ts
@@ -97,7 +97,69 @@ function body(fontFamily: string, fontFamilyEa: string, fontSize: number): TextB
   } as TextBody;
 }
 
+function twoLineBody(fontFamily: string, fontFamilyEa: string, fontSize: number): TextBody {
+  const textBody = body(fontFamily, fontFamilyEa, fontSize);
+  const first = textBody.paragraphs[0]!.runs[0] as TextRunData;
+  textBody.paragraphs[0]!.runs = [
+    { ...first, text: '一行目' },
+    { type: 'break' } as unknown as TextRunData,
+    { ...first, text: '二行目' },
+  ];
+  return textBody;
+}
+
 describe('pptx spAutoFit top anchoring', () => {
+  it('keeps implicit multi-line pitch separate from the taller resolved font box (#1473)', () => {
+    const fontSize = 32;
+    const actualAscent = fontSize * 0.78;
+    const actualDescent = fontSize * 0.18;
+    const fontAscent = fontSize * 0.98;
+    const fontDescent = fontSize * 0.37;
+    const { ctx, draws } = recordingContext(
+      actualAscent,
+      actualDescent,
+      true,
+      fontAscent,
+      fontDescent,
+    );
+    const textBody = twoLineBody('Meiryo', 'Meiryo', fontSize);
+
+    renderTextBody(ctx, textBody, 0, 0, 400, 46, SCALE);
+
+    expect(draws.map(({ text }) => text)).toEqual(['一行目', '二行目']);
+    expect(draws[0]!.y).toBeCloseTo(actualAscent, 5);
+    // A resolved Canvas design box may be useful for required bounds, but it is
+    // not PowerPoint's implicit baseline pitch when a:lnSpc is omitted.
+    expect(draws[1]!.y - draws[0]!.y).toBeCloseTo(fontSize * 1.2, 5);
+
+    const neededHeight = renderTextBody(
+      ctx, textBody, 0, 0, 400, 46, SCALE,
+      null, 0, false, false, '#000000', undefined, undefined, undefined, true,
+    );
+    // The final line still reserves the live font box below the last baseline:
+    // one baseline pitch plus one full resolved line box.
+    expect(neededHeight).toBeCloseTo(fontSize * 1.2 + fontAscent + fontDescent, 5);
+  });
+
+  it('preserves explicit percentage line spacing under spAutoFit (#1473)', () => {
+    const fontSize = 32;
+    const { ctx, draws } = recordingContext(
+      fontSize * 0.78,
+      fontSize * 0.18,
+      true,
+      fontSize * 0.98,
+      fontSize * 0.37,
+    );
+    const textBody = twoLineBody('Meiryo', 'Meiryo', fontSize);
+    textBody.paragraphs[0]!.spaceLine = { type: 'pct', val: 150000 };
+
+    renderTextBody(ctx, textBody, 0, 0, 400, 46, SCALE);
+
+    // a:spcPct is based on PowerPoint's natural single-line box; only the
+    // omitted a:lnSpc path is recalculated by this fix.
+    expect(draws[1]!.y - draws[0]!.y).toBeCloseTo(fontSize * 1.2 * 1.5, 5);
+  });
+
   it.each([
     ['theme-resolved heading face', 'Meiryo', 'Meiryo', 32, 46],
     ['explicit Meiryo face', 'Meiryo', 'Meiryo', 36, 50.9],

--- a/packages/pptx/src/sp-autofit-top-anchor.test.ts
+++ b/packages/pptx/src/sp-autofit-top-anchor.test.ts
@@ -109,6 +109,32 @@ function twoLineBody(fontFamily: string, fontFamilyEa: string, fontSize: number)
 }
 
 describe('pptx spAutoFit top anchoring', () => {
+  it.each([
+    ['Meiryo', 12], ['Meiryo', 18], ['Meiryo', 24], ['Meiryo', 32],
+    ['Arial', 12], ['Arial', 18], ['Arial', 24], ['Arial', 32],
+  ] as const)(
+    'uses the PowerPoint 120%% implicit pitch for %s at %d pt with and without spAutoFit',
+    (fontFamily, fontSize) => {
+      for (const autoFit of ['none', 'sp'] as const) {
+        const { ctx, draws } = recordingContext(
+          fontSize * 0.78,
+          fontSize * 0.18,
+          true,
+          fontSize * 0.98,
+          fontSize * 0.37,
+        );
+        const textBody = {
+          ...twoLineBody(fontFamily, fontFamily, fontSize),
+          autoFit,
+        };
+
+        renderTextBody(ctx, textBody, 0, 0, 400, 46, SCALE);
+
+        expect(draws[1]!.y - draws[0]!.y).toBeCloseTo(fontSize * 1.2, 5);
+      }
+    },
+  );
+
   it('keeps implicit multi-line pitch separate from the taller resolved font box (#1473)', () => {
     const fontSize = 32;
     const actualAscent = fontSize * 0.78;

--- a/packages/pptx/src/sp-autofit-top-anchor.test.ts
+++ b/packages/pptx/src/sp-autofit-top-anchor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { intendedSingleLinePx, type TextRunData } from '@silurus/ooxml-core';
+import type { TextRunData } from '@silurus/ooxml-core';
 import { renderTextBody } from './renderer.js';
 import type { Paragraph, TextBody } from './types.js';
 
@@ -253,36 +253,35 @@ describe('pptx spAutoFit top anchoring', () => {
     expect(draws[0]!.y).toBeCloseTo(fontAscent, 5);
   });
 
-  it('falls back to the authored font design box when Canvas has no font metrics', () => {
+  it('falls back to the natural line box when Canvas has no font metrics', () => {
     const fontSize = 32;
     const { ctx, draws } = recordingContext(fontSize * 0.82, fontSize * 0.18, false);
     const textBody = body('Meiryo', 'Meiryo', fontSize);
     renderTextBody(ctx, textBody, 0, 0, 400, 46, SCALE);
-    const designedLineHeight = intendedSingleLinePx('Meiryo', fontSize);
+    const naturalLineHeight = fontSize * 1.2;
 
-    expect(draws[0]!.y).toBeCloseTo(designedLineHeight * 0.8, 5);
+    expect(draws[0]!.y).toBeCloseTo(naturalLineHeight * 0.8, 5);
     expect(renderTextBody(
       ctx, textBody, 0, 0, 400, 46, SCALE,
       null, 0, false, false, '#000000', undefined, undefined, undefined, true,
-    )).toBeCloseTo(designedLineHeight, 5);
+    )).toBeCloseTo(naturalLineHeight, 5);
   });
 
-  it('does not apply live spAutoFit metrics to fixed text', () => {
+  it('keeps fixed text independent of the authored font design box', () => {
     const fontSize = 32;
     const { ctx, draws } = recordingContext(fontSize * 0.98, fontSize * 0.37);
     const textBody = { ...body('Meiryo', 'Meiryo', fontSize), autoFit: 'none' as const };
     renderTextBody(ctx, textBody, 0, 0, 400, 46, SCALE);
 
-    expect(draws[0]!.y).toBeCloseTo(intendedSingleLinePx('Meiryo', fontSize) * 0.8, 5);
+    expect(draws[0]!.y).toBeCloseTo(fontSize * 0.98, 5);
   });
 
-  it('keeps the established natural line box for spAutoFit fonts without a taller design floor', () => {
+  it('uses live containment metrics for any tall resolved spAutoFit face', () => {
     const fontSize = 32;
     const { ctx, draws } = recordingContext(fontSize * 0.98, fontSize * 0.37);
     const textBody = body('Arial', 'Arial', fontSize);
     renderTextBody(ctx, textBody, 0, 0, 400, 46, SCALE);
 
-    expect(intendedSingleLinePx('Arial', fontSize)).toBeLessThan(fontSize * 1.2);
     expect(draws[0]!.y).toBeCloseTo(fontSize * 0.98, 5);
   });
 });


### PR DESCRIPTION
## Summary

- use PowerPoint's natural implicit line pitch for PPTX text, so multi-line Meiryo text no longer accumulates a font-design-box height when `a:lnSpc` is omitted
- keep `spAutoFit` glyph containment separate from baseline advance while preserving explicit percentage/point spacing and top-anchor visible-ink alignment
- wrap contiguous Latin words intact at CJK boundaries, including across formatting-run seams

No migration is required.

Closes #1473
Closes #1474

## Root cause

The PPTX renderer promoted a tabled authored font's design line box to implicit line pitch. For Meiryo this raised the baseline advance from the natural 1.2× point-size base to about 1.596×. The `spAutoFit` path also used a live Canvas font box as both required glyph bounds and every baseline advance. PowerPoint treats containment and baseline pitch separately.

Mixed CJK/Latin runs also classified every character as an East Asian break unit, while a Latin token in the next formatting run could be treated as having no break opportunity at all. The result depended on the run boundary rather than the text boundary.

## Specification and observed Office behavior

- ECMA-376 Part 1 §21.1.2.1.4 (`spAutoFit`) controls shape fitting and does not define line spacing.
- §21.1.2.2.5 and §21.1.2.2.11 (`lnSpc`, `spcPct`) make the largest text point size the basis and preserve authored percentage/point spacing.
- §21.1.2.2.7 (`eaLnBrk`) and §20.1.10.85 (`ST_TextWrappingType`) govern the relevant line-breaking behavior.
- PowerPoint-produced boundary output shows an approximately 120%-of-point-size implicit pitch for Meiryo at 12/18/24/32 pt, for Meiryo and Arial, for fixed and `spAutoFit` text, for paragraph and automatic wraps, for all three vertical anchors, and for mixed line sizes. This 120% value is an observed compatibility rule rather than a numeric ECMA-376 requirement.

## Verification

- 117 PPTX test files / 832 tests passed, including the 12/18/24/32 pt PowerPoint boundary matrix for Meiryo and Arial with and without `spAutoFit`
- TypeScript project build passed
- `git diff --check` passed
- boundary-deck renderer line positions match PowerPoint within 0–2 pixels across the tested size/wrap/anchor cases
- full local private PPTX self-VRT: 17 of 19 inputs pixel-identical; four changed slides across the other two inputs were individually compared with their PowerPoint PDF references, and every one improved in Office-reference pixel match
- all 19 worker/main renderer comparisons passed

## Adversarial review

- no sample-specific branch, new empirical multiplier, or magic threshold was introduced; the existing natural 1.2× base is now applied consistently when PPTX line spacing is omitted
- explicit OOXML line spacing remains authoritative; only implicit spacing changes
- live font bounds govern `spAutoFit` containment, while point-size-based pitch governs line-to-line advance
- the compatibility claim is bounded to the Office-produced cases listed above; explicit-spacing leading placement outside baseline pitch is not broadened by this change
- DOCX uses its own retained layout pipeline. XLSX shape text retains separately tested Excel-specific design-floor behavior, so this correction is intentionally PPTX-specific
- Latin grouping is linear and reduces measurement units; no new unbounded allocation, fan-out, worker transfer, or cross-package dependency was added
