### PR TITLE
fix(zip): tolerate local timestamp mismatches

### DIFF
--- a/packages/docx/src/document-pull-worker.test.ts
+++ b/packages/docx/src/document-pull-worker.test.ts
@@ -12,6 +12,7 @@ import {
   createLocalDocumentPullTransport,
   DocumentPullWorker,
   MaterializedDocumentCursorArchive,
+  readDocxDocumentCursorUsage,
   type DocxDocumentCursorArchive,
 } from './document-pull-worker.js';
 import type { DocxDocumentModel } from './types.js';
@@ -68,6 +69,23 @@ const identity: PullSessionIdentity<number> = {
 };
 
 describe('DOCX document pull integration', () => {
+  it('allows only the degraded-container missing usage checkpoint', () => {
+    const unavailable = {
+      document_cursor_resource_usage: () => {
+        throw new Error('document cursor usage is unavailable');
+      },
+    } as unknown as DocxDocumentCursorArchive;
+    expect(readDocxDocumentCursorUsage((operation) => operation(unavailable))).toBeUndefined();
+
+    const violation = {
+      document_cursor_resource_usage: () => {
+        throw new Error('OOXML_RESOURCE_LIMIT: usage checkpoint failed');
+      },
+    } as unknown as DocxDocumentCursorArchive;
+    expect(() => readDocxDocumentCursorUsage((operation) => operation(violation)))
+      .toThrow('OOXML_RESOURCE_LIMIT: usage checkpoint failed');
+  });
+
   it('materializes acknowledged body units and a body-free terminal envelope', async () => {
     const archive = new FakeArchive();
     const worker = new DocumentPullWorker(() => archive);

--- a/packages/docx/src/document-pull-worker.ts
+++ b/packages/docx/src/document-pull-worker.ts
@@ -35,6 +35,26 @@ export interface DocxDocumentCursorArchive {
   close_document_session(): void;
 }
 
+export type DocxDocumentArchiveExecutor = <T>(
+  operation: (archive: DocxDocumentCursorArchive) => T,
+) => T;
+
+/** Decode the cursor checkpoint while preserving the degraded-container path. */
+export function readDocxDocumentCursorUsage(
+  execute: DocxDocumentArchiveExecutor,
+): ReturnType<typeof decodeOoxmlResourceUsage> | undefined {
+  try {
+    const bytes = execute((archive) => archive.document_cursor_resource_usage?.());
+    return bytes ? decodeOoxmlResourceUsage(bytes) : undefined;
+  } catch (error) {
+    // A corrupt container is represented by a degraded terminal document and
+    // has no PackageOperation ledger. Only that unavailable checkpoint is
+    // optional; malformed checkpoints and real parser/resource failures escape.
+    if (String(error).includes('document cursor usage is unavailable')) return undefined;
+    throw error;
+  }
+}
+
 /**
  * Destructive, bounded cursor over an already-materialized compatibility model.
  * This is used only when render-worker capability detection requires the model
@@ -213,11 +233,7 @@ export class DocumentPullWorker {
         },
         cancel: () => this.executeArchive((archive) => archive.cancel_document_cursor()),
         close: () => this.executeArchive((archive) => archive.close_document_session()),
-        resourceUsage: () => {
-          const bytes = this.executeArchive((archive) =>
-            archive.document_cursor_resource_usage?.());
-          return bytes ? decodeOoxmlResourceUsage(bytes) : undefined;
-        },
+        resourceUsage: () => readDocxDocumentCursorUsage(this.executeArchive),
       },
     });
   }

--- a/packages/docx/src/internal/node-acquisition.ts
+++ b/packages/docx/src/internal/node-acquisition.ts
@@ -1,6 +1,5 @@
 import type { OoxmlResourceUsageSnapshot } from '@silurus/ooxml-core';
 import {
-  decodeOoxmlResourceUsage,
   normalizeLoadResourceOptions,
   OoxmlResourceMetricsSession,
   parseResourceLimitError,
@@ -15,7 +14,10 @@ import {
   type WasmModuleRuntime,
 } from '@silurus/ooxml-core/internal/wasm-runtime-generation';
 import type { DocxDocumentCursorArchive } from '../document-pull-worker.js';
-import { DocumentPullWorker } from '../document-pull-worker.js';
+import {
+  DocumentPullWorker,
+  readDocxDocumentCursorUsage,
+} from '../document-pull-worker.js';
 // @ts-ignore wasm-pack generated module has no declaration entry
 import * as docxWasm from '../wasm/docx_parser.js';
 
@@ -135,7 +137,7 @@ export async function acquireDocxNodeDocument<TResult>(
         metrics.observeUsage(checkpoint);
       },
     });
-    usage ??= decodeUsage(archive.document_cursor_resource_usage());
+    usage ??= readDocxDocumentCursorUsage((operation) => operation(archive));
     metrics.observeUsage(usage);
     metrics.checkpoint('model streamed');
     await pull.reset();
@@ -154,14 +156,6 @@ export async function acquireDocxNodeDocument<TResult>(
     const normalized = parseResourceLimitError(error) ?? error;
     metrics.fail(normalized);
     throw normalized;
-  }
-}
-
-function decodeUsage(bytes: Uint8Array): OoxmlResourceUsageSnapshot | undefined {
-  try {
-    return decodeOoxmlResourceUsage(bytes);
-  } catch {
-    return undefined;
   }
 }
 

--- a/packages/node/src/docx-document-session.test.ts
+++ b/packages/node/src/docx-document-session.test.ts
@@ -37,6 +37,17 @@ describe('Node bounded DOCX document session', () => {
     }
   });
 
+  it('materializes a package with a local-only ZIP timestamp mismatch', async () => {
+    const mismatched = Buffer.from(bytes);
+    const local = mismatched.indexOf(Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+    expect(local).toBeGreaterThanOrEqual(0);
+    mismatched.writeUInt16LE(mismatched.readUInt16LE(local + 10) ^ 1, local + 10);
+    mismatched.writeUInt16LE(mismatched.readUInt16LE(local + 12) ^ 1, local + 12);
+
+    const document = await materializeDocxDocument(mismatched);
+    expect(document.body.length).toBeGreaterThan(0);
+  });
+
   it('matches compatibility pagination and renders one caller-owned canvas at a time', async () => {
     const expected = await materializeDocxDocument(bytes);
     const measure = factory.createCanvas(1, 1).getContext('2d');

--- a/packages/ooxml-common/src/zip.rs
+++ b/packages/ooxml-common/src/zip.rs
@@ -631,11 +631,15 @@ fn validate_local_entry(
         || le_u16(data, local + 4) != le_u16(data, entry.header + 6)
         || le_u16(data, local + 6) != Some(fields.flags)
         || le_u16(data, local + 8) != Some(fields.compression_method)
-        || le_u16(data, local + 10) != le_u16(data, entry.header + 12)
-        || le_u16(data, local + 12) != le_u16(data, entry.header + 14)
     {
         return None;
     }
+
+    // ECMA-376 Part 2, Annex B.2 requires duplicated local/central fields to
+    // agree, including the DOS timestamp. Some otherwise consistent packages
+    // carry a timestamp-only mismatch (#1495). Accept that bounded compatibility
+    // case because timestamps do not select or validate the payload; names,
+    // flags, compression, CRC, sizes, descriptors, and bounds remain exact.
 
     let payload_end = data_start.checked_add(usize::try_from(fields.compressed_size).ok()?)?;
     if payload_end > directory.start {
@@ -1604,6 +1608,28 @@ mod tests {
             zip::ZipArchive::with_config(preflight.read_config(), Cursor::new(bytes.as_slice()))
                 .unwrap();
         preflight.validate_archive_item_names(&mut archive).unwrap();
+    }
+
+    #[test]
+    fn preflight_accepts_local_and_central_timestamp_mismatch() {
+        let mut bytes = archive_bytes_with_single("word/document.xml", b"document");
+        let central = last_signature(&bytes, CENTRAL_DIRECTORY_HEADER_SIGNATURE);
+        assert_eq!(le_u16(&bytes, 10), le_u16(&bytes, central + 12));
+        assert_eq!(le_u16(&bytes, 12), le_u16(&bytes, central + 14));
+
+        bytes[10..12].copy_from_slice(&1u16.to_le_bytes());
+        bytes[12..14].copy_from_slice(&34u16.to_le_bytes());
+
+        let preflight = preflight_archive_limits(&bytes)
+            .expect("timestamp-only mismatch is a bounded compatibility case");
+        let mut archive =
+            zip::ZipArchive::with_config(preflight.read_config(), Cursor::new(bytes.as_slice()))
+                .unwrap();
+        preflight.validate_archive_item_names(&mut archive).unwrap();
+        let mut entry = archive.by_name("word/document.xml").unwrap();
+        let mut body = Vec::new();
+        entry.read_to_end(&mut body).unwrap();
+        assert_eq!(body, b"document");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- accept local-versus-central DOS timestamp differences as a bounded compatibility case
- retain exact validation of names, flags, compression, CRC, sizes, descriptors, and archive bounds
- keep degraded DOCX container diagnostics from being masked by an unavailable cursor-usage checkpoint
- add shared ZIP and Node public-API regression coverage

ECMA-376 Part 2 Annex B.2 normatively requires duplicated header fields to agree, including timestamps. This PR deliberately documents and limits the compatibility exception to the two timestamp fields reported in #1495.

## Verification

- cargo test -p ooxml-common: 504 passed plus 1 doc-test
- cargo test -p docx-parser -p xlsx-parser -p pptx-parser --quiet: all suites passed
- vitest document-pull-worker and Node DOCX session: 14 passed
- TypeScript project build and DOCX/Node focused typechecks passed
- cargo fmt --check and git diff --check passed

## Adversarial review

No unresolved findings. The review verified specification fidelity and the documented deviation, confirmed no sample/path-specific branches or magic thresholds, preserved every payload and resource-safety check, inspected DOCX/XLSX/PPTX shared ZIP wiring, and found no new allocations, scans, caching, concurrency, or rendering behavior. VRT is not applicable because layout and paint paths are unchanged.

Fixes #1495