### PR TITLE
fix(core): contain failed image cleanup promises

### DIFF
--- a/packages/core/src/image/bitmap-image-by-path.test.ts
+++ b/packages/core/src/image/bitmap-image-by-path.test.ts
@@ -918,6 +918,30 @@ describe('acquireBitmapCacheLease (render-pass liveness)', () => {
     await Promise.resolve();
   };
 
+  it('handles a failed cleanup promise while its render lease remains open', async () => {
+    const owner = {};
+    const failure = new Error('expected image decode failure');
+    const unhandled: unknown[] = [];
+    const recordUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', recordUnhandled);
+
+    try {
+      await withBitmapCacheLease(owner, undefined, async () => {
+        await expect(getCachedDerivedBitmap('test', 'failed', owner, async () => {
+          throw failure;
+        })).rejects.toBe(failure);
+
+        // A sibling image can keep the render pass alive after this decode has
+        // been contained. Node reports an unhandled rejection before the next
+        // timer when an internal cleanup branch has no rejection handler yet.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(unhandled).toEqual([]);
+      });
+    } finally {
+      process.off('unhandledRejection', recordUnhandled);
+    }
+  });
+
   it('defers an LRU-eviction close past the cap until the lease is released', async () => {
     const closed: string[] = [];
     vi.stubGlobal('createImageBitmap', vi.fn(async (blob: Blob) => {

--- a/packages/core/src/image/bitmap-image-by-path.ts
+++ b/packages/core/src/image/bitmap-image-by-path.ts
@@ -801,7 +801,15 @@ function getCachedOwnedBitmap(
   }
 
   const produced = withDecodedImageSlot(owner, produce);
-  const ownedPromise = produced.then(({ bitmap, owned }) => (owned ? bitmap : null));
+  // This branch exists only so eviction/teardown can eventually close a surface
+  // owned by the entry. A failed producer owns nothing to close, so normalize
+  // that outcome immediately instead of retaining a rejected cleanup promise.
+  // In particular, a render-pass lease may defer consuming this branch until a
+  // slower sibling image settles; leaving it rejected meanwhile would surface a
+  // global unhandled rejection even though the caller handled `promise` below.
+  const ownedPromise = produced
+    .then(({ bitmap, owned }) => (owned ? bitmap : null))
+    .catch(() => null);
   const promise = produced.then(({ bitmap, owned }) => {
     try {
       registerActiveBitmap(owner, bitmap);


### PR DESCRIPTION
## Outcome

Contained image decode failures no longer surface as global unhandled promise rejections while a sibling image keeps a render lease open. The caller-facing decode promise still rejects normally, so renderers and resource-limit handling retain their existing behavior.

Closes #1477.

## Changes

- Make the cleanup-only bitmap ownership branch non-rejecting because a failed producer owns no surface to close.
- Add a deterministic regression test that holds the render lease across the unhandled-rejection checkpoint.

## Verification

- Core bitmap cache and decode-gate tests: 40 passed
- Core image subsystem: 310 passed
- Representative DOCX, XLSX, and PPTX image tests: 127 passed
- Workspace typecheck
- Diff whitespace check

## Adversarial review

Passed. The review confirmed that the public caller-facing promise still preserves decode, TIFF, and resource-limit failures; only the cleanup handle converts producer failure to a null surface. Existing lease, eviction, retry, close-once, cache-budget, and cross-format tests pass. The change adds no format heuristics, thresholds, public API changes, or new unbounded work. ECMA-376 image semantics are unchanged; this corrects internal promise ownership and lifecycle only.