### PR TITLE
feat(fonts): allow a custom Google Fonts CSS origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,41 @@ per-render argument. (Excel stores "Insert > Equation" as OMML inside the shared
 DrawingML `<xdr:txBody>` grammar, so `XlsxViewer` renders equations embedded in
 shapes / text boxes the same way.)
 
+### Custom Google Fonts CSS service
+
+Use `googleFontsCssOrigin` to select the China endpoint or an internal
+Google Fonts-compatible CSS service:
+
+```ts
+await DocxDocument.load(data, {
+  useGoogleFonts: true,
+  googleFontsCssOrigin: 'https://fonts.googleapis.cn',
+});
+
+// An internal service can serve both CSS and font files.
+await DocxDocument.load(data, {
+  useGoogleFonts: true,
+  googleFontsCssOrigin: 'https://fonts.internal.example',
+});
+```
+
+The default is `https://fonts.googleapis.com`. Supply an HTTP(S) origin, optionally
+with a port or trailing slash, without a path, query, fragment, or credentials.
+The loader preserves CSS endpoint paths and family queries, such as
+`/css2?family=Carlito:ital,wght@0,400;0,700;1,400;1,700&display=swap`.
+The option applies to DOCX, XLSX, and PPTX engines and self-loading viewers,
+including worker and progressive loading. It does not enable font loading by
+itself.
+
+Font files are fetched from the URLs returned in the CSS. Relative URLs resolve
+against the stylesheet's final URL, including after redirects. For a fully
+internal deployment, the service must also host the required fonts and return
+internal font URLs; proxying CSS that still references public font URLs is not
+sufficient. Configure CORS and, where applicable, your application's `connect-src`
+and `font-src` CSP directives for the selected CSS and font hosts. Failed loads
+retain the existing system-font fallback; the loader does not retry another
+public CSS origin.
+
 ### Optional rendering modules
 
 Classic DrawingML 2-D chart families are included in every format entry.
@@ -1099,7 +1134,7 @@ try {
   The package counters and raster-image guards are deterministic admission limits, not exact JavaScript/WASM process-memory accounting. XML trees, document models, canvas backing stores, browser decoder overhead, renderer state, and browser-managed SVG/vector parse or decoded storage can still require several times the measured input. SVG has no portable decoded-byte measure or explicit browser release primitive; the library count-bounds its cache and revokes owned object URLs, but cannot charge it as RGBA bytes. The defaults therefore reduce risk but cannot promise that an OOM is impossible on every device. Running parse and render work in `mode: 'worker'` can contain many failures away from the main UI thread, but a Worker is not a separate operating-system process or a strict memory sandbox.
 
   A measured limit crossing is reported as `OoxmlResourceLimitError`. A residual WASM failure that reaches a recognized trap-shaped boundary is reported conservatively as `parser-crashed`, not `parser-oom`: with the current aborting Rust/WASM boundary, panic, allocation failure, explicit `unreachable`, and stack overflow can lose their distinct causes and converge on the same generic runtime error. Inferring OOM from an exception class or message would misclassify some parser defects as large-file failures. Reliable OOM classification would require preserving a structured cause before the trap across every relevant allocation path; it cannot be recovered from the generic trap afterward. The WebAssembly JavaScript embedding also permits implementation-defined stack/OOM failures, including an indistinguishable plain `Error` or process termination, so converting and poisoning every engine-level failure cannot be guaranteed.
-- **No network by default.** The library does not send telemetry or analytics, and does not contact third-party services unless you ask it to. In particular, theme webfonts, Office font metric substitutes (Carlito/Caladea), and the script fallback fonts are **not** loaded from Google Fonts unless you pass `useGoogleFonts: true` to the relevant `Viewer` / `load(...)` options — supported uniformly by `DocxViewer`, `PptxViewer`, `XlsxViewer`, and `XlsxSheetViewer`. When enabled, fonts for non-Latin scripts are supplied on demand from Noto families so text does not fall back to tofu: Arabic (Noto Naskh/Sans Arabic), CJK (Noto Sans/Serif KR · SC · TC · JP, picked per document language so shared Han glyphs take the right shapes), Cyrillic (Noto Sans/Serif), Hebrew (Noto Sans/Serif Hebrew, RTL), Thai (Noto Sans Thai) and Devanagari (Noto Sans Devanagari). No font binaries ship in the bundle. Enabling this option causes the end-user's browser to send an HTTP request (IP and User-Agent) to `fonts.googleapis.com`, which may have GDPR implications for your application — consider self-hosting the required fonts via `@font-face` instead.
+- **No network by default.** The library does not send telemetry or analytics, and does not contact third-party services unless you ask it to. In particular, theme webfonts, Office font metric substitutes (Carlito/Caladea), and the script fallback fonts are **not** loaded from Google Fonts unless you pass `useGoogleFonts: true` to the relevant `Viewer` / `load(...)` options — supported uniformly by `DocxViewer`, `PptxViewer`, `XlsxViewer`, and `XlsxSheetViewer`. When enabled, fonts for non-Latin scripts are supplied on demand from Noto families so text does not fall back to tofu: Arabic (Noto Naskh/Sans Arabic), CJK (Noto Sans/Serif KR · SC · TC · JP, picked per document language so shared Han glyphs take the right shapes), Cyrillic (Noto Sans/Serif), Hebrew (Noto Sans/Serif Hebrew, RTL), Thai (Noto Sans Thai) and Devanagari (Noto Sans Devanagari). No font binaries ship in the bundle. Enabling this option causes the end-user's browser to send an HTTP request (IP and User-Agent) to `fonts.googleapis.com` (or your configured `googleFontsCssOrigin` service), which may have GDPR implications for your application — consider self-hosting the required fonts via `@font-face` instead.
 - **XML parsing.** Uses `roxmltree`, which does not resolve external entities (XXE-safe by default).
 - **Encrypted OOXML ([MS-OFFCRYPTO] Agile Encryption).** Password-protected `.docx` / `.xlsx` / `.pptx` files are OLE2/CFB containers, not ZIPs. Pass `password` to `load(...)` and the file is decrypted **client-side** via WebCrypto — no bytes and no password leave the browser:
   ```ts

--- a/packages/core/src/fonts/preload.test.ts
+++ b/packages/core/src/fonts/preload.test.ts
@@ -52,6 +52,7 @@ interface FakeFace {
   family: string;
   source: string;
   loadCalls: number;
+  descriptors?: object;
   load: () => Promise<FakeFace>;
 }
 
@@ -375,5 +376,111 @@ describe('preloadGoogleFonts — dedup + unloadGoogleFonts (SPA leak)', () => {
     expect(added).toHaveLength(2); // B still holds
     unloadGoogleFonts(b);
     expect(added).toHaveLength(0);
+  });
+});
+
+
+
+describe('custom Google Fonts CSS origins', () => {
+  it.each(['document', 'worker'])('uses a custom CSS origin in %s', async (context) => {
+    const { set, added } = installFakes();
+    delete G.document;
+    delete G.self;
+    G[context === 'document' ? 'document' : 'self'] = { fonts: set };
+    const css = CSS.replaceAll('https://fonts.gstatic.com', 'https://fonts.internal.example');
+    G.fetch = vi.fn(async () => ({ ok: true, text: async () => css }));
+
+    await preloadGoogleFonts(['Calibri'], MAP, undefined, 'https://fonts.internal.example/');
+
+    expect(G.fetch).toHaveBeenCalledWith('https://fonts.internal.example/css2?family=Carlito');
+    expect(added).toHaveLength(2);
+    expect(added.every((face) => face.source.includes('https://fonts.internal.example/'))).toBe(true);
+    expect(added.every((face) => face.loadCalls === 1)).toBe(true);
+    expect(added[0].descriptors).toMatchObject({ style: 'italic', weight: '700', unicodeRange: 'U+0000-00FF' });
+    expect(MAP.calibri.url).toBe('https://fonts.googleapis.com/css2?family=Carlito');
+  });
+
+  it('preserves the endpoint path and family query with an HTTP origin and port', async () => {
+    const { set } = installFakes();
+    G.document = { fonts: set };
+    const map = { calibri: { ...MAP.calibri, url: MAP.calibri.url + ':ital,wght@0,400;1,700&display=swap' } };
+    await preloadGoogleFonts(['Calibri'], map, undefined, 'http://fonts.internal.example:8080');
+    expect(G.fetch).toHaveBeenCalledWith('http://fonts.internal.example:8080/css2?family=Carlito:ital,wght@0,400;1,700&display=swap');
+  });
+
+  it('uses the font URLs returned by the China CSS service', async () => {
+    const { set, added } = installFakes();
+    G.document = { fonts: set };
+    G.fetch = vi.fn(async () => ({ ok: true, text: async () => CSS.replaceAll('fonts.gstatic.com', 'fonts.gstatic.cn') }));
+    await preloadGoogleFonts(['Calibri'], MAP, undefined, 'https://fonts.googleapis.cn');
+    expect(G.fetch).toHaveBeenCalledWith('https://fonts.googleapis.cn/css2?family=Carlito');
+    expect(added[0].source).toContain('https://fonts.gstatic.cn/');
+  });
+
+  it('isolates concurrent origins and deduplicates normalized origins independently', async () => {
+    const { set } = installFakes();
+    G.document = { fonts: set };
+    const [globalFaces, internalFaces, internalAgain] = await Promise.all([
+      preloadGoogleFonts(['Calibri'], MAP),
+      preloadGoogleFonts(['Calibri'], MAP, undefined, 'https://fonts.internal.example'),
+      preloadGoogleFonts(['Calibri'], MAP, undefined, 'https://fonts.internal.example/'),
+    ]);
+    expect(G.fetch).toHaveBeenCalledTimes(2);
+    expect(globalFaces[0]).not.toBe(internalFaces[0]);
+    expect(internalFaces[0]).toBe(internalAgain[0]);
+    unloadGoogleFonts(internalFaces);
+    unloadGoogleFonts(internalAgain);
+    expect(set.faces).toEqual(globalFaces);
+    unloadGoogleFonts(globalFaces);
+    expect(set.faces).toHaveLength(0);
+  });
+
+  it.each([
+    ['url("../files/a.woff2")', 'url("https://fonts.internal.example/files/a.woff2")'],
+    ["url('/files/a.woff2')", 'url("https://fonts.internal.example/files/a.woff2")'],
+    ['url(a.woff2)', 'url("https://fonts.internal.example/styles/a.woff2")'],
+    ['url(//assets.internal.example/a.woff2)', 'url("https://assets.internal.example/a.woff2")'],
+    ['url(https://fonts.gstatic.com/s/a.woff2)', 'url(https://fonts.gstatic.com/s/a.woff2)'],
+  ])('resolves font sources relative to the final stylesheet URL: %s', async (src, expected) => {
+    const { set, added } = installFakes();
+    G.document = { fonts: set };
+    G.fetch = vi.fn(async () => ({
+      ok: true, url: 'https://fonts.internal.example/styles/redirected.css',
+      text: async () => `@font-face { font-family: Carlito; src: ${src}; }`,
+    }));
+    await preloadGoogleFonts(['Calibri'], MAP, undefined, 'https://fonts.internal.example');
+    expect(added[0].source).toBe(expected);
+  });
+
+  it('resolves a relative font source against the requested URL when response.url is unavailable', async () => {
+    const { set, added } = installFakes();
+    G.document = { fonts: set };
+    G.fetch = vi.fn(async () => ({ ok: true, text: async () => '@font-face { font-family: Carlito; src: local("Carlito"), url(/fonts/a.woff2) format("woff2"); }' }));
+    await preloadGoogleFonts(['Calibri'], MAP, undefined, 'https://fonts.internal.example');
+    expect(added[0].source).toBe('local("Carlito"), url("https://fonts.internal.example/fonts/a.woff2") format("woff2")');
+  });
+
+  it('leaves unrelated stylesheet hosts unchanged', async () => {
+    const { set } = installFakes();
+    G.document = { fonts: set };
+    const map = { calibri: { ...MAP.calibri, url: 'https://fonts.googleapis.com.example.com/css2?family=Carlito' } };
+    await preloadGoogleFonts(['Calibri'], map, undefined, 'https://fonts.internal.example');
+    expect(G.fetch).toHaveBeenCalledExactlyOnceWith(map.calibri.url);
+  });
+
+  it.each(['', '/fonts', 'file:///fonts', 'ftp://fonts.example', 'https://fonts.example/proxy', 'https://fonts.example?key=1', 'https://fonts.example#fragment', 'https://user:pass@fonts.example'])('rejects an invalid origin before fetching: %s', async (origin) => {
+    const { set } = installFakes();
+    G.document = { fonts: set };
+    await expect(preloadGoogleFonts(['Calibri'], MAP, undefined, origin)).rejects.toThrow(/googleFontsCssOrigin/);
+    expect(G.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not fall back to a public origin after a custom service fails', async () => {
+    const { set } = installFakes();
+    G.document = { fonts: set };
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    G.fetch = vi.fn(async () => ({ ok: false, status: 503 }));
+    expect(await preloadGoogleFonts(['Calibri'], MAP, undefined, 'https://fonts.internal.example')).toEqual([]);
+    expect(G.fetch).toHaveBeenCalledExactlyOnceWith('https://fonts.internal.example/css2?family=Carlito');
   });
 });

--- a/packages/core/src/fonts/preload.ts
+++ b/packages/core/src/fonts/preload.ts
@@ -22,6 +22,7 @@
  * use a system fallback and shift once a later interaction re-rasterized
  * the canvas after the font landed.
  */
+import type { LoadOptions } from '../types/load-options.js';
 import { retainFace, releaseFaces } from './font-registry.js';
 
 export interface FontPreloadEntry {
@@ -143,14 +144,48 @@ function googleFaceSignature(url: string, f: ParsedFontFace): string {
   ].join('|');
 }
 
+/** An origin keeps the built-in CSS endpoint paths and family queries intact. */
+function normalizeGoogleFontsCssOrigin(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const invalid = () => new TypeError(
+    'googleFontsCssOrigin must be an HTTP(S) origin without a path, query, fragment, or credentials',
+  );
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw invalid();
+  }
+  if ((url.protocol !== 'https:' && url.protocol !== 'http:') ||
+      url.username || url.password || url.pathname !== '/' || url.search || url.hash ||
+      value.includes('?') || value.includes('#')) throw invalid();
+  return url.origin;
+}
+
+/** FontFace URL sources resolve in the document/worker realm unless made
+ * absolute. A CSS service may serve fonts relative to its own stylesheet,
+ * including after a redirect, so resolve those references before registration. */
+function resolveFontSources(src: string, stylesheetUrl: string): string {
+  return src.replace(
+    /url\(\s*(?:"([^"]*)"|'([^']*)'|([^\s)]+))\s*\)/gi,
+    (match, doubleQuoted: string | undefined, singleQuoted: string | undefined, bare: string | undefined) => {
+      const value = doubleQuoted ?? singleQuoted ?? bare ?? '';
+      if (/^[a-z][a-z\d+.-]*:/i.test(value)) return match;
+      return `url("${new URL(value, stylesheetUrl).href}")`;
+    },
+  );
+}
+
 export async function preloadGoogleFonts(
   fontNames: Iterable<string | null | undefined>,
   map: Record<string, FontPreloadEntry>,
   targetFontSet: FontFaceSet | null = activeFontSet(),
+  cssOrigin?: LoadOptions['googleFontsCssOrigin'],
 ): Promise<FontFace[]> {
   const fonts = targetFontSet;
   if (!fonts || typeof FontFace === 'undefined' || typeof fetch === 'undefined') return [];
 
+  const origin = normalizeGoogleFontsCssOrigin(cssOrigin);
   const seen = new Set<string>();
   const targetFamilies = new Set<string>();
   const cssUrls = new Set<string>();
@@ -175,13 +210,16 @@ export async function preloadGoogleFonts(
     seen.add(key);
     const entry = map[key];
     if (!entry) continue;
-    cssUrls.add(entry.url);
+    const url = origin
+      ? entry.url.replace(/^https:\/\/fonts\.googleapis\.com(?=[/?#]|$)/i, () => origin)
+      : entry.url;
+    cssUrls.add(url);
     const family = (entry.loadFamily ?? requestedName).toLowerCase();
     targetFamilies.add(family);
-    let targets = urlTargets.get(entry.url);
+    let targets = urlTargets.get(url);
     if (!targets) {
       targets = new Set<string>();
-      urlTargets.set(entry.url, targets);
+      urlTargets.set(url, targets);
     }
     targets.add(family);
   }
@@ -203,7 +241,11 @@ export async function preloadGoogleFonts(
           try {
             const res = await fetch(url);
             if (!res.ok) throw new Error(`HTTP ${res.status}`);
-            return parseFontFaceRules(await res.text());
+            const stylesheetUrl = res.url || url;
+            return parseFontFaceRules(await res.text()).map((rule) => ({
+              ...rule,
+              src: resolveFontSources(rule.src, stylesheetUrl),
+            }));
           } catch {
             cssFetches.delete(url); // free the slot so a later call retries
             for (const family of urlTargets.get(url) ?? []) {

--- a/packages/core/src/types/load-options.ts
+++ b/packages/core/src/types/load-options.ts
@@ -57,15 +57,26 @@ export interface ProgressiveLayoutPartial {
 export interface LoadOptions {
   /**
    * Opt in to loading webfont substitutes from Google Fonts
-   * (`fonts.googleapis.com`). Default `false` — the canvas falls back to
-   * locally available fonts.
+   * (`fonts.googleapis.com` or `googleFontsCssOrigin`). Default `false` —
+   * the canvas falls back to locally available fonts.
    *
-   * When enabled, end-user IP / User-Agent is sent to Google, which may
-   * have privacy / GDPR implications for your application. To avoid the
+   * When using Google endpoints, end-user IP / User-Agent is sent to Google,
+   * which may have privacy / GDPR implications for your application. To avoid the
    * third-party request, host the substitutes yourself and reference them
    * via `@font-face` in your application CSS.
    */
   useGoogleFonts?: boolean;
+  /**
+   * HTTP(S) origin of a Google Fonts-compatible CSS service, e.g.
+   * `https://fonts.googleapis.cn` or `https://fonts.internal.example`.
+   * Defaults to `https://fonts.googleapis.com`. Supply an origin only (no
+   * path, query, fragment, or credentials); CSS paths and queries are preserved.
+   * Requires `useGoogleFonts: true`. Font files are loaded from the URLs in
+   * the returned CSS, with relative URLs resolved against the stylesheet URL.
+   * For an offline deployment, the service must also serve the font files
+   * and return URLs reachable on that network.
+   */
+  googleFontsCssOrigin?: string;
   /**
    * Password for an encrypted OOXML file ([MS-OFFCRYPTO] Agile Encryption).
    *

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -1589,6 +1589,7 @@ export interface LoadOptions extends LoadOptions__emitterCollision1 {
 }
 interface LoadOptions__emitterCollision1 {
     useGoogleFonts?: boolean;
+    googleFontsCssOrigin?: string;
     password?: string;
     wasmUrl?: string | URL;
     maxZipEntryBytes?: number;

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -381,6 +381,7 @@ export class DocxDocument {
    *  shared FontFaceSet for the lifetime of the SPA (deduped + refcounted in core,
    *  so a web font shared with another open document survives until both go). */
   private _googleFontFaces: FontFace[] = [];
+  private _googleFontsCssOrigin: CoreLoadOptions['googleFontsCssOrigin'];
   /** One stable closure per instance: core's path-keyed SVG cache namespaces on
    *  this identity, so two open documents never swap a shared zip path (e.g.
    *  word/media/image1.svg). Reusing one reference also lets the SVG cache hit
@@ -475,6 +476,7 @@ export class DocxDocument {
     let doc: DocxDocument | undefined;
     try {
       doc = new DocxDocument(worker, mode, defaultCurrentDateMs, opts.wasmUrl);
+      doc._googleFontsCssOrigin = opts.googleFontsCssOrigin;
       doc._metrics = metrics;
       // The variant the caller will actually render, recorded for BOTH render
       // modes and recorded BEFORE the parse: geometry accessors and the
@@ -552,6 +554,8 @@ export class DocxDocument {
         doc._googleFontFaces = await preloadGoogleFonts(
           docxFontPreloadNames(doc._document),
           DOCX_GOOGLE_FONTS,
+          undefined,
+          opts.googleFontsCssOrigin,
         );
       }
       // ECMA-376 §17.8.1 / §17.8.3 — register the document's embedded fonts (via
@@ -807,7 +811,7 @@ export class DocxDocument {
     const res = await this._bridge.request(
       (id) =>
         this._mode === 'worker'
-          ? ({ type: 'parse', id, data: buffer, resourcePolicy, useGoogleFonts, defaultCurrentDateMs: documentLayoutRuntimeOf(this).defaultCurrentDateMs, ...this._parseViewFields(), renderers } satisfies RenderWorkerRequest)
+          ? ({ type: 'parse', id, data: buffer, resourcePolicy, useGoogleFonts, googleFontsCssOrigin: this._googleFontsCssOrigin, defaultCurrentDateMs: documentLayoutRuntimeOf(this).defaultCurrentDateMs, ...this._parseViewFields(), renderers } satisfies RenderWorkerRequest)
           : ({ type: 'parse', id, data: buffer, resourcePolicy } satisfies WorkerRequest),
       [buffer],
       { timeoutMs },
@@ -1109,6 +1113,7 @@ export class DocxDocument {
           data: buffer,
           resourcePolicy,
           useGoogleFonts,
+          googleFontsCssOrigin: this._googleFontsCssOrigin,
           defaultCurrentDateMs: documentLayoutRuntimeOf(this).defaultCurrentDateMs,
           ...this._parseViewFields(),
           renderers,

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -257,6 +257,8 @@ self.onmessage = async (e: MessageEvent<RenderWorkerWireRequest | WorkerSvgDecod
         googleFaces = await preloadGoogleFonts(
           docxFontPreloadNames(model),
           DOCX_GOOGLE_FONTS,
+          undefined,
+          req.googleFontsCssOrigin,
         );
       }
       googleFontFaces = googleFaces;

--- a/packages/docx/src/resource-policy-wiring.test.ts
+++ b/packages/docx/src/resource-policy-wiring.test.ts
@@ -9,6 +9,7 @@ describe('DocxDocument resource-policy wiring', () => {
     const instance = Object.create(DocxDocument.prototype) as Record<string, unknown>;
     attachDocumentLayoutRuntime(instance, 0);
     instance._mode = 'worker';
+    instance._googleFontsCssOrigin = 'https://fonts.internal.example';
     instance._bridge = {
       request: vi.fn(async (createRequest: (id: number) => Record<string, unknown>) => {
         request = createRequest(7);
@@ -57,6 +58,7 @@ describe('DocxDocument resource-policy wiring', () => {
       id: 7,
       resourcePolicy: policy,
     });
+    expect(request).toHaveProperty('googleFontsCssOrigin', 'https://fonts.internal.example');
     expect(request).not.toHaveProperty('maxZipEntryBytes');
     expect(request).not.toHaveProperty('parserResourceLimits');
     expect(onUsage).toHaveBeenCalledWith(expect.objectContaining({

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -646,6 +646,7 @@ export class DocxScrollViewer implements ZoomableViewer {
       const doc = await this._documentOwner.replace(() => DocxDocument.load(source, {
         password: this._opts.password,
         useGoogleFonts: this._opts.useGoogleFonts,
+        googleFontsCssOrigin: this._opts.googleFontsCssOrigin,
         maxZipEntryBytes: this._opts.maxZipEntryBytes,
         resourceLimits: this._opts.resourceLimits,
         debug: this._opts.debug,

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -286,6 +286,7 @@ export class DocxViewer implements ZoomableViewer {
       const doc = await this._documentOwner.replace(() => DocxDocument.load(source, {
         password: this._opts.password,
         useGoogleFonts: this._opts.useGoogleFonts,
+        googleFontsCssOrigin: this._opts.googleFontsCssOrigin,
         maxZipEntryBytes: this._opts.maxZipEntryBytes,
         resourceLimits: this._opts.resourceLimits,
         debug: this._opts.debug,

--- a/packages/docx/src/worker-protocol.ts
+++ b/packages/docx/src/worker-protocol.ts
@@ -104,7 +104,7 @@ export type RenderWorkerRequest =
   // changes measured widths, so each combination is a genuinely different
   // pagination with its own page count. Omitted means the document's default
   // view, which is what every load selected before these existed.
-  | { type: 'parse'; id: number; data: ArrayBuffer; resourcePolicy: NormalizedOoxmlResourcePolicy; useGoogleFonts?: boolean; defaultCurrentDateMs: number; currentDateMs?: number; showTrackedChanges?: boolean; renderers?: WorkerRendererDescriptors; progressiveLayout?: boolean }
+  | { type: 'parse'; id: number; data: ArrayBuffer; resourcePolicy: NormalizedOoxmlResourcePolicy; useGoogleFonts?: boolean; googleFontsCssOrigin?: import('@silurus/ooxml-core').LoadOptions['googleFontsCssOrigin']; defaultCurrentDateMs: number; currentDateMs?: number; showTrackedChanges?: boolean; renderers?: WorkerRendererDescriptors; progressiveLayout?: boolean }
   | { type: 'selectLayoutView'; id: number; currentDateMs: number; showTrackedChanges: boolean }
   | { type: 'renderPage'; id: number; pageIndex: number; opts: WireRenderPageOptions }
   // IX6 — collect a page's text-run geometry WITHOUT transferring a bitmap. The

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -1002,6 +1002,7 @@ export type LoadOptions = LoadOptions__emitterCollision1 & {
 };
 interface LoadOptions__emitterCollision1 {
     useGoogleFonts?: boolean;
+    googleFontsCssOrigin?: string;
     password?: string;
     wasmUrl?: string | URL;
     maxZipEntryBytes?: number;

--- a/packages/pptx/src/presentation-destroy.test.ts
+++ b/packages/pptx/src/presentation-destroy.test.ts
@@ -240,6 +240,7 @@ describe('PptxPresentation.destroy() — rejects in-flight worker requests', () 
     const presentation = await PptxPresentation.load(new ArrayBuffer(0), {
       mode: 'main',
       useGoogleFonts: false,
+      googleFontsCssOrigin: 'https://fonts.internal.example',
     });
 
     expect(fetch).not.toHaveBeenCalled();

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -261,6 +261,7 @@ export class PptxPresentation {
    *  the shared FontFaceSet for the lifetime of the SPA (deduped + refcounted in
    *  core, so a web font shared with another open deck survives until both go). */
   private _googleFontFaces: FontFace[] = [];
+  private _googleFontsCssOrigin: CoreLoadOptions['googleFontsCssOrigin'];
   /** Embedded Font parts registered into the main-thread FontFaceSet. */
   private _embeddedFontFaces: FontFace[] = [];
   private _embeddedFontAliases: ReadonlyMap<string, string> = new Map();
@@ -371,6 +372,7 @@ export class PptxPresentation {
     let pres: PptxPresentation | undefined;
     try {
       pres = new PptxPresentation(worker, mode, opts.wasmUrl);
+      pres._googleFontsCssOrigin = opts.googleFontsCssOrigin;
       pres._metrics = metrics;
       if (opts.math && mode === 'worker' && !rendererDescriptors?.math) {
         console.warn(
@@ -430,6 +432,8 @@ export class PptxPresentation {
             pres._embeddedFontAliases,
           ),
           PPTX_GOOGLE_FONTS,
+          undefined,
+          opts.googleFontsCssOrigin,
         );
       }
       metrics.succeed({ slides: pres.slideCount });
@@ -470,7 +474,7 @@ export class PptxPresentation {
     const response = await this._bridge.request(
       (id) =>
         this._mode === 'worker'
-          ? ({ kind: 'parse', id, buffer, resourcePolicy, useGoogleFonts, renderers } satisfies RenderWorkerRequest)
+          ? ({ kind: 'parse', id, buffer, resourcePolicy, useGoogleFonts, googleFontsCssOrigin: this._googleFontsCssOrigin, renderers } satisfies RenderWorkerRequest)
           : ({ kind: 'parse', id, buffer, resourcePolicy } satisfies PptxWorkerRequest),
       [buffer],
       { timeoutMs },
@@ -608,7 +612,7 @@ export class PptxPresentation {
       ).filter((name): name is string => !!name && !loadedGoogleFonts.has(name));
       if (requested.length === 0) return;
       for (const name of requested) loadedGoogleFonts.add(name);
-      this._googleFontFaces.push(...await preloadGoogleFonts(requested, PPTX_GOOGLE_FONTS));
+      this._googleFontFaces.push(...await preloadGoogleFonts(requested, PPTX_GOOGLE_FONTS, undefined, this._googleFontsCssOrigin));
     };
     const full = (async () => {
       for (let slideIndex = 0; slideIndex < bootstrap.slideCount; slideIndex += 1) {
@@ -648,7 +652,7 @@ export class PptxPresentation {
       (id) => {
         this._parseRequestId = id;
         return {
-          kind: 'parse', id, buffer, resourcePolicy, useGoogleFonts, renderers,
+          kind: 'parse', id, buffer, resourcePolicy, useGoogleFonts, googleFontsCssOrigin: this._googleFontsCssOrigin, renderers,
           progressiveLayout: true,
         } satisfies RenderWorkerRequest;
       },

--- a/packages/pptx/src/render-worker.ts
+++ b/packages/pptx/src/render-worker.ts
@@ -198,7 +198,7 @@ async function openPresentation(request: Extract<RenderWorkerRequest, { kind: 'p
         embedded.aliases,
       ).filter((name): name is string => !!name && !loadedGoogleFonts.has(name));
       for (const name of requested) loadedGoogleFonts.add(name);
-      if (requested.length) await preloadGoogleFonts(requested, PPTX_GOOGLE_FONTS);
+      if (requested.length) await preloadGoogleFonts(requested, PPTX_GOOGLE_FONTS, undefined, request.googleFontsCssOrigin);
     };
     for (let index = 0; index < bootstrap.slideCount; index += 1) {
       await slides.withSlide(index, () => undefined);
@@ -240,6 +240,8 @@ async function openPresentation(request: Extract<RenderWorkerRequest, { kind: 'p
       const substitutes = await preloadGoogleFonts(
         excludeEmbeddedFontFamilies(preflight.fontPreloadNames, embedded.aliases),
         PPTX_GOOGLE_FONTS,
+        undefined,
+        request.googleFontsCssOrigin,
       );
       return [...embedded.faces, ...substitutes];
     })();

--- a/packages/pptx/src/resource-policy-wiring.test.ts
+++ b/packages/pptx/src/resource-policy-wiring.test.ts
@@ -7,6 +7,7 @@ describe('PptxPresentation resource-policy wiring', () => {
     let request: Record<string, unknown> | undefined;
     const instance = Object.create(PptxPresentation.prototype) as Record<string, unknown>;
     instance._mode = 'worker';
+    instance._googleFontsCssOrigin = 'https://fonts.internal.example';
     instance._bridge = {
       request: vi.fn(async (createRequest: (id: number) => Record<string, unknown>) => {
         request = createRequest(3);
@@ -55,6 +56,7 @@ describe('PptxPresentation resource-policy wiring', () => {
     )._parse(new ArrayBuffer(1), policy, false, 30_000, onUsage);
 
     expect(request).toMatchObject({ kind: 'parse', id: 3, resourcePolicy: policy });
+    expect(request).toHaveProperty('googleFontsCssOrigin', 'https://fonts.internal.example');
     expect(request).not.toHaveProperty('maxZipEntryBytes');
     expect(request).not.toHaveProperty('parserResourceLimits');
     expect(onUsage).toHaveBeenCalledWith(expect.objectContaining({

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -602,6 +602,7 @@ export class PptxScrollViewer implements ZoomableViewer {
       const pres = await this._presentationOwner.replace(() => PptxPresentation.load(source, {
         password: this._opts.password,
         useGoogleFonts: this._opts.useGoogleFonts,
+        googleFontsCssOrigin: this._opts.googleFontsCssOrigin,
         maxZipEntryBytes: this._opts.maxZipEntryBytes,
         resourceLimits: this._opts.resourceLimits,
         debug: this._opts.debug,

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -329,6 +329,7 @@ export class PptxViewer implements ZoomableViewer {
       const engine = await this.presentationOwner.replace(() => PptxPresentation.load(source, {
         password: this.opts.password,
         useGoogleFonts: this.opts.useGoogleFonts,
+        googleFontsCssOrigin: this.opts.googleFontsCssOrigin,
         maxZipEntryBytes: this.opts.maxZipEntryBytes,
         resourceLimits: this.opts.resourceLimits,
         debug: this.opts.debug,

--- a/packages/pptx/src/worker-protocol.ts
+++ b/packages/pptx/src/worker-protocol.ts
@@ -88,6 +88,7 @@ export type RenderWorkerRequest =
       buffer: ArrayBuffer;
       resourcePolicy: NormalizedOoxmlResourcePolicy;
       useGoogleFonts?: boolean;
+      googleFontsCssOrigin?: import('@silurus/ooxml-core').LoadOptions['googleFontsCssOrigin'];
       renderers?: WorkerRendererDescriptors;
       progressiveLayout?: boolean;
     }

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -1147,6 +1147,7 @@ export interface LoadOptions extends LoadOptions__emitterCollision1 {
 }
 interface LoadOptions__emitterCollision1 {
     useGoogleFonts?: boolean;
+    googleFontsCssOrigin?: string;
     password?: string;
     wasmUrl?: string | URL;
     maxZipEntryBytes?: number;

--- a/packages/xlsx/src/delimited-text-protocol.ts
+++ b/packages/xlsx/src/delimited-text-protocol.ts
@@ -8,6 +8,7 @@ export type DelimitedTextParseRequest = {
   readonly data: ArrayBuffer;
   readonly options: ResolvedDelimitedTextOptions;
   readonly useGoogleFonts?: boolean;
+  readonly googleFontsCssOrigin?: import('@silurus/ooxml-core').LoadOptions['googleFontsCssOrigin'];
   readonly renderers?: WorkerRendererDescriptors;
 };
 

--- a/packages/xlsx/src/render-worker.ts
+++ b/packages/xlsx/src/render-worker.ts
@@ -227,7 +227,7 @@ self.onmessage = async (e: MessageEvent<
         sheetCache.set(0, parsed.worksheet);
         sheetCacheUsage.set(0, measured);
         fontsLoaded = req.useGoogleFonts
-          ? preloadGoogleFonts(xlsxFontPreloadNames(parsed.workbook), XLSX_GOOGLE_FONTS)
+          ? preloadGoogleFonts(xlsxFontPreloadNames(parsed.workbook), XLSX_GOOGLE_FONTS, undefined, req.googleFontsCssOrigin)
           : Promise.resolve();
         const worksheetJson = new TextEncoder()
           .encode(JSON.stringify(parsed.worksheet)).buffer as ArrayBuffer;
@@ -265,7 +265,7 @@ self.onmessage = async (e: MessageEvent<
         // every styled font name, plus the generic Arabic fallbacks. Fonts must
         // land before rendering (which measures text), so we keep the promise
         // and await it in the renderViewport handler.
-        fontsLoaded = preloadGoogleFonts(xlsxFontPreloadNames(workbook), XLSX_GOOGLE_FONTS);
+        fontsLoaded = preloadGoogleFonts(xlsxFontPreloadNames(workbook), XLSX_GOOGLE_FONTS, undefined, req.googleFontsCssOrigin);
       }
       post({ type: 'parsed', id, workbook, usage: bootstrap.usage });
       return;

--- a/packages/xlsx/src/resource-policy-wiring.test.ts
+++ b/packages/xlsx/src/resource-policy-wiring.test.ts
@@ -83,13 +83,13 @@ describe('XlsxWorkbook resource-policy wiring', () => {
         ): Promise<void>;
         getWorksheet(index: number): Promise<unknown>;
       }
-    )._load(new ArrayBuffer(1), {}, policy, onUsage);
+    )._load(new ArrayBuffer(1), { googleFontsCssOrigin: 'https://fonts.internal.example' }, policy, onUsage);
     await (
       instance as unknown as { getWorksheet(index: number): Promise<unknown> }
     ).getWorksheet(0);
 
     expect(requests).toHaveLength(4);
-    expect(requests[0]).toMatchObject({ type: 'parse', resourcePolicy: policy });
+    expect(requests[0]).toMatchObject({ type: 'parse', resourcePolicy: policy, googleFontsCssOrigin: 'https://fonts.internal.example' });
     expect(requests[1]).toMatchObject({ type: 'openSheetSession', sheetIndex: 0 });
     expect(requests[1]).not.toHaveProperty('resourcePolicy');
     expect(requests[1]).not.toHaveProperty('maxZipEntryBytes');

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -1213,6 +1213,7 @@ class XlsxViewerEngine implements ZoomableViewer {
       const wb = await this.acquisition.replace(() => XlsxWorkbook[loadXlsxSheetSource](source, {
           password: this.opts.password,
           useGoogleFonts: this.opts.useGoogleFonts,
+          googleFontsCssOrigin: this.opts.googleFontsCssOrigin,
           maxZipEntryBytes: this.opts.maxZipEntryBytes,
           resourceLimits: this.opts.resourceLimits,
           debug: this.opts.debug,

--- a/packages/xlsx/src/workbook-delimited-text.test.ts
+++ b/packages/xlsx/src/workbook-delimited-text.test.ts
@@ -85,7 +85,7 @@ afterEach(() => {
 describe('XlsxSheetViewer delimited-text workbook bridge', () => {
   it('loads CSV off the main thread without initializing XLSX WASM', async () => {
     const source = new TextEncoder().encode('id,name\n00123,Ada').buffer as ArrayBuffer;
-    const workbook = await XlsxWorkbook[loadXlsxSheetSource](source, {}, {
+    const workbook = await XlsxWorkbook[loadXlsxSheetSource](source, { googleFontsCssOrigin: 'https://fonts.internal.example' }, {
       format: 'csv',
       sheetName: 'Import',
     });
@@ -94,6 +94,7 @@ describe('XlsxSheetViewer delimited-text workbook bridge', () => {
     expect(worker.messages).toHaveLength(1);
     expect(worker.messages[0]).toMatchObject({
       type: 'parseDelimitedText',
+      googleFontsCssOrigin: 'https://fonts.internal.example',
       options: { delimiter: ',', encoding: 'utf-8', sheetName: 'Import' },
     });
     expect(worker.messages[0]).not.toMatchObject({ type: 'init' });

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -170,6 +170,7 @@ export class XlsxWorkbook {
   /** Web-font registrations are per FontFaceSet. Same-origin child windows have
    * their own set even when they share this workbook instance. */
   private googleFontNames: string[] = [];
+  private googleFontsCssOrigin: CoreLoadOptions['googleFontsCssOrigin'];
   private readonly retainedFontSets = new Map<FontFaceSet, RetainedFontSet>();
   private fontsDestroyed = false;
   private _mode: 'main' | 'worker' = 'main';
@@ -292,6 +293,7 @@ export class XlsxWorkbook {
       let workbook: XlsxWorkbook | undefined;
       try {
         const loaded = new XlsxWorkbook(worker, mode, undefined, false);
+        loaded.googleFontsCssOrigin = opts.googleFontsCssOrigin;
         workbook = loaded;
         loaded.metrics = metrics;
         await loaded._loadDelimitedText(
@@ -366,6 +368,7 @@ export class XlsxWorkbook {
     let wb: XlsxWorkbook | undefined;
     try {
       wb = new XlsxWorkbook(worker, mode, opts.wasmUrl);
+      wb.googleFontsCssOrigin = opts.googleFontsCssOrigin;
       wb.metrics = metrics;
       await wb._load(
         buffer,
@@ -457,6 +460,7 @@ export class XlsxWorkbook {
               data: workerData,
               resourcePolicy,
               useGoogleFonts: !!opts.useGoogleFonts,
+              googleFontsCssOrigin: opts.googleFontsCssOrigin,
               renderers: rendererDescriptors,
             } satisfies RenderWorkerRequest)
           : ({
@@ -533,6 +537,7 @@ export class XlsxWorkbook {
         data,
         options,
         useGoogleFonts: !!opts.useGoogleFonts,
+        googleFontsCssOrigin: opts.googleFontsCssOrigin,
         renderers: rendererDescriptors,
       } satisfies DelimitedTextParseRequest),
       [data],
@@ -567,7 +572,7 @@ export class XlsxWorkbook {
     if (retained) {
       retained.refs++;
     } else {
-      const loading = preloadGoogleFonts(this.googleFontNames, XLSX_GOOGLE_FONTS, fontSet);
+      const loading = preloadGoogleFonts(this.googleFontNames, XLSX_GOOGLE_FONTS, fontSet, this.googleFontsCssOrigin);
       retained = { refs: 1, faces: null, loading };
       this.retainedFontSets.set(fontSet, retained);
       loading.then((faces) => {

--- a/packages/xlsx/src/worker-protocol.ts
+++ b/packages/xlsx/src/worker-protocol.ts
@@ -224,7 +224,7 @@ export function extractViewerRenderContext(opts: WireRenderViewportOptions): {
 // `init` arm is copied verbatim from `WorkerRequest`.
 export type RenderWorkerRequest =
   | { type: 'init'; wasmUrl: string }
-  | { type: 'parse'; id: number; data: ArrayBuffer; resourcePolicy: NormalizedOoxmlResourcePolicy; useGoogleFonts?: boolean; renderers?: import('@silurus/ooxml-core/worker').WorkerRendererDescriptors }
+  | { type: 'parse'; id: number; data: ArrayBuffer; resourcePolicy: NormalizedOoxmlResourcePolicy; useGoogleFonts?: boolean; googleFontsCssOrigin?: import('@silurus/ooxml-core').LoadOptions['googleFontsCssOrigin']; renderers?: import('@silurus/ooxml-core/worker').WorkerRendererDescriptors }
   | DelimitedTextParseRequest
   | ({ type: 'openSheetSession'; id: number; sheetIndex: number; sheetName: string } & PullSessionIdentity<number>)
   | {

--- a/site/src/lib/api-reference.ts
+++ b/site/src/lib/api-reference.ts
@@ -86,6 +86,7 @@ const RESOURCE_METRICS_METHOD = { sig: 'getResourceMetrics(): Promise<OoxmlResou
 const DEBUG = { name: 'debug', type: 'boolean', def: 'false', desc: 'Print one content-free, Ratatui-inspired resource report when the measured load or Node session finishes or fails. Browser DevTools use typography-only %c styling to keep Unicode borders and gauges aligned without changing foreground or background colours; Node and Worker consoles receive one plain argument. Use onResourceMetrics instead for production collection.', emphasis: 'Use onResourceMetrics instead for production collection.' };
 const ZIP = { name: 'maxZipEntryBytes', type: 'number', def: 'resource policy default', desc: 'Deprecated compatibility alias for resourceLimits.maxArchiveEntryBytes. It is scheduled for removal in a future breaking release; new code should use resourceLimits. Existing positive values retain their per-entry meaning; zero / negative values fall back to the standard default.', emphasis: 'It is scheduled for removal in a future breaking release; new code should use resourceLimits.' };
 const GFONTS = { name: 'useGoogleFonts', type: 'boolean', def: 'false', desc: 'Load metric-compatible webfonts and non-Latin script fallbacks (Noto Arabic / CJK KR·SC·TC·JP / Cyrillic / Hebrew / Thai / Devanagari) from Google Fonts so layout matches Office and non-Latin text never falls back to tofu. Off by default for privacy.', emphasis: 'Off by default for privacy.' };
+const GFONTS_CSS_ORIGIN = { name: 'googleFontsCssOrigin', type: 'string', def: "'https://fonts.googleapis.com'", desc: 'HTTP(S) origin of a Google Fonts-compatible CSS service, such as https://fonts.googleapis.cn or an internal font server. Requires useGoogleFonts: true. CSS paths and queries are preserved; font file URLs come from the returned CSS, with relative URLs resolved against the stylesheet.' };
 const PASSWORD = { name: 'password', type: 'string', def: 'undefined', desc: 'Password for an Agile-encrypted OOXML file. Available on self-loading Viewer constructors and headless load(); borrowed fromDocument(), fromPresentation(), and fromWorkbook() factories omit load-only options because their engine is already loaded.', emphasis: 'Available on self-loading Viewer constructors and headless load()' };
 const DPR = { name: 'dpr', type: 'number', def: 'devicePixelRatio', desc: 'Device pixel ratio for the backing store (crispness on HiDPI).' };
 const WASM_URL = { name: 'wasmUrl', type: 'string | URL', def: 'bundled asset', desc: 'Override the URL the parser worker fetches the WebAssembly module from. By default each format resolves the `*_parser_bg.wasm` asset that ships next to its bundle (relative to the module URL); set this to serve it from a CDN or a self-hosted path instead (a relative value resolves against the document URL). Pointing it at a mismatched or missing file makes load() reject when the worker instantiates it.', emphasis: 'Override the URL the parser worker fetches the WebAssembly module from.' };
@@ -243,6 +244,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { name: 'width', type: 'number', def: '960', desc: 'Canvas CSS width in px; height is derived from the slide aspect ratio.' },
         DPR,
         GFONTS,
+        GFONTS_CSS_ORIGIN,
         PASSWORD,
         { name: 'enableTextSelection', type: 'boolean', def: 'false', desc: 'Overlay a transparent text layer so users can select & copy slide text.' },
         { name: 'enableElementSelection', type: 'boolean', def: 'false', desc: 'Enable read-only slide-element selection with a non-editable outline and element context; no editor model is exposed.' },
@@ -299,7 +301,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
       name: 'PptxPresentation',
       ctor: 'await PptxPresentation.load(source, options?)',
       note: 'Headless engine — parse once, render any slide into any canvas you supply (scroll views, thumbnail grids, master–detail).',
-      options: [GFONTS, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, TIFF, MODE, ...PPTX_PROGRESSIVE_OPTIONS],
+      options: [GFONTS, GFONTS_CSS_ORIGIN, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, TIFF, MODE, ...PPTX_PROGRESSIVE_OPTIONS],
       methods: [
         { sig: 'static load(source, options?): Promise<PptxPresentation>', desc: 'Parse a deck from a URL or ArrayBuffer. With progressiveLayout, resolve when the opening slide is paintable.' },
         { sig: 'get slideCount(): number', desc: 'Total slides.' },
@@ -348,6 +350,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         ON_HYPERLINK_CLICK,
         ENABLE_HYPERLINKS,
         GFONTS,
+        GFONTS_CSS_ORIGIN,
         PASSWORD,
         ZIP,
         RESOURCE_LIMITS,
@@ -394,6 +397,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { name: 'width', type: 'number', desc: 'Canvas CSS width in px; height is auto-computed from the page aspect ratio.' },
         DPR,
         GFONTS,
+        GFONTS_CSS_ORIGIN,
         PASSWORD,
         { name: 'enableTextSelection', type: 'boolean', def: 'false', desc: 'Overlay a transparent text layer for native selection & copy.' },
         ...DOCX_LAYOUT_VIEW_OPTIONS,
@@ -447,7 +451,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
       name: 'DocxDocument',
       ctor: 'await DocxDocument.load(source, options?)',
       note: 'Headless engine — render any page into any canvas you supply.',
-      options: [GFONTS, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, TIFF, MODE, ...DOCX_LAYOUT_VIEW_OPTIONS, DOCX_PROGRESSIVE_LAYOUT, DOCX_SLICE_LAYOUT, DOCX_LAYOUT_PROGRESS, DOCX_LAYOUT_PARTIAL, DOCX_LAYOUT_COMPLETE],
+      options: [GFONTS, GFONTS_CSS_ORIGIN, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, TIFF, MODE, ...DOCX_LAYOUT_VIEW_OPTIONS, DOCX_PROGRESSIVE_LAYOUT, DOCX_SLICE_LAYOUT, DOCX_LAYOUT_PROGRESS, DOCX_LAYOUT_PARTIAL, DOCX_LAYOUT_COMPLETE],
       methods: [
         { sig: 'static load(source, options?): Promise<DocxDocument>', desc: 'Parse a document from a URL or ArrayBuffer. With progressiveLayout, resolve when the opening pages are paintable while pagination continues in the background.' },
         { sig: 'get comments(): readonly Readonly<DocComment>[]', desc: 'Immutable detached comments and replies stored in the document.' },
@@ -495,6 +499,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         ON_HYPERLINK_CLICK,
         ENABLE_HYPERLINKS,
         GFONTS,
+        GFONTS_CSS_ORIGIN,
         PASSWORD,
         ZIP,
         RESOURCE_LIMITS,
@@ -553,6 +558,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         FIND_HIGHLIGHT_COLORS,
         { name: 'hiddenSheetMode', type: "'show' | 'skip' | 'dim'", def: "'show'", desc: 'How hidden / very-hidden sheets (`<sheet state>`, §18.2.19) appear in the tab bar. `show` renders a tab like any other; `skip` hides the tab (`display:none`) and makes sequential navigation jump over it; `dim` renders the tab at reduced opacity. Mirrors pptx `hiddenSlideMode`.' },
         GFONTS,
+        GFONTS_CSS_ORIGIN,
         PASSWORD,
         ZIP,
         RESOURCE_LIMITS,
@@ -626,6 +632,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { name: 'hiddenSheetMode', type: "'show' | 'skip' | 'dim'", def: "'show'", desc: 'Controls sequential navigation and hidden-sheet visibility without adding tab chrome.' },
         { name: 'onViewportChange', type: '(offset: XlsxViewportOffset) => void', desc: 'Called with the clamped logical CSS-pixel offset after the active viewport moves. Horizontal x is measured from column A independently of browser RTL scrollLeft conventions.' },
         GFONTS,
+        GFONTS_CSS_ORIGIN,
         PASSWORD,
         WASM_URL,
         ZIP,
@@ -682,7 +689,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
       name: 'XlsxWorkbook',
       ctor: 'await XlsxWorkbook.load(source, options?)',
       note: 'Headless engine — parse once, render any sheet viewport into any canvas you supply.',
-      options: [GFONTS, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, TIFF, MODE],
+      options: [GFONTS, GFONTS_CSS_ORIGIN, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, TIFF, MODE],
       methods: [
         { sig: 'static load(source, options?): Promise<XlsxWorkbook>', desc: 'Parse a workbook from a URL or ArrayBuffer.' },
         { sig: 'get sheetNames(): string[]', desc: 'Names of all sheets.' },


### PR DESCRIPTION
Closes #1497

Allow applications to use a regional mirror or an internal Google Fonts-compatible CSS service through the shared `googleFontsCssOrigin?: string` load option.

```ts
await DocxDocument.load(data, {
  useGoogleFonts: true,
  googleFontsCssOrigin: 'https://fonts.internal.example',
});
```

The default remains `https://fonts.googleapis.com`, and `useGoogleFonts` still defaults to `false`. No migration is required. `https://fonts.googleapis.cn` is supported through the same option, without region-specific behavior.

The loader replaces only the built-in Google CSS origin, preserving endpoint paths and family queries. Font files follow the URLs returned by the service; relative references resolve against the stylesheet's final URL, including redirects. An internal service must therefore serve the required fonts and return internal font URLs. Failed custom-service requests retain the existing system-font fallback without retrying a public CSS origin.

The option is forwarded through DOCX, XLSX, and PPTX engines and viewers, including render workers, progressive loading, XLSX delimited-text loading, and registration in additional FontFaceSets. Fetch caches use the resolved CSS URL, preserving per-origin isolation and deduplication. README, API reference, and public declaration baselines are updated.

Validation:

- Full Vitest suite with `OOXML_REQUIRE_SKIA=1` and `--maxWorkers=4`: 9000 passed, 25 skipped across 792 files. The initial default-concurrency run overlapped with builds and had one existing Node rendering test hit its 5-second timeout; that file passed independently, and the full rerun passed without changing timeouts or source.
- Private-corpus harness tests: 2 passed.
- `pnpm typecheck`, `pnpm build`, and `pnpm build:packages:ci` passed after generating all three WASM parsers.
- `pnpm check:public-api:built` passed, including all three declaration baselines and viewer API symmetry.
- Production render-worker, optional ChartEx/TIFF bundle-boundary, and public type-export checks passed.
- Source lint and its 8 rule tests passed; 145 architecture, compatibility-evidence, public-API-checker, and resource-policy generator tests passed, along with the corresponding source checks.
- Standalone package build ownership tests: 2 passed.
- `git diff --check` passed.

Adversarial review: this is resource-source configuration with no OOXML parsing or layout-rule changes. All three format integrations were inspected. It preserves the existing fetch count, cache ownership, and reference-counted font cleanup. Focused tests cover main/worker FontFaceSets, internal and China endpoints, origin validation and normalization, concurrent origins, CSS-relative URLs and redirects, preservation of absolute font URLs, and failure without public-origin fallback.

These are local checks; GitHub PR CI will provide the remaining Rust and browser smoke/VRT coverage.

This pull request and its implementation were generated with GPT-6 Astra.
