### PR TITLE
fix(rendering): bound adversarial path and WordArt work

### DIFF
--- a/packages/core/src/image/emf.test.ts
+++ b/packages/core/src/image/emf.test.ts
@@ -83,6 +83,7 @@ const EMR = {
   CREATEBRUSHINDIRECT: 39,
   DELETEOBJECT: 40,
   MOVETOEX: 27,
+  LINETO: 54,
   BEGINPATH: 59,
   ENDPATH: 60,
   CLOSEFIGURE: 61,
@@ -93,6 +94,7 @@ const EMR = {
   POLYGON16: 86,
   POLYLINE16: 87,
   POLYBEZIERTO16: 88,
+  POLYPOLYGON16: 91,
   CREATEDIBPATTERNBRUSHPT: 94,
 } as const;
 
@@ -987,8 +989,12 @@ describe('playEmf — picture frame mapping + path clip', () => {
       record(EMR.SELECTOBJECT, (w) => w.u32(1)),
       record(EMR.BEGINPATH, () => {}),
       record(EMR.POLYLINE16, (w) =>
-        w.i32(10).i32(10).i32(90).i32(90).u32(3)
-          .i16(10).i16(10).i16(90).i16(10).i16(90).i16(90),
+        w.i32(10).i32(10).i32(90).i32(10).u32(2)
+          .i16(10).i16(10).i16(90).i16(10),
+      ),
+      record(EMR.POLYLINE16, (w) =>
+        w.i32(90).i32(10).i32(90).i32(90).u32(2)
+          .i16(90).i16(10).i16(90).i16(90),
       ),
       record(EMR.ENDPATH, () => {}),
       record(EMR.FILLPATH, (w) => w.i32(10).i32(10).i32(90).i32(90)),
@@ -1000,6 +1006,61 @@ describe('playEmf — picture frame mapping + path clip', () => {
     expect(m.calls.filter((call) => call.op === 'lineTo')).toHaveLength(2);
     expect(m.calls.filter((call) => call.op === 'stroke')).toHaveLength(0);
     expect(m.calls.filter((call) => call.op === 'fill')).toHaveLength(1);
+  });
+
+  it('discards a path bracket that exceeds the cumulative geometry budget', () => {
+    const file = concat(
+      emfHeader(0, 0, 100, 100),
+      record(EMR.CREATEBRUSHINDIRECT, (w) => w.u32(1).u32(0).u32(0x0000ff00).u32(0)),
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)),
+      record(EMR.BEGINPATH, () => {}),
+      record(EMR.MOVETOEX, (w) => w.i32(0).i32(0)),
+      record(EMR.POLYLINE16, (w) =>
+        w.i32(0).i32(0).i32(30).i32(30).u32(3)
+          .i16(0).i16(0).i16(20).i16(20).i16(30).i16(30),
+      ),
+      record(EMR.LINETO, (w) => w.i32(40).i32(40)),
+      record(EMR.ENDPATH, () => {}),
+      record(EMR.FILLPATH, (w) => w.i32(0).i32(0).i32(40).i32(40)),
+      // Rendering must recover after the rejected bracket.
+      record(EMR.CREATEPEN, (w) => w.u32(2).u32(0).i32(1).i32(0).u32(0)),
+      record(EMR.SELECTOBJECT, (w) => w.u32(2)),
+      record(EMR.POLYLINE16, (w) =>
+        w.i32(0).i32(0).i32(10).i32(10).u32(2).i16(0).i16(0).i16(10).i16(10),
+      ),
+      record(EMR.EOF, () => {}),
+    );
+    const m = makeRecordingCtx();
+
+    const playWithLimits = playEmf as unknown as (
+      bytes: Uint8Array,
+      ctx: CanvasRenderingContext2D,
+      width: number,
+      height: number,
+      limits: { maxPathCommands: number },
+    ) => boolean;
+    expect(playWithLimits(file, m.ctx, 100, 100, { maxPathCommands: 4 })).toBe(true);
+    expect(m.calls.filter((call) => call.op === 'fill')).toHaveLength(0);
+    expect(m.calls.filter((call) => call.op === 'stroke')).toHaveLength(1);
+  });
+
+  it('rejects a poly-polygon whose per-polygon counts exceed its declared total', () => {
+    const file = concat(
+      emfHeader(0, 0, 100, 100),
+      record(EMR.CREATEBRUSHINDIRECT, (w) => w.u32(1).u32(0).u32(0x0000ff00).u32(0)),
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)),
+      record(EMR.POLYPOLYGON16, (w) =>
+        w.i32(0).i32(0).i32(50).i32(50)
+          .u32(1).u32(1) // one polygon, falsely declares one total point
+          .u32(3)
+          .i16(0).i16(0).i16(50).i16(0).i16(50).i16(50),
+      ),
+      record(EMR.EOF, () => {}),
+    );
+    const m = makeRecordingCtx();
+
+    playEmf(file, m.ctx, 100, 100);
+    expect(m.calls.filter((call) => call.op === 'fill')).toHaveLength(0);
   });
 
   it('decodes a 4bpp DIB pattern brush (MATLAB bar-chart fill colour)', () => {

--- a/packages/core/src/image/emf.ts
+++ b/packages/core/src/image/emf.ts
@@ -303,6 +303,41 @@ interface PlayState {
   stack: SavedDc[]; // SAVEDC/RESTOREDC graphics-state stack
   drew: boolean;
   inPath: boolean; // between BEGINPATH and ENDPATH — geometry builds a path, no draw
+  pathCommandCount: number;
+  pathDiscarded: boolean;
+  maxPathCommands: number;
+}
+
+/**
+ * Maximum Canvas path commands retained by one EMF path bracket. This preserves
+ * every previously admitted single geometry record: POLYPOLYGON may contain up
+ * to 0x200000 points in at most 0x10000 closed sub-paths. The cumulative bound
+ * prevents many individually valid records from multiplying that retained work.
+ */
+const MAX_EMF_PATH_COMMANDS = 0x200000 + 0x10000;
+
+interface EmfReplayLimits {
+  /** Package-internal override used by focused boundary tests. */
+  maxPathCommands?: number;
+}
+
+function reservePathCommands(s: PlayState, additional: number): boolean {
+  if (!s.inPath) return true;
+  if (s.pathDiscarded) return false;
+  const next = s.pathCommandCount + additional;
+  if (!Number.isSafeInteger(next) || additional < 0 || next > s.maxPathCommands) {
+    // Never leave a paintable prefix of an over-budget attacker-controlled path.
+    s.ctx.beginPath();
+    s.pathDiscarded = true;
+    return false;
+  }
+  s.pathCommandCount = next;
+  return true;
+}
+
+function readablePointCount(c: EmfCursor, count: number, rp: PointReader): number {
+  const bytesPerPoint = rp === readPoint16 ? 4 : 8;
+  return Math.min(count, Math.floor(c.remaining / bytesPerPoint));
 }
 
 /** Snapshot of the graphics state pushed by EMR_SAVEDC. */
@@ -584,6 +619,7 @@ function strokePolyline(s: PlayState, c: EmfCursor, rp: PointReader): void {
     return;
   }
   const { ctx } = s;
+  const appendPath = reservePathCommands(s, readablePointCount(c, count, rp));
   if (!s.inPath) ctx.beginPath();
   let lx = 0;
   let ly = 0;
@@ -591,8 +627,10 @@ function strokePolyline(s: PlayState, c: EmfCursor, rp: PointReader): void {
     if (c.remaining < 4) break;
     const [xl, yl] = rp(c);
     const [px, py] = toPx(s, xl, yl);
-    if (i === 0) ctx.moveTo(px, py);
-    else ctx.lineTo(px, py);
+    if (appendPath) {
+      if (i === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    }
     lx = xl;
     ly = yl;
   }
@@ -614,6 +652,7 @@ function strokePolylineTo(s: PlayState, c: EmfCursor, rp: PointReader): void {
   if (count < 1 || count > 0x100000) return;
   const { ctx } = s;
   const draw = s.inPath || (s.curPen != null && s.curPen.stroke != null);
+  const appendPath = !s.inPath || reservePathCommands(s, readablePointCount(c, count, rp));
   if (draw) {
     if (!s.inPath) {
       ctx.beginPath();
@@ -624,7 +663,7 @@ function strokePolylineTo(s: PlayState, c: EmfCursor, rp: PointReader): void {
   for (let i = 0; i < count; i++) {
     if (c.remaining < 4) break;
     const [xl, yl] = rp(c);
-    if (draw) {
+    if (draw && appendPath) {
       const [px, py] = toPx(s, xl, yl);
       ctx.lineTo(px, py);
     }
@@ -645,6 +684,7 @@ function fillStrokePolygon(s: PlayState, c: EmfCursor, rp: PointReader): void {
   const count = c.u32();
   if (count < 2 || count > 0x100000) return;
   const { ctx } = s;
+  const appendPath = reservePathCommands(s, readablePointCount(c, count, rp) + 1);
   if (!s.inPath) ctx.beginPath();
   let started = false;
   for (let i = 0; i < count; i++) {
@@ -652,12 +692,12 @@ function fillStrokePolygon(s: PlayState, c: EmfCursor, rp: PointReader): void {
     const [xl, yl] = rp(c);
     const [px, py] = toPx(s, xl, yl);
     if (!started) {
-      ctx.moveTo(px, py);
+      if (appendPath) ctx.moveTo(px, py);
       started = true;
-    } else ctx.lineTo(px, py);
+    } else if (appendPath) ctx.lineTo(px, py);
   }
   if (!started) return;
-  ctx.closePath();
+  if (appendPath) ctx.closePath();
   if (s.inPath) return; // path bracket: defer fill/stroke
   if (s.curBrush && s.curBrush.fill != null) {
     ctx.fillStyle = s.curBrush.fill;
@@ -683,6 +723,16 @@ function strokePolyBezier(
   c.skip(16);
   const count = c.u32();
   if (count < 1 || count > 0x100000) return;
+  const readableCount = readablePointCount(c, count, rp);
+  const appendPath = !s.inPath || reservePathCommands(s, readableCount);
+  if (s.inPath && !appendPath) {
+    for (let i = 0; i < readableCount; i++) {
+      const [xl, yl] = rp(c);
+      s.curX = xl;
+      s.curY = yl;
+    }
+    return;
+  }
   const pts: Array<[number, number]> = [];
   for (let i = 0; i < count; i++) {
     if (c.remaining < 4) break;
@@ -740,11 +790,20 @@ function fillStrokePolyPoly(
   if (numPolys <= 0 || numPolys > 0x10000) return;
   if (totalPoints <= 0 || totalPoints > 0x200000) return;
   const counts: number[] = [];
+  let countedPoints = 0;
   for (let i = 0; i < numPolys; i++) {
     if (c.remaining < 4) return;
-    counts.push(c.u32());
+    const count = c.u32();
+    countedPoints += count;
+    if (!Number.isSafeInteger(countedPoints) || countedPoints > 0x200000) return;
+    counts.push(count);
   }
+  if (countedPoints !== totalPoints) return;
   const { ctx } = s;
+  const appendPath = reservePathCommands(
+    s,
+    readablePointCount(c, totalPoints, rp) + (isPolygon ? numPolys : 0),
+  );
   if (!s.inPath) ctx.beginPath(); // in a path bracket: accumulate, don't reset
   let any = false;
   for (const cnt of counts) {
@@ -755,11 +814,13 @@ function fillStrokePolyPoly(
     for (let i = 0; i < cnt; i++) {
       if (c.remaining < 4) break;
       const [xl, yl] = rp(c);
-      const [px, py] = toPx(s, xl, yl);
-      if (i === 0) ctx.moveTo(px, py);
-      else ctx.lineTo(px, py);
+      if (appendPath) {
+        const [px, py] = toPx(s, xl, yl);
+        if (i === 0) ctx.moveTo(px, py);
+        else ctx.lineTo(px, py);
+      }
     }
-    if (isPolygon) ctx.closePath();
+    if (isPolygon && appendPath) ctx.closePath();
     any = true;
   }
   if (!any || s.inPath) return; // path bracket: geometry added, defer fill/stroke
@@ -783,12 +844,15 @@ function fillStrokeRect(s: PlayState, l: number, t: number, r: number, b: number
   const c1 = toPx(s, r, t);
   const c2 = toPx(s, r, b);
   const c3 = toPx(s, l, b);
+  const appendPath = reservePathCommands(s, 5);
   if (!s.inPath) ctx.beginPath();
-  ctx.moveTo(c0[0], c0[1]);
-  ctx.lineTo(c1[0], c1[1]);
-  ctx.lineTo(c2[0], c2[1]);
-  ctx.lineTo(c3[0], c3[1]);
-  ctx.closePath();
+  if (appendPath) {
+    ctx.moveTo(c0[0], c0[1]);
+    ctx.lineTo(c1[0], c1[1]);
+    ctx.lineTo(c2[0], c2[1]);
+    ctx.lineTo(c3[0], c3[1]);
+    ctx.closePath();
+  }
   if (s.inPath) return; // path bracket: defer fill/stroke
   if (s.curBrush && s.curBrush.fill != null) {
     ctx.fillStyle = s.curBrush.fill;
@@ -805,12 +869,12 @@ function fillStrokeRect(s: PlayState, l: number, t: number, r: number, b: number
 
 /** Consume the current path with the selected brush and/or pen ([MS-EMF] 2.3.10). */
 function paintSelectedPath(s: PlayState, fill: boolean, stroke: boolean): void {
-  if (fill && s.curBrush?.fill != null) {
+  if (!s.pathDiscarded && fill && s.curBrush?.fill != null) {
     s.ctx.fillStyle = s.curBrush.fill;
     s.ctx.fill(s.fillRule);
     s.drew = true;
   }
-  if (stroke && s.curPen?.stroke != null) {
+  if (!s.pathDiscarded && stroke && s.curPen?.stroke != null) {
     s.ctx.strokeStyle = s.curPen.stroke;
     s.ctx.lineWidth = deviceLineWidth(s, s.curPen.width);
     s.ctx.stroke();
@@ -819,6 +883,8 @@ function paintSelectedPath(s: PlayState, fill: boolean, stroke: boolean): void {
   // EMR_FILLPATH / STROKEPATH / STROKEANDFILLPATH close the path bracket.
   // Clear Canvas's persistent current path so later records cannot repaint it.
   s.ctx.beginPath();
+  s.pathCommandCount = 0;
+  s.pathDiscarded = false;
 }
 
 // ── object creators ──────────────────────────────────────────────────────────
@@ -1069,7 +1135,14 @@ function doStretchDibits(s: PlayState, c: EmfCursor, dv: DataView, recStart: num
  * optional BITBLT/STRETCHDIBITS path, which needs a temp OffscreenCanvas and is
  * skipped gracefully when absent).
  */
-export function playEmf(bytes: Uint8Array, ctx: AnyCtx, W: number, H: number): boolean {
+export function playEmf(bytes: Uint8Array, ctx: AnyCtx, W: number, H: number): boolean;
+export function playEmf(
+  bytes: Uint8Array,
+  ctx: AnyCtx,
+  W: number,
+  H: number,
+  limits: EmfReplayLimits = {},
+): boolean {
   if (!isEmf(bytes)) return false;
   if (W <= 0 || H <= 0) return false;
 
@@ -1111,6 +1184,12 @@ export function playEmf(bytes: Uint8Array, ctx: AnyCtx, W: number, H: number): b
     stack: [],
     drew: false,
     inPath: false,
+    pathCommandCount: 0,
+    pathDiscarded: false,
+    maxPathCommands: Number.isSafeInteger(limits.maxPathCommands)
+      && (limits.maxPathCommands as number) > 0
+      ? Math.min(limits.maxPathCommands as number, MAX_EMF_PATH_COMMANDS)
+      : MAX_EMF_PATH_COMMANDS,
   };
 
   let pos = 0;
@@ -1313,10 +1392,12 @@ export function playEmf(bytes: Uint8Array, ctx: AnyCtx, W: number, H: number): b
           // build the path instead of drawing it, until ENDPATH.
           s.ctx.beginPath();
           s.inPath = true;
+          s.pathCommandCount = 0;
+          s.pathDiscarded = false;
           break;
         }
         case EMR.CLOSEFIGURE: {
-          if (s.inPath) s.ctx.closePath();
+          if (s.inPath && reservePathCommands(s, 1)) s.ctx.closePath();
           break;
         }
         case EMR.ENDPATH: {
@@ -1341,11 +1422,15 @@ export function playEmf(bytes: Uint8Array, ctx: AnyCtx, W: number, H: number): b
           // relies on, e.g. sample-13 Fig.3 clips a bar-chart DIB to the bar
           // shapes so its background is masked out). Scoped by the enclosing
           // SAVEDC/RESTOREDC.
-          try {
-            s.ctx.clip(s.fillRule);
-          } catch {
-            /* a ctx without clip() (some mocks): leave unclipped */
+          if (!s.pathDiscarded) {
+            try {
+              s.ctx.clip(s.fillRule);
+            } catch {
+              /* a ctx without clip() (some mocks): leave unclipped */
+            }
           }
+          s.pathCommandCount = 0;
+          s.pathDiscarded = false;
           break;
         }
         case EMR.SELECTOBJECT: {
@@ -1442,7 +1527,7 @@ export function playEmf(bytes: Uint8Array, ctx: AnyCtx, W: number, H: number): b
         case EMR.MOVETOEX: {
           s.curX = c.i32();
           s.curY = c.i32();
-          if (s.inPath) {
+          if (s.inPath && reservePathCommands(s, 1)) {
             const [px, py] = toPx(s, s.curX, s.curY);
             s.ctx.moveTo(px, py);
           }
@@ -1451,7 +1536,7 @@ export function playEmf(bytes: Uint8Array, ctx: AnyCtx, W: number, H: number): b
         case EMR.LINETO: {
           const xl = c.i32();
           const yl = c.i32();
-          if (s.inPath) {
+          if (s.inPath && reservePathCommands(s, 1)) {
             const [px1, py1] = toPx(s, xl, yl);
             s.ctx.lineTo(px1, py1);
           } else if (s.curPen && s.curPen.stroke != null) {

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1693,7 +1693,13 @@ export function layoutParagraph(
     const tokens = runText.split(/(\s+)/).flatMap((token) => {
       if (!token) return [];
       if (/^\s+$/u.test(token)) return [{ text: token, breakBefore: false }];
-      return splitLatinCompoundToken(token);
+      // Authored hyphens are soft-wrap seams only. WordArt deliberately lays
+      // text out at infinite width before mapping it to a curve, so fragmenting
+      // a compound there adds repeated prefix measurement without changing a
+      // possible line break.
+      return Number.isFinite(maxWidthPx)
+        ? splitLatinCompoundToken(token)
+        : [{ text: token, breakBefore: false }];
     });
 
     for (const tokenPart of tokens) {
@@ -2898,12 +2904,6 @@ function renderWarpedText(
   const anchoredBaseline = lines[clockwise ? lineCount - 1 : 0]!.baseline;
   for (let li = 0; li < lineCount; li++) {
     const { line, alignment } = lines[li];
-    const outset = env.singleEdge
-      ? Math.max(0, clockwise ? anchoredBaseline - lines[li]!.baseline : lines[li]!.baseline - anchoredBaseline)
-      : 0;
-    const lineEnv = outset > 0
-      ? buildWarpEnvelope(preset, adj, boxW + 2 * outset, boxH + 2 * outset) ?? env
-      : env;
     // Per-line vertical band [v0, v1] of the envelope's height. One line fills
     // the whole band; multiple lines split it evenly top→bottom.
     const v0 = li / lineCount;
@@ -2933,6 +2933,14 @@ function renderWarpedText(
       if (m.actualBoundingBoxDescent > 0) maxD = Math.max(maxD, m.actualBoundingBoxDescent);
     }
     if (totalW <= 0) continue;
+    // Empty manual lines affect authored baseline spacing, but have no glyphs
+    // to map. Avoid rebuilding a sampled curve for them.
+    const outset = env.singleEdge
+      ? Math.max(0, clockwise ? anchoredBaseline - lines[li]!.baseline : lines[li]!.baseline - anchoredBaseline)
+      : 0;
+    const lineEnv = outset > 0
+      ? buildWarpEnvelope(preset, adj, boxW + 2 * outset, boxH + 2 * outset) ?? env
+      : env;
 
     // PowerPoint's WordArt semantics for the envelope (paired-edge) presets:
     // the FLAT text's INK RECTANGLE (totalW × ink height) is first STRETCHED to

--- a/packages/pptx/src/wordart-follow-path.test.ts
+++ b/packages/pptx/src/wordart-follow-path.test.ts
@@ -40,6 +40,7 @@ function apply(m: M, x: number, y: number): { x: number; y: number } {
  *  fillText — i.e. each warped glyph's baseline point after all transforms. */
 function trackingCtx() {
   const glyphs: Array<{ ch: string; x: number; y: number }> = [];
+  const measurements: string[] = [];
   let ctm: M = I;
   const stack: M[] = [];
   let fillStyle = '';
@@ -61,11 +62,14 @@ function trackingCtx() {
     textAlign: 'left' as CanvasTextAlign,
     textBaseline: 'alphabetic' as CanvasTextBaseline,
     // Fixed 10px/char advance and ink metrics → predictable natural width.
-    measureText: (s: string) => ({
-      width: [...s].length * 10,
-      actualBoundingBoxAscent: 7,
-      actualBoundingBoxDescent: 2,
-    }),
+    measureText: (s: string) => {
+      measurements.push(s);
+      return {
+        width: [...s].length * 10,
+        actualBoundingBoxAscent: 7,
+        actualBoundingBoxDescent: 2,
+      };
+    },
     fillText: (t: string, x: number, y: number) => {
       const p = apply(ctm, x, y);
       glyphs.push({ ch: t, x: p.x, y: p.y });
@@ -93,7 +97,7 @@ function trackingCtx() {
     clip: () => {},
     rect: () => {},
   };
-  return { ctx: ctx as unknown as CanvasRenderingContext2D, glyphs };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, glyphs, measurements };
 }
 
 function run(text: string, over: Partial<TextRunData> = {}): TextRunData {
@@ -317,5 +321,15 @@ describe('WordArt Follow Path — single-edge span (issue #846)', () => {
     renderTextBody(ctx, warpBody('textArchUp', long), 0, 0, BOX_W, BOX_H, SCALE);
     const s = span(glyphs);
     expect(s).toBeGreaterThan(BOX_W * 0.5);
+  });
+
+  it('does not create wrap-only fragments for infinite-width WordArt layout', () => {
+    const compound = Array.from({ length: 100 }, () => 'word').join('-');
+    const { ctx, measurements } = trackingCtx();
+    renderTextBody(ctx, warpBody('textArchUp', compound), 0, 0, BOX_W, BOX_H, SCALE);
+
+    // The flat no-wrap pass and warped mapping may measure the full segment a
+    // small fixed number of times. They must not measure every growing prefix.
+    expect(measurements.filter((text) => [...text].length > 1)).toHaveLength(3);
   });
 });

--- a/packages/pptx/src/wordart-resource-bounds.test.ts
+++ b/packages/pptx/src/wordart-resource-bounds.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Paragraph, TextBody } from './types.js';
+import type { TextRunData } from '@silurus/ooxml-core';
+
+const { buildWarpEnvelope } = vi.hoisted(() => ({ buildWarpEnvelope: vi.fn() }));
+
+vi.mock('@silurus/ooxml-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@silurus/ooxml-core')>();
+  buildWarpEnvelope.mockImplementation((_preset, _adj, width = 620) => ({
+    top: [{ x: 0, y: 0 }, { x: width, y: 0 }],
+    bottom: [{ x: 0, y: 0 }, { x: width, y: 0 }],
+    topLen: [0, width], bottomLen: [0, width], singleEdge: true,
+  }));
+  return { ...actual, buildWarpEnvelope };
+});
+
+import { renderTextBody } from './renderer.js';
+
+function run(text: string): TextRunData {
+  return {
+    type: 'text', text, bold: null, italic: null, underline: false,
+    strikethrough: false, fontSize: 40, color: '000000', fontFamily: 'Arial',
+  };
+}
+
+function bodyWithEmptyLines(emptyLineCount: number): TextBody {
+  const paragraph: Paragraph = {
+    alignment: 'ctr', marL: 0, marR: 0, indent: 0,
+    spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
+    bullet: { type: 'none' }, defFontSize: null, defColor: null,
+    defBold: null, defItalic: null, defFontFamily: null, tabStops: [],
+    eaLnBrk: true,
+    runs: [run('A'), ...Array.from({ length: emptyLineCount }, () => ({ type: 'break' as const }))],
+  } as Paragraph;
+  return {
+    verticalAnchor: 'ctr', paragraphs: [paragraph], defaultFontSize: 40,
+    defaultBold: null, defaultItalic: null, lIns: 0, rIns: 0, tIns: 0, bIns: 0,
+    wrap: 'square', vert: 'horz', autoFit: 'none',
+    textWarp: { preset: 'textArchUp', adj: [] },
+  } as TextBody;
+}
+
+function mockCtx(): CanvasRenderingContext2D {
+  return {
+    font: '', fillStyle: '', direction: 'ltr', textAlign: 'left', textBaseline: 'alphabetic',
+    measureText: (text: string) => ({
+      width: text.length * 10, actualBoundingBoxAscent: 7, actualBoundingBoxDescent: 2,
+    }) as TextMetrics,
+    save() {}, restore() {}, translate() {}, rotate() {}, scale() {}, fillText() {},
+  } as unknown as CanvasRenderingContext2D;
+}
+
+describe('WordArt rendering resource bounds', () => {
+  beforeEach(() => buildWarpEnvelope.mockClear());
+
+  it('skips per-line envelope construction for empty manual lines', () => {
+    renderTextBody(mockCtx(), bodyWithEmptyLines(100), 0, 0, 620, 150, 1 / 12700);
+
+    // One base envelope and, at most, one expanded envelope for the painted line.
+    expect(buildWarpEnvelope).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Outcome

Bounds three renderer work-amplification paths reachable from untrusted document content:

- caps the cumulative Canvas geometry retained by one EMF path bracket, using the largest previously admitted single-record geometry envelope;
- avoids soft-wrap fragment expansion for infinite-width WordArt layout;
- skips sampled warp-envelope construction for empty manual lines.

The EMF limit is implementation resource governance, not an OOXML semantic restriction. An exhausted bracket is discarded rather than painting a partial attacker-controlled path, and later independent geometry can still render.

## Verification

- 60 focused EMF and WordArt tests
- full test suite: 8,967 passed, 25 skipped
- typecheck and production builds for the affected packages
- exact previous-renderer private VRT: 51 DOCX documents, 139 XLSX workbooks, and 35 PPTX decks / 361 slides
- main/worker parity: DOCX 4 tests, XLSX 3 tests, PPTX all 35 private decks
- validated remediation of all three low-severity CWE-400 findings from the release-delta security review

## Adversarial review

APPROVE. The change preserves specification semantics, adds no sample-specific branch or empirical scale factor, keeps shared EMF policy in core and WordArt-specific layout in PPTX, maintains main/worker wiring, and keeps the existing public `playEmf` signature.

## Migration

No migration is required.
