### PR TITLE
fix(pptx): honor level colors and authored table height

### DIFF
--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -3124,6 +3124,9 @@ fn produce_slide_unit_with_journal(
             let master_color = master_root
                 .map(|root| parse_master_txstyle_color(root, &theme))
                 .unwrap_or_default();
+            let master_level_colors = master_root
+                .map(|root| parse_master_level_colors(root, &theme))
+                .unwrap_or_default();
             let master_level_bullets = master_root
                 .map(|root| {
                     parse_master_level_bullets(
@@ -3139,6 +3142,7 @@ fn produce_slide_unit_with_journal(
                 theme,
                 master_bg,
                 master_color,
+                master_level_colors,
                 master_level_bullets,
             }
         });
@@ -3149,11 +3153,18 @@ fn produce_slide_unit_with_journal(
         // a clrMapOvr slide passes the OVERRIDE-adjusted pair so its layout colors
         // flip with the override (mirrors the master theme-dependent recompute
         // above), everything else is the frozen bundle maps.
-        let (layout_theme, layout_master_bullets): (&PptxTheme, &HashMap<String, LevelBullets>) =
-            match effective_master.as_ref() {
-                Some(e) => (&e.theme, &e.master_level_bullets),
-                None => (&bundle.theme, &bundle.master_level_bullets),
-            };
+        let (layout_theme, layout_master_colors, layout_master_bullets): (
+            &PptxTheme,
+            &HashMap<String, LevelColors>,
+            &HashMap<String, LevelBullets>,
+        ) = match effective_master.as_ref() {
+            Some(e) => (&e.theme, &e.master_level_colors, &e.master_level_bullets),
+            None => (
+                &bundle.theme,
+                &bundle.master_level_colors,
+                &bundle.master_level_bullets,
+            ),
+        };
         // Build a `ParsedLayout` from a layout XML string with the resolved
         // theme/bullets and this bundle's remaining (theme-independent) maps.
         let build_parsed_layout = |lx: &str, zip: &mut PptxZip| -> ParsedLayout {
@@ -3162,6 +3173,7 @@ fn produce_slide_unit_with_journal(
                 &bundle.master_font_sizes,
                 &bundle.master_font_families,
                 &bundle.master_level_font_sizes,
+                layout_master_colors,
                 &bundle.master_level_indents,
                 layout_master_bullets,
                 &bundle.master_anchors,
@@ -6190,6 +6202,7 @@ mod tests {
                 None,
                 None,
                 [None; 9],
+                std::array::from_fn(|_| None),
                 Default::default(), // inherited_level_indents
                 &empty_level_bullets(),
                 None,
@@ -6276,6 +6289,7 @@ mod tests {
             &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
+            &HashMap::new(),
             &master_indents,
             &HashMap::new(),
             &HashMap::new(),
@@ -6352,6 +6366,7 @@ mod tests {
                 &m_f64,
                 &m_str,
                 &m_lfs,
+                &HashMap::new(),
                 &m_li,
                 &m_lb,
                 &m_str,
@@ -6727,6 +6742,101 @@ mod tests {
             Some("112233".to_string()),
             "an explicit layout idx colour takes priority over the master default"
         );
+    }
+
+    /// ECMA-376 §21.1.2.4: `pPr@lvl="1"` selects `lvl2pPr`. A layout's
+    /// lvl1 colour must not become a body-wide fallback for nested paragraphs;
+    /// the matching master lvl2 colour remains the inherited value when the
+    /// layout leaves lvl2 unspecified.
+    #[test]
+    fn placeholder_text_color_inherits_from_matching_list_level() {
+        let mut theme = HashMap::new();
+        theme.insert("tx1".to_owned(), "505050".to_owned());
+        theme.insert("tx2".to_owned(), "68217A".to_owned());
+
+        let master_xml = r#"<p:sldMaster
+          xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <p:cSld><p:spTree/></p:cSld>
+          <p:txStyles><p:bodyStyle>
+            <a:lvl1pPr><a:defRPr><a:solidFill><a:schemeClr val="tx2"/></a:solidFill></a:defRPr></a:lvl1pPr>
+            <a:lvl2pPr><a:defRPr><a:solidFill><a:schemeClr val="tx1"/></a:solidFill></a:defRPr></a:lvl2pPr>
+          </p:bodyStyle></p:txStyles>
+        </p:sldMaster>"#;
+        let master_doc = roxmltree::Document::parse(master_xml).unwrap();
+        let master_colors = parse_master_level_colors(master_doc.root_element(), &theme);
+
+        let layout_xml = r#"<p:sldLayout
+          xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <p:cSld><p:spTree><p:sp>
+            <p:nvSpPr><p:nvPr><p:ph type="body" idx="10"/></p:nvPr></p:nvSpPr>
+            <p:spPr/>
+            <p:txBody><a:bodyPr/><a:lstStyle>
+              <a:lvl1pPr><a:defRPr><a:solidFill><a:schemeClr val="tx2"/></a:solidFill></a:defRPr></a:lvl1pPr>
+              <a:lvl2pPr><a:defRPr/></a:lvl2pPr>
+            </a:lstStyle><a:p/></p:txBody>
+          </p:sp></p:spTree></p:cSld>
+        </p:sldLayout>"#;
+        let layout_doc = roxmltree::Document::parse(layout_xml).unwrap();
+        let mut zip = PptxZip::new(Cursor::new(empty_zip_bytes())).unwrap();
+        let placeholders = parse_layout_placeholders(
+            layout_doc.root_element(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &master_colors,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &theme,
+            "ppt/slideLayouts",
+            &HashMap::new(),
+            &mut zip,
+        );
+        let inherited = placeholders.lookup_level_colors("body", Some(10));
+        assert_eq!(inherited[0].as_deref(), Some("68217A"));
+        assert_eq!(inherited[1].as_deref(), Some("505050"));
+
+        let body_xml = r#"<a:txBody xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <a:bodyPr/><a:lstStyle/><a:p><a:pPr lvl="1"/><a:r><a:t>Nested</a:t></a:r></a:p>
+        </a:txBody>"#;
+        let body_doc = roxmltree::Document::parse(body_xml).unwrap();
+        let body = parse_text_body(
+            body_doc.root_element(),
+            &theme,
+            &HashMap::new(),
+            "ppt/slides",
+            None,
+            None,
+            [None; 9],
+            inherited,
+            Default::default(),
+            &empty_level_bullets(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            ShapeKind::Sp,
+            &mut zip,
+        );
+        assert_eq!(body.paragraphs[0].def_color.as_deref(), Some("505050"));
     }
 
     /// ECMA-376 §20.1.4.2.27 (`CT_TableStyleCellStyle`) — a cell style's fill is
@@ -7136,10 +7246,11 @@ mod tests {
                 &theme,
                 &rels,
                 "ppt/slides",
-                None,               // inherited_font_size
-                None,               // inherited_font_family
-                [None; 9],          // inherited_level_font_sizes
-                Default::default(), // inherited_level_indents
+                None,                          // inherited_font_size
+                None,                          // inherited_font_family
+                [None; 9],                     // inherited_level_font_sizes
+                std::array::from_fn(|_| None), // inherited_level_colors
+                Default::default(),            // inherited_level_indents
                 &empty_level_bullets(),
                 None, // inherited_bold
                 None, // inherited_italic
@@ -7213,6 +7324,7 @@ mod tests {
                 None,
                 None,
                 [None; 9],
+                std::array::from_fn(|_| None),
                 Default::default(),
                 &empty_level_bullets(),
                 None,
@@ -7299,6 +7411,7 @@ mod tests {
                 None,
                 None,
                 [None; 9],
+                std::array::from_fn(|_| None),
                 Default::default(), // inherited_level_indents
                 &empty_level_bullets(),
                 None,
@@ -7389,6 +7502,7 @@ mod tests {
                 None,
                 None,
                 [None; 9],
+                std::array::from_fn(|_| None),
                 Default::default(),
                 &empty_level_bullets(),
                 None,

--- a/packages/pptx/parser/src/master.rs
+++ b/packages/pptx/parser/src/master.rs
@@ -12,11 +12,12 @@ use crate::shape::{
     extract_decorative_shapes, resolve_picture_shape_properties, PictureShapeProperties,
 };
 use crate::text::{
-    empty_level_bullets, extract_level_bullets, extract_level_font_sizes, extract_level_indents,
-    extract_lvl1_font_size, has_any_level_bullet, has_any_level_indent, has_any_level_size,
-    merge_level_bullets, merge_level_indents, merge_level_sizes, read_level_bullets,
+    empty_level_bullets, extract_level_bullets, extract_level_colors, extract_level_font_sizes,
+    extract_level_indents, extract_lvl1_font_size, has_any_level_bullet, has_any_level_color,
+    has_any_level_indent, has_any_level_size, merge_level_bullets, merge_level_colors,
+    merge_level_indents, merge_level_sizes, read_level_bullets, read_level_colors,
     read_level_font_sizes, read_level_indents, text_property_color, BuMarker, LevelBullets,
-    LevelFontSizes, LevelIndents,
+    LevelColors, LevelFontSizes, LevelIndents,
 };
 use crate::theme::{
     bake_clr_map, parse_theme_part, resolve_theme_typeface, PptxSchemeResolver, PptxTheme,
@@ -70,6 +71,9 @@ pub(crate) struct LayoutPlaceholders {
     /// Per-list-level default font sizes (pt) per placeholder type.
     pub(crate) by_type_level_sizes: HashMap<String, LevelFontSizes>,
     pub(crate) by_type_master_level_sizes: HashMap<String, LevelFontSizes>,
+    pub(crate) by_idx_level_colors: HashMap<u32, LevelColors>,
+    pub(crate) by_type_level_colors: HashMap<String, LevelColors>,
+    pub(crate) by_type_master_level_colors: HashMap<String, LevelColors>,
     /// Per-list-level paragraph indents (`marL`/`marR`/`indent`, EMU) per
     /// placeholder idx — what a paragraph with no own `marL`/`marR`/`indent`
     /// inherits from the authored list-style cascade (ECMA-376 §21.1.2.4.13),
@@ -374,6 +378,35 @@ impl LayoutPlaceholders {
                 }
             })
             .unwrap_or([None; 9])
+    }
+
+    pub(crate) fn lookup_level_colors(&self, ph_type: &str, ph_idx: Option<u32>) -> LevelColors {
+        if let Some(i) = ph_idx {
+            return self
+                .by_idx_level_colors
+                .get(&i)
+                .cloned()
+                .or_else(|| self.by_type_master_level_colors.get(ph_type).cloned())
+                .or_else(|| {
+                    if ph_type == "obj" {
+                        self.by_type_master_level_colors.get("").cloned()
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_else(|| std::array::from_fn(|_| None));
+        }
+        self.by_type_level_colors
+            .get(ph_type)
+            .cloned()
+            .or_else(|| {
+                if ph_type == "body" {
+                    self.by_type_level_colors.get("").cloned()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_else(|| std::array::from_fn(|_| None))
     }
 
     /// Per-list-level inherited paragraph indents (lvl1..lvl9). Same idx-strict
@@ -1204,6 +1237,57 @@ pub(crate) fn parse_master_level_font_sizes(
     map
 }
 
+/// Per-list-level default run colours from the master placeholder cascade.
+/// Per-placeholder list styles win per level; missing levels fall back to the
+/// matching master txStyles category.
+pub(crate) fn parse_master_level_colors(
+    root: roxmltree::Node<'_, '_>,
+    theme: &HashMap<String, String>,
+) -> HashMap<String, LevelColors> {
+    let mut specific: HashMap<String, LevelColors> = HashMap::new();
+    if let Some(sp_tree) = child(root, "cSld").and_then(|n| child(n, "spTree")) {
+        for sp in sp_tree
+            .children()
+            .filter(|n| n.is_element() && n.tag_name().name() == "sp")
+        {
+            if let Some(ph) = sp
+                .descendants()
+                .find(|n| n.is_element() && n.tag_name().name() == "ph")
+            {
+                let ph_type = attr(&ph, "type").unwrap_or_default();
+                if let Some(tx_body) = child(sp, "txBody") {
+                    let colors = extract_level_colors(tx_body, theme);
+                    if has_any_level_color(&colors) {
+                        specific.entry(ph_type).or_insert(colors);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut generic: HashMap<String, LevelColors> = HashMap::new();
+    if let Some(tx_styles) = child(root, "txStyles") {
+        for (style_name, ph_types) in MASTER_TXSTYLE_PH_TYPES {
+            if let Some(style_node) = child(tx_styles, style_name) {
+                let colors = read_level_colors(style_node, theme);
+                if has_any_level_color(&colors) {
+                    for ph_type in *ph_types {
+                        generic.insert((*ph_type).to_owned(), colors.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    for (ph_type, colors) in generic {
+        specific
+            .entry(ph_type)
+            .and_modify(|current| *current = merge_level_colors(current, &colors))
+            .or_insert(colors);
+    }
+    specific
+}
+
 /// Per-list-level paragraph indents (`marL`/`marR`/`indent`, EMU) from the master,
 /// keyed by ph_type. Mirrors `parse_master_level_font_sizes` exactly (same per-shape
 /// lstStyle then `txStyles` tiers via `MASTER_TXSTYLE_PH_TYPES`): a master body
@@ -1550,6 +1634,7 @@ pub(crate) fn parse_layout_placeholders(
     master_font_sizes: &HashMap<String, f64>,
     master_font_families: &HashMap<String, String>,
     master_level_font_sizes: &HashMap<String, LevelFontSizes>,
+    master_level_colors: &HashMap<String, LevelColors>,
     master_level_indents: &HashMap<String, LevelIndents>,
     master_level_bullets: &HashMap<String, LevelBullets>,
     master_anchors: &HashMap<String, String>,
@@ -1572,6 +1657,7 @@ pub(crate) fn parse_layout_placeholders(
         by_type_master_font_size: master_font_sizes.clone(),
         by_type_master_font_family: master_font_families.clone(),
         by_type_master_level_sizes: master_level_font_sizes.clone(),
+        by_type_master_level_colors: master_level_colors.clone(),
         by_type_master_level_indents: master_level_indents.clone(),
         by_type_master_level_bullets: master_level_bullets.clone(),
         by_type_master_anchor: master_anchors.clone(),
@@ -1628,6 +1714,9 @@ pub(crate) fn parse_layout_placeholders(
         let layout_level_sizes: LevelFontSizes = child(sp, "txBody")
             .map(extract_level_font_sizes)
             .unwrap_or([None; 9]);
+        let layout_level_colors: LevelColors = child(sp, "txBody")
+            .map(|tx_body| extract_level_colors(tx_body, theme))
+            .unwrap_or_else(|| std::array::from_fn(|_| None));
         // Per-level indents (marL/marR/indent) from the layout placeholder's own
         // lstStyle, the inherited list-indent cascade (ECMA-376 §21.1.2.4.13).
         let layout_level_indents: LevelIndents = child(sp, "txBody")
@@ -1797,6 +1886,14 @@ pub(crate) fn parse_layout_placeholders(
                 if has_any_level_size(&level_sizes) {
                     lph.by_idx_level_sizes.entry(idx).or_insert(level_sizes);
                 }
+                let empty_colors: LevelColors = std::array::from_fn(|_| None);
+                let level_colors = merge_level_colors(
+                    &layout_level_colors,
+                    master_level_colors.get(&ph_type).unwrap_or(&empty_colors),
+                );
+                if has_any_level_color(&level_colors) {
+                    lph.by_idx_level_colors.entry(idx).or_insert(level_colors);
+                }
                 // Per-level indents: layout lstStyle wins per axis/level, else master.
                 let level_indents = merge_level_indents(
                     &layout_level_indents,
@@ -1896,6 +1993,16 @@ pub(crate) fn parse_layout_placeholders(
                 lph.by_type_level_sizes
                     .entry(ph_type.clone())
                     .or_insert(type_level_sizes);
+            }
+            let empty_colors: LevelColors = std::array::from_fn(|_| None);
+            let type_level_colors = merge_level_colors(
+                &layout_level_colors,
+                master_level_colors.get(&ph_type).unwrap_or(&empty_colors),
+            );
+            if has_any_level_color(&type_level_colors) {
+                lph.by_type_level_colors
+                    .entry(ph_type.clone())
+                    .or_insert(type_level_colors);
             }
             let type_level_indents = merge_level_indents(
                 &layout_level_indents,
@@ -2013,6 +2120,11 @@ pub(crate) fn parse_layout_placeholders(
             .entry(ph_type.clone())
             .or_insert(*value);
     }
+    for (ph_type, value) in master_level_colors {
+        lph.by_type_level_colors
+            .entry(ph_type.clone())
+            .or_insert_with(|| value.clone());
+    }
     for (ph_type, value) in master_level_indents {
         lph.by_type_level_indents
             .entry(ph_type.clone())
@@ -2092,6 +2204,7 @@ pub(crate) fn parse_layout(
     master_font_sizes: &HashMap<String, f64>,
     master_font_families: &HashMap<String, String>,
     master_level_font_sizes: &HashMap<String, LevelFontSizes>,
+    master_level_colors: &HashMap<String, LevelColors>,
     master_level_indents: &HashMap<String, LevelIndents>,
     master_level_bullets: &HashMap<String, LevelBullets>,
     master_anchors: &HashMap<String, String>,
@@ -2122,6 +2235,7 @@ pub(crate) fn parse_layout(
         master_font_sizes,
         master_font_families,
         master_level_font_sizes,
+        master_level_colors,
         master_level_indents,
         master_level_bullets,
         master_anchors,
@@ -2190,6 +2304,7 @@ pub(crate) struct ParsedMaster {
     pub(crate) master_font_sizes: HashMap<String, f64>,
     pub(crate) master_font_families: HashMap<String, String>,
     pub(crate) master_level_font_sizes: HashMap<String, LevelFontSizes>,
+    pub(crate) master_level_colors: HashMap<String, LevelColors>,
     pub(crate) master_level_indents: HashMap<String, LevelIndents>,
     pub(crate) master_level_bullets: HashMap<String, LevelBullets>,
     pub(crate) master_anchors: HashMap<String, String>,
@@ -2223,6 +2338,8 @@ pub(crate) struct EffectiveMaster {
     pub(crate) master_bg: Option<Fill>,
     /// Master txStyles placeholder colors re-resolved against `theme`.
     pub(crate) master_color: HashMap<String, String>,
+    /// Master list-level colours re-resolved against `theme`.
+    pub(crate) master_level_colors: HashMap<String, LevelColors>,
     /// Master per-level bullet colors re-resolved against `theme`.
     pub(crate) master_level_bullets: HashMap<String, LevelBullets>,
 }
@@ -2315,6 +2432,9 @@ pub(crate) fn build_master_bundle(
     let master_level_font_sizes = master_root
         .map(parse_master_level_font_sizes)
         .unwrap_or_default();
+    let master_level_colors = master_root
+        .map(|root| parse_master_level_colors(root, &theme))
+        .unwrap_or_default();
     let master_level_indents = master_root
         .map(parse_master_level_indents)
         .unwrap_or_default();
@@ -2367,6 +2487,7 @@ pub(crate) fn build_master_bundle(
         master_font_sizes,
         master_font_families,
         master_level_font_sizes,
+        master_level_colors,
         master_level_indents,
         master_level_bullets,
         master_anchors,
@@ -2417,6 +2538,7 @@ mod placeholder_geometry_tests {
             master_font_sizes,
             &HashMap::<String, String>::new(),
             &HashMap::<String, LevelFontSizes>::new(),
+            &HashMap::<String, LevelColors>::new(),
             &HashMap::<String, LevelIndents>::new(),
             &HashMap::<String, LevelBullets>::new(),
             &HashMap::<String, String>::new(),
@@ -2677,6 +2799,7 @@ mod placeholder_geometry_tests {
 
         let placeholders = parse_layout_placeholders(
             doc.root_element(),
+            &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),

--- a/packages/pptx/parser/src/shape.rs
+++ b/packages/pptx/parser/src/shape.rs
@@ -1138,6 +1138,15 @@ pub(crate) fn parse_shape(
     } else {
         empty_level_bullets()
     };
+    let inherited_level_colors = if ph_node.is_some()
+        && style_node
+            .and_then(|style| child(style, "fontRef"))
+            .is_none()
+    {
+        lph.lookup_level_colors(&ph_type, ph_idx)
+    } else {
+        std::array::from_fn(|_| None)
+    };
     let text_body = child(sp_node, "txBody").map(|n| {
         parse_text_body(
             n,
@@ -1147,6 +1156,7 @@ pub(crate) fn parse_shape(
             inherited_font_size,
             inherited_font_family,
             inherited_level_font_sizes,
+            inherited_level_colors,
             inherited_level_indents,
             &inherited_level_bullets,
             inherited_bold,
@@ -2210,6 +2220,7 @@ pub(crate) fn parse_table_cell(
             None,
             None,
             [None; 9],
+            std::array::from_fn(|_| None),
             Default::default(), // inherited_level_indents
             &empty_level_bullets(),
             None,
@@ -3470,6 +3481,54 @@ mod style_ref_tests {
 
         assert!(shape.stroke.is_none());
         assert!(matches!(shape.fill, Some(Fill::None)));
+    }
+
+    #[test]
+    fn slide_font_ref_replaces_placeholder_list_level_color() {
+        let theme = PptxTheme::default();
+        let mut placeholders = LayoutPlaceholders::default();
+        placeholders.by_idx_level_colors.insert(
+            7,
+            std::array::from_fn(|level| {
+                if level == 1 {
+                    Some("68217A".to_owned())
+                } else {
+                    None
+                }
+            }),
+        );
+        let doc = roxmltree::Document::parse(
+            r#"<p:sp xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <p:nvSpPr><p:cNvPr id="1" name="Placeholder"/><p:cNvSpPr/><p:nvPr><p:ph type="body" idx="7"/></p:nvPr></p:nvSpPr>
+              <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="100000" cy="100000"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr>
+              <p:style><a:fontRef idx="minor"><a:srgbClr val="FFFFFF"/></a:fontRef></p:style>
+              <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:pPr lvl="1"/><a:r><a:t>Styled text</a:t></a:r></a:p></p:txBody>
+            </p:sp>"#,
+        )
+        .unwrap();
+        let mut zip = empty_zip();
+
+        let shape = parse_shape(
+            doc.root_element(),
+            &placeholders,
+            &theme,
+            &HashMap::new(),
+            "ppt/slides",
+            None,
+            &mut zip,
+        )
+        .expect("shape");
+
+        assert_eq!(shape.default_text_color.as_deref(), Some("FFFFFF"));
+        assert_eq!(
+            shape
+                .text_body
+                .as_ref()
+                .and_then(|body| body.paragraphs.first())
+                .and_then(|paragraph| paragraph.def_color.as_deref()),
+            None,
+            "an explicit slide fontRef must remain authoritative over placeholder list styles"
+        );
     }
 
     #[test]

--- a/packages/pptx/parser/src/smartart_fallback.rs
+++ b/packages/pptx/parser/src/smartart_fallback.rs
@@ -308,6 +308,7 @@ fn append_point_paragraphs(
         None,
         None,
         Default::default(),
+        std::array::from_fn(|_| None),
         Default::default(),
         &empty_level_bullets(),
         None,

--- a/packages/pptx/parser/src/text.rs
+++ b/packages/pptx/parser/src/text.rs
@@ -69,6 +69,45 @@ pub(crate) fn merge_level_sizes(
     out
 }
 
+/// Per-list-level default text colours. Index 0..=8 maps to
+/// `lvl1pPr`..`lvl9pPr` (ECMA-376 §21.1.2.4). Keeping these per level is
+/// essential: applying a layout's lvl1 colour as a body-wide fallback makes a
+/// `pPr@lvl="1"` paragraph inherit the wrong tier.
+pub(crate) type LevelColors = [Option<String>; 9];
+
+pub(crate) fn read_level_colors(
+    list_style: roxmltree::Node<'_, '_>,
+    theme: &HashMap<String, String>,
+) -> LevelColors {
+    let mut out: LevelColors = std::array::from_fn(|_| None);
+    for (lvl, slot) in out.iter_mut().enumerate() {
+        let tag = format!("lvl{}pPr", lvl + 1);
+        *slot = list_style
+            .children()
+            .find(|n| n.is_element() && n.tag_name().name() == tag)
+            .and_then(|lp| child(lp, "defRPr"))
+            .and_then(|rp| text_property_color(rp, theme));
+    }
+    out
+}
+
+pub(crate) fn extract_level_colors(
+    tx_body: roxmltree::Node<'_, '_>,
+    theme: &HashMap<String, String>,
+) -> LevelColors {
+    child(tx_body, "lstStyle")
+        .map(|list_style| read_level_colors(list_style, theme))
+        .unwrap_or_else(|| std::array::from_fn(|_| None))
+}
+
+pub(crate) fn has_any_level_color(colors: &LevelColors) -> bool {
+    colors.iter().any(Option::is_some)
+}
+
+pub(crate) fn merge_level_colors(primary: &LevelColors, fallback: &LevelColors) -> LevelColors {
+    std::array::from_fn(|lvl| primary[lvl].clone().or_else(|| fallback[lvl].clone()))
+}
+
 /// Per-list-level paragraph indents (EMU) — the `marL`/`marR`/`indent` attributes
 /// of a `<a:lvlNpPr>` (ECMA-376 §21.1.2.4.13; `lvlNpPr` is a
 /// `CT_TextParagraphProperties`, so these are attributes ON the level element
@@ -452,6 +491,7 @@ pub(crate) fn parse_text_body(
     inherited_font_size: Option<f64>,
     inherited_font_family: Option<String>,
     inherited_level_font_sizes: LevelFontSizes,
+    inherited_level_colors: LevelColors,
     inherited_level_indents: LevelIndents,
     inherited_level_bullets: &LevelBullets,
     inherited_bold: Option<bool>,
@@ -640,6 +680,8 @@ pub(crate) fn parse_text_body(
     // their size by `lvl` so nested bullets shrink (ECMA-376 §21.1.2.4).
     let own_level_sizes = extract_level_font_sizes(tx_body);
     let effective_level_sizes = merge_level_sizes(&own_level_sizes, &inherited_level_font_sizes);
+    let own_level_colors = extract_level_colors(tx_body, theme);
+    let effective_level_colors = merge_level_colors(&own_level_colors, &inherited_level_colors);
     // Effective per-list-level indents: this shape's own lstStyle wins per
     // axis/level, else the layout/master inherited per-level indents. A paragraph
     // that omits marL/marR/indent picks them by `lvl` from this cascade before
@@ -726,6 +768,17 @@ pub(crate) fn parse_text_body(
             )
         })
         .collect();
+
+    // A paragraph's own pPr > defRPr remains the most specific colour. When
+    // absent, inherit the defRPr fill from the matching list level rather than
+    // the text body's lvl1 default. `pPr@lvl="1"` selects lvl2pPr.
+    for paragraph in &mut paragraphs {
+        if paragraph.def_color.is_none() {
+            paragraph.def_color = effective_level_colors
+                .get(paragraph.lvl as usize)
+                .and_then(Clone::clone);
+        }
+    }
 
     // ECMA-376 §21.1.2.3.9, ST_TextCapsType §20.1.10.64: a run inherits
     // cap="all"/"small" from the shape's own lstStyle defRPr, else from the

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -4063,9 +4063,10 @@ export function renderTextBody(
   // paths byte-identical.
   eaVertUpright = false,
   // A zero-height table row asks PowerPoint to derive its height from the
-  // natural line box. A positive a:tr@h is instead an authored minimum: use the
-  // glyph-size box when checking whether content actually exceeds that minimum,
-  // so implicit leading alone does not enlarge an already-sufficient row.
+  // natural line box. Office treats a positive a:tr@h as an authored minimum
+  // ([MS-OE376] §2.1.1347): use the glyph-size box when checking whether content
+  // actually exceeds that minimum, so implicit leading alone does not enlarge
+  // an already-sufficient row.
   measureNaturalLineSpacing = measureOnly,
 ): number | void {
   // Vertical text: rotate rendering context so text flows top-to-bottom.
@@ -4437,30 +4438,43 @@ export function renderTextBody(
       // An Office-produced boundary deck confirms that this is independent of
       // the chosen font and of spAutoFit: Meiryo and Arial, fixed and spAutoFit
       // shapes all keep the same omitted-lnSpc pitch at a given point size.
-      // An explicit percentage is instead based directly on that authored size
-      // (ECMA-376 §21.1.2.2.5/.11). Table measurement therefore retains the
-      // natural 120% box only when line spacing is omitted in an auto-height
-      // row. A positive a:tr@h remains a minimum and uses the glyph-size box for
-      // overflow measurement. Neither path substitutes the font's design box
-      // for PowerPoint's natural baseline pitch.
+      // Percentage spacing scales this renderer's PowerPoint-compatible natural
+      // line box (ECMA-376 §21.1.2.2.5/.11 defines the authored percentage;
+      // Office output supplies the line-box compatibility behaviour). A positive
+      // a:tr@h remains a minimum: a lone terminal line may fit by its glyph box,
+      // while multi-line content must retain every painted line box. Neither
+      // path substitutes the font's design box for the baseline pitch.
       const naturalSingle = maxSizePx * 1.2;
       const useResolvedFontMetrics = isSpAutoFit && resolvedFontLine > naturalSingle;
       // A live resolved font box describes containment, not baseline advance.
       // Keeping the two values separate prevents a tall Meiryo design box from
       // being repeated between every pair of lines under spAutoFit (#1473).
       const implicitSingle = naturalSingle;
-      let lineHeight: number;
+      // Paint and table measurement must agree for explicitly authored
+      // percentage spacing. Positive rows with omitted lnSpc retain the
+      // existing glyph-box containment rule: the implicit leading is not by
+      // itself evidence that PowerPoint grows the authored minimum. An explicit
+      // percentage, however, is part of the authored content extent, and every
+      // line in a multi-line body consumes the painted line box.
+      const isFinalBodyLine = paraIdx === body.paragraphs.length - 1 && isLast;
+      const isOnlyBodyLine = body.paragraphs.length === 1 && lines.length === 1;
+      let paintedLineHeight: number;
       if (para.spaceLine) {
         if (para.spaceLine.type === 'pct') {
-          const percentageBase = measureOnly ? maxSizePx : naturalSingle;
-          lineHeight = percentageBase * (para.spaceLine.val / 100000);
+          paintedLineHeight = naturalSingle * (para.spaceLine.val / 100000);
         } else {
-          lineHeight = para.spaceLine.val * PT_TO_EMU * scale;
+          paintedLineHeight = para.spaceLine.val * PT_TO_EMU * scale;
         }
       } else {
-        lineHeight = measureOnly && !isSpAutoFit
-          ? (measureNaturalLineSpacing ? naturalSingle : maxSizePx)
-          : implicitSingle;
+        paintedLineHeight = implicitSingle;
+      }
+      let lineHeight = paintedLineHeight;
+      if (measureOnly && !isSpAutoFit && !measureNaturalLineSpacing) {
+        if (!para.spaceLine) {
+          lineHeight = maxSizePx;
+        } else if (para.spaceLine.type === 'pct' && isFinalBodyLine && isOnlyBodyLine) {
+          lineHeight = maxSizePx * (para.spaceLine.val / 100000);
+        }
       }
       // PowerPoint retains its established percentage-line advance, but seats
       // glyphs from a tall resolved fallback inside the authored percentage
@@ -6429,15 +6443,25 @@ export function renderTable(
     return w;
   };
 
-  // ── Row heights: ECMA-376 §21.1.3.18 (a:tr@h) is a MINIMUM ────────────────
-  // PowerPoint grows a row to fit its tallest cell's laid-out text (like
-  // Word's "at least" line rule). A literal h=0 therefore becomes
+  // ── Row heights: Office minimum-row semantics ─────────────────────────────
+  // ECMA-376 §21.1.3.18 defines a:tr@h as the row height; [MS-OE376]
+  // §2.1.1347 additionally constrains it to zero or at least the minimum row
+  // height. PowerPoint grows a row to fit its tallest cell's laid-out text. A
+  // literal h=0 therefore becomes
   // content-driven. We measure each cell's text body at its spanned width
   // (reusing the same renderTextBody machinery via measureOnly) and take
   // max(tr@h, tallest single-row cell content). A rowSpan cell distributes
   // its content height across the rows it covers so it doesn't inflate the
   // first row.
-  const rowHeights = el.rows.map(r => emuToPx(r.height, scale));
+  const authoredRowHeights = el.rows.map(r => emuToPx(r.height, scale));
+  const rowHeights = [...authoredRowHeights];
+  const authoredRowsTotalEmu = el.rows.reduce((sum, row) => sum + row.height, 0);
+  // The graphic-frame extent is the table's authored outer height. PowerPoint
+  // can leave slack between that extent and the sum of positive a:tr@h minima;
+  // that discrepancy signals that text-driven row growth was present when the
+  // table was authored. When the positive minima already fill the frame, do not
+  // invent growth merely because browser font metrics wrap differently.
+  const hasAuthoredRowGrowthSignal = el.height > authoredRowsTotalEmu;
 
   // First pass: single-row (rowSpan ≤ 1) cells set their own row's minimum.
   for (let ri = 0; ri < el.rows.length; ri++) {
@@ -6447,6 +6471,7 @@ export function renderTable(
       if (cell.hMerge || cell.vMerge) continue;
       if ((cell.rowSpan || 1) > 1) continue;
       if (!cell.textBody) continue;
+      if (row.height > 0 && !hasAuthoredRowGrowthSignal) continue;
       const cellW = spannedWidth(ci, cell.gridSpan || 1);
       const needed = (renderTextBody(
         ctx, cell.textBody, 0, 0, cellW, 0, scale, null, 0, false, false,
@@ -6470,6 +6495,7 @@ export function renderTable(
       const hasAutoHeightRow = el.rows
         .slice(ri, Math.min(el.rows.length, ri + span))
         .some((spannedRow) => spannedRow.height === 0);
+      if (!hasAutoHeightRow && !hasAuthoredRowGrowthSignal) continue;
       const needed = (renderTextBody(
         ctx, cell.textBody, 0, 0, cellW, 0, scale, null, 0, false, false,
         '#000000', slideNumber, rc, undefined, true, undefined, false, hasAutoHeightRow,

--- a/packages/pptx/src/table-border-single-draw.test.ts
+++ b/packages/pptx/src/table-border-single-draw.test.ts
@@ -205,6 +205,68 @@ describe('DrawingML <a:tbl> — shared interior gridline drawn once (spec-silent
     expect(horizontalAt(render(t), 18)).toHaveLength(1);
   });
 
+  it('grows a positive row for every painted baseline before the final glyph box', () => {
+    // [MS-OE376] §2.1.1347 gives Office's minimum-row rule. A lone terminal line
+    // may fit by its glyph box, but multi-line content consumes every line box
+    // used by paint. Three 18pt lines at explicit 100% use 3 * 21.6pt plus
+    // 3.6pt top/bottom insets = 72pt.
+    const textBody = {
+      verticalAnchor: 'ctr',
+      paragraphs: [{
+        alignment: 'l', marL: 0, marR: 0, indent: 0,
+        spaceBefore: null, spaceAfter: null,
+        spaceLine: { type: 'pct', val: 100000 },
+        runs: [
+          { type: 'text', text: 'one', fontSize: 18, fontFamily: 'Arial' },
+          { type: 'break' },
+          { type: 'text', text: 'two', fontSize: 18, fontFamily: 'Arial' },
+          { type: 'break' },
+          { type: 'text', text: 'three', fontSize: 18, fontFamily: 'Arial' },
+        ],
+        bullet: { type: 'none' }, eaLnBrk: true,
+      }],
+      defaultFontSize: null, defaultBold: null, defaultItalic: null,
+      lIns: 0, rIns: 0, tIns: 3.6 * EMU, bIns: 3.6 * EMU,
+      wrap: 'square', vert: 'horz', autoFit: 'none',
+    } as unknown as TextBody;
+    const t = tableOf([[cell({ textBody, borderB: ln() })]], [COL]);
+    t.rows[0].height = 60 * EMU;
+    t.height = 72 * EMU;
+
+    expect(horizontalAt(render(t), 72)).toHaveLength(1);
+  });
+
+  it('does not invent positive-row growth when row minima already fill the frame', () => {
+    const textBody = {
+      verticalAnchor: 'ctr',
+      paragraphs: [{
+        alignment: 'l', marL: 0, marR: 0, indent: 0,
+        spaceBefore: null, spaceAfter: null,
+        spaceLine: { type: 'pct', val: 100000 },
+        runs: [
+          { type: 'text', text: 'one', fontSize: 18, fontFamily: 'Arial' },
+          { type: 'break' },
+          { type: 'text', text: 'two', fontSize: 18, fontFamily: 'Arial' },
+          { type: 'break' },
+          { type: 'text', text: 'three', fontSize: 18, fontFamily: 'Arial' },
+        ],
+        bullet: { type: 'none' }, eaLnBrk: true,
+      }],
+      defaultFontSize: null, defaultBold: null, defaultItalic: null,
+      lIns: 0, rIns: 0, tIns: 3.6 * EMU, bIns: 3.6 * EMU,
+      wrap: 'square', vert: 'horz', autoFit: 'none',
+    } as unknown as TextBody;
+    const t = tableOf([
+      [cell({ textBody, borderB: ln() })],
+      [cell({ borderT: ln() })],
+    ], [COL]);
+    t.rows[0].height = 60 * EMU;
+    t.rows[1].height = 40 * EMU;
+    t.height = 100 * EMU;
+
+    expect(horizontalAt(render(t), 60)).toHaveLength(1);
+  });
+
   it('shared VERTICAL gridline is drawn exactly ONCE (not once per cell)', () => {
     // Left cell right = 1pt; right cell left = 1pt (same). Previously TWO strokes
     // at x=60 (one per cell); now exactly one.


### PR DESCRIPTION
## Summary

- inherit placeholder run colors from the matching DrawingML list level instead of treating level-one color as a body-wide default
- keep explicit slide font references authoritative over inherited placeholder list colors
- align positive table-row growth with authored graphic-frame slack and painted percentage line spacing
- add focused parser and renderer regression coverage

No migration is required.

## Specification

- ECMA-376 Part 1 sections 21.1.2.4.13-14 and 21.1.3.18
- MS-OE376 section 2.1.1347

## Verification

- PPTX parser library suite: 296 passed
- focused PPTX renderer tests: 23 passed
- workspace typecheck: passed
- complete local private PPTX self-VRT against the merge-base: 31 of 35 files exact; every changed page individually adjudicated against Office output
- complete private PPTX worker parity: 35 of 35 passed

## Adversarial review

The final diff contains no sample-name or path branches, empirical thresholds, or cross-format changes. The parser retains the nine bounded DrawingML list levels, theme remapping remains on the existing master/layout path, and the renderer adds only linear row accounting. DOCX, XLSX, and core are intentionally unaffected because both behaviors are PresentationML placeholder and table orchestration concerns.