### PR TITLE
fix(fonts): resolve native Noto CJK web font aliases

### DIFF
--- a/packages/core/src/fonts/preload.test.ts
+++ b/packages/core/src/fonts/preload.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { preloadGoogleFonts, unloadGoogleFonts, parseFontFaceRules, _resetCssCacheForTests, type FontPreloadEntry } from './preload.js';
 import { _resetFontRegistryForTests } from './font-registry.js';
+import { SCRIPT_GOOGLE_FONTS } from './scripts.js';
 
 const G = globalThis as Record<string, unknown>;
 const ORIG = { document: G.document, self: G.self, fetch: G.fetch, FontFace: G.FontFace };
@@ -87,6 +88,45 @@ const MAP: Record<string, FontPreloadEntry> = {
 };
 
 describe('preloadGoogleFonts', () => {
+  it('trims a native Noto CJK name and fetches the aliased Google family', async () => {
+    const { set, added } = installFakes();
+    G.document = { fonts: set };
+    delete G.self;
+    const notoCss = CSS.replaceAll('Carlito', 'Noto Sans SC');
+    G.fetch = vi.fn(async () => ({ ok: true, text: async () => notoCss }));
+
+    await preloadGoogleFonts(['  NoTo SaNs CjK Sc  '], SCRIPT_GOOGLE_FONTS);
+
+    expect(G.fetch).toHaveBeenCalledWith(expect.stringContaining('family=Noto+Sans+SC'));
+    expect(added.map((face) => face.family)).toEqual(['Noto Sans SC', 'Noto Sans SC']);
+    expect(added.every((face) => face.loadCalls === 1)).toBe(true);
+  });
+
+  it('fetches and registers the Google Fonts HK sans family for its native alias', async () => {
+    const { set, added } = installFakes();
+    G.document = { fonts: set };
+    delete G.self;
+    const notoCss = CSS.replaceAll('Carlito', 'Noto Sans HK');
+    G.fetch = vi.fn(async () => ({ ok: true, text: async () => notoCss }));
+
+    await preloadGoogleFonts(['Noto Sans CJK HK'], SCRIPT_GOOGLE_FONTS);
+
+    expect(G.fetch).toHaveBeenCalledWith(expect.stringContaining('family=Noto+Sans+HK'));
+    expect(added.map((face) => face.family)).toEqual(['Noto Sans HK', 'Noto Sans HK']);
+  });
+
+  it('does not request a Google Fonts substitute for the native HK serif family', async () => {
+    const { set } = installFakes();
+    G.document = { fonts: set };
+    delete G.self;
+    const fetch = vi.fn();
+    G.fetch = fetch;
+
+    await preloadGoogleFonts(['Noto Serif CJK HK'], SCRIPT_GOOGLE_FONTS);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it('fetches the CSS once, registers FontFaces and force-loads them (document.fonts)', async () => {
     const { set, added } = installFakes();
     G.document = { fonts: set };

--- a/packages/core/src/fonts/preload.ts
+++ b/packages/core/src/fonts/preload.ts
@@ -168,13 +168,15 @@ export async function preloadGoogleFonts(
 
   for (const name of fontNames) {
     if (!name) continue;
-    const key = name.toLowerCase();
+    const requestedName = name.trim();
+    if (!requestedName) continue;
+    const key = requestedName.toLowerCase();
     if (seen.has(key)) continue;
     seen.add(key);
     const entry = map[key];
     if (!entry) continue;
     cssUrls.add(entry.url);
-    const family = (entry.loadFamily ?? name).toLowerCase();
+    const family = (entry.loadFamily ?? requestedName).toLowerCase();
     targetFamilies.add(family);
     let targets = urlTargets.get(entry.url);
     if (!targets) {

--- a/packages/core/src/fonts/scripts.test.ts
+++ b/packages/core/src/fonts/scripts.test.ts
@@ -6,6 +6,8 @@ import {
   cjkFallbackChain,
   NON_CJK_SANS_FALLBACKS,
   NON_CJK_SERIF_FALLBACKS,
+  GOOGLE_CJK_FONT_ALIASES,
+  googleCjkFontAlias,
   SCRIPT_GOOGLE_FONTS,
   SCRIPT_PRELOAD_NAMES,
   ScriptPreloadAccumulator,
@@ -23,6 +25,15 @@ function assertResolvable(names: string[]): void {
 }
 
 describe('classifyCjkFont — Office font name → CJK language', () => {
+  it('classifies native Noto CJK names across case and surrounding whitespace', () => {
+    expect(classifyCjkFont(' Noto Sans CJK SC ')).toBe('sc');
+    expect(classifyCjkFont('nOtO SeRiF CjK Tc')).toBe('tc');
+    expect(classifyCjkFont('Noto Sans CJK JP')).toBe('jp');
+    expect(classifyCjkFont('Noto Serif CJK KR')).toBe('kr');
+    expect(classifyCjkFont(' Noto Sans CJK HK ')).toBe('hk');
+    expect(classifyCjkFont('Noto Serif CJK HK')).toBe('hk');
+  });
+
   it('classifies Korean faces (Malgun Gothic, Batang, Gulim, Dotum, 돋움)', () => {
     expect(classifyCjkFont('Malgun Gothic')).toBe('kr');
     expect(classifyCjkFont('Batang')).toBe('kr');
@@ -163,6 +174,14 @@ describe('cjkFallbackChain — language-specific Noto CJK ordering', () => {
     expect(cjkFallbackChain('sc', 'sans')[0]).toBe('Noto Sans SC');
     expect(cjkFallbackChain('tc', 'sans')[0]).toBe('Noto Sans TC');
     expect(cjkFallbackChain('jp', 'sans')[0]).toBe('Noto Sans JP');
+    expect(cjkFallbackChain('hk', 'sans')[0]).toBe('Noto Sans HK');
+  });
+
+  it('does not add HK to non-HK fallback chains', () => {
+    for (const lang of ['kr', 'sc', 'tc', 'jp'] as const) {
+      expect(cjkFallbackChain(lang, 'sans')).not.toContain('Noto Sans HK');
+      expect(cjkFallbackChain(lang, 'serif')).not.toContain('Noto Serif HK');
+    }
   });
 
   it('places the matching Noto CJK first (serif)', () => {
@@ -170,6 +189,10 @@ describe('cjkFallbackChain — language-specific Noto CJK ordering', () => {
     expect(cjkFallbackChain('sc', 'serif')[0]).toBe('Noto Serif SC');
     expect(cjkFallbackChain('tc', 'serif')[0]).toBe('Noto Serif TC');
     expect(cjkFallbackChain('jp', 'serif')[0]).toBe('Noto Serif JP');
+  });
+
+  it('does not invent or substitute a Google Fonts serif family for HK', () => {
+    expect(cjkFallbackChain('hk', 'serif')).toEqual([]);
   });
 
   it('includes the other CJK languages after the matching one (so shared Han still resolves)', () => {
@@ -195,6 +218,32 @@ describe('non-CJK fallback constants', () => {
 });
 
 describe('SCRIPT_GOOGLE_FONTS / SCRIPT_PRELOAD_NAMES', () => {
+  it('maps every native Noto CJK name to its Google Fonts family', () => {
+    expect(GOOGLE_CJK_FONT_ALIASES).toEqual({
+      'noto sans cjk sc': 'Noto Sans SC',
+      'noto serif cjk sc': 'Noto Serif SC',
+      'noto sans cjk tc': 'Noto Sans TC',
+      'noto serif cjk tc': 'Noto Serif TC',
+      'noto sans cjk jp': 'Noto Sans JP',
+      'noto serif cjk jp': 'Noto Serif JP',
+      'noto sans cjk kr': 'Noto Sans KR',
+      'noto serif cjk kr': 'Noto Serif KR',
+      'noto sans cjk hk': 'Noto Sans HK',
+    });
+    expect(googleCjkFontAlias('  NOTO SANS CJK SC ')).toBe('Noto Sans SC');
+    expect(googleCjkFontAlias('Noto Serif CJK KR')).toBe('Noto Serif KR');
+    expect(googleCjkFontAlias('Noto Sans CJK HK')).toBe('Noto Sans HK');
+    expect(googleCjkFontAlias('Noto Serif CJK HK')).toBeNull();
+    expect(googleCjkFontAlias('Noto Sans SC')).toBeNull();
+
+    for (const [alias, family] of Object.entries(GOOGLE_CJK_FONT_ALIASES)) {
+      expect(SCRIPT_GOOGLE_FONTS[alias]).toEqual({
+        ...SCRIPT_GOOGLE_FONTS[family.toLowerCase()],
+        loadFamily: family,
+      });
+    }
+  });
+
   it('maps every script Noto family to a Google Fonts URL', () => {
     for (const name of SCRIPT_PRELOAD_NAMES) {
       const entry = SCRIPT_GOOGLE_FONTS[name.toLowerCase()];
@@ -205,11 +254,17 @@ describe('SCRIPT_GOOGLE_FONTS / SCRIPT_PRELOAD_NAMES', () => {
 
   it('includes CJK, Cyrillic-covering, Thai, Devanagari, Hebrew families', () => {
     expect(SCRIPT_GOOGLE_FONTS['noto sans kr']).toBeDefined();
+    expect(SCRIPT_GOOGLE_FONTS['noto sans hk']).toBeDefined();
+    expect(SCRIPT_GOOGLE_FONTS['noto serif hk']).toBeUndefined();
     expect(SCRIPT_GOOGLE_FONTS['noto serif sc']).toBeDefined();
     expect(SCRIPT_GOOGLE_FONTS['noto sans thai']).toBeDefined();
     expect(SCRIPT_GOOGLE_FONTS['noto sans devanagari']).toBeDefined();
     expect(SCRIPT_GOOGLE_FONTS['noto sans hebrew']).toBeDefined();
     expect(SCRIPT_GOOGLE_FONTS['noto serif hebrew']).toBeDefined();
+  });
+
+  it('preloads only the available HK sans family for shared Han text', () => {
+    expect(scriptPreloadNamesForText(['香港'], 'hk')).toEqual(['Noto Sans HK']);
   });
 });
 

--- a/packages/core/src/fonts/scripts.ts
+++ b/packages/core/src/fonts/scripts.ts
@@ -11,7 +11,7 @@
  *
  * ## Why CJK is handled differently from the other scripts
  *
- * KR / SC / TC / JP share the Han (漢字) block but render those shared
+ * KR / SC / TC / HK / JP share the Han (漢字) block but render those shared
  * codepoints with DIFFERENT glyph shapes (e.g. 直/海/骨 differ between
  * Japanese, Simplified Chinese, Traditional Chinese, Korean conventions).
  * Canvas text falls back PER GLYPH down the font-family chain, so whichever
@@ -19,7 +19,7 @@
  * glyph. We therefore cannot just append all four — we must put the Noto CJK
  * matching the document's CJK language FIRST. {@link classifyCjkFont} derives
  * that language from the requested Office font name (and CJK-only Unicode
- * markers in the name). The other three CJK Notos still follow, so a stray
+ * markers in the name). The other available CJK Notos still follow, so a stray
  * codepoint missing from the primary face (rare) resolves to a sibling rather
  * than tofu.
  *
@@ -33,8 +33,34 @@
  * handled by the existing bidi line logic in each package.
  */
 
-export type CjkLang = 'kr' | 'sc' | 'tc' | 'jp';
+export type CjkLang = 'kr' | 'sc' | 'tc' | 'hk' | 'jp';
 export type FontVariant = 'sans' | 'serif';
+
+/**
+ * Native Noto CJK family names used by Linux packages → Google Fonts CSS
+ * family names. The browser treats these as distinct families, so preload and
+ * Canvas routing must consult this same table.
+ */
+export const GOOGLE_CJK_FONT_ALIASES = {
+  'noto sans cjk sc': 'Noto Sans SC',
+  'noto serif cjk sc': 'Noto Serif SC',
+  'noto sans cjk tc': 'Noto Sans TC',
+  'noto serif cjk tc': 'Noto Serif TC',
+  'noto sans cjk jp': 'Noto Sans JP',
+  'noto serif cjk jp': 'Noto Serif JP',
+  'noto sans cjk kr': 'Noto Sans KR',
+  'noto serif cjk kr': 'Noto Serif KR',
+  'noto sans cjk hk': 'Noto Sans HK',
+  // Google Fonts does not provide Noto Serif HK. Keep the native serif name
+  // authored by OOXML and do not infer a TC web-font alias.
+} as const satisfies Record<string, string>;
+
+/** Return the Google Fonts family for a native Noto CJK name. */
+export function googleCjkFontAlias(family: string | null | undefined): string | null {
+  if (!family) return null;
+  const key = family.trim().toLowerCase() as keyof typeof GOOGLE_CJK_FONT_ALIASES;
+  return GOOGLE_CJK_FONT_ALIASES[key] ?? null;
+}
 
 /**
  * Classify a requested Office font name into a CJK language, or `null` when it
@@ -49,6 +75,9 @@ export type FontVariant = 'sans' | 'serif';
  *             STKaiti, STFangsong, STHeiti, STXihei, LiSu, YouYuan.
  * - Traditional Chinese : PMingLiU/MingLiU (細明體/新細明體), Microsoft JhengHei
  *             (微軟正黑體), DFKai-SB (標楷體), MingLiU_HKSCS, Kaiti TC.
+ * - Hong Kong : Noto Sans/Serif CJK HK. Only the sans family has a matching
+ *             Google Fonts family; serif classification remains useful as a
+ *             locale hint but has no inferred web-font substitute.
  * - Japanese : Yu Gothic/Mincho (游ゴシック/游明朝), Meiryo (メイリオ),
  *             MS Gothic/Mincho (ＭＳ ゴシック/明朝), Hiragino (ヒラギノ),
  *             plus the Hiragana/Katakana marker in the name.
@@ -59,14 +88,18 @@ export type FontVariant = 'sans' | 'serif';
  */
 export function classifyCjkFont(family: string | null | undefined): CjkLang | null {
   if (!family) return null;
-  const l = family.toLowerCase();
+  const normalized = googleCjkFontAlias(family) ?? family.trim();
+  const l = normalized.toLowerCase();
+
+  const noto = l.match(/^noto\s+(?:sans|serif)\s+(?:cjk\s+)?(sc|tc|hk|jp|kr)$/);
+  if (noto) return noto[1] as CjkLang;
 
   // --- Unicode-script markers in the name (script-exclusive ranges) ---
   // Hangul (Jamo U+1100–11FF, Compatibility Jamo U+3130–318F, Syllables
   // U+AC00–D7AF) → Korean. 돋움 / 맑은 고딕 etc.
-  if (/[ᄀ-ᇿ㄰-㆏가-힯]/.test(family)) return 'kr';
+  if (/[ᄀ-ᇿ㄰-㆏가-힯]/.test(normalized)) return 'kr';
   // Hiragana (U+3040–309F) / Katakana (U+30A0–30FF) → Japanese. メイリオ etc.
-  if (/[぀-ヿ]/.test(family)) return 'jp';
+  if (/[぀-ヿ]/.test(normalized)) return 'jp';
 
   // --- Latin transliterations + Han names. Order matters: TC tokens that
   //     contain an SC-looking substring are matched first. ---
@@ -75,7 +108,7 @@ export function classifyCjkFont(family: string | null | undefined): CjkLang | nu
   // generic "hei", and MingLiU family before any "ming" heuristics).
   if (
     /jhenghei|微軟正黑|新細明|細明|pmingliu|mingliu|dfkai|標楷|華康|cns11643|kaiti tc|ming\s*liu/.test(l) ||
-    /新細明體|細明體|標楷體|微軟正黑體|華康/.test(family)
+    /新細明體|細明體|標楷體|微軟正黑體|華康/.test(normalized)
   ) {
     return 'tc';
   }
@@ -83,7 +116,7 @@ export function classifyCjkFont(family: string | null | undefined): CjkLang | nu
   // Simplified Chinese
   if (
     /simsun|nsimsun|simhei|simkai|simfang|yahei|dengxian|fangsong|kaiti|youyuan|lisu|stsong|stkaiti|stfangsong|stheiti|stxihei|stzhongsong|songti sc|heiti sc|微软雅黑/.test(l) ||
-    /宋体|黑体|楷体|仿宋|等线|微软雅黑|隶书|幼圆/.test(family)
+    /宋体|黑体|楷体|仿宋|等线|微软雅黑|隶书|幼圆/.test(normalized)
   ) {
     return 'sc';
   }
@@ -96,7 +129,7 @@ export function classifyCjkFont(family: string | null | undefined): CjkLang | nu
   // Japanese (Latin transliterations). Yu/MS Gothic+Mincho, Meiryo, Hiragino.
   if (
     /\bmeiryo\b|\byu\s*(gothic|mincho)\b|yugothic|yumincho|hiragino|\bms\s*(gothic|mincho|pgothic|pmincho|ui\s*gothic)\b|\bms[pg]?(gothic|mincho)\b|ipa(ex)?(gothic|mincho)|noto\s+(sans|serif)\s+jp|游ゴシック|游明朝|ＭＳ|メイリオ|ヒラギノ/.test(l) ||
-    /游ゴシック|游明朝|ＭＳ ゴシック|ＭＳ 明朝|ＭＳ Ｐゴシック|メイリオ|ヒラギノ/.test(family)
+    /游ゴシック|游明朝|ＭＳ ゴシック|ＭＳ 明朝|ＭＳ Ｐゴシック|メイリオ|ヒラギノ/.test(normalized)
   ) {
     return 'jp';
   }
@@ -185,11 +218,12 @@ export function isComplexScriptCodePoint(cp: number): boolean {
 
 /**
  * Ordered Noto CJK family names for a given language, primary face first so the
- * browser resolves shared Han glyphs to that language's shapes. The other three
- * follow as a last-resort so a codepoint absent from the primary face does not
- * fall to tofu.
+ * browser resolves shared Han glyphs to that language's shapes. Other available
+ * regional faces follow as a last resort. Google Fonts has no Noto Serif HK, so
+ * the HK serif chain is intentionally empty instead of silently substituting TC.
  */
 export function cjkFallbackChain(lang: CjkLang, variant: FontVariant): string[] {
+  if (lang === 'hk' && variant === 'serif') return [];
   const prefix = variant === 'serif' ? 'Noto Serif' : 'Noto Sans';
   const order: Record<CjkLang, CjkLang[]> = {
     // Primary language first; the rest in a stable order. The trailing list is
@@ -197,10 +231,13 @@ export function cjkFallbackChain(lang: CjkLang, variant: FontVariant): string[] 
     jp: ['jp', 'sc', 'tc', 'kr'],
     sc: ['sc', 'tc', 'jp', 'kr'],
     tc: ['tc', 'sc', 'jp', 'kr'],
+    hk: ['hk', 'tc', 'sc', 'jp', 'kr'],
     kr: ['kr', 'jp', 'sc', 'tc'],
   };
-  const suffix: Record<CjkLang, string> = { kr: 'KR', sc: 'SC', tc: 'TC', jp: 'JP' };
-  return order[lang].map((x) => `${prefix} ${suffix[x]}`);
+  const suffix: Record<CjkLang, string> = {
+    kr: 'KR', sc: 'SC', tc: 'TC', hk: 'HK', jp: 'JP',
+  };
+  return order[lang].map((candidate) => `${prefix} ${suffix[candidate]}`);
 }
 
 /**
@@ -233,22 +270,35 @@ export const NON_CJK_SERIF_FALLBACKS = [
 const w = (q: string) =>
   `https://fonts.googleapis.com/css2?family=${q}:wght@400;700&display=swap`;
 
-/**
- * Lower-cased Noto family name → Google Fonts CSS URL for every script face the
- * renderers may reference. Merged into each package's `*_GOOGLE_FONTS` map so a
- * single source of truth defines the URLs. `loadFamily` is omitted because
- * Google Fonts serves these under the same family name we request.
- */
-export const SCRIPT_GOOGLE_FONTS: Record<string, { url: string; loadFamily?: string }> = {
-  // CJK — sans + serif per language.
+const CJK_GOOGLE_FONTS: Record<string, { url: string; loadFamily?: string }> = {
   'noto sans kr': { url: w('Noto+Sans+KR') },
   'noto sans sc': { url: w('Noto+Sans+SC') },
   'noto sans tc': { url: w('Noto+Sans+TC') },
+  'noto sans hk': { url: w('Noto+Sans+HK') },
   'noto sans jp': { url: w('Noto+Sans+JP') },
   'noto serif kr': { url: w('Noto+Serif+KR') },
   'noto serif sc': { url: w('Noto+Serif+SC') },
   'noto serif tc': { url: w('Noto+Serif+TC') },
   'noto serif jp': { url: w('Noto+Serif+JP') },
+};
+
+const CJK_GOOGLE_FONT_ALIAS_PRELOADS = Object.fromEntries(
+  Object.entries(GOOGLE_CJK_FONT_ALIASES).map(([alias, family]) => [
+    alias,
+    { ...CJK_GOOGLE_FONTS[family.toLowerCase()], loadFamily: family },
+  ]),
+) as Record<string, { url: string; loadFamily: string }>;
+
+/**
+ * Lower-cased Noto family name → Google Fonts CSS URL for every script face the
+ * renderers may reference. Merged into each package's `*_GOOGLE_FONTS` map so a
+ * single source of truth defines the URLs. Native CJK alias entries set
+ * `loadFamily` because Google Fonts registers the shorter family name.
+ */
+export const SCRIPT_GOOGLE_FONTS: Record<string, { url: string; loadFamily?: string }> = {
+  // CJK — sans + serif per language, except HK (sans only on Google Fonts).
+  ...CJK_GOOGLE_FONTS,
+  ...CJK_GOOGLE_FONT_ALIAS_PRELOADS,
   // Latin/Cyrillic/Greek base (also the non-CJK sans/serif tail head).
   'noto sans': { url: w('Noto+Sans') },
   'noto serif': { url: w('Noto+Serif') },
@@ -267,7 +317,7 @@ export const SCRIPT_GOOGLE_FONTS: Record<string, { url: string; loadFamily?: str
  * Mirrors the existing Arabic self-referencing entries.
  */
 export const SCRIPT_PRELOAD_NAMES: string[] = [
-  'Noto Sans KR', 'Noto Sans SC', 'Noto Sans TC', 'Noto Sans JP',
+  'Noto Sans KR', 'Noto Sans SC', 'Noto Sans TC', 'Noto Sans HK', 'Noto Sans JP',
   'Noto Serif KR', 'Noto Serif SC', 'Noto Serif TC', 'Noto Serif JP',
   'Noto Sans', 'Noto Serif',
   'Noto Sans Devanagari', 'Noto Sans Thai',
@@ -417,21 +467,24 @@ export class ScriptPreloadAccumulator {
   names(): string[] {
     const names: string[] = [];
 
-    // CJK: each detected language contributes its Sans+Serif pair. Hangul → 'kr',
-    // Kana → 'jp', shared Han → the language hint (or 'jp' default) UNLESS Hangul
-    // or Kana already pinned a CJK language, in which case Han resolves to one of
-    // those faces and needs no extra family.
+    // CJK: each detected language contributes its available Sans+Serif faces.
+    // HK contributes only Sans. Hangul → 'kr', Kana → 'jp', shared Han → the
+    // language hint (or 'jp' default) UNLESS Hangul or Kana already pinned a CJK
+    // language, in which case Han resolves to one of those faces and needs no
+    // extra family.
     const cjkLangs = new Set<CjkLang>();
     if (this.hasHangul) cjkLangs.add('kr');
     if (this.hasKana) cjkLangs.add('jp');
     if (this.hasHan && cjkLangs.size === 0) {
       cjkLangs.add(this.cjkLang ?? 'jp');
     }
-    // Stable order: kr, sc, tc, jp.
-    for (const lang of ['kr', 'sc', 'tc', 'jp'] as const) {
+    // Stable order: kr, sc, tc, hk, jp. HK is sans-only because Google Fonts
+    // does not provide Noto Serif HK.
+    for (const lang of ['kr', 'sc', 'tc', 'hk', 'jp'] as const) {
       if (cjkLangs.has(lang)) {
-        const suffix = { kr: 'KR', sc: 'SC', tc: 'TC', jp: 'JP' }[lang];
-        names.push(`Noto Sans ${suffix}`, `Noto Serif ${suffix}`);
+        const suffix = { kr: 'KR', sc: 'SC', tc: 'TC', hk: 'HK', jp: 'JP' }[lang];
+        names.push(`Noto Sans ${suffix}`);
+        if (lang !== 'hk') names.push(`Noto Serif ${suffix}`);
       }
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -154,6 +154,8 @@ export { canvasFontString, createCanvasFontRoute, type CanvasFontRoute } from '.
 export {
   classifyCjkFont,
   classifyFontGeneric,
+  GOOGLE_CJK_FONT_ALIASES,
+  googleCjkFontAlias,
   isComplexScriptCodePoint,
   cjkFallbackChain,
   NON_CJK_SANS_FALLBACKS,

--- a/packages/docx/src/font-family.test.ts
+++ b/packages/docx/src/font-family.test.ts
@@ -110,6 +110,25 @@ describe('normalizeFontFamily — Latin fonts lead with Latin faces, JP companio
 });
 
 describe('normalizeFontFamily — CJK language-specific Noto ordering', () => {
+  it('routes native Noto CJK names through the loaded Google family', () => {
+    const sans = normalizeFontFamily('Noto Sans CJK SC');
+    expect(sans.startsWith('"Noto Sans CJK SC", "Noto Sans SC", ')).toBe(true);
+
+    const serif = normalizeFontFamily('Noto Serif CJK TC');
+    expect(serif.startsWith('"Noto Serif CJK TC", "Noto Serif TC", ')).toBe(true);
+    expect(serif.endsWith('serif')).toBe(true);
+  });
+
+  it('routes HK sans through Google Fonts without inventing an HK serif alias', () => {
+    expect(normalizeFontFamily('Noto Sans CJK HK').startsWith(
+      '"Noto Sans CJK HK", "Noto Sans HK", ',
+    )).toBe(true);
+
+    const serif = normalizeFontFamily('Noto Serif CJK HK');
+    expect(serif).not.toContain('"Noto Serif HK"');
+    expect(serif).not.toContain('"Noto Serif TC"');
+  });
+
   it('puts Noto Sans KR first for Korean sans faces (Malgun Gothic, Gulim, Dotum, 돋움)', () => {
     for (const f of ['Malgun Gothic', 'Gulim', 'Dotum', '돋움']) {
       const chain = normalizeFontFamily(f);

--- a/packages/docx/src/google-fonts.ts
+++ b/packages/docx/src/google-fonts.ts
@@ -15,9 +15,10 @@ import { docxRenderedTextUsages } from './document-content.js';
  *  {@link GOOGLE_FONT_SUBSTITUTES} supplies the Office substitutes (Calibri →
  *  Carlito, Cambria → Caladea), the popular free web fonts and the Arabic Noto
  *  fallbacks — shared with pptx/xlsx. {@link SCRIPT_GOOGLE_FONTS} adds the
- *  CJK (KR/SC/TC/JP) / Cyrillic / Thai / Devanagari / Hebrew Noto faces the
- *  renderer appends to the font chain (CJK ordered by document language). Both
- *  load only when `useGoogleFonts` is on — no binaries ship in the bundle. DOCX
+ *  CJK (KR/SC/TC/JP, plus HK sans) / Cyrillic / Thai / Devanagari / Hebrew
+ *  Noto faces the renderer appends to the font chain. CJK fallbacks are ordered
+ *  by document language. Both load only when `useGoogleFonts` is on — no binaries
+ *  ship in the bundle. DOCX
  *  currently has no format-specific additions. */
 export const DOCX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   ...GOOGLE_FONT_SUBSTITUTES,

--- a/packages/pptx/src/font-stack.test.ts
+++ b/packages/pptx/src/font-stack.test.ts
@@ -33,6 +33,7 @@ describe('cssFontStack — CJK language-specific Noto ordering', () => {
     const serif = cssFontStack('Noto Serif CJK HK');
     expect(serif).not.toContain('"Noto Serif HK"');
     expect(serif).not.toContain('"Noto Serif TC"');
+    expect(serif).not.toMatch(/,\s*,/);
   });
 
   it('Korean sans (Malgun Gothic) → Noto Sans KR leads the CJK tail', () => {

--- a/packages/pptx/src/font-stack.test.ts
+++ b/packages/pptx/src/font-stack.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { buildFont, cssFontStack } from './renderer.js';
+import { buildFont, cssFontStack, renderTextBody } from './renderer.js';
+import type { TextBody } from './types.js';
 
 describe('cssFontStack — Arabic faces keep the Arabic chain (regression)', () => {
   it('leads with the Arabic Noto fallbacks for an Arabic-script face', () => {
@@ -14,6 +15,26 @@ describe('cssFontStack — Arabic faces keep the Arabic chain (regression)', () 
 });
 
 describe('cssFontStack — CJK language-specific Noto ordering', () => {
+  it('routes a native Noto CJK name through the loaded Google family', () => {
+    const sans = cssFontStack('Noto Sans CJK SC');
+    expect(sans.startsWith('"Noto Sans CJK SC", "Noto Sans SC", ')).toBe(true);
+    expect(sans.match(/"Noto Sans SC"/g)).toHaveLength(1);
+
+    const serif = cssFontStack('Noto Serif CJK TC');
+    expect(serif.startsWith('"Noto Serif CJK TC", "Noto Serif TC", ')).toBe(true);
+    expect(serif.endsWith('serif')).toBe(true);
+  });
+
+  it('routes HK sans through Google Fonts without inventing an HK serif alias', () => {
+    expect(cssFontStack('Noto Sans CJK HK').startsWith(
+      '"Noto Sans CJK HK", "Noto Sans HK", ',
+    )).toBe(true);
+
+    const serif = cssFontStack('Noto Serif CJK HK');
+    expect(serif).not.toContain('"Noto Serif HK"');
+    expect(serif).not.toContain('"Noto Serif TC"');
+  });
+
   it('Korean sans (Malgun Gothic) → Noto Sans KR leads the CJK tail', () => {
     const stack = cssFontStack('Malgun Gothic');
     expect(stack).toContain('"Noto Sans KR"');
@@ -80,6 +101,80 @@ describe('cssFontStack — serif/sans generic classification (core classifier)',
 });
 
 describe('buildFont — style encoded in a face name', () => {
+  it('builds the aliased family stack from a trimmed native name', () => {
+    const font = buildFont(false, false, 24, ' Noto Sans CJK SC ', {
+      themeMajorFont: null,
+      themeMinorFont: null,
+      dpr: 1,
+    });
+    expect(font).toMatch(/^24px "Noto Sans CJK SC", "Noto Sans SC", /);
+  });
+
+  it('uses the same resolved alias stack for measurement and paint', () => {
+    let font = '';
+    let fillStyle = '';
+    let direction: CanvasDirection = 'ltr';
+    const measuredFonts: string[] = [];
+    const paintedFonts: string[] = [];
+    const ctx = {
+      get font() { return font; },
+      set font(value: string) { font = value; },
+      get fillStyle() { return fillStyle; },
+      set fillStyle(value: string) { fillStyle = value; },
+      get direction() { return direction; },
+      set direction(value: CanvasDirection) { direction = value; },
+      measureText: () => {
+        measuredFonts.push(font);
+        return {
+          width: 40,
+          actualBoundingBoxAscent: 16,
+          actualBoundingBoxDescent: 4,
+          fontBoundingBoxAscent: 16,
+          fontBoundingBoxDescent: 4,
+        };
+      },
+      fillText: () => { paintedFonts.push(font); },
+      fillRect: () => {},
+      drawImage: () => {},
+      save: () => {},
+      restore: () => {},
+      translate: () => {},
+      rotate: () => {},
+      scale: () => {},
+      beginPath: () => {},
+      moveTo: () => {},
+      lineTo: () => {},
+      stroke: () => {},
+      clip: () => {},
+      rect: () => {},
+    } as unknown as CanvasRenderingContext2D;
+    const body = {
+      verticalAnchor: 't',
+      paragraphs: [{
+        alignment: 'l', marL: 0, marR: 0, indent: 0, lvl: 0,
+        spaceBefore: null, spaceAfter: null, spaceLine: null,
+        bullet: { type: 'none' },
+        defFontSize: null, defColor: null, defBold: null, defItalic: null,
+        defFontFamily: null, tabStops: [], eaLnBrk: true,
+        runs: [{
+          type: 'text', text: '中文', bold: null, italic: null,
+          underline: false, strikethrough: false, fontSize: 20,
+          color: '000000', fontFamily: 'Noto Sans CJK SC',
+          fontFamilyEa: 'Noto Sans CJK SC',
+        }],
+      }],
+      defaultFontSize: 20, defaultBold: null, defaultItalic: null,
+      lIns: 0, rIns: 0, tIns: 0, bIns: 0,
+      wrap: 'none', vert: 'horz', autoFit: 'none',
+    } as TextBody;
+
+    renderTextBody(ctx, body, 0, 0, 400, 100, 1 / 12700);
+
+    const resolved = paintedFonts.find((value) => value.includes('"Noto Sans SC"'));
+    expect(resolved).toBeDefined();
+    expect(measuredFonts).toContain(resolved);
+  });
+
   it('selects a presentation-scoped embedded alias instead of the global authored family', () => {
     const font = buildFont(false, false, 24, 'Deck Sans', {
       themeMajorFont: null,

--- a/packages/pptx/src/presentation-destroy.test.ts
+++ b/packages/pptx/src/presentation-destroy.test.ts
@@ -210,6 +210,42 @@ describe('PptxPresentation.destroy() — rejects in-flight worker requests', () 
     expect(added).toHaveLength(0);
   });
 
+  it('does not request remote fonts when useGoogleFonts is false', async () => {
+    G.Worker = SilentWorker;
+    G.location = { href: 'http://localhost/' };
+    installFontFaceSet();
+    const fetch = vi.fn(async () => ({ ok: true, text: async () => CSS }));
+    G.fetch = fetch;
+    vi.spyOn(
+      PptxPresentation.prototype as unknown as {
+        _parse(buffer: ArrayBuffer, resourcePolicy: object): Promise<void>;
+      },
+      '_parse',
+    ).mockImplementationOnce(async function (this: PptxPresentation) {
+      (this as unknown as { _preflight: object })._preflight = {
+        slideCount: 0,
+        slideWidth: 914400,
+        slideHeight: 914400,
+        defaultTextColor: null,
+        majorFont: 'Noto Sans CJK SC',
+        minorFont: null,
+        hlinkColor: null,
+        folHlinkColor: null,
+        embeddedFonts: [],
+        slides: [],
+        fontPreloadNames: ['Noto Sans CJK SC'],
+      };
+    });
+
+    const presentation = await PptxPresentation.load(new ArrayBuffer(0), {
+      mode: 'main',
+      useGoogleFonts: false,
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+    presentation.destroy();
+  });
+
   it('terminates directly when construction fails before the factory owns an instance', async () => {
     G.Worker = SilentWorker;
     G.location = { href: 'not a valid base URL' };

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -840,9 +840,10 @@ export function cssFontStack(normalized: string, authoredFamily = normalized): s
   }
   const variant: 'sans' | 'serif' = generic === 'serif' ? 'serif' : 'sans';
   const cjk = classifyCjkFont(authoredFamily);
-  const cjkPart = cjk
-    ? `${quoteAll(cjkFallbackChain(cjk, variant).filter((name) => name !== googleAlias))}, `
-    : '';
+  const cjkFamilies = cjk
+    ? cjkFallbackChain(cjk, variant).filter((name) => name !== googleAlias)
+    : [];
+  const cjkPart = cjkFamilies.length > 0 ? `${quoteAll(cjkFamilies)}, ` : '';
   const nonCjk = variant === 'serif' ? NON_CJK_SERIF_FALLBACKS : NON_CJK_SANS_FALLBACKS;
   const nonCjkPart = `${quoteAll(nonCjk)}, `;
   return `"${normalized}", ${subPart}${aliasPart}${cjkPart}${nonCjkPart}${generic}`;

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -65,6 +65,7 @@ import {
   clampCanvasSize,
   classifyCjkFont,
   classifyFontGeneric,
+  googleCjkFontAlias,
   cjkFallbackChain,
   NON_CJK_SANS_FALLBACKS,
   NON_CJK_SERIF_FALLBACKS,
@@ -830,6 +831,8 @@ export function cssFontStack(normalized: string, authoredFamily = normalized): s
   const generic = genericFallback(authoredFamily);
   const sub = OFFICE_FONT_SUBSTITUTE[authoredFamily.toLowerCase()];
   const subPart = sub ? `"${sub}", ` : '';
+  const googleAlias = googleCjkFontAlias(authoredFamily);
+  const aliasPart = googleAlias ? `"${googleAlias}", ` : '';
   // Arabic faces keep the historical chain unchanged (Arabic leads; appending a
   // CJK or non-CJK tail would let Latin/digits leak away from the Arabic face).
   if (isArabicScriptFace(authoredFamily)) {
@@ -837,10 +840,12 @@ export function cssFontStack(normalized: string, authoredFamily = normalized): s
   }
   const variant: 'sans' | 'serif' = generic === 'serif' ? 'serif' : 'sans';
   const cjk = classifyCjkFont(authoredFamily);
-  const cjkPart = cjk ? `${quoteAll(cjkFallbackChain(cjk, variant))}, ` : '';
+  const cjkPart = cjk
+    ? `${quoteAll(cjkFallbackChain(cjk, variant).filter((name) => name !== googleAlias))}, `
+    : '';
   const nonCjk = variant === 'serif' ? NON_CJK_SERIF_FALLBACKS : NON_CJK_SANS_FALLBACKS;
   const nonCjkPart = `${quoteAll(nonCjk)}, `;
-  return `"${normalized}", ${subPart}${cjkPart}${nonCjkPart}${generic}`;
+  return `"${normalized}", ${subPart}${aliasPart}${cjkPart}${nonCjkPart}${generic}`;
 }
 
 /**

--- a/packages/xlsx/src/font-stack.test.ts
+++ b/packages/xlsx/src/font-stack.test.ts
@@ -20,6 +20,26 @@ describe('fontStackFor — default Latin chain (regression)', () => {
 });
 
 describe('fontStackFor — CJK language-specific Noto ordering', () => {
+  it('routes a native Noto CJK name through the loaded Google family', () => {
+    const sans = fontStackFor(' Noto Sans CJK JP ');
+    expect(sans.startsWith('"Noto Sans CJK JP", "Noto Sans JP", ')).toBe(true);
+    expect(sans.match(/"Noto Sans JP"/g)).toHaveLength(1);
+
+    const serif = fontStackFor('Noto Serif CJK KR');
+    expect(serif.startsWith('"Noto Serif CJK KR", "Noto Serif KR", ')).toBe(true);
+    expect(serif.endsWith('serif')).toBe(true);
+  });
+
+  it('routes HK sans through Google Fonts without inventing an HK serif alias', () => {
+    expect(fontStackFor('Noto Sans CJK HK').startsWith(
+      '"Noto Sans CJK HK", "Noto Sans HK", ',
+    )).toBe(true);
+
+    const serif = fontStackFor('Noto Serif CJK HK');
+    expect(serif).not.toContain('"Noto Serif HK"');
+    expect(serif).not.toContain('"Noto Serif TC"');
+  });
+
   it('Korean sans (Malgun Gothic) → Noto Sans KR leads the tail', () => {
     const tail = cssTailFor('Malgun Gothic');
     expect(tail.startsWith('"Noto Sans KR"')).toBe(true);

--- a/packages/xlsx/src/font-stack.test.ts
+++ b/packages/xlsx/src/font-stack.test.ts
@@ -38,6 +38,7 @@ describe('fontStackFor — CJK language-specific Noto ordering', () => {
     const serif = fontStackFor('Noto Serif CJK HK');
     expect(serif).not.toContain('"Noto Serif HK"');
     expect(serif).not.toContain('"Noto Serif TC"');
+    expect(serif).not.toMatch(/,\s*,/);
   });
 
   it('Korean sans (Malgun Gothic) → Noto Sans KR leads the tail', () => {

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -14,7 +14,7 @@ import type {
 } from '@silurus/ooxml-core';
 import { chartImageFillKey, paintOptionalImagePlaceholder } from '@silurus/ooxml-core';
 import { placePhoneticRuns } from './phonetic.js';
-import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, rasterizeMathSvg, tintMathRaster, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, isUax14NoBreakPair, containsSeaScript, isGraphemeFillText, seaMixedBreakOffsets, fitSeaWordPrefix, graphemeClusterOffsets, xlsxBorderDashArray, drawImageCropped, hexToRgba, intendedSingleLinePx, verticalTrLongMark, verticalVertGlyphReachable, applyStroke, resolveFill, type SparklineModel, type MathNode, type MathRenderer, type RasterizedMathSvg } from '@silurus/ooxml-core';
+import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, rasterizeMathSvg, tintMathRaster, classifyCjkFont, classifyFontGeneric, googleCjkFontAlias, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, isUax14NoBreakPair, containsSeaScript, isGraphemeFillText, seaMixedBreakOffsets, fitSeaWordPrefix, graphemeClusterOffsets, xlsxBorderDashArray, drawImageCropped, hexToRgba, intendedSingleLinePx, verticalTrLongMark, verticalVertGlyphReachable, applyStroke, resolveFill, type SparklineModel, type MathNode, type MathRenderer, type RasterizedMathSvg } from '@silurus/ooxml-core';
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValueWithColor } from './number-format.js';
 import { type CfContext, type CfResult, compileCf, evaluateCf } from './conditional-format.js';
@@ -113,7 +113,12 @@ export function cssTailFor(name: string | null | undefined): string {
     return DEFAULT_FONT_FAMILY;
   }
   const serif = generic === 'serif';
-  const cjkPart = cjkFallbackChain(cjk, serif ? 'serif' : 'sans')
+  const googleAlias = googleCjkFontAlias(name);
+  const cjkPart = [
+    ...(googleAlias ? [googleAlias] : []),
+    ...cjkFallbackChain(cjk, serif ? 'serif' : 'sans')
+      .filter((family) => family !== googleAlias),
+  ]
     .map((n) => `"${n}"`)
     .join(', ');
   const tail = serif ? NON_CJK_SERIF_TAIL : NON_CJK_SANS_TAIL;
@@ -124,7 +129,8 @@ export function cssTailFor(name: string | null | undefined): string {
 
 /** Full CSS font-family list for a cell font name (named face first). */
 export function fontStackFor(name: string | null | undefined): string {
-  return name ? `"${name}", ${cssTailFor(name)}` : DEFAULT_FONT_FAMILY;
+  const normalized = name?.trim();
+  return normalized ? `"${normalized}", ${cssTailFor(normalized)}` : DEFAULT_FONT_FAMILY;
 }
 
 const DEFAULT_FONT_SIZE = 11;

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -114,17 +114,19 @@ export function cssTailFor(name: string | null | undefined): string {
   }
   const serif = generic === 'serif';
   const googleAlias = googleCjkFontAlias(name);
-  const cjkPart = [
+  const cjkFamilies = [
     ...(googleAlias ? [googleAlias] : []),
     ...cjkFallbackChain(cjk, serif ? 'serif' : 'sans')
       .filter((family) => family !== googleAlias),
-  ]
+  ];
+  const cjkPart = cjkFamilies
     .map((n) => `"${n}"`)
     .join(', ');
+  const cjkPrefix = cjkPart ? `${cjkPart}, ` : '';
   const tail = serif ? NON_CJK_SERIF_TAIL : NON_CJK_SANS_TAIL;
   const genericKeyword = serif ? 'serif' : 'sans-serif';
   // CJK Noto leads, then Latin/metric substitutes, Arabic, non-CJK scripts.
-  return `${cjkPart}, "Calibri", "Carlito", "Cambria", "Caladea", Arial, "Noto Naskh Arabic", "Noto Sans Arabic", ${tail}, ${genericKeyword}`;
+  return `${cjkPrefix}"Calibri", "Carlito", "Cambria", "Caladea", Arial, "Noto Naskh Arabic", "Noto Sans Arabic", ${tail}, ${genericKeyword}`;
 }
 
 /** Full CSS font-family list for a cell font name (named face first). */


### PR DESCRIPTION
## Summary

- Preserve the authored Linux Noto CJK family while routing Canvas fallback to the equivalent Google Fonts family.
- Share one explicit alias catalog between on-demand preload and DOCX, PPTX, and XLSX font stacks.
- Cover SC, TC, JP, KR, and the available HK sans family without inventing an unsupported Noto Serif HK mapping.
- Keep empty optional CJK fallback segments syntactically valid so Canvas never retains a preceding run's font.

This supersedes #1465 so the maintainer follow-up can be included while preserving @z2014's original commit and authorship.

## Behavior and compatibility

- The original OOXML font name remains first in every stack.
- Remote loading remains gated by `useGoogleFonts` and on-demand document use.
- Embedded fonts and existing Office metric-compatible substitutions keep their priority.
- Google Fonts does not provide Noto Serif HK, so the native HK serif name is preserved without an inferred TC substitution.
- No migration is required.

## Verification

- Focused core, DOCX, PPTX, and XLSX font suites: 136 passed.
- Full unit/integration suite: 8,915 passed, 25 skipped; private-corpus harness tests: 2 passed.
- TypeScript workspace build passed after rebuilding generated WASM.
- Merge-base-bound private self-VRT against `c0b3e3e8df050620204587b00beb3cc137c1364e`: DOCX 51, PPTX 19, and XLSX 139 documents passed with no pixel differences.
- PPTX private main/worker parity: 19 passed.
- `git diff --check` passed.

## Adversarial review

- The mapping follows the published Noto/Google Fonts family identities; it does not rewrite OOXML data or introduce sample-specific inference.
- The alias table and lookups are bounded constant-size work. Existing font loading, caching, refcounting, failure cleanup, and opt-in resource policy are unchanged.
- Shared classification and preload policy remain in core; format packages retain only their stack construction and tests.
- DOCX, PPTX, and XLSX preload and Canvas paths were inspected explicitly. Main and worker rendering use the same shared catalog.
