### PR TITLE
fix(core,docx,pptx): round programmatic scroll targets forward

### DIFF
--- a/packages/core/src/internal/virtual-scroll.ts
+++ b/packages/core/src/internal/virtual-scroll.ts
@@ -2,6 +2,7 @@ export {
   computeUniformVisibleWindow,
   computeVisibleWindow,
   createVirtualScrollGeometry,
+  resolveItemStartScrollTop,
   type VirtualScrollGeometry,
   type VisibleRange,
   type VisibleWindow,

--- a/packages/core/src/layout/virtual-scroll.test.ts
+++ b/packages/core/src/layout/virtual-scroll.test.ts
@@ -287,7 +287,8 @@ describe('fractional item-start navigation targets', () => {
   it('keeps a viewport just before a fractional boundary on the preceding item', () => {
     expect(computeVisibleRange(heights, 10, 110, 50, 0).topIndex).toBe(0);
     expect(computeVisibleRange(heights, 10, 220, 50, 0).topIndex).toBe(1);
-    expect(computeUniformVisibleWindow(3, 100.4, 10, 110, 50, 0).topIndex).toBe(0);
+    // viewportHeight 0 mirrors PPTX's arbitrary coordinate-to-slide lookup.
+    expect(computeUniformVisibleWindow(3, 100.4, 10, 110, 0, 0).topIndex).toBe(0);
   });
 
   it('keeps the exact item boundary inclusive', () => {

--- a/packages/core/src/layout/virtual-scroll.test.ts
+++ b/packages/core/src/layout/virtual-scroll.test.ts
@@ -4,6 +4,7 @@ import {
   computeVisibleRange,
   computeVisibleWindow,
   createVirtualScrollGeometry,
+  resolveItemStartScrollTop,
 } from './virtual-scroll.js';
 
 // Design §5.1 contract. computeVisibleRange(heights, gap, scrollTop,
@@ -278,42 +279,28 @@ describe('cached virtual-scroll geometry', () => {
   });
 });
 
-describe('top-index boundary — fractional offsets and browser scrollTop rounding', () => {
-  // Page/slide heights are pt × a fractional fit/zoom scale, so offsets are
-  // almost never integers (e.g. 1193.4). A browser snaps a programmatic
-  // scrollTop to an integer, landing strictly BELOW the target item's offset;
-  // without a rounding tolerance scrollToPage(k) reports topIndex k−1 even
-  // though item k is what the viewport top shows. The boundary therefore
-  // counts a scrollTop within 1 CSS px below an item start as that item —
-  // without moving the pinned convention that the gap otherwise belongs to
-  // the preceding item.
-  //
-  // heights 100.4 × 3, gap 10 → offsets [0, 110.4, 220.8].
+describe('fractional item-start navigation targets', () => {
+  // heights 100.4 × 3, gap 10 → offsets [0, 110.4, 220.8]. Visible-range
+  // boundaries stay exact for manual scrolling and arbitrary coordinate lookup.
   const heights = [100.4, 100.4, 100.4];
 
-  it('scrollTop = floor(offsets[k]) still attributes the top to item k', () => {
-    // The exact programmatic-navigation case: target 110.4, landed 110.
-    expect(computeVisibleRange(heights, 10, Math.floor(110.4), 50, 0).topIndex).toBe(1);
-    expect(computeVisibleRange(heights, 10, Math.floor(220.8), 50, 0).topIndex).toBe(2);
+  it('keeps a viewport just before a fractional boundary on the preceding item', () => {
+    expect(computeVisibleRange(heights, 10, 110, 50, 0).topIndex).toBe(0);
+    expect(computeVisibleRange(heights, 10, 220, 50, 0).topIndex).toBe(1);
+    expect(computeUniformVisibleWindow(3, 100.4, 10, 110, 50, 0).topIndex).toBe(0);
   });
 
-  it('scrollTop exactly at offsets[k] attributes the top to item k (unchanged)', () => {
+  it('keeps the exact item boundary inclusive', () => {
     expect(computeVisibleRange(heights, 10, 110.4, 50, 0).topIndex).toBe(1);
-  });
-
-  it('a top genuinely inside the gap, beyond rounding distance, stays on the preceding item', () => {
-    // 110.4 − gap/2 − 2 = 103.4: well inside the gap — the 1 px band must not
-    // reach this far (the user is still on the tail of item 0).
-    expect(computeVisibleRange(heights, 10, 103.4, 50, 0).topIndex).toBe(0);
-    // Just outside the band: 110.4 − 1.5.
-    expect(computeVisibleRange(heights, 10, 108.9, 50, 0).topIndex).toBe(0);
-  });
-
-  it('uniform windows share the same boundary (slides)', () => {
-    // stride 110.4 → slide 1 starts at 110.4.
-    expect(computeUniformVisibleWindow(3, 100.4, 10, Math.floor(110.4), 50, 0).topIndex).toBe(1);
     expect(computeUniformVisibleWindow(3, 100.4, 10, 110.4, 50, 0).topIndex).toBe(1);
-    expect(computeUniformVisibleWindow(3, 100.4, 10, 103.4, 50, 0).topIndex).toBe(0);
-    expect(computeUniformVisibleWindow(3, 100.4, 10, 108.9, 50, 0).topIndex).toBe(0);
+  });
+
+  it('rounds only a programmatic item-start target forward and respects maxTop', () => {
+    expect(resolveItemStartScrollTop(110.4, 500)).toBe(111);
+    expect(resolveItemStartScrollTop(110, 500)).toBe(110);
+    expect(resolveItemStartScrollTop(110.4, 110.6)).toBe(110.6);
+    expect(resolveItemStartScrollTop(110.4, 110.2)).toBe(110.2);
+    expect(resolveItemStartScrollTop(-5, 500)).toBe(0);
+    expect(resolveItemStartScrollTop(50, -10)).toBe(0);
   });
 });

--- a/packages/core/src/layout/virtual-scroll.test.ts
+++ b/packages/core/src/layout/virtual-scroll.test.ts
@@ -277,3 +277,43 @@ describe('cached virtual-scroll geometry', () => {
     });
   });
 });
+
+describe('top-index boundary — fractional offsets and browser scrollTop rounding', () => {
+  // Page/slide heights are pt × a fractional fit/zoom scale, so offsets are
+  // almost never integers (e.g. 1193.4). A browser snaps a programmatic
+  // scrollTop to an integer, landing strictly BELOW the target item's offset;
+  // without a rounding tolerance scrollToPage(k) reports topIndex k−1 even
+  // though item k is what the viewport top shows. The boundary therefore
+  // counts a scrollTop within 1 CSS px below an item start as that item —
+  // without moving the pinned convention that the gap otherwise belongs to
+  // the preceding item.
+  //
+  // heights 100.4 × 3, gap 10 → offsets [0, 110.4, 220.8].
+  const heights = [100.4, 100.4, 100.4];
+
+  it('scrollTop = floor(offsets[k]) still attributes the top to item k', () => {
+    // The exact programmatic-navigation case: target 110.4, landed 110.
+    expect(computeVisibleRange(heights, 10, Math.floor(110.4), 50, 0).topIndex).toBe(1);
+    expect(computeVisibleRange(heights, 10, Math.floor(220.8), 50, 0).topIndex).toBe(2);
+  });
+
+  it('scrollTop exactly at offsets[k] attributes the top to item k (unchanged)', () => {
+    expect(computeVisibleRange(heights, 10, 110.4, 50, 0).topIndex).toBe(1);
+  });
+
+  it('a top genuinely inside the gap, beyond rounding distance, stays on the preceding item', () => {
+    // 110.4 − gap/2 − 2 = 103.4: well inside the gap — the 1 px band must not
+    // reach this far (the user is still on the tail of item 0).
+    expect(computeVisibleRange(heights, 10, 103.4, 50, 0).topIndex).toBe(0);
+    // Just outside the band: 110.4 − 1.5.
+    expect(computeVisibleRange(heights, 10, 108.9, 50, 0).topIndex).toBe(0);
+  });
+
+  it('uniform windows share the same boundary (slides)', () => {
+    // stride 110.4 → slide 1 starts at 110.4.
+    expect(computeUniformVisibleWindow(3, 100.4, 10, Math.floor(110.4), 50, 0).topIndex).toBe(1);
+    expect(computeUniformVisibleWindow(3, 100.4, 10, 110.4, 50, 0).topIndex).toBe(1);
+    expect(computeUniformVisibleWindow(3, 100.4, 10, 103.4, 50, 0).topIndex).toBe(0);
+    expect(computeUniformVisibleWindow(3, 100.4, 10, 108.9, 50, 0).topIndex).toBe(0);
+  });
+});

--- a/packages/core/src/layout/virtual-scroll.ts
+++ b/packages/core/src/layout/virtual-scroll.ts
@@ -18,10 +18,7 @@ export interface VisibleWindow {
    *  onVisiblePageChange. A viewport top strictly inside the gap BETWEEN items i
    *  and i+1 is attributed to item i (gap = trailing padding of the preceding
    *  item — the standard virtualization convention; mount-safe, and flips to i+1
-   *  at `offsets[i+1]`). Exception: the flip happens up to
-   *  TOP_EDGE_ROUNDING_EPSILON (1 CSS px) EARLY, because fractional offsets meet
-   *  a browser-snapped integer scrollTop at exactly that boundary — see the
-   *  constant's doc. */
+   *  exactly at `offsets[i+1]`). */
   topIndex: number;
   /** `leading` + Σ heights + (n-1)*gap + `trailing` (gap between items only, none
    *  after the last) → spacer height. With no padding this reduces to
@@ -61,18 +58,18 @@ function clamp(v: number, lo: number, hi: number): number {
 }
 
 /**
- * Rounding tolerance at the top-edge boundary, in CSS px. Item offsets are
- * fractional (pt × a fractional fit/zoom scale, e.g. 1193.4), but browsers
- * snap a programmatic `scrollTop` to an integer, landing strictly BELOW the
- * target item's offset — without this tolerance `scrollToPage(k)` reports
- * `topIndex` k−1 even though item k is what the viewport top shows.
+ * Resolve a programmatic item-start scroll target for a scroll surface that may
+ * quantize assigned offsets to whole CSS pixels. Rounding forward guarantees a
+ * fractional item start cannot land just before that item. The result remains
+ * clamped to the real maximum, which may itself be fractional near the end.
  *
- * Exactly 1 px: it covers the integer snap and nothing more. A viewport top
- * deeper inside the gap still belongs to the preceding item (the user is
- * reading its tail), so a wider band — e.g. gap/2 — would misattribute
- * genuine scroll positions, not just rounding artifacts.
+ * Keep this adjustment on navigation targets rather than visible-range queries:
+ * those queries also serve manual scrolling and arbitrary coordinate lookup,
+ * where an epsilon would move the documented item boundary.
  */
-const TOP_EDGE_ROUNDING_EPSILON = 1;
+export function resolveItemStartScrollTop(target: number, maxTop: number): number {
+  return Math.min(Math.max(0, maxTop), Math.ceil(Math.max(0, target)));
+}
 
 /** Build the variable-height prefix geometry once per layout/scale revision. */
 export function createVirtualScrollGeometry(
@@ -110,16 +107,11 @@ export function computeVisibleWindow(
     return { start: 0, end: -1, topIndex: 0, offsets, totalHeight: 0 };
   }
 
-  // The top edge gets TOP_EDGE_ROUNDING_EPSILON slack: a scrollTop snapped by
-  // the browser to an integer just below a fractional item start still counts
-  // as that item. The bottom edge needs no such slack — a sub-pixel difference
-  // there never changes which items intersect the viewport.
-  const topEdge = scrollTop + TOP_EDGE_ROUNDING_EPSILON;
   let lo = 0;
   let hi = n;
   while (lo < hi) {
     const mid = (lo + hi) >>> 1;
-    if (offsets[mid] <= topEdge) lo = mid + 1;
+    if (offsets[mid] <= scrollTop) lo = mid + 1;
     else hi = mid;
   }
   const topIndex = clamp(lo - 1, 0, n - 1);
@@ -157,14 +149,10 @@ export function computeUniformVisibleWindow(
   const leading = pad?.leading ?? 0;
   const trailing = pad?.trailing ?? 0;
   const stride = itemHeight + gap;
-  // Same boundary rule as computeVisibleWindow: the +1 px slack only ever
-  // flips the single boundary the browser's integer scrollTop snap can cross,
-  // because a real slide stride is always ≫ 1 px.
-  const topEdge = scrollTop + TOP_EDGE_ROUNDING_EPSILON;
   const topIndex = clamp(
-    topEdge < leading
+    scrollTop < leading
       ? 0
-      : stride > 0 ? Math.floor((topEdge - leading) / stride) : itemCount - 1,
+      : stride > 0 ? Math.floor((scrollTop - leading) / stride) : itemCount - 1,
     0,
     itemCount - 1,
   );

--- a/packages/core/src/layout/virtual-scroll.ts
+++ b/packages/core/src/layout/virtual-scroll.ts
@@ -18,7 +18,10 @@ export interface VisibleWindow {
    *  onVisiblePageChange. A viewport top strictly inside the gap BETWEEN items i
    *  and i+1 is attributed to item i (gap = trailing padding of the preceding
    *  item — the standard virtualization convention; mount-safe, and flips to i+1
-   *  exactly at `offsets[i+1]`). */
+   *  at `offsets[i+1]`). Exception: the flip happens up to
+   *  TOP_EDGE_ROUNDING_EPSILON (1 CSS px) EARLY, because fractional offsets meet
+   *  a browser-snapped integer scrollTop at exactly that boundary — see the
+   *  constant's doc. */
   topIndex: number;
   /** `leading` + Σ heights + (n-1)*gap + `trailing` (gap between items only, none
    *  after the last) → spacer height. With no padding this reduces to
@@ -57,6 +60,20 @@ function clamp(v: number, lo: number, hi: number): number {
   return v < lo ? lo : v > hi ? hi : v;
 }
 
+/**
+ * Rounding tolerance at the top-edge boundary, in CSS px. Item offsets are
+ * fractional (pt × a fractional fit/zoom scale, e.g. 1193.4), but browsers
+ * snap a programmatic `scrollTop` to an integer, landing strictly BELOW the
+ * target item's offset — without this tolerance `scrollToPage(k)` reports
+ * `topIndex` k−1 even though item k is what the viewport top shows.
+ *
+ * Exactly 1 px: it covers the integer snap and nothing more. A viewport top
+ * deeper inside the gap still belongs to the preceding item (the user is
+ * reading its tail), so a wider band — e.g. gap/2 — would misattribute
+ * genuine scroll positions, not just rounding artifacts.
+ */
+const TOP_EDGE_ROUNDING_EPSILON = 1;
+
 /** Build the variable-height prefix geometry once per layout/scale revision. */
 export function createVirtualScrollGeometry(
   heights: readonly number[],
@@ -93,11 +110,16 @@ export function computeVisibleWindow(
     return { start: 0, end: -1, topIndex: 0, offsets, totalHeight: 0 };
   }
 
+  // The top edge gets TOP_EDGE_ROUNDING_EPSILON slack: a scrollTop snapped by
+  // the browser to an integer just below a fractional item start still counts
+  // as that item. The bottom edge needs no such slack — a sub-pixel difference
+  // there never changes which items intersect the viewport.
+  const topEdge = scrollTop + TOP_EDGE_ROUNDING_EPSILON;
   let lo = 0;
   let hi = n;
   while (lo < hi) {
     const mid = (lo + hi) >>> 1;
-    if (offsets[mid] <= scrollTop) lo = mid + 1;
+    if (offsets[mid] <= topEdge) lo = mid + 1;
     else hi = mid;
   }
   const topIndex = clamp(lo - 1, 0, n - 1);
@@ -135,10 +157,14 @@ export function computeUniformVisibleWindow(
   const leading = pad?.leading ?? 0;
   const trailing = pad?.trailing ?? 0;
   const stride = itemHeight + gap;
+  // Same boundary rule as computeVisibleWindow: the +1 px slack only ever
+  // flips the single boundary the browser's integer scrollTop snap can cross,
+  // because a real slide stride is always ≫ 1 px.
+  const topEdge = scrollTop + TOP_EDGE_ROUNDING_EPSILON;
   const topIndex = clamp(
-    scrollTop < leading
+    topEdge < leading
       ? 0
-      : stride > 0 ? Math.floor((scrollTop - leading) / stride) : itemCount - 1,
+      : stride > 0 ? Math.floor((topEdge - leading) / stride) : itemCount - 1,
     0,
     itemCount - 1,
   );

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -2381,6 +2381,28 @@ describe('DocxScrollViewer — navigation, resize, empty (T6)', () => {
     v.destroy();
   });
 
+  it('topVisiblePage survives the browser scrollTop snap below a fractional page offset', () => {
+    // Page heights are pt × the fit scale; with a fractional scale the offsets
+    // are fractional. A real browser snaps a programmatic scrollTop to an
+    // integer, landing strictly BELOW the target page's offset — the top-index
+    // boundary must still report the page the viewport top actually shows.
+    const { v, scrollHost, container } = setup();
+    container.clientWidth = 199.9;
+    scrollHost.clientWidth = 199.9; // fractional fit scale → fractional page px
+    v.resizeForTest();
+
+    v.scrollToPage(3);
+    // Precondition: page 3's offset IS fractional, and an exact landing reports 3.
+    expect(scrollHost.scrollTop % 1).not.toBe(0);
+    expect(v.topVisiblePage).toBe(3);
+
+    // Simulate the browser's integer snap and the resulting scroll event.
+    scrollHost.scrollTop = Math.floor(scrollHost.scrollTop);
+    scrollHost.dispatch('scroll');
+    expect(v.topVisiblePage).toBe(3);
+    v.destroy();
+  });
+
   it('ResizeObserver re-fit preserves the zoom multiplier', () => {
     // zoomMax headroom: base 1.5, 2× zoom → 3.0; after the width doubles the new
     // base is 3.0 so the preserved scale is 6.0. zoomMin/zoomMax are ABSOLUTE

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -2381,24 +2381,25 @@ describe('DocxScrollViewer — navigation, resize, empty (T6)', () => {
     v.destroy();
   });
 
-  it('topVisiblePage survives the browser scrollTop snap below a fractional page offset', () => {
-    // Page heights are pt × the fit scale; with a fractional scale the offsets
-    // are fractional. A real browser snaps a programmatic scrollTop to an
-    // integer, landing strictly BELOW the target page's offset — the top-index
-    // boundary must still report the page the viewport top actually shows.
+  it('rounds a fractional page target forward before an integer-quantizing scrollTo', () => {
     const { v, scrollHost, container } = setup();
     container.clientWidth = 199.9;
     scrollHost.clientWidth = 199.9; // fractional fit scale → fractional page px
     v.resizeForTest();
 
-    v.scrollToPage(3);
-    // Precondition: page 3's offset IS fractional, and an exact landing reports 3.
-    expect(scrollHost.scrollTop % 1).not.toBe(0);
-    expect(v.topVisiblePage).toBe(3);
+    let requestedTop = -1;
+    (scrollHost as FakeEl & {
+      scrollTo: (opts: { top: number }) => void;
+    }).scrollTo = ({ top }) => {
+      requestedTop = top;
+      scrollHost.scrollTop = Math.floor(top);
+    };
 
-    // Simulate the browser's integer snap and the resulting scroll event.
-    scrollHost.scrollTop = Math.floor(scrollHost.scrollTop);
-    scrollHost.dispatch('scroll');
+    v.scrollToPage(3);
+    const fractionalTarget = 3 * (PAGE_H * 199.9 / 200 + GAP);
+    expect(fractionalTarget % 1).not.toBe(0);
+    expect(requestedTop).toBe(Math.ceil(fractionalTarget));
+    expect(scrollHost.scrollTop).toBe(requestedTop);
     expect(v.topVisiblePage).toBe(3);
     v.destroy();
   });

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -3,6 +3,7 @@ import type { FindHighlightColors, FindMatch, FindMatchesOptions, HyperlinkTarge
 import {
   computeVisibleWindow,
   createVirtualScrollGeometry,
+  resolveItemStartScrollTop,
   type VirtualScrollGeometry,
   type VisibleRange,
 } from '@silurus/ooxml-core/internal/virtual-scroll';
@@ -2245,7 +2246,9 @@ export class DocxScrollViewer implements ZoomableViewer {
    * Scroll so page `index`'s top edge sits at the viewport top. Clamps `index` to
    * `[0, pageCount-1]` (the pager convention) and the resulting scrollTop to
    * `[0, totalHeight − viewportHeight]` so the last pages don't scroll past the
-   * end. A no-op when nothing is loaded or the document is empty.
+   * end. Fractional item-start targets are rounded forward to a whole CSS pixel
+   * so an integer-quantizing scroll surface cannot land on the preceding page.
+   * A no-op when nothing is loaded or the document is empty.
    *
    * `opts.behavior` ('auto' | 'smooth', default 'auto') is honoured via
    * `scrollHost.scrollTo({ top, behavior })` when the host supports it (a real
@@ -2272,7 +2275,7 @@ export class DocxScrollViewer implements ZoomableViewer {
     );
     const target = r.offsets[clamped] ?? 0;
     const maxTop = Math.max(0, r.totalHeight - this._scrollHost.clientHeight);
-    const top = Math.min(maxTop, Math.max(0, target));
+    const top = resolveItemStartScrollTop(target, maxTop);
     const host = this._scrollHost as HTMLDivElement & {
       scrollTo?: (opts: { top: number; behavior?: 'auto' | 'smooth' }) => void;
     };

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -2545,24 +2545,25 @@ describe('PptxScrollViewer — navigation, resize, empty (T6)', () => {
     v.destroy();
   });
 
-  it('topVisibleSlide survives the browser scrollTop snap below a fractional slide offset', () => {
-    // Slide heights are natural-px × the fit scale; with a fractional scale the
-    // offsets are fractional. A real browser snaps a programmatic scrollTop to
-    // an integer, landing strictly BELOW the target slide's offset — the
-    // top-index boundary must still report the slide the viewport top shows.
+  it('rounds a fractional slide target forward before an integer-quantizing scrollTo', () => {
     const { v, scrollHost, container } = setup();
     container.clientWidth = 199.9;
     scrollHost.clientWidth = 199.9; // fractional fit scale → fractional slide px
     v.resizeForTest();
 
-    v.scrollToSlide(3);
-    // Precondition: slide 3's offset IS fractional, and an exact landing reports 3.
-    expect(scrollHost.scrollTop % 1).not.toBe(0);
-    expect(v.topVisibleSlide).toBe(3);
+    let requestedTop = -1;
+    (scrollHost as FakeEl & {
+      scrollTo: (opts: { top: number }) => void;
+    }).scrollTo = ({ top }) => {
+      requestedTop = top;
+      scrollHost.scrollTop = Math.floor(top);
+    };
 
-    // Simulate the browser's integer snap and the resulting scroll event.
-    scrollHost.scrollTop = Math.floor(scrollHost.scrollTop);
-    scrollHost.dispatch('scroll');
+    v.scrollToSlide(3);
+    const fractionalTarget = 3 * (SLIDE_H * 199.9 / 200 + GAP);
+    expect(fractionalTarget % 1).not.toBe(0);
+    expect(requestedTop).toBe(Math.ceil(fractionalTarget));
+    expect(scrollHost.scrollTop).toBe(requestedTop);
     expect(v.topVisibleSlide).toBe(3);
     v.destroy();
   });

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -2545,6 +2545,28 @@ describe('PptxScrollViewer — navigation, resize, empty (T6)', () => {
     v.destroy();
   });
 
+  it('topVisibleSlide survives the browser scrollTop snap below a fractional slide offset', () => {
+    // Slide heights are natural-px × the fit scale; with a fractional scale the
+    // offsets are fractional. A real browser snaps a programmatic scrollTop to
+    // an integer, landing strictly BELOW the target slide's offset — the
+    // top-index boundary must still report the slide the viewport top shows.
+    const { v, scrollHost, container } = setup();
+    container.clientWidth = 199.9;
+    scrollHost.clientWidth = 199.9; // fractional fit scale → fractional slide px
+    v.resizeForTest();
+
+    v.scrollToSlide(3);
+    // Precondition: slide 3's offset IS fractional, and an exact landing reports 3.
+    expect(scrollHost.scrollTop % 1).not.toBe(0);
+    expect(v.topVisibleSlide).toBe(3);
+
+    // Simulate the browser's integer snap and the resulting scroll event.
+    scrollHost.scrollTop = Math.floor(scrollHost.scrollTop);
+    scrollHost.dispatch('scroll');
+    expect(v.topVisibleSlide).toBe(3);
+    v.destroy();
+  });
+
   it('ResizeObserver re-fit preserves the zoom multiplier', () => {
     // zoomMax headroom: base 1.0, 2× zoom → 2.0; after the width doubles the new
     // base is 2.0 so the preserved scale is 4.0. zoomMin/zoomMax are ABSOLUTE

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -1,6 +1,7 @@
 import { EMU_PER_PX, zoomStepScale, anchoredZoomOffset, nextZoomStep, prevZoomStep, fitScale, type FindHighlightColors, type FindMatch, type FindMatchesOptions, type HyperlinkTarget, type OoxmlResourceMetrics, type ViewerContextMenuEvent, type ZoomableViewer, openExternalHyperlink } from '@silurus/ooxml-core';
 import {
   computeUniformVisibleWindow,
+  resolveItemStartScrollTop,
   type VisibleWindow,
 } from '@silurus/ooxml-core/internal/virtual-scroll';
 import {
@@ -2313,7 +2314,9 @@ export class PptxScrollViewer implements ZoomableViewer {
    * Scroll so slide `index`'s top edge sits at the viewport top. Clamps `index` to
    * `[0, slideCount-1]` (the pager convention) and the resulting scrollTop to
    * `[0, totalHeight − viewportHeight]` so the last slides don't scroll past the
-   * end. A no-op when nothing is loaded or the deck is empty.
+   * end. Fractional item-start targets are rounded forward to a whole CSS pixel
+   * so an integer-quantizing scroll surface cannot land on the preceding slide.
+   * A no-op when nothing is loaded or the deck is empty.
    *
    * `opts.behavior` ('auto' | 'smooth', default 'auto') is honoured via
    * `scrollHost.scrollTo({ top, behavior })` when the host supports it (a real
@@ -2334,7 +2337,7 @@ export class PptxScrollViewer implements ZoomableViewer {
     const r = this._rangeAt(0, this._overscan());
     const target = this._slideOffset(clamped);
     const maxTop = Math.max(0, r.totalHeight - this._scrollHost.clientHeight);
-    const top = Math.min(maxTop, Math.max(0, target));
+    const top = resolveItemStartScrollTop(target, maxTop);
     const host = this._scrollHost as HTMLDivElement & {
       scrollTo?: (opts: { top: number; behavior?: 'auto' | 'smooth' }) => void;
     };


### PR DESCRIPTION
## Problem

Programmatic page and slide navigation can report the preceding item when a fractional item-start offset is quantized below its boundary by the scroll surface.

## Final fix

- Preserve exact visible-window boundaries for manual scrolling and arbitrary coordinate lookup.
- Round only programmatic item-start targets forward to a whole CSS pixel before assigning scrollTop.
- Keep the target clamped to maxTop, including fractional end-of-document positions.
- Share the target resolver in core and use it from the DOCX and PPTX scroll viewers.

The initial implementation added a global 1 CSS px epsilon to visible-window searches. Adversarial review rejected that scope because it changed ordinary manual-scroll attribution and PPTX coordinate-to-slide lookup. The final implementation confines quantization handling to scrollToPage and scrollToSlide.

## Tests and verification

- Focused core, DOCX, and PPTX scroll-viewer tests: 297 passed.
- Broad core, DOCX, and PPTX suites: 7,664 passed, 3 skipped.
- TypeScript build/typecheck: passed.
- Production build: passed.
- GitHub CI: audit, rust, smoke, and typecheck passed.

No Canvas painter, renderer, OOXML parser, or layout-output code changed, so image VRT is not applicable to this navigation-only behavior. Integer-quantizing scroll surfaces are covered directly by viewer integration tests.

## Security and adversarial review

- No reportable security findings or malware indicators.
- No dependency, lockfile, workflow, binary, executable-mode, symlink, submodule, encoded-payload, network/process-execution, or invisible-control-character changes.
- O(1), allocation-free target resolution; existing virtualization bounds remain unchanged.
- DOCX and PPTX integrations are covered; XLSX does not use this virtual-scroll path.

Spec: N/A — browser scroll-position compatibility, no OOXML behavior change.