### PR TITLE
chore(release): 0.86.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,9 +211,9 @@ be committed.
 
 Typical local-only paths:
 
-- `packages/docx/public/private/`
-- `packages/xlsx/public/private/`
-- `packages/pptx/public/private/`
+- `packages/docx/public/private/docx/`
+- `packages/xlsx/public/private/xlsx/`
+- `packages/pptx/public/private/pptx/`
 - `packages/*/src/*privateDemo.stories.ts`
 - `packages/*/src/wasm/`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ the corresponding minor release.
 
 ## Unreleased
 
+## 0.86.1 — 2026-09-06
+
+Compatible patch release improving older PowerPoint compatibility, curved-text
+layout, Word pagination fidelity, and rendering resource bounds.
+
+- **older PowerPoint fidelity:** legacy reflected text, preset shapes, diagram
+  fallbacks, table fills and borders, authored row heights, and inherited text
+  colors now follow the saved presentation more closely.
+- **curved PowerPoint text:** Follow Path WordArt uses concentric per-line paths,
+  keeps authored Latin hyphens as valid wrap points in ordinary text, and avoids
+  overlap or excessive rotation in no-wrap curved text.
+- **resilient presentation loading:** primary slides use a measured complexity
+  allowance for dense but valid content while dependency parts retain their
+  stricter limit, and file opening uses the same modern loading indicator as the
+  rest of the viewer.
+- **resolved Word font metrics:** CJK line allocation is derived from the font
+  resource actually selected by the browser or embedded in the document. This
+  removes the previous Meiryo-only resource override without guessing a
+  substitute when the authored font is unavailable.
+- **Word page fields:** complex fields whose markers share a run preserve their
+  authored order, so page-dependent footer values such as page numbers remain
+  visible after pagination.
+- **bounded rendering work:** crafted EMF path brackets, hyphen-rich curved text,
+  and empty WordArt lines can no longer multiply Canvas work beyond the
+  renderer's established resource envelope.
+- **compatibility:** no existing option or method is removed or renamed, and no
+  application changes are required.
+
 ## 0.86.0 — 2026-09-05
 
 Compatible minor release improving PowerPoint text fidelity, Markdown review

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.86.0"
+version = "0.86.1"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.86.0",
+  "version": "0.86.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.86.0",
+  "version": "0.86.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.86.0",
+  "version": "0.86.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/tests/visual/page-number.spec.ts
+++ b/packages/docx/tests/visual/page-number.spec.ts
@@ -31,7 +31,7 @@ const CASES: { file: string; pageCount: number; width: number; expected: string[
   // §17.6.12 continuous restart (#804): continuous start=50 shares p.1 and spills.
   // The DISTINGUISHING signal is that the section's FIRST OWNED page shows 51 (not
   // 50) — the shared page it does not own counts as the section's page 50. Word's
-  // PDF (public/private/sample-27.pdf) is 3 pages [Page 1, Page 51, Page 52]; this
+  // PDF (public/private/docx/sample-27.pdf) is 3 pages [Page 1, Page 51, Page 52]; this
   // renderer packs ~50 body paragraphs per page vs Word's ~46, so it fits section 2
   // in ONE fewer page and shows [1, 51] over 2 pages. That page-DENSITY gap is a
   // separate pagination-fidelity concern, out of scope for #804 — the RESTART

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.86.0",
+  "version": "0.86.1",
   "description": "Internal workspace adapter for DOCX / XLSX / PPTX Markdown projection",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.86.0"
+version = "0.86.1"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.86.0",
+  "version": "0.86.1",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/src/bench-parse.mjs
+++ b/packages/node/src/bench-parse.mjs
@@ -16,7 +16,7 @@
  *   node packages/node/src/bench-parse.mjs <file> [iterations]
  *
  * Example:
- *   node packages/node/src/bench-parse.mjs packages/docx/public/private/sample-10.docx
+ *   node packages/node/src/bench-parse.mjs packages/docx/public/private/docx/sample-10.docx
  *
  * Requires the WASM artifacts to be freshly built (`pnpm build:wasm`) so it
  * measures the current parser source, not a stale committed pkg.

--- a/packages/node/src/docx-anchored-chart.probe.test.ts
+++ b/packages/node/src/docx-anchored-chart.probe.test.ts
@@ -32,7 +32,7 @@ const ROOT = resolve(HERE, '../../..');
 const docxMod = skia ? await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)') : null;
 const rendererMod = skia ? await loadDocxRendererForTests() : null;
 
-const SAMPLE_24 = resolve(ROOT, 'packages/docx/public/private/sample-24.docx');
+const SAMPLE_24 = resolve(ROOT, 'packages/docx/public/private/docx/sample-24.docx');
 const haveSample = existsSync(SAMPLE_24);
 const sampleBytes = haveSample ? readFileSync(SAMPLE_24) : null;
 

--- a/packages/node/src/docx-bookmark-nav.test.ts
+++ b/packages/node/src/docx-bookmark-nav.test.ts
@@ -38,7 +38,7 @@ const docxMod = skia ? await importForTests(() => import('./docx.ts'), './docx.t
 const rendererMod = skia ? await loadDocxRendererForTests() : null;
 const navMod = skia ? await loadDocxBookmarkNavForTests() : null;
 
-const samplePath = (n: number) => resolve(ROOT, `packages/docx/public/private/sample-${n}.docx`);
+const samplePath = (n: number) => resolve(ROOT, `packages/docx/public/private/docx/sample-${n}.docx`);
 const haveSample11 = existsSync(samplePath(11));
 
 describe.skipIf(!skia || !docxMod || !rendererMod || !navMod || !haveSample11)(

--- a/packages/node/src/docx-continuous-columns.test.ts
+++ b/packages/node/src/docx-continuous-columns.test.ts
@@ -41,7 +41,7 @@ type DocxLayout = ReturnType<DocxRendererModule['layoutDocument']>;
 type RetainedBodyNode = DocxLayout['pages'][number]['layers']['body'][number];
 
 const samplePath = (n: number) =>
-  resolve(ROOT, `packages/docx/public/private/sample-${n}.docx`);
+  resolve(ROOT, `packages/docx/public/private/docx/sample-${n}.docx`);
 const haveSamples =
   existsSync(samplePath(5)) && existsSync(samplePath(12)) && existsSync(samplePath(13));
 

--- a/packages/node/src/docx-font-advance-bias.probe.test.ts
+++ b/packages/node/src/docx-font-advance-bias.probe.test.ts
@@ -51,7 +51,7 @@ const ROOT = resolve(HERE, '../../..');
 const docxMod = skia ? await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)') : null;
 const rendererMod = skia ? await loadDocxRendererForTests() : null;
 
-const samplePath = (n: number) => resolve(ROOT, `packages/docx/public/private/sample-${n}.docx`);
+const samplePath = (n: number) => resolve(ROOT, `packages/docx/public/private/docx/sample-${n}.docx`);
 const have = (n: number) => existsSync(samplePath(n));
 
 interface Run { text: string; x: number; y: number; w: number; h: number; fontSize: number }

--- a/packages/node/src/docx-vertical-table-cells.probe.test.ts
+++ b/packages/node/src/docx-vertical-table-cells.probe.test.ts
@@ -79,7 +79,7 @@ const rendererMod = await loadDocxRendererForTests();
 type Any = any;
 
 const SAMPLE = fileURLToPath(
-  new URL('../../docx/public/private/sample-52.docx', import.meta.url),
+  new URL('../../docx/public/private/docx/sample-52.docx', import.meta.url),
 );
 const MINCHO = '/System/Library/Fonts/ヒラギノ明朝 ProN.ttc';
 const havePrereqs = existsSync(SAMPLE) && existsSync(MINCHO);

--- a/packages/node/src/docx-vertical-textbox-crossaxis.probe.test.ts
+++ b/packages/node/src/docx-vertical-textbox-crossaxis.probe.test.ts
@@ -48,7 +48,7 @@ const rendererMod = await loadDocxRendererForTests();
 type Any = any;
 
 const SAMPLE = fileURLToPath(
-  new URL('../../docx/public/private/sample-53.docx', import.meta.url),
+  new URL('../../docx/public/private/docx/sample-53.docx', import.meta.url),
 );
 const MINCHO = '/System/Library/Fonts/ヒラギノ明朝 ProN.ttc';
 const havePrereqs = existsSync(SAMPLE) && existsSync(MINCHO);

--- a/packages/node/src/verify-chart-regressions.probe.test.ts
+++ b/packages/node/src/verify-chart-regressions.probe.test.ts
@@ -19,10 +19,10 @@ const { Canvas } = (skia ?? {}) as Skia;
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(HERE, '../../..');
-const SAMPLE_14 = resolve(ROOT, 'packages/pptx/public/private/sample-14.pptx');
-const SAMPLE_30 = resolve(ROOT, 'packages/xlsx/public/private/sample-30.xlsx');
-const SAMPLE_17 = resolve(ROOT, 'packages/pptx/public/private/sample-17.pptx');
-const SAMPLE_18 = resolve(ROOT, 'packages/pptx/public/private/sample-18.pptx');
+const SAMPLE_14 = resolve(ROOT, 'packages/pptx/public/private/pptx/sample-14.pptx');
+const SAMPLE_30 = resolve(ROOT, 'packages/xlsx/public/private/xlsx/sample-30.xlsx');
+const SAMPLE_17 = resolve(ROOT, 'packages/pptx/public/private/pptx/sample-17.pptx');
+const SAMPLE_18 = resolve(ROOT, 'packages/pptx/public/private/pptx/sample-18.pptx');
 
 const varySamples = [SAMPLE_17, SAMPLE_18].filter((p) => existsSync(p));
 const pptxMod = skia && (existsSync(SAMPLE_14) || varySamples.length > 0)

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.86.0",
+  "version": "0.86.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -3318,8 +3318,8 @@ mod tests {
 
     // Local-only sample (redistribution-prohibited, gitignored). Tests that
     // depend on it must skip gracefully on a clean checkout / in CI where the
-    // file is absent. See packages/pptx/public/private/.
-    const LOCAL_SAMPLE_2: &str = "../public/private/sample-2.pptx";
+    // file is absent. See packages/pptx/public/private/pptx/.
+    const LOCAL_SAMPLE_2: &str = "../public/private/pptx/sample-2.pptx";
 
     struct SlideJsonLimitOverride(Option<u64>);
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity local viewer for Office files (.docx / .xlsx / .pptx), powered by Rust/WASM and Canvas. Optional MCP integration can share requested context with an AI agent.",
-  "version": "0.86.0",
+  "version": "0.86.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.86.0",
+  "version": "0.86.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.86.0",
+  "version": "0.86.1",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",

--- a/site/src/announcement-content.test.ts
+++ b/site/src/announcement-content.test.ts
@@ -249,16 +249,16 @@ describe('v0.81 ChartEx migration guide', () => {
 
 describe('stable documentation boundaries', () => {
   it('keeps the current bundle measurements on one stable page', () => {
-    expect(bundleSizePage).toContain('Current production assets for v0.86.0');
+    expect(bundleSizePage).toContain('Current production assets for v0.86.1');
     expect(bundleSizePage).toContain('DOCX static JavaScript');
-    expect(bundleSizePage).toMatch(/<td>1,967 KiB<\/td>\s*<td>479 KiB<\/td>/);
+    expect(bundleSizePage).toMatch(/<td>1,979 KiB<\/td>\s*<td>482 KiB<\/td>/);
     expect(bundleSizePage).toContain('XLSX static JavaScript');
-    expect(bundleSizePage).toMatch(/<td>1,283 KiB<\/td>\s*<td>306 KiB<\/td>/);
+    expect(bundleSizePage).toMatch(/<td>1,292 KiB<\/td>\s*<td>309 KiB<\/td>/);
     expect(bundleSizePage).toContain('PPTX static JavaScript');
-    expect(bundleSizePage).toMatch(/<td>1,330 KiB<\/td>\s*<td>311 KiB<\/td>/);
-    expect(bundleSizePage).toContain('<tr><th>DOCX parser WASM</th><td>1,792 KiB</td><td>744 KiB</td></tr>');
+    expect(bundleSizePage).toMatch(/<td>1,335 KiB<\/td>\s*<td>312 KiB<\/td>/);
+    expect(bundleSizePage).toContain('<tr><th>DOCX parser WASM</th><td>1,794 KiB</td><td>746 KiB</td></tr>');
     expect(bundleSizePage).toContain('<tr><th>XLSX parser WASM</th><td>1,581 KiB</td><td>651 KiB</td></tr>');
-    expect(bundleSizePage).toContain('<tr><th>PPTX parser WASM</th><td>1,653 KiB</td><td>651 KiB</td></tr>');
+    expect(bundleSizePage).toContain('<tr><th>PPTX parser WASM</th><td>1,678 KiB</td><td>659 KiB</td></tr>');
     expect(bundleSizePage).toContain('ChartEx');
     expect(bundleSizePage.match(/<th>TIFF image codec<\/th>/g)).toHaveLength(1);
     expect(bundleSizePage).toContain('<td>22.2 KiB</td><td>6.7 KiB</td>');

--- a/site/src/pages/bundle-size.astro
+++ b/site/src/pages/bundle-size.astro
@@ -15,7 +15,7 @@ import SiteFooter from '../components/SiteFooter.astro';
       <div class="wrap">
         <p class="eyebrow">Current measurement</p>
         <h1>Bundle size.</h1>
-        <p>Current production assets for v0.86.0.</p>
+        <p>Current production assets for v0.86.1.</p>
       </div>
     </header>
 
@@ -28,18 +28,18 @@ import SiteFooter from '../components/SiteFooter.astro';
           <tbody>
             <tr>
               <th>DOCX static JavaScript</th>
-              <td>1,967 KiB</td>
-              <td>479 KiB</td>
+              <td>1,979 KiB</td>
+              <td>482 KiB</td>
             </tr>
             <tr>
               <th>XLSX static JavaScript</th>
-              <td>1,283 KiB</td>
-              <td>306 KiB</td>
+              <td>1,292 KiB</td>
+              <td>309 KiB</td>
             </tr>
             <tr>
               <th>PPTX static JavaScript</th>
-              <td>1,330 KiB</td>
-              <td>311 KiB</td>
+              <td>1,335 KiB</td>
+              <td>312 KiB</td>
             </tr>
           </tbody>
         </table>
@@ -66,9 +66,9 @@ import SiteFooter from '../components/SiteFooter.astro';
             <tr><th>Asset</th><th>Raw</th><th>gzip</th></tr>
           </thead>
           <tbody>
-            <tr><th>DOCX parser WASM</th><td>1,792 KiB</td><td>744 KiB</td></tr>
+            <tr><th>DOCX parser WASM</th><td>1,794 KiB</td><td>746 KiB</td></tr>
             <tr><th>XLSX parser WASM</th><td>1,581 KiB</td><td>651 KiB</td></tr>
-            <tr><th>PPTX parser WASM</th><td>1,653 KiB</td><td>651 KiB</td></tr>
+            <tr><th>PPTX parser WASM</th><td>1,678 KiB</td><td>659 KiB</td></tr>
             <tr><th>MathJax runtime</th><td>3,025 KiB</td><td>1,084 KiB</td></tr>
           </tbody>
         </table>


### PR DESCRIPTION
## Outcome

Prepare the compatible 0.86.1 patch release with older presentation fidelity, curved-text layout, resolved Word font resources, same-run page fields, and bounded rendering work. No migration is required.

This PR updates the changelog, production bundle measurements, all shipped package versions, the VS Code extension version, and the MCP server version/lockfile. Local-only sample references and agent guidance now follow the per-extension private corpus directories.

## Verification

- full repository suite: 8,967 passed, 25 skipped
- DOCX architecture, compatibility, public-API, package-build, and boundary gates passed
- typecheck and production package/site builds passed
- Storybook production build passed; representative local-only DOCX, PPTX, and XLSX stories rendered without failed requests
- restored local PPTX parser probes passed
- MCP server cargo check passed
- immutable full local self-VRT against the release merge-base, repeated after the final path corrections: 51 DOCX documents, 35 PPTX presentations, and 139 XLSX workbooks all exact
- PPTX main/worker parity: all 35 local presentations passed
- release metadata checks and diff whitespace checks passed

## Adversarial review

APPROVE. The cumulative release delta was rechecked for specification fidelity, sample-specific behavior, empirical tuning, work amplification, allocation and cleanup, module boundaries, and cross-format wiring. The three low-severity work-amplification findings identified during release-delta review were fixed before this release candidate. The primary-slide complexity allowance remains isolated from shared dependency parts and is documented as implementation resource governance rather than an OOXML rule. The final path-only correction changes no production renderer, model, or resource policy. No unresolved blocker remains.

Final local user verification is complete. Merge, tag, and GitHub Release remain gated on required CI checks.