### PR TITLE
fix(pptx): correct multiline curved WordArt placement

### DIFF
--- a/docs/pptx-follow-path-compatibility.md
+++ b/docs/pptx-follow-path-compatibility.md
@@ -1,0 +1,87 @@
+# PPTX Follow Path multiline compatibility
+
+Multiline arch and circle WordArt now keeps its lines outside the authored
+ellipse, with the correct line order and authored spacing. No migration is
+required. Single-line and paired-edge WordArt rendering are unchanged.
+
+## Specification boundary
+
+ECMA-376 Part 1 §20.1.9.19 (`a:prstTxWarp`) describes text-envelope mapping.
+The preset definitions supply the authored path and adjustment angles. The
+single-edge, multiline placement convention below is **observed PowerPoint
+compatibility**, not a normative consequence of the paired-edge mapping rule.
+
+## Office evidence
+
+PowerPoint for Mac 16.112.3 opened a synthetic 38-slide, 76-case matrix and
+exported PDF and a separately saved PPTX. The audited shape transforms, warp
+adjustments, body settings, paragraph spacing, breaks and run properties were
+unchanged after saving. Six additional flat-text control slides isolate line
+spacing from the curve transformation. These are local verification artifacts,
+not redistributable regression baselines.
+
+The matrix covers:
+
+- One through four lines, paragraphs and manual breaks.
+- Arch Up, Arch Down and Circle; default and 135°/225° adjustment angles;
+  shape rotations of ±70°.
+- 50–200% and 18/36 pt line spacing, paragraph before/after spacing.
+- Arial and Times New Roman; 12/24/36 pt and mixed-size lines.
+- Widths 200/400/600 px, heights 80/180/320 px, alignment and vertical anchors.
+- Unequal line widths, descenders, wrapping, and short/overlength controls.
+
+For clockwise paths, the last baseline is anchored to the authored ellipse;
+preceding lines expand outward. For counterclockwise paths, the first baseline
+is anchored and subsequent lines expand outward. Direction comes from path
+winding, not the screen position or a preset-name rule.
+
+Each line is evaluated on its own concentric ellipse, adding its baseline
+outset to both radii. Its natural text width and paragraph alignment are then
+mapped against that line's arc length. Reusing the original curve and shifting
+glyphs along its normals does not reproduce the aspect-ratio controls.
+
+The flat controls support reusing the renderer's existing natural line-box
+policy (1.2 times text size, scaled by percentage spacing, or authored point
+spacing) and baseline placement. Paragraph gaps are retained between paragraphs.
+The patch removes the unrelated paired-edge vertical-band fraction from
+single-edge baseline placement.
+
+## Limits of the compatibility claim
+
+This fixes line ordering, radial placement and spacing; it is not a claim of
+pixel-identical Office typography. Native output retains small coordinate and
+paragraph-versus-manual-break differences, including up to approximately
+1.33 CSS px in equal-size controls. The existing polyline tangent sampling,
+font substitutions and glyph metrics remain unchanged. Mixed-font and mixed-size
+placement uses the existing line-box approximation, not newly recovered font
+shaping metrics.
+
+The overlength controls also expose a pre-existing glyph-shrink discrepancy.
+This patch does not change overlength fitting or infer its conditions from a
+single case. It does not change paired-edge deformation, vertical text, font
+loading, or the shared chart renderer.
+
+## Adversarial review and regression evidence
+
+- Specification: the normative envelope rule and observed single-edge policy
+  are explicitly separated. No sample names, path checks, new empirical scale
+  factors or changed VRT thresholds occur in the implementation.
+- Design: paragraph layout stays in PPTX; ellipse evaluation and arc-length
+  mapping reuse the existing pure core geometry. DOCX/XLSX have no integration
+  with this PPTX WordArt routine; their shared chart and text code is untouched.
+- Resources: the existing line list gains one scalar baseline per line. There
+  is at most one fixed-size envelope evaluation per expanded line, outside the
+  glyph loop. No new cache, bitmap, worker transfer, asynchronous fan-out or
+  document-wide work is introduced.
+- Tests: focused cases cover both windings, circles, adjusted angles, manual
+  breaks, percentage/point/paragraph spacing, mixed sizes and independently
+  expanded ellipses. Test coordinate units now match actual font units.
+- Self-VRT: a clean detached previous-renderer checkout at
+  `ca5a05083375751760b58be0b7f3a1c79ee37aa1`, with rebuilt WASM and a distinct
+  port, supplies the immutable baseline. All 35 private PPTX inputs and all
+  361 slides were compared. Exactly one slide changed; previous, candidate and
+  Office output were explicitly compared, confirming corrected multiline
+  ordering, separation and visibility. The other 360 slides are pixel-equal.
+  All 35 complete-corpus worker-parity tests pass. The exact self-VRT command
+  deliberately remains red for the one adjudicated intended change; references
+  were not updated to conceal it.

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2741,7 +2741,8 @@ function renderWarpedText(
 
   // Lay each paragraph out flat at the natural size (no wrap — WordArt fits the
   // shape width itself). Collect every line's segments in order.
-  const lines: Array<{ line: LayoutLine; alignment: Paragraph['alignment'] }> = [];
+  const lines: Array<{ line: LayoutLine; alignment: Paragraph['alignment']; baseline: number }> = [];
+  let flatTop = 0;
   for (const para of body.paragraphs) {
     const paraDefaultFontSizePx =
       para.defFontSize != null ? para.defFontSize * PT_TO_EMU * scale : bodyDefaultFontSizePx;
@@ -2761,7 +2762,19 @@ function renderWarpedText(
       rc,
       0,
     );
-    for (const line of laid) lines.push({ line, alignment: para.alignment });
+    if (lines.length > 0) flatTop += (para.spaceBefore ?? 0) / 100 * PT_TO_EMU * scale;
+    for (const line of laid) {
+      const size = line.segments.reduce((max, seg) => Math.max(max, seg.sizePx), 0) || paraDefaultFontSizePx;
+      // Same natural line box as ordinary PowerPoint text. The independent
+      // flat/Follow Path Office controls cover 50–200%, fixed point spacing,
+      // mixed sizes and paragraph gaps; no warp-specific pitch multiplier.
+      const height = para.spaceLine?.type === 'pts'
+        ? para.spaceLine.val * PT_TO_EMU * scale
+        : size * 1.2 * (para.spaceLine ? para.spaceLine.val / 100000 : 1);
+      lines.push({ line, alignment: para.alignment, baseline: flatTop + height * 0.8 });
+      flatTop += height;
+    }
+    flatTop += (para.spaceAfter ?? 0) / 100 * PT_TO_EMU * scale;
   }
   if (lines.length === 0) return;
 
@@ -2786,8 +2799,24 @@ function renderWarpedText(
   };
 
   const lineCount = lines.length;
+  // Follow Path is not the paired-edge vertical-band operation in §20.1.9.19.
+  // Office-produced controls show concentric ellipses: clockwise paths anchor
+  // the last line, counterclockwise paths the first. Derive winding from the
+  // authored path, not screen up/down (adjusted arches can cross either half).
+  const p0 = env.top[0];
+  const p1 = env.top[1];
+  const clockwise = p0 && p1
+    ? (p0.x - boxW / 2) * (p1.y - boxH / 2) - (p0.y - boxH / 2) * (p1.x - boxW / 2) > 0
+    : true;
+  const anchoredBaseline = lines[clockwise ? lineCount - 1 : 0]!.baseline;
   for (let li = 0; li < lineCount; li++) {
     const { line, alignment } = lines[li];
+    const outset = env.singleEdge
+      ? Math.max(0, clockwise ? anchoredBaseline - lines[li]!.baseline : lines[li]!.baseline - anchoredBaseline)
+      : 0;
+    const lineEnv = outset > 0
+      ? buildWarpEnvelope(preset, adj, boxW + 2 * outset, boxH + 2 * outset) ?? env
+      : env;
     // Per-line vertical band [v0, v1] of the envelope's height. One line fills
     // the whole band; multiple lines split it evenly top→bottom.
     const v0 = li / lineCount;
@@ -2854,7 +2883,7 @@ function renderWarpedText(
     const warpBoxH = env.singleEdge ? inkH : inkH / (v1 - v0);
     // Follow Path: fraction of the arc the natural-width text actually spans.
     // 1 for paired-edge (no clamp); ≤1 for arch/circle.
-    const followScale = followPathUScale(env, totalW);
+    const followScale = followPathUScale(lineEnv, totalW);
     // A Follow Path warp keeps the text's natural arc length, but its paragraph
     // alignment still selects where that shorter segment sits on the path.
     // PowerPoint-generated circular diagrams commonly use centred paragraphs;
@@ -2862,13 +2891,6 @@ function renderWarpedText(
     const followOffset = env.singleEdge
       ? (1 - followScale) * (alignment === 'r' ? 1 : alignment === 'ctr' ? 0.5 : 0)
       : 0;
-    // Follow Path has one authored baseline curve. Manual breaks and separate
-    // paragraphs form additional natural-height lines on the INSIDE of that
-    // curve; they do not all reuse the identical baseline. Select the normal
-    // that points toward the shape centre so this works for both Arch Up and
-    // Arch Down without preset-name branching. The 120% pitch is the same
-    // natural PowerPoint line spacing used by ordinary text below.
-    const followLineOffset = env.singleEdge ? li * maxSize * 1.2 : 0;
 
     // Walk glyphs left→right. `penW` accumulates the flat advance so each glyph's
     // CENTRE maps to its u fraction; the glyph is drawn at a per-glyph transform.
@@ -2887,7 +2909,7 @@ function renderWarpedText(
         const chW = ctx.measureText(ch).width + ls;
         // Blend the per-line vertical band into the baseline fraction so line 2
         // sits below line 1 within the envelope.
-        const bandFrac = v0 + baselineFrac * (v1 - v0);
+        const bandFrac = env.singleEdge ? baselineFrac : v0 + baselineFrac * (v1 - v0);
 
         // Paired-edge (envelope) presets: the envelope map is NON-affine within a
         // glyph (on Inflate/Deflate the vertical stretch varies across the glyph's
@@ -2926,16 +2948,9 @@ function renderWarpedText(
         // naturally sized, paragraph-aligned arc segment rather than the whole
         // path. `followScale` is 1 for paired-edge presets (unchanged).
         const u = followOffset + ((penW + chW / 2) / totalW) * followScale;
-        const g = warpGlyphTransform(env, u, warpBoxH, bandFrac);
-        if (followLineOffset !== 0) {
-          const nx = -Math.sin(g.angle);
-          const ny = Math.cos(g.angle);
-          const toCentreX = boxW / 2 - g.x;
-          const toCentreY = boxH / 2 - g.y;
-          const inward = nx * toCentreX + ny * toCentreY >= 0 ? 1 : -1;
-          g.x += nx * followLineOffset * inward;
-          g.y += ny * followLineOffset * inward;
-        }
+        const g = warpGlyphTransform(lineEnv, u, warpBoxH, bandFrac);
+        g.x -= outset;
+        g.y -= outset;
         ctx.save();
         ctx.translate(boxX + g.x, boxY + g.y);
         ctx.rotate(g.angle);

--- a/packages/pptx/src/wordart-follow-path.test.ts
+++ b/packages/pptx/src/wordart-follow-path.test.ts
@@ -167,7 +167,7 @@ function warpBodyWithBreak(preset: string, first: string, second: string): TextB
 // Follow Path should visibly compress its span.
 const BOX_W = 620; // 6.2in → 620px
 const BOX_H = 150; // 1.5in → 150px
-const SCALE = 1; // fontSize already in px via measureText; scale is passthrough here
+const SCALE = 1 / 12700; // 40 pt becomes 40 px; match the mocked pixel geometry.
 
 /** Horizontal device-space span of all placed glyph origins. */
 function span(glyphs: Array<{ x: number }>): number {
@@ -215,13 +215,88 @@ describe('WordArt Follow Path — single-edge span (issue #846)', () => {
     expect(glyphs[0]!.y).toBeCloseTo(expected.y, 1);
   });
 
-  it('places lines after a manual break on distinct inward baselines', () => {
+  it('keeps the last clockwise line on the authored arch and expands preceding lines', () => {
     const { ctx, glyphs } = trackingCtx();
     renderTextBody(ctx, warpBodyWithBreak('textArchUp', 'Top', 'Bottom'), 0, 0, BOX_W, BOX_H, SCALE);
 
     const topY = glyphs.slice(0, 3).reduce((sum, glyph) => sum + glyph.y, 0) / 3;
     const bottomY = glyphs.slice(3).reduce((sum, glyph) => sum + glyph.y, 0) / 6;
     expect(bottomY - topY).toBeGreaterThan(20);
+    expect(topY).toBeLessThan(0);
+    expect(bottomY).toBeLessThan(10);
+  });
+
+  it('expands later counterclockwise lines outside the lower arch', () => {
+    const { ctx, glyphs } = trackingCtx();
+    renderTextBody(ctx, warpBodyWithBreak('textArchDown', 'A', 'A'), 0, 0, BOX_W, BOX_H, SCALE);
+    expect(glyphs[1]!.y - glyphs[0]!.y).toBeCloseTo(48, 0);
+    expect(glyphs[0]!.y).toBeGreaterThan(BOX_H);
+  });
+
+  it('honours fixed line spacing independently of the font size', () => {
+    const body = warpBodyWithBreak('textArchUp', 'A', 'A');
+    body.paragraphs[0]!.spaceLine = { type: 'pts', val: 18 };
+    const { ctx, glyphs } = trackingCtx();
+    renderTextBody(ctx, body, 0, 0, BOX_W, BOX_H, SCALE);
+    expect(glyphs[1]!.y - glyphs[0]!.y).toBeCloseTo(18, 0);
+  });
+
+  it('retains paragraph spacing only between paragraphs', () => {
+    const body = warpBody('textArchUp', 'A');
+    body.paragraphs[0]!.spaceBefore = 1200;
+    body.paragraphs[0]!.spaceAfter = 600;
+    body.paragraphs.push({ ...body.paragraphs[0]! });
+    const { ctx, glyphs } = trackingCtx();
+    renderTextBody(ctx, body, 0, 0, BOX_W, BOX_H, SCALE);
+    expect(glyphs[1]!.y - glyphs[0]!.y).toBeCloseTo(66, 0);
+    expect(glyphs[1]!.y).toBeLessThan(10);
+  });
+
+  it.each([50, 100, 150, 200])('uses %i%% authored line spacing', (percent) => {
+    const body = warpBodyWithBreak('textArchUp', 'A', 'A');
+    body.paragraphs[0]!.spaceLine = { type: 'pct', val: percent * 1000 };
+    const { ctx, glyphs } = trackingCtx();
+    renderTextBody(ctx, body, 0, 0, BOX_W, BOX_H, SCALE);
+    expect(glyphs[1]!.y - glyphs[0]!.y).toBeCloseTo(48 * percent / 100, 0);
+  });
+
+  it('accumulates mixed-size line boxes before anchoring the last baseline', () => {
+    const body = warpBody('textArchUp', 'A');
+    body.paragraphs = [16, 32, 48].map(size => ({ ...body.paragraphs[0]!, runs: [run('A', { fontSize: size })] }));
+    const { ctx, glyphs } = trackingCtx();
+    renderTextBody(ctx, body, 0, 0, BOX_W, BOX_H, SCALE);
+    expect(glyphs[1]!.y - glyphs[0]!.y).toBeCloseTo(34.56, 0);
+    expect(glyphs[2]!.y - glyphs[1]!.y).toBeCloseTo(53.76, 0);
+    expect(glyphs[2]!.y).toBeLessThan(10);
+  });
+
+  it.each([135, 225])('uses path winding for a %i degree downward arch', (angle) => {
+    const body = warpBodyWithBreak('textArchDown', 'A', 'A');
+    body.textWarp!.adj = [angle * 60000];
+    const { ctx, glyphs } = trackingCtx();
+    renderTextBody(ctx, body, 0, 0, BOX_W, BOX_H, SCALE);
+    // These authored counterclockwise arcs are on the TOP half; following
+    // screen-down instead of path winding would reverse the outward order.
+    expect(glyphs[1]!.y).toBeLessThan(glyphs[0]!.y - 40);
+  });
+
+  it('anchors the final circle line and expands preceding lines radially', () => {
+    const { ctx, glyphs } = trackingCtx();
+    renderTextBody(ctx, warpBodyWithBreak('textCircle', 'A', 'A'), 0, 0, BOX_W, BOX_H, SCALE);
+    expect(glyphs[0]!.x - glyphs[1]!.x).toBeCloseTo(48, 0);
+    expect(glyphs[1]!.x).toBeGreaterThan(BOX_W - 10);
+  });
+
+  it('recomputes each line on its expanded ellipse, including arc-length alignment', () => {
+    const body = warpBodyWithBreak('textArchUp', 'ABCDEFG', 'ABCDEFG');
+    const multi = trackingCtx();
+    renderTextBody(multi.ctx, body, 0, 0, 200, 180, SCALE);
+    const outer = trackingCtx();
+    renderTextBody(outer.ctx, warpBody('textArchUp', 'ABCDEFG'), -48, -48, 296, 276, SCALE);
+    for (let i = 0; i < 7; i++) {
+      expect(multi.glyphs[i]!.x).toBeCloseTo(outer.glyphs[i]!.x, 6);
+      expect(multi.glyphs[i]!.y).toBeCloseTo(outer.glyphs[i]!.y, 6);
+    }
   });
 
   it('textCircle keeps the word compact rather than scattering around the ellipse', () => {


### PR DESCRIPTION
## Outcome

Fix multiline arch/circle WordArt whose labels overlapped, reversed line order or disappeared behind adjacent shapes. No migration is required. Single-line WordArt, paired-edge deformation and shared chart rendering are unchanged.

## Cause and fix

Follow Path incorrectly reused the original curve for every line, shifted later lines inward, discarded authored spacing and mixed in paired-edge vertical-band fractions. Preserve flat baseline positions, anchor by authored path winding, and evaluate each expanded line on its own concentric ellipse before arc-length alignment.

## Specification and adversarial review

ECMA-376 Part 1 §20.1.9.19 supplies the envelope/preset context; the single-edge multiline convention is observed Office compatibility, not a normative paired-edge rule. A native PowerPoint matrix covers 76 curved-text cases plus 12 independent flat controls, including dimensions, angles, fonts, sizes, line spacing and paragraph spacing. See `docs/pptx-follow-path-compatibility.md` for evidence and limits.

Final review found no unresolved in-scope blockers: no sample-specific branches, new empirical scale factors, threshold changes, shared-format changes, caches, bitmap allocation or asynchronous fan-out. At most one bounded envelope evaluation is added per expanded line. Paragraph policy stays in PPTX and uses existing core geometry. DOCX/XLSX integration points were inspected; neither calls this routine, and their shared renderer is unchanged. Small existing font/glyph-sampling differences and the separately observed pre-existing overlength fitting limitation are explicitly documented, not presented as solved.

## Verification

- TDD: four new failures reproduced before the implementation; all 18 focused Follow Path tests now pass.
- Focused WordArt/core/node tests: 44 passed.
- Complete Vitest run: 8,959 passed, 25 skipped, six sandbox loopback failures. The two affected suites were rerun with local networking available: all 12 tests passed, resolving all six failures.
- TypeScript project build and `git diff --check` passed.
- Previous-renderer self-VRT: all 35 private PPTX files / 361 slides, immutable baseline `ca5a05083375751760b58be0b7f3a1c79ee37aa1`, rebuilt baseline WASM, distinct baseline/candidate ports. Exactly one slide changed; all 360 others are pixel-identical. Explicit previous/candidate/Office comparison adjudicated that one slide as the intended fix. The exact VRT command remains red for this intended difference; references and thresholds were not changed.
- Full private worker parity: 35/35 passed.
- Actual local site upload/viewing checked at its narrower rendered width, including the reported curved-text pages.

Private documents and generated verification artifacts are not included in this PR.
