### PR TITLE
fix(rendering): complete progressive callbacks for fast loads

### DIFF
--- a/packages/docx/src/document-progressive-complete.test.ts
+++ b/packages/docx/src/document-progressive-complete.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { OoxmlResourceUsageSnapshot, WorkerLike } from '@silurus/ooxml-core';
+import { DocxDocument } from './document.js';
+import { layoutSourceStore } from './layout-source-model-adapter.js';
+import { installStubCanvas, syntheticDocxModel } from './testing/synthetic-document.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The `onLayoutComplete` terminal-callback contract for main-mode progressive
+// loads: exactly one success notification per load, whether or not the
+// document was long enough to publish partials first.
+//
+// `layoutDocumentProgressively` only publishes a preview when the body has
+// more than MIN_PROGRESSIVE_ENTRIES entries, so a short document's drain
+// completes with `publishedLayout === null`. The success notification used to
+// be gated on that local, so consumers of a fast document never learned the
+// layout was complete — the terminal callback contract silently depended on
+// document speed.
+//
+// These tests drive the REAL `DocxDocument.load` progressive block: `_parse`
+// is stubbed to install a synthetic model/source (the WASM parse is not what
+// is under test), and the final usage probe is stubbed because the inert
+// inline worker cannot answer it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+class SilentWorker implements WorkerLike {
+  postMessage(): void {}
+  addEventListener(): void {}
+  removeEventListener(): void {}
+  terminate(): void {}
+}
+
+const globals = globalThis as Record<string, unknown>;
+const originals = {
+  Worker: globals.Worker,
+  location: globals.location,
+};
+
+const USAGE: OoxmlResourceUsageSnapshot = {
+  archiveEntryCount: 1,
+  declaredInflatedBytes: 0,
+  largestInflatedEntryBytes: 0,
+  distinctInflatedBytes: 0,
+  operationInflatedBytes: 0,
+};
+
+beforeAll(() => {
+  installStubCanvas();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  globals.Worker = originals.Worker;
+  globals.location = originals.location;
+});
+
+/** Stub the WASM parse with a synthetic document of `paragraphs` body entries. */
+function installMainModeParse(paragraphs: number): void {
+  globals.Worker = SilentWorker;
+  globals.location = { href: 'http://localhost/' };
+  vi.spyOn(
+    DocxDocument.prototype as unknown as {
+      _parse(
+        buffer: ArrayBuffer,
+        resourcePolicy: unknown,
+        useGoogleFonts?: boolean,
+        timeoutMs?: number,
+        onUsage?: unknown,
+        renderers?: unknown,
+        progressive?: unknown,
+      ): Promise<void>;
+    },
+    '_parse',
+  ).mockImplementation(async function (this: DocxDocument) {
+    const doc = this as unknown as {
+      _document: unknown;
+      _source: unknown;
+      _meta: unknown;
+    };
+    const model = syntheticDocxModel('plain', { paragraphs });
+    doc._document = model;
+    doc._source = layoutSourceStore(model);
+    doc._meta = null;
+  });
+  vi.spyOn(
+    DocxDocument.prototype as unknown as {
+      _resourceUsage(timeoutMs: number): Promise<OoxmlResourceUsageSnapshot>;
+    },
+    '_resourceUsage',
+  ).mockResolvedValue(USAGE);
+}
+
+describe('main-mode progressive load: onLayoutComplete contract', () => {
+  it('notifies completion exactly once for a fast document that publishes nothing early', async () => {
+    // Three body entries stay under the preview threshold, so the drain
+    // completes before any partial could be shown: no onLayoutPartial, and
+    // load() resolves on the finished layout itself. The completion callback
+    // must still fire — load() resolving is not a substitute for it.
+    installMainModeParse(3);
+    const completions: unknown[] = [];
+    const partials: unknown[] = [];
+
+    const doc = await DocxDocument.load(new ArrayBuffer(0), {
+      progressiveLayout: true,
+      onLayoutComplete: (error) => completions.push(error),
+      onLayoutPartial: (partial) => partials.push(partial),
+    });
+    await doc.waitUntilLayoutComplete();
+
+    expect(partials).toHaveLength(0);
+    expect(completions).toEqual([undefined]);
+    expect(doc.layoutComplete).toBe(true);
+    doc.destroy();
+  });
+
+  it('notifies completion exactly once after partials for a long document', async () => {
+    // Long enough to cross several page-count checkpoints: load() resolves on
+    // the opening publication and the drain keeps publishing. The completion
+    // callback fires once, after the last partial, never twice.
+    installMainModeParse(600);
+    const completions: unknown[] = [];
+    const partials: number[] = [];
+
+    const doc = await DocxDocument.load(new ArrayBuffer(0), {
+      progressiveLayout: true,
+      onLayoutComplete: (error) => completions.push(error),
+      onLayoutPartial: (partial) => partials.push(partial.availableUnits),
+    });
+    await doc.waitUntilLayoutComplete();
+
+    expect(partials.length).toBeGreaterThan(0);
+    expect(completions).toEqual([undefined]);
+    expect(doc.layoutComplete).toBe(true);
+    doc.destroy();
+  }, 300_000);
+});

--- a/packages/docx/src/document-worker-progressive.test.ts
+++ b/packages/docx/src/document-worker-progressive.test.ts
@@ -224,6 +224,40 @@ describe('worker-mode progressive load', () => {
     expect(completed).toBe(1);
   });
 
+  it('reports completion exactly once when the worker publishes nothing (fast document)', async () => {
+    // A document short enough to finish before the first checkpoint push never
+    // sends `layoutPartial`: load() resolves on the authoritative meta itself.
+    // The terminal callback contract must not depend on that — the consumer
+    // registered for completion either way.
+    const completions: unknown[] = [];
+    const harness = progressiveDocument({
+      onComplete: (error) => completions.push(error),
+    });
+
+    harness.settle({ type: 'parsedMeta', id: 11, meta: fullMeta(2) });
+    await harness.parsed;
+    await harness.document.waitUntilLayoutComplete();
+
+    expect(harness.document.pageCount).toBe(2);
+    expect(harness.document.layoutComplete).toBe(true);
+    expect(completions).toEqual([undefined]);
+  });
+
+  it('reports completion exactly once after partials (no double-fire)', async () => {
+    const completions: unknown[] = [];
+    const harness = progressiveDocument({
+      onComplete: (error) => completions.push(error),
+    });
+
+    harness.push({ type: 'layoutPartial', forId: 11, partial: partial(2, { review: REVIEW }) });
+    await harness.parsed;
+    harness.push({ type: 'layoutPartial', forId: 11, partial: partial(9) });
+    harness.settle({ type: 'parsedMeta', id: 11, meta: fullMeta(40) });
+    await harness.document.waitUntilLayoutComplete();
+
+    expect(completions).toEqual([undefined]);
+  });
+
   it('sends the default view as no view fields at all', async () => {
     // Keeps the wire shape identical to what pre-variant builds sent, so a
     // default load cannot accidentally select a different key.

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -703,11 +703,12 @@ export class DocxDocument {
               exact: true,
               complete: true,
             });
-            if (publishedLayout !== null) {
-              progressiveDocument._layoutObservers.notify(
-                'onLayoutComplete', opts.onLayoutComplete,
-              );
-            }
+            // The terminal success callback fires exactly once per load,
+            // whether or not any partial was published — consumers must not
+            // have to infer completion from document speed.
+            progressiveDocument._layoutObservers.notify(
+              'onLayoutComplete', opts.onLayoutComplete,
+            );
             // Nothing was published: there was nothing to show early, so
             // load() resolves here, on the layout that would have been built
             // anyway. Resolving an already-resolved deferred is a no-op.
@@ -965,9 +966,10 @@ export class DocxDocument {
     // A load whose worker published nothing resolves here instead — there was
     // never anything to show early, so `load()` waited for the real document.
     progressive.firstPublication.resolve();
-    if (progressive.published) {
-      this._layoutObservers.notify('onLayoutComplete', progressive.onComplete);
-    }
+    // The terminal success callback fires exactly once per load, published
+    // partials or not; `settled` above keeps the failure path from ever
+    // adding a second notification.
+    this._layoutObservers.notify('onLayoutComplete', progressive.onComplete);
   }
 
   /** Bookmark pages and the review anchor projections are derived from the

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -183,10 +183,12 @@ export interface LoadOptions extends CoreLoadOptions {
    */
   progressiveLayout?: boolean;
   /**
-   * Called once the full layout has replaced the provisional one, or with the
-   * failure if background layout threw. Only fires when
-   * {@link progressiveLayout} actually deferred work. Observer failures are
-   * reported and isolated from the layout result.
+   * Called exactly once when a successful {@link progressiveLayout} load has
+   * reached its authoritative full layout, whether that happens before or
+   * after `load()` resolves. A failure after an early publication is delivered
+   * as the argument; a failure before the first publication rejects `load()`
+   * directly and does not call this observer. Observer failures are reported
+   * and isolated from the layout result.
    */
   onLayoutComplete?: (error?: unknown) => void;
   /**

--- a/packages/pptx/src/presentation-progressive.test.ts
+++ b/packages/pptx/src/presentation-progressive.test.ts
@@ -514,7 +514,7 @@ describe('PptxPresentation progressive layout lifecycle', () => {
   });
 
   it.each(['main', 'worker'] as const)(
-    'treats a one-slide progressive %s load as complete without a deferred callback',
+    'reports completion once for a one-slide progressive %s load',
     async (mode) => {
       const bootstrap = {
         slideCount: 1,
@@ -573,13 +573,52 @@ describe('PptxPresentation progressive layout lifecycle', () => {
       (presentation as unknown as {
         _finishProgressiveLayout(prefix: typeof complete, progressive: typeof lifecycle): void;
       })._finishProgressiveLayout(complete, lifecycle);
+      // A duplicate terminal response is ignored by the settled guard.
+      (presentation as unknown as {
+        _finishProgressiveLayout(prefix: typeof complete, progressive: typeof lifecycle): void;
+      })._finishProgressiveLayout(complete, lifecycle);
       await lifecycle.firstPublication.promise;
 
       expect(lifecycle.deferred).toBe(false);
       expect(presentation.layoutComplete).toBe(true);
-      expect(onComplete).not.toHaveBeenCalled();
+      expect(onComplete).toHaveBeenCalledTimes(1);
+      expect(onComplete).toHaveBeenCalledWith();
     },
   );
+
+  it('keeps a one-slide pre-release failure on the load rejection channel', () => {
+    const instance = Object.create(PptxPresentation.prototype) as Record<string, unknown>;
+    Object.assign(instance, {
+      _destroyed: false,
+      _layoutWaiters: new Set(),
+      _layoutLifecycle: new ProgressiveLayoutLifecycle(),
+      _layoutObservers: new ProgressiveLayoutObserverNotifier(),
+      _availableSlideCount: 1,
+      _progressiveWatchdog: undefined,
+      _progressiveWatchdogMs: undefined,
+    });
+    const presentation = instance as unknown as PptxPresentation;
+    const reject = vi.fn();
+    const onComplete = vi.fn();
+    const lifecycle = {
+      // A complete one-slide prefix is retained internally, so `published` is
+      // true even though `load()` has not been released and no work was deferred.
+      firstPublication: { promise: Promise.resolve(), resolve: vi.fn(), reject },
+      published: true,
+      deferred: false,
+      settled: false,
+      onComplete,
+    };
+    const error = new Error('authoritative response failed');
+
+    (presentation as unknown as {
+      _failProgressiveLayout(cause: unknown, progressive: typeof lifecycle): void;
+    })._failProgressiveLayout(error, lifecycle);
+
+    expect(reject).toHaveBeenCalledOnce();
+    expect(reject).toHaveBeenCalledWith(error);
+    expect(onComplete).not.toHaveBeenCalled();
+  });
 
   it('completes an actual one-slide main parse before releasing load', async () => {
     const bootstrap = {
@@ -644,7 +683,8 @@ describe('PptxPresentation progressive layout lifecycle', () => {
     expect(slideSessionId).toBeGreaterThan(0);
     expect(presentation.layoutComplete).toBe(true);
     expect(presentation.availableSlideCount).toBe(1);
-    expect(onComplete).not.toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith();
   });
 
   it('waits for the authoritative final response in an actual one-slide worker parse', async () => {
@@ -707,6 +747,7 @@ describe('PptxPresentation progressive layout lifecycle', () => {
     });
     await parsing;
     expect(presentation.layoutComplete).toBe(true);
-    expect(onComplete).not.toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith();
   });
 });

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -117,9 +117,11 @@ export type LoadOptions = CoreLoadOptions & {
   onLayoutProgress?: (progress: Readonly<ProgressiveLayoutProgress>) => void;
   /** Called for each additional paintable prefix after `load()` resolves. Observer failures are isolated. */
   onLayoutPartial?: (progress: Readonly<ProgressiveLayoutPartial>) => void;
-  /** Called once background preflight completes, or with its failure. Only
-   * fires when progressive loading actually deferred work after `load()`.
-   * Observer failures are isolated. */
+  /** Called exactly once when a successful {@link progressiveLayout} load has
+   * completed its authoritative preflight, whether that happens before or
+   * after `load()` resolves. A failure after an early publication is delivered
+   * as the argument; a failure before the first publication rejects `load()`
+   * directly and does not call this observer. Observer failures are isolated. */
   onLayoutComplete?: (error?: unknown) => void;
 };
 
@@ -812,9 +814,7 @@ export class PptxPresentation {
       exact: true,
       complete: true,
     });
-    if (progressive.deferred) {
-      this._layoutObservers.notify('onLayoutComplete', progressive.onComplete);
-    }
+    this._layoutObservers.notify('onLayoutComplete', progressive.onComplete);
   }
 
   private _failProgressiveLayout(error: unknown, progressive: ProgressiveLoad): void {
@@ -822,7 +822,10 @@ export class PptxPresentation {
     progressive.settled = true;
     this._clearProgressiveWatchdog();
     if (this._destroyed) return;
-    if (!progressive.published) {
+    // `published` also becomes true for a complete one-slide prefix retained
+    // internally until the authoritative response. Only `deferred` means
+    // `load()` was actually released and the error must use the callback path.
+    if (!progressive.deferred) {
       progressive.firstPublication.reject(error);
       return;
     }

--- a/site/src/lib/api-reference.ts
+++ b/site/src/lib/api-reference.ts
@@ -166,7 +166,7 @@ const DOCX_LAYOUT_PARTIAL: ApiOption = {
 const DOCX_LAYOUT_COMPLETE: ApiOption = {
   name: 'onLayoutComplete',
   type: '(error?: unknown) => void',
-  desc: 'Called once the authoritative full layout replaces the provisional one, or with the background failure. It fires only when progressiveLayout actually deferred work after load() resolved. Observer exceptions are reported once and never change the layout result.',
+  desc: 'With progressiveLayout enabled, called exactly once when a successful load reaches its authoritative full layout, even when load() itself waited for completion. A failure after an early publication is passed as the argument; a failure before the first publication rejects load() directly without calling this observer. Observer exceptions are reported once and never change the layout result.',
   detailsHref: '/docx#progressive-layout',
   detailsLabel: 'Progressive layout guide',
 };
@@ -196,7 +196,7 @@ const PPTX_LAYOUT_PARTIAL: ApiOption = {
 const PPTX_LAYOUT_COMPLETE: ApiOption = {
   name: 'onLayoutComplete',
   type: '(error?: unknown) => void',
-  desc: 'Called once every slide is paintable, or with the background failure. It fires only when progressiveLayout deferred work after load() resolved. Observer exceptions are reported once and never change the layout result.',
+  desc: 'With progressiveLayout enabled, called exactly once when a successful load makes every slide paintable, even when load() itself waited for completion. A failure after an early publication is passed as the argument; a failure before the first publication rejects load() directly without calling this observer. Observer exceptions are reported once and never change the layout result.',
   detailsHref: '/pptx#progressive-layout',
   detailsLabel: 'Progressive layout guide',
 };


### PR DESCRIPTION
## Problem

Progressive completion callbacks depended on whether a partial layout happened to be published before the authoritative result:

- DOCX main-thread layout notified only after an earlier preview.
- DOCX worker layout notified only after an earlier partial push.
- PPTX used the same deferred-work gate for one-slide presentations.

Fast files can still emit progress while finishing before the first useful partial. Consumers that use `onLayoutComplete` as the terminal event therefore never received a success signal, and the shared DOCX/PPTX callback contract varied with document size and timing.

## Fix

- Call `onLayoutComplete` exactly once for every successful load with `progressiveLayout` enabled, whether the authoritative layout is reached before or after `load()` resolves.
- Preserve the existing failure split: failures before the first public layout reject `load()` directly; failures after an early publication are delivered to `onLayoutComplete` and `waitUntilLayoutComplete()`.
- Apply the same contract to DOCX and PPTX and update the public API descriptions.
- Keep duplicate terminal responses and teardown quiet through the existing settled-state guards.
- Correct the one-slide PPTX pre-release failure classification: a retained complete prefix is not an early publication, so an authoritative-response failure rejects `load()` instead of leaving it pending.

No migration is required. Consumers may remove quiet-period fallback logic that existed only to compensate for a missing success callback.

## Verification

- DOCX/PPTX full suites and API-reference test: 454 files, 4,308 tests passed, 1 skipped.
- Focused progressive lifecycle suite after rebasing onto current `main`: 16 files, 136 tests passed.
- TypeScript project build passed.
- `ast-grep scan` passed with pre-existing warnings only.
- `git diff --check` passed.

## Adversarial review

- Contract fidelity: public source documentation and the site API reference now match the implementation, including the pre-publication failure exception.
- Cross-format wiring: DOCX main and worker paths plus PPTX main and worker paths are covered; XLSX has no progressive-layout lifecycle.
- Exactly-once and error routing: duplicate completion, post-publication failure, pre-publication failure, observer exceptions, and destroy paths are covered by focused tests.
- Resource and performance impact: the change adds one constant-time observer call only for successful fast progressive loads; it adds no retained state, parsing, layout, paint, or worker-transfer work.
- Heuristics and OOXML fidelity: no parsing or rendering rule changed and no new threshold or sample-specific behavior was introduced.

Co-Authored-By: Kimi <noreply@moonshot.ai>
