### PR TITLE
feat(fonts): add locale-aware CJK fallback option

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,8 +573,36 @@ page count, or completion state changes), `onVisibleSlideChange` (fires when the
 top-most visible slide or PPTX completion state changes; its slide count is
 final from first paint), and `onError` (async per-page render failures are routed
 here instead of crashing the scroll loop). The parse/render knobs from the
-headless engines (`mode`, `useGoogleFonts`, `googleFontsCssOrigin`, `resourceLimits`, the deprecated
+headless engines (`mode`, `useGoogleFonts`, `googleFontsCssOrigin`, `cjkFallback`, `resourceLimits`, the deprecated
 `maxZipEntryBytes` alias, `math`, `dpr`) are accepted too.
+
+### CJK fallback region
+
+All document engines and viewers accept `cjkFallback: 'auto' | 'sc' | 'tc' | 'hk' | 'jp' | 'kr'`.
+It chooses the regional fallback for ambiguous Han text; authored fonts and
+recognized document font regions retain priority.
+
+```ts
+const viewer = new DocxViewer(canvas, { cjkFallback: 'sc' });
+```
+
+Omitting the option is equivalent to `'auto'`: at load time, resolve the first
+usable CJK language from `<html lang>`, then `navigator.languages` in order,
+then `navigator.language`. If none is available, use `'jp'`. For Chinese,
+explicit Hans/Hant maps to SC/TC and takes precedence over region; without an
+explicit script, HK/MO maps to HK and TW maps to TC. Bare `zh` maps to SC.
+Japanese and Korean map to JP and KR.
+The resolved preference is shared with workers and remains fixed for that load.
+
+No migration is required. Ambiguous Han text can now use different regional
+glyphs according to the host language. Set an explicit region for reproducible
+output, including in Node. This option does not enable Google Fonts; use
+`useGoogleFonts: true` or provide local/self-hosted fallback fonts as usual.
+HK retains the existing sans-only webfont support. This option covers document
+text, spreadsheet cells/shapes, and slide text; embedded chart and equation
+renderers retain their own font policies. XLSX automatic script inference uses
+the shared-string table; inline cell strings and shape text do not contribute
+to that workbook-level inference.
 
 ### Markdown export
 

--- a/packages/core/src/fonts/cjk-fallback.test.ts
+++ b/packages/core/src/fonts/cjk-fallback.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cjkLangFromLanguage, resolveCjkFallback } from './cjk-fallback.js';
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('CJK fallback language policy', () => {
+  it.each([
+    ['zh', 'sc'], ['zh-CN', 'sc'], ['zh-SG', 'sc'], ['zh-Hans', 'sc'],
+    ['zh-TW', 'tc'], ['zh-Hant', 'tc'], ['zh-HK', 'hk'], ['zh-MO', 'hk'],
+    ['zh-Hans-HK', 'sc'], ['zh-Hans-TW', 'sc'], ['zh-Hant-CN', 'tc'], ['zh-Hant-HK', 'tc'],
+    ['JA-jp', 'jp'], ['ko-KR', 'kr'], ['ko-Hang', 'kr'], ['ja-Hani', 'jp'], ['zh-Latn', null], ['en-US', null], ['', null],
+    ['not_a_locale', null], ['en-x-zh-Hant', null], ['zh-u-rg-twzzzz', 'sc'],
+  ])('%s maps to %s', (language, expected) => {
+    expect(cjkLangFromLanguage(language)).toBe(expected);
+  });
+
+  it('uses HTML before ordered browser preferences and supports explicit overrides', () => {
+    vi.stubGlobal('document', { documentElement: { lang: 'zh-TW' } });
+    vi.stubGlobal('navigator', { languages: ['ja', 'zh-CN'], language: 'ko' });
+    expect(resolveCjkFallback()).toBe('tc');
+    expect(resolveCjkFallback('auto')).toBe('tc');
+    expect(resolveCjkFallback('sc')).toBe('sc');
+  });
+
+  it('skips irrelevant/invalid languages and falls back to navigator.language', () => {
+    vi.stubGlobal('document', { documentElement: { lang: 'en' } });
+    vi.stubGlobal('navigator', { languages: ['en', 'invalid_locale', 'zh-CN', 'ja'], language: 'ko' });
+    expect(resolveCjkFallback()).toBe('sc');
+    vi.stubGlobal('navigator', { languages: ['en'], language: 'ko' });
+    expect(resolveCjkFallback()).toBe('kr');
+  });
+
+  it('rejects unsupported options before loading', () => {
+    expect(() => resolveCjkFallback('ja' as never)).toThrow(TypeError);
+  });
+
+  it('retains a deterministic JP default without browser globals', () => {
+    vi.stubGlobal('document', undefined);
+    vi.stubGlobal('navigator', undefined);
+    expect(resolveCjkFallback()).toBe('jp');
+    expect(resolveCjkFallback('hk')).toBe('hk');
+  });
+});

--- a/packages/core/src/fonts/cjk-fallback.ts
+++ b/packages/core/src/fonts/cjk-fallback.ts
@@ -1,0 +1,43 @@
+import type { CjkLang } from './scripts.js';
+
+/** Region used only when the document does not identify a CJK fallback. */
+export type CjkFallback = 'auto' | CjkLang;
+
+/** BCP 47 language → font region. These defaults are application policy,
+ * not an OOXML font selection rule. Explicit scripts win over regions. */
+export function cjkLangFromLanguage(language: string | null | undefined): CjkLang | null {
+  if (!language?.trim()) return null;
+  let locale: Intl.Locale;
+  try { locale = new Intl.Locale(language.trim()); } catch { return null; }
+  const { language: lang, script, region } = locale;
+  if (lang === 'ja') return !script || ['Jpan', 'Hani', 'Hira', 'Kana'].includes(script) ? 'jp' : null;
+  if (lang === 'ko') return !script || ['Kore', 'Hang', 'Hani'].includes(script) ? 'kr' : null;
+  if (lang !== 'zh') return null;
+  if (script === 'Hans') return 'sc';
+  if (script === 'Hant') return 'tc';
+  if (script) return null;
+  if (region === 'HK' || region === 'MO') return 'hk';
+  if (region === 'TW') return 'tc';
+  return 'sc';
+}
+
+/** Snapshot on the loading realm before any asynchronous work. Workers receive
+ * the concrete result; rendering never reads ambient language preferences. */
+export function resolveCjkFallback(option: CjkFallback = 'auto'): CjkLang {
+  if (option !== 'auto') {
+    if (['sc', 'tc', 'hk', 'jp', 'kr'].includes(option)) return option;
+    throw new TypeError('cjkFallback must be auto, sc, tc, hk, jp, or kr');
+  }
+  const html = typeof document === 'undefined'
+    ? null : cjkLangFromLanguage(document.documentElement?.lang);
+  if (html) return html;
+  if (typeof navigator !== 'undefined') {
+    for (const language of navigator.languages ?? []) {
+      const region = cjkLangFromLanguage(language);
+      if (region) return region;
+    }
+    const region = cjkLangFromLanguage(navigator.language);
+    if (region) return region;
+  }
+  return 'jp';
+}

--- a/packages/core/src/fonts/scripts.ts
+++ b/packages/core/src/fonts/scripts.ts
@@ -389,6 +389,15 @@ export class ScriptPreloadAccumulator {
 
   constructor(private readonly cjkLang: CjkLang | null) {}
 
+  scriptCjkLanguage(): CjkLang | null {
+    return this.hasHangul ? 'kr' : this.hasKana ? 'jp' : null;
+  }
+
+  /** Strong script evidence for ambiguous Han, shared with format font stacks. */
+  preferredCjkLanguage(): CjkLang {
+    return this.scriptCjkLanguage() ?? this.cjkLang ?? 'jp';
+  }
+
   clone(): ScriptPreloadAccumulator {
     const copy = new ScriptPreloadAccumulator(this.cjkLang);
     copy.hasHan = this.hasHan;
@@ -464,7 +473,7 @@ export class ScriptPreloadAccumulator {
     }
   }
 
-  names(): string[] {
+  names(explicitCjkHint = false): string[] {
     const names: string[] = [];
 
     // CJK: each detected language contributes its available Sans+Serif faces.
@@ -475,7 +484,7 @@ export class ScriptPreloadAccumulator {
     const cjkLangs = new Set<CjkLang>();
     if (this.hasHangul) cjkLangs.add('kr');
     if (this.hasKana) cjkLangs.add('jp');
-    if (this.hasHan && cjkLangs.size === 0) {
+    if (this.hasHan && (cjkLangs.size === 0 || explicitCjkHint)) {
       cjkLangs.add(this.cjkLang ?? 'jp');
     }
     // Stable order: kr, sc, tc, hk, jp. HK is sans-only because Google Fonts
@@ -501,8 +510,17 @@ export class ScriptPreloadAccumulator {
 export function scriptPreloadNamesForText(
   text: Iterable<string>,
   cjkLang: CjkLang | null,
+  explicitCjkHint = false,
 ): string[] {
   const accumulator = new ScriptPreloadAccumulator(cjkLang);
   accumulator.addText(text);
-  return accumulator.names();
+  return accumulator.names(explicitCjkHint);
+}
+
+
+/** Resolve a bounded format-owned text stream using the preloader's script facts. */
+export function cjkFallbackForText(text: Iterable<string>, fallback: CjkLang): CjkLang {
+  const scripts = new ScriptPreloadAccumulator(fallback);
+  scripts.addText(text);
+  return scripts.preferredCjkLanguage();
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -167,8 +167,10 @@ export {
   type CanvasFontBoxProbeContext,
   type CanvasFontBoxProbeOptions,
 } from './fonts/canvas-font-box';
+export { resolveCjkFallback, cjkLangFromLanguage, type CjkFallback } from './fonts/cjk-fallback.js';
 export {
   classifyCjkFont,
+  cjkFallbackForText,
   classifyFontGeneric,
   GOOGLE_CJK_FONT_ALIASES,
   googleCjkFontAlias,

--- a/packages/core/src/types/load-options.ts
+++ b/packages/core/src/types/load-options.ts
@@ -1,3 +1,4 @@
+import type { CjkFallback } from '../fonts/cjk-fallback.js';
 import type { MathRenderer } from '../math/mathjax';
 import type { ChartThreeDRenderer } from '../chart/three-d-contract';
 import type { ChartRegionMapRenderer } from '../chart/region-map-contract';
@@ -66,6 +67,14 @@ export interface LoadOptions {
    * via `@font-face` in your application CSS.
    */
   useGoogleFonts?: boolean;
+  /**
+   * Region for ambiguous CJK font fallback. Authored fonts and recognized
+   * document font regions retain priority. `auto` (also the omitted default)
+   * snapshots HTML lang, then navigator.languages / navigator.language;
+   * without a usable CJK language it uses `jp`. Bare `zh` uses `sc`.
+   * Set an explicit region for reproducible output. Does not enable webfonts.
+   */
+  cjkFallback?: CjkFallback;
   /**
    * Override the Google Fonts-compatible CSS service origin used when
    * `useGoogleFonts` is enabled. Must be an HTTP(S) origin (a scheme, host, and

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -895,6 +895,8 @@ export interface ChartTrendline {
     lineHidden?: boolean | null;
 }
 export type ChartType = 'line' | 'stackedLine' | 'stackedLinePct' | 'clusteredBar' | 'clusteredBarH' | 'stackedBar' | 'stackedBarH' | 'stackedBarPct' | 'stackedBarHPct' | 'area' | 'stackedArea' | 'stackedAreaPct' | 'pie' | 'doughnut' | 'scatter' | 'bubble' | 'radar' | 'waterfall' | 'stock' | 'surface' | 'surface3D' | 'boxWhisker' | 'sunburst' | 'treemap' | string;
+export type CjkFallback = 'auto' | CjkLang;
+type CjkLang = 'kr' | 'sc' | 'tc' | 'hk' | 'jp';
 export type CollectPageRunsOptions = Pick<RenderPageOptions, 'width' | 'currentDate' | 'showTrackedChanges'>;
 export interface ColSpec {
     widthPt: number;
@@ -1589,6 +1591,7 @@ export interface LoadOptions extends LoadOptions__emitterCollision1 {
 }
 interface LoadOptions__emitterCollision1 {
     useGoogleFonts?: boolean;
+    cjkFallback?: CjkFallback;
     googleFontsCssOrigin?: string;
     password?: string;
     wasmUrl?: string | URL;

--- a/packages/docx/src/document-content.ts
+++ b/packages/docx/src/document-content.ts
@@ -13,6 +13,7 @@ import type {
 
 type InternalRenderedFontAxes = Readonly<{
   fontFamilyHighAnsi?: string | null;
+  langEastAsia?: string;
   fontFamilyEastAsia?: string | null;
   fontFamilyCs?: string | null;
   boldCs?: boolean;
@@ -24,6 +25,7 @@ type InternalRenderedFontAxes = Readonly<{
  * affect line metrics even when they paint no glyphs. */
 export interface DocxRenderedTextUsage {
   text: string;
+  eastAsiaLanguage?: string;
   fontFamilies: readonly (string | null | undefined)[];
   /** Families eligible for ASCII/high-ANSI scalars in this rendered string. */
   latinFontFamilies?: readonly (string | null | undefined)[];
@@ -95,6 +97,7 @@ function* runUsages(run: DocRun): Generator<DocxRenderedTextUsage> {
     const text = run as DocxTextRun & InternalRenderedFontAxes;
     yield {
       text: run.text,
+      eastAsiaLanguage: text.langEastAsia,
       fontFamilies: [run.fontFamily, text.fontFamilyHighAnsi, run.fontFamilyEastAsia],
       latinFontFamilies: [run.fontFamily, text.fontFamilyHighAnsi],
       eastAsianFontFamilies: [run.fontFamilyEastAsia ?? run.fontFamily],
@@ -103,6 +106,7 @@ function* runUsages(run: DocRun): Generator<DocxRenderedTextUsage> {
     };
     yield {
       text: run.text,
+      eastAsiaLanguage: text.langEastAsia,
       fontFamilies: [run.fontFamilyCs],
       bold: run.boldCs ?? false,
       italic: run.italicCs ?? false,
@@ -111,6 +115,7 @@ function* runUsages(run: DocRun): Generator<DocxRenderedTextUsage> {
     const field = run as FieldRun & InternalRenderedFontAxes;
     yield {
       text: field.fallbackText,
+      eastAsiaLanguage: field.langEastAsia,
       fontFamilies: [field.fontFamily, field.fontFamilyHighAnsi, field.fontFamilyEastAsia],
       latinFontFamilies: [field.fontFamily, field.fontFamilyHighAnsi],
       eastAsianFontFamilies: [field.fontFamilyEastAsia ?? field.fontFamily],
@@ -119,6 +124,7 @@ function* runUsages(run: DocRun): Generator<DocxRenderedTextUsage> {
     };
     yield {
       text: field.fallbackText,
+      eastAsiaLanguage: field.langEastAsia,
       fontFamilies: [field.fontFamilyCs],
       bold: field.boldCs ?? false,
       italic: field.italicCs ?? false,

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -1,3 +1,4 @@
+import { resolveCjkFallback, type CjkLang } from '@silurus/ooxml-core';
 import InlineWorker from './worker.ts?worker&inline';
 import wasmAssetUrl from './wasm/docx_parser_bg.wasm?url';
 import {
@@ -317,6 +318,7 @@ function snapshotReviewData(
 
 export class DocxDocument {
   private _metrics: OoxmlResourceMetricsSession | null = null;
+  private _cjkFallback: CjkLang = 'jp';
   private _document: DocxDocumentModel | null = null;
   private _source: LayoutSourceStore | null = null;
   private _meta: DocumentMeta | null = null;
@@ -436,6 +438,7 @@ export class DocxDocument {
   }
 
   static async load(source: string | ArrayBuffer, opts: LoadOptions = {}): Promise<DocxDocument> {
+    const cjkFallback = resolveCjkFallback(opts.cjkFallback);
     const resourceOptions = normalizeLoadResourceOptions(opts);
     const googleFontsCssOrigin = opts.useGoogleFonts
       ? normalizeGoogleFontsCssOrigin(opts.googleFontsCssOrigin)
@@ -480,6 +483,7 @@ export class DocxDocument {
     try {
       doc = new DocxDocument(worker, mode, defaultCurrentDateMs, opts.wasmUrl);
       doc._metrics = metrics;
+      doc._cjkFallback = cjkFallback;
       // The variant the caller will actually render, recorded for BOTH render
       // modes and recorded BEFORE the parse: geometry accessors and the
       // per-call option fill-in (`_withActiveView`) read it, the wire options
@@ -555,7 +559,7 @@ export class DocxDocument {
       doc._tiff = doc._mode === 'worker' ? undefined : opts.tiff;
       if (doc._mode === 'main' && opts.useGoogleFonts && doc._document) {
         doc._googleFontFaces = await preloadGoogleFonts(
-          docxFontPreloadNames(doc._document),
+          docxFontPreloadNames(doc._document, cjkFallback),
           DOCX_GOOGLE_FONTS,
           undefined,
           googleFontsCssOrigin,
@@ -594,6 +598,7 @@ export class DocxDocument {
             doc._source.fontFamilyCharsets,
           ),
           useGoogleFonts: !!opts.useGoogleFonts,
+          cjkFallback,
           embeddedFaces: doc._embeddedFontFaces,
           googleFaces: doc._googleFontFaces,
           mathResources: preparedMath?.records,
@@ -816,7 +821,7 @@ export class DocxDocument {
     const res = await this._bridge.request(
       (id) =>
         this._mode === 'worker'
-          ? ({ type: 'parse', id, data: buffer, resourcePolicy, useGoogleFonts, googleFontsCssOrigin, defaultCurrentDateMs: documentLayoutRuntimeOf(this).defaultCurrentDateMs, ...this._parseViewFields(), renderers } satisfies RenderWorkerRequest)
+          ? ({ type: 'parse', id, data: buffer, resourcePolicy, useGoogleFonts, googleFontsCssOrigin, cjkFallback: this._cjkFallback, defaultCurrentDateMs: documentLayoutRuntimeOf(this).defaultCurrentDateMs, ...this._parseViewFields(), renderers } satisfies RenderWorkerRequest)
           : ({ type: 'parse', id, data: buffer, resourcePolicy } satisfies WorkerRequest),
       [buffer],
       { timeoutMs },
@@ -1120,6 +1125,7 @@ export class DocxDocument {
           resourcePolicy,
           useGoogleFonts,
           googleFontsCssOrigin,
+          cjkFallback: this._cjkFallback,
           defaultCurrentDateMs: documentLayoutRuntimeOf(this).defaultCurrentDateMs,
           ...this._parseViewFields(),
           renderers,

--- a/packages/docx/src/font-family.test.ts
+++ b/packages/docx/src/font-family.test.ts
@@ -221,3 +221,23 @@ describe('normalizeFontFamily — per-document memoization is transparent', () =
     expect(namedNull).not.toBe(nullChain);
   });
 });
+
+
+describe('document-scoped ambiguous CJK fallback', () => {
+  it('keeps Latin substitutes ahead of SC and preserves authored JP fonts', () => {
+    const sc = normalizeFontFamilyUncached('Arial', {}, {}, 'sc');
+    expect(sc.indexOf('"Arial"')).toBeLessThan(sc.indexOf('"Noto Sans SC"'));
+    expect(sc.indexOf('"Noto Sans SC"')).toBeLessThan(sc.indexOf('"Noto Sans JP"'));
+    const jp = normalizeFontFamilyUncached('Meiryo', {}, {}, 'sc');
+    expect(jp.indexOf('"Noto Sans JP"')).toBeLessThan(jp.indexOf('"Noto Sans SC"'));
+  });
+
+  it('builds regional routes without mutating shared source facts', () => {
+    const facts = { Arial: 'swiss' };
+    expect(normalizeFontFamilyUncached('Arial', facts, {}, 'sc'))
+      .toContain('"Noto Sans SC", "Noto Sans TC"');
+    expect(normalizeFontFamilyUncached('Arial', facts, {}, 'tc'))
+      .toContain('"Noto Sans TC", "Noto Sans SC"');
+    expect(facts).toEqual({ Arial: 'swiss' });
+  });
+});

--- a/packages/docx/src/google-fonts.test.ts
+++ b/packages/docx/src/google-fonts.test.ts
@@ -128,3 +128,29 @@ describe('DOCX_GOOGLE_FONTS — shared registry consolidation (oracle)', () => {
     });
   });
 });
+
+
+it('preloads the configured fallback only for ambiguous Han', () => {
+  expect(docxFontPreloadNames(docWith('漢字'), 'sc')).toContain('Noto Sans SC');
+  expect(docxFontPreloadNames(docWith('漢字'), 'sc')).not.toContain('Noto Sans JP');
+  expect(docxFontPreloadNames(docWith('Hello'), 'sc')).toEqual(['Calibri', 'Calibri']);
+  expect(docxFontPreloadNames(docWith('漢字', 'Meiryo'), 'sc')).toContain('Noto Sans JP');
+  expect(docxFontPreloadNames(docWith('漢字かな'), 'sc')).toContain('Noto Sans JP');
+});
+
+
+it('preloads an explicitly authored East Asian run language ahead of host preference', () => {
+  const doc = docWith('漢字');
+  Object.assign((doc.body[0] as { runs: object[] }).runs[0], { langEastAsia: 'ja-JP' });
+  const names = docxFontPreloadNames(doc, 'sc');
+  expect(names).toContain('Noto Sans JP');
+  expect(names).not.toContain('Noto Sans SC');
+});
+
+
+it('preloads the explicit Chinese region even when the same run contains kana', () => {
+  const doc = docWith('漢字かな');
+  Object.assign((doc.body[0] as { runs: object[] }).runs[0], { langEastAsia: 'zh-CN' });
+  expect(docxFontPreloadNames(doc, 'tc')).toContain('Noto Sans SC');
+  expect(docxFontPreloadNames(doc, 'tc')).toContain('Noto Sans JP');
+});

--- a/packages/docx/src/google-fonts.ts
+++ b/packages/docx/src/google-fonts.ts
@@ -1,5 +1,8 @@
+import { ScriptPreloadAccumulator } from '@silurus/ooxml-core/internal/script-preload-accumulator';
+import type { CjkLang } from '@silurus/ooxml-core';
 import {
   classifyCjkFont,
+  cjkLangFromLanguage,
   scriptPreloadNamesForText,
   GOOGLE_FONT_SUBSTITUTES,
   SCRIPT_GOOGLE_FONTS,
@@ -45,12 +48,26 @@ function* docxTextRuns(doc: DocxDocumentModel): Generator<string> {
  */
 export function docxFontPreloadNames(
   doc: DocxDocumentModel,
+  fallback?: CjkLang,
 ): (string | null | undefined)[] {
   const cjkLang =
-    classifyCjkFont(doc.majorFont) ?? classifyCjkFont(doc.minorFont) ?? null;
-  return [
-    doc.majorFont,
-    doc.minorFont,
-    ...scriptPreloadNamesForText(docxTextRuns(doc), cjkLang),
-  ];
+    classifyCjkFont(doc.majorFont) ?? classifyCjkFont(doc.minorFont) ?? fallback ?? null;
+  const scripts = new ScriptPreloadAccumulator(cjkLang);
+  const languageNames = new Set<string>();
+  for (const usage of docxRenderedTextUsages(doc)) {
+    const region = cjkLangFromLanguage(usage.eastAsiaLanguage);
+    if (region) {
+      for (const name of scriptPreloadNamesForText([usage.text], region, true)) languageNames.add(name);
+    } else {
+      scripts.addText([usage.text]);
+    }
+  }
+  return [doc.majorFont, doc.minorFont, ...new Set([...scripts.names(), ...languageNames])];
+}
+
+
+export function docxScriptCjkLanguage(doc: DocxDocumentModel): CjkLang | null {
+  const scripts = new ScriptPreloadAccumulator(null);
+  scripts.addText(docxTextRuns(doc));
+  return scripts.scriptCjkLanguage();
 }

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -170,6 +170,7 @@ export {
   type OoxmlResourceLimit,
   type OoxmlResourceLimitErrorDetails,
   type OoxmlResourceLimits,
+  type CjkFallback,
   type OoxmlResourceMetric,
   type OoxmlResourceMetrics,
   type OoxmlResourceMetricsCheckpoint,

--- a/packages/docx/src/layout-runtime.ts
+++ b/packages/docx/src/layout-runtime.ts
@@ -1,3 +1,4 @@
+import { classifyCjkFont, type CjkLang } from '@silurus/ooxml-core';
 import { withVertFeatureCanvasScope } from '@silurus/ooxml-core';
 import type { DocxDocumentModel } from './types.js';
 import type { ResolvedFontMetric } from './layout/text.js';
@@ -36,11 +37,13 @@ function createConcreteBodyLayoutKernel(
   source: LayoutSourceStore,
   measureContext: MeasurementTextContext | null,
   resolvedLocalFonts: Readonly<Record<string, ResolvedFontMetric>>,
+  cjkFallback?: CjkLang,
 ): BodyLayoutKernel {
   return createProductionBodyLayoutRuntime(
     source,
     measureContext,
     resolvedLocalFonts,
+    cjkFallback,
   ).kernel;
 }
 
@@ -50,6 +53,7 @@ export function createLayoutServices(
     readonly localMetrics?: Readonly<Record<string, ResolvedFontMetric>>;
     readonly fontMetrics?: Readonly<Record<string, ResolvedFontMetric>>;
     readonly useGoogleFonts?: boolean;
+    readonly cjkFallback?: CjkLang;
     readonly mathResources?: readonly MathLayoutResource[];
     readonly mathDrawables?: ReadonlyMap<string, CanvasImageSource>;
     readonly measureContext?: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | null;
@@ -149,8 +153,11 @@ export function createLayoutServices(
     ...localMetrics,
     ...options.fontMetrics,
   });
+  const cjkFallback = source.fonts.scriptCjkLanguage
+    ?? classifyCjkFont(source.fonts.majorFamily) ?? classifyCjkFont(source.fonts.minorFamily) ?? options.cjkFallback;
   const services = createProductionLayoutServices(source, {
     ...options,
+    cjkFallback,
     resolvedFontMetricCandidates,
     localMetrics,
     fontMetrics: inputFontMetrics,
@@ -169,6 +176,7 @@ export function createLayoutServices(
       source,
       context,
       fontMetrics,
+      cjkFallback,
     ),
   );
   return services;

--- a/packages/docx/src/layout-source-model-adapter.ts
+++ b/packages/docx/src/layout-source-model-adapter.ts
@@ -1,6 +1,6 @@
 import type { DocParagraph, DocRun, DocxDocumentModel, HeadersFooters } from './types.js';
 import { docxRenderedFontFamilies } from './document-content.js';
-import { docxFontPreloadNames } from './google-fonts.js';
+import { docxFontPreloadNames, docxScriptCjkLanguage } from './google-fonts.js';
 import { resolveDocumentLayoutSettings } from './layout-context.js';
 import { getDefaultFontSize } from './line-layout.js';
 import { docDefaultFontSizePt } from './layout/measurement-environment.js';
@@ -471,6 +471,7 @@ function buildLayoutSourceModelAdapter(
     embeddedFonts: [...(privateDocument.embeddedFonts ?? [])],
     renderedFamilies: docxRenderedFontFamilies(privateDocument),
     preloadNames: docxFontPreloadNames(privateDocument),
+    scriptCjkLanguage: docxScriptCjkLanguage(privateDocument),
     defaultBodyFontSizePt: docDefaultFontSizePt(privateDocument),
   };
 

--- a/packages/docx/src/layout/font-service.test.ts
+++ b/packages/docx/src/layout/font-service.test.ts
@@ -19,6 +19,17 @@ const faces: readonly FontInventoryFace[] = [
 ];
 
 describe('font layout services', () => {
+  it('snapshots regional routes and includes their contents in the font fingerprint', () => {
+    const routes = { sc: { Calibri: 'Carlito, "Noto Sans SC", sans-serif' } };
+    const resolver = createFontResolver(faces, { regionalFamilyLists: routes });
+    routes.sc.Calibri = 'Carlito, "Noto Sans TC", sans-serif';
+    const changed = createFontResolver(faces, { regionalFamilyLists: routes });
+    const request = { requestedFamily: 'Calibri', language: 'zh-CN' };
+    expect(resolver.resolve(request).route.familyList).toContain('Noto Sans SC');
+    expect(changed.resolve(request).route.familyList).toContain('Noto Sans TC');
+    expect(resolver.fingerprint).not.toBe(changed.fingerprint);
+  });
+
   it('records embedded, local, Google, substitute, and generic resolution', () => {
     const resolver = createFontResolver(faces);
 

--- a/packages/docx/src/layout/font-service.ts
+++ b/packages/docx/src/layout/font-service.ts
@@ -1,3 +1,4 @@
+import { cjkLangFromLanguage, type CjkLang } from '@silurus/ooxml-core';
 import type { LayoutDiagnostic } from './types.js';
 import { stableFingerprint } from './fingerprint.js';
 import { createCanvasFontRoute, type CanvasFontRoute } from '@silurus/ooxml-core';
@@ -6,6 +7,8 @@ export type FontResolutionSource = 'embedded' | 'local' | 'google' | 'substitute
 export type FontStyle = 'normal' | 'italic';
 
 export interface FontRequest {
+  readonly cjkFallback?: CjkLang;
+  readonly language?: string;
   readonly requestedFamily?: string | null;
   readonly genericFamily?: 'serif' | 'sans-serif' | 'monospace';
   readonly weight?: number;
@@ -37,6 +40,8 @@ export interface FontInventoryFace {
 }
 
 export interface FontResolverOptions {
+  /** Immutable regional routes; their concrete outputs participate in cache identity. */
+  readonly regionalFamilyLists?: Partial<Record<CjkLang, Readonly<Record<string, string>>>>;
   /** Stable DOCX fallback routes derived from document metadata and rendered faces. */
   readonly nativeFamilyLists?: Readonly<Record<string, string>>;
 }
@@ -103,7 +108,24 @@ export function createFontResolver(
       .map(([family, familyList]) => [normalizeFamily(family), familyList] as const)
       .sort(([a], [b]) => a.localeCompare(b)),
   ));
-  const fingerprint = stableFingerprint('fonts', { faces, nativeFamilyLists });
+  const regionalFamilyLists = Object.freeze(Object.fromEntries(
+    Object.entries(options.regionalFamilyLists ?? {}).map(([region, lists]) => [
+      region,
+      Object.freeze(Object.fromEntries(Object.entries(lists)
+        .map(([family, list]) => [normalizeFamily(family), list])
+        .sort(([a], [b]) => a.localeCompare(b)))),
+    ]).sort(([a], [b]) => String(a).localeCompare(String(b))),
+  )) as Readonly<Partial<Record<CjkLang, Readonly<Record<string, string>>>>>;
+  const familyListFor = (
+    family: string,
+    language: string | undefined,
+    fallback: CjkLang | undefined,
+  ): string | undefined => {
+    const region = cjkLangFromLanguage(language) ?? fallback;
+    return (region ? regionalFamilyLists[region]?.[normalizeFamily(family)] : undefined)
+      ?? nativeFamilyLists[normalizeFamily(family)];
+  };
+  const fingerprint = stableFingerprint('fonts', { faces, nativeFamilyLists, regionalFamilyLists });
 
   return Object.freeze({
     fingerprint,
@@ -121,7 +143,10 @@ export function createFontResolver(
               message: `ECMA-376 §17.8.2 implementation-dependent font substitution: ${requestedFamily} resolved to ${face.resolvedFamily}`,
             }]
           : [];
-        const familyList = cssFamilyList(face.resolvedFamily, request.genericFamily ?? 'sans-serif');
+        const fallbackList = familyListFor(requestedFamily, request.language, request.cjkFallback);
+        const familyList = fallbackList
+          ? `${quoteCssFamily(face.resolvedFamily)}, ${fallbackList}`
+          : cssFamilyList(face.resolvedFamily, request.genericFamily ?? 'sans-serif');
         return freezeResolution({
           requestedFamily,
           resolvedFamily: face.resolvedFamily,
@@ -137,7 +162,7 @@ export function createFontResolver(
       const generic = request.genericFamily ?? 'sans-serif';
       const authored = request.requestedFamily?.trim();
       if (authored) {
-        const familyList = nativeFamilyLists[normalizeFamily(authored)]
+        const familyList = familyListFor(authored, request.language, request.cjkFallback)
           ?? cssFamilyList(authored, generic);
         return freezeResolution({
           requestedFamily,
@@ -153,7 +178,10 @@ export function createFontResolver(
       return freezeResolution({
         requestedFamily,
         resolvedFamily: generic,
-        route: createCanvasFontRoute(generic, 'generic'),
+        route: createCanvasFontRoute(
+          familyListFor(generic, request.language, request.cjkFallback) ?? generic,
+          'generic',
+        ),
         source: 'generic',
         weight,
         style,

--- a/packages/docx/src/layout/layout-source-store.ts
+++ b/packages/docx/src/layout/layout-source-store.ts
@@ -67,6 +67,7 @@ export interface LayoutSourceFontFacts {
   readonly minorFamily: string | null;
   readonly embeddedFonts: readonly EmbeddedFontRef[];
   readonly renderedFamilies: readonly string[];
+  readonly scriptCjkLanguage?: import('@silurus/ooxml-core').CjkLang | null;
   readonly preloadNames: readonly (string | null | undefined)[];
   readonly defaultBodyFontSizePt: number;
 }

--- a/packages/docx/src/layout/production-body-layout.ts
+++ b/packages/docx/src/layout/production-body-layout.ts
@@ -1,3 +1,4 @@
+import type { CjkLang } from '@silurus/ooxml-core';
 import type { BodyElement, DocParagraph, DocTable, DocTableCell, DocRun, ImageRun, ChartRun, ShapeRun, SectionProps } from '../types';
 import type { ResolvedFontMetric } from '@silurus/ooxml-core';
 import { type FloatRect, FLOAT_OVERLAP_EPS, isWrapFloat } from '../float-layout.js';
@@ -73,6 +74,7 @@ export function createProductionBodyLayoutRuntime(
   source: LayoutSourceStore,
   measureContext: MeasurementTextContext | null,
   resolvedLocalFonts: Readonly<Record<string, ResolvedFontMetric>>,
+  cjkFallback?: CjkLang,
 ) {
   prepareBodyFrameMetadata(source.blocks.body);
   const model = source.acquisition;
@@ -3057,6 +3059,9 @@ function effCellMargins(
 // drift against the whole-string measure (約物半角 contextual collapse stays
 // honoured). See packages/core/src/text/justify-positions.ts.
 
+  // Keep the canonical layout-runtime transport explicit. Regional glyph
+  // selection itself belongs to the text service and is applied only to Han.
+  void cjkFallback;
   const kernel = buildConcreteBodyLayoutKernel(source, measureContext, resolvedLocalFonts);
   return Object.freeze({
     kernel,

--- a/packages/docx/src/layout/production-services.ts
+++ b/packages/docx/src/layout/production-services.ts
@@ -1,3 +1,4 @@
+import { type CjkLang } from '@silurus/ooxml-core';
 import {
   canvasFontString,
   measureResolvedCanvasFontBoxRatio,
@@ -44,6 +45,7 @@ export interface ProductionLayoutServiceOptions {
   readonly localMetrics?: Readonly<Record<string, ResolvedFontMetric>>;
   readonly fontMetrics?: Readonly<Record<string, ResolvedFontMetric>>;
   readonly useGoogleFonts?: boolean;
+  readonly cjkFallback?: CjkLang;
   readonly mathResources?: readonly MathLayoutResource[];
   readonly mathDrawables?: ReadonlyMap<string, CanvasImageSource>;
   readonly measureContext: MeasurementTextContext | null;
@@ -200,6 +202,13 @@ export function createProductionLayoutServices(
   ])];
   const text = createTextLayoutService({
     fonts: createFontResolver(inventory, {
+      regionalFamilyLists: Object.fromEntries((['sc', 'tc', 'hk', 'jp', 'kr'] as const).map(region => [
+        region,
+        Object.fromEntries([...new Set([...routedFontFamilies, 'sans-serif', 'serif', 'monospace'])]
+          .map(family => [family, normalizeFontFamilyUncached(
+            family, source.fonts.familyClasses, source.fonts.familyPitches, region,
+          )])),
+      ])),
       nativeFamilyLists: Object.fromEntries(routedFontFamilies.map((family) => [
         family,
         normalizeFontFamilyUncached(
@@ -209,6 +218,7 @@ export function createProductionLayoutServices(
         ),
       ])),
     }),
+    cjkFallback: options.cjkFallback,
     fontMetrics,
     eastAsiaFontCharsets: fontFamilyCharsets,
     genericFamilies: Object.fromEntries(routedFontFamilies.map((family) => [

--- a/packages/docx/src/layout/services-integration.test.ts
+++ b/packages/docx/src/layout/services-integration.test.ts
@@ -822,3 +822,41 @@ describe('production layout service integration', () => {
     expect(main.math.fingerprint).toBe(worker.math.fingerprint);
   });
 });
+
+
+it('retains CJK routes in registered and generic fonts with different service fingerprints', () => {
+  const document = model({ majorFont: 'Calibri', minorFont: 'Calibri' });
+  const options = { measureContext: measureContext(), useGoogleFonts: true,
+    googleFaces: [{ family: 'Carlito', status: 'loaded', weight: '400', style: 'normal' }] as FontFace[],
+  };
+  const sc = createLayoutServices(document, { ...options, cjkFallback: 'sc' });
+  const tc = createLayoutServices(document, { ...options, cjkFallback: 'tc' });
+  expect(sc.text.fingerprint).not.toBe(tc.text.fingerprint);
+  const request = { text: '漢', slot: 'eastAsia' as const, fonts: { eastAsia: 'Calibri' } };
+  // The resolved substitute must keep its CJK fallback during measurement and paint.
+  const scRun = sc.text.resolve(request);
+  expect(scRun.route.familyList).toContain('Noto Sans SC');
+  expect(tc.text.resolve(request).route.familyList).toContain('Noto Sans TC');
+});
+
+
+it('uses preserved DOCX language on Han-only runs and keeps authored fonts authoritative', () => {
+  const services = createLayoutServices(model({ majorFont: 'Calibri', fontFamilyClasses: { SimSun: 'roman' } }), {
+    measureContext: measureContext(), cjkFallback: 'sc',
+  });
+  const japanese = services.text.resolve({
+    text: '漢', fonts: { ascii: 'Calibri' }, slot: 'eastAsia', eastAsiaLanguage: 'ja-JP',
+  }).route.familyList;
+  expect(japanese.indexOf('Noto Sans JP')).toBeLessThan(japanese.indexOf('Noto Sans SC'));
+  const chinese = services.text.resolve({
+    text: '漢', fonts: { eastAsia: 'SimSun' }, slot: 'eastAsia', eastAsiaLanguage: 'ja-JP',
+  }).route.familyList;
+  expect(chinese.indexOf('Noto Serif SC')).toBeLessThan(chinese.indexOf('Noto Serif JP'));
+  const latin = services.text.resolve({
+    text: 'à', fonts: { ascii: 'Calibri' }, slot: 'eastAsia', eastAsiaLanguage: 'ja-JP',
+  }).route.familyList;
+  const neutralLatin = services.text.resolve({
+    text: 'à', fonts: { ascii: 'Calibri' }, slot: 'eastAsia',
+  }).route.familyList;
+  expect(latin).toBe(neutralLatin);
+});

--- a/packages/docx/src/layout/text.ts
+++ b/packages/docx/src/layout/text.ts
@@ -3,6 +3,7 @@ import {
   classifyFontGeneric,
   graphemeClusterOffsets,
   normalizeFontMetricFamily,
+  type CjkLang,
   type ResolvedFontMetric,
 } from '@silurus/ooxml-core';
 import type {
@@ -285,6 +286,10 @@ export interface TextShapeRequest {
 }
 
 export interface TextFontResolveRequest {
+  /** Text covered by this request. Language-selected regional fallback applies
+   * only when the text actually contains Han; it must not capture Latin glyphs. */
+  readonly text?: string;
+  readonly eastAsiaLanguage?: string;
   readonly fonts: TextFontSlots;
   readonly themeFonts?: TextFontSlots;
   readonly themeFontPresence?: TextFontSlotPresence;
@@ -368,6 +373,7 @@ export interface TextLayoutService {
 export interface TextLayoutServiceInput {
   readonly fonts: FontResolver;
   readonly measurer: GlyphMeasurer;
+  readonly cjkFallback?: CjkLang;
   readonly fontMetrics?: Readonly<Record<string, Readonly<ResolvedFontMetric>>>;
   /** Exact local aliases also participate in resolution; retained separately
    * from resource-only metrics so an embedded face is never mislabeled local. */
@@ -572,6 +578,7 @@ export function createTextLayoutService(input: TextLayoutServiceInput): TextLayo
   const fingerprint = stableFingerprint('text', {
     fonts: input.fonts.fingerprint,
     measurer: input.measurer.fingerprint,
+    cjkFallback: input.cjkFallback ?? null,
     fontMetrics,
     eastAsiaFontCharsets,
     genericFamilies,
@@ -587,8 +594,13 @@ export function createTextLayoutService(input: TextLayoutServiceInput): TextLayo
       // consumer policy changes only the script classes covered by Word output
       // evidence; every authored direct/theme face remains authoritative above.
       : request.genericFamily ?? defaultGenericForSlot(request.slot);
+    const hasHan = /\p{Script=Han}/u.test(request.text ?? '');
     return input.fonts.resolve({
       requestedFamily: authoredFamily,
+      cjkFallback: hasHan ? input.cjkFallback : undefined,
+      language: request.slot === 'eastAsia' && hasHan
+        ? request.eastAsiaLanguage
+        : undefined,
       genericFamily,
       weight: request.weight,
       style: request.style,
@@ -713,6 +725,8 @@ export function createTextLayoutService(input: TextLayoutServiceInput): TextLayo
           themeFonts: request.themeFonts,
           themeFontPresence: request.themeFontPresence,
           slot: group.script,
+          text: group.text,
+          eastAsiaLanguage: request.eastAsiaLanguage,
           weight: request.weight,
           style: request.style,
           genericFamily: request.genericFamily,

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -1,3 +1,4 @@
+import type { CjkLang } from '@silurus/ooxml-core';
 // DOCX line-layout engine — the pure segmentation + line-breaking + measurement
 // kernel that both the paginator and the paint pass call to turn a paragraph's
 // runs into laid-out lines and line-box heights (ECMA-376 §17.3.1.x line
@@ -760,10 +761,10 @@ export const ARABIC_TAIL_SANS = ['Noto Naskh Arabic', 'Noto Sans Arabic'] as con
  * collision so their position is immaterial; they sit before the generic so
  * the browser's per-glyph fallback can reach them.
  */
-export function sansTail(cjk: ReturnType<typeof classifyCjkFont>): string {
+export function sansTail(cjk: ReturnType<typeof classifyCjkFont>, fallback?: CjkLang): string {
   const cjkPart =
-    cjk && cjk !== 'jp'
-      ? cjkFallbackChain(cjk, 'sans')
+    (cjk ?? fallback) && (cjk ?? fallback) !== 'jp'
+      ? cjkFallbackChain((cjk ?? fallback) as CjkLang, 'sans')
       : // JP / stray-CJK sans faces: historical system-font hints, then the Noto
         // CJK siblings so a CJK glyph still resolves on hosts lacking them.
         ['Noto Sans JP', 'Hiragino Sans', 'Meiryo', ...cjkFallbackChain('jp', 'sans').slice(1)];
@@ -778,10 +779,10 @@ export function sansTail(cjk: ReturnType<typeof classifyCjkFont>): string {
 }
 
 /** Serif counterpart of {@link sansTail}. */
-export function serifTail(cjk: ReturnType<typeof classifyCjkFont>): string {
+export function serifTail(cjk: ReturnType<typeof classifyCjkFont>, fallback?: CjkLang): string {
   const cjkPart =
-    cjk && cjk !== 'jp'
-      ? cjkFallbackChain(cjk, 'serif')
+    (cjk ?? fallback) && (cjk ?? fallback) !== 'jp'
+      ? cjkFallbackChain((cjk ?? fallback) as CjkLang, 'serif')
       : // JP / stray-CJK serif faces: historical mincho system hints, then Noto
         // serif CJK siblings.
         [
@@ -888,8 +889,14 @@ export function normalizeFontFamilyUncached(
   family: string | null,
   fontFamilyClasses: Record<string, string>,
   fontFamilyPitches: Record<string, string> = {},
+  cjkFallback?: CjkLang,
 ): string {
-  if (!family) return sansTail(null);
+  if (!family || family === 'sans-serif') return sansTail(null, cjkFallback);
+  if (family === 'serif') return serifTail(null, cjkFallback);
+  const monoTail = cjkFallback
+    ? `"Courier New", ${quoteAll(cjkFallbackChain(cjkFallback, 'sans'))}, monospace`
+    : '"Courier New", monospace';
+  if (family === 'monospace') return monoTail;
 
   const escape = (s: string) => s.replace(/"/g, '\\"');
   const head = `"${escape(family)}"`;
@@ -917,9 +924,13 @@ export function normalizeFontFamilyUncached(
   //    geometric Arabic faces instead pair with a sans Latin fallback.
   if (isArabicSubstituteFont(family)) {
     if (NASKH_SERIF_ARABIC_FONTS.has(lower)) {
-      return `${head}, "Noto Naskh Arabic", "Noto Sans Arabic", "Noto Serif", "Noto Sans JP", "Hiragino Sans", serif`;
+      return cjkFallback
+        ? `${head}, "Noto Naskh Arabic", "Noto Sans Arabic", "Noto Serif", ${sansTail(null, cjkFallback).replace(/sans-serif$/, 'serif')}`
+        : `${head}, "Noto Naskh Arabic", "Noto Sans Arabic", "Noto Serif", "Noto Sans JP", "Hiragino Sans", serif`;
     }
-    return `${head}, "Noto Sans Arabic", "Noto Naskh Arabic", "Noto Sans JP", "Hiragino Sans", sans-serif`;
+    return cjkFallback
+      ? `${head}, "Noto Sans Arabic", "Noto Naskh Arabic", ${sansTail(null, cjkFallback)}`
+      : `${head}, "Noto Sans Arabic", "Noto Naskh Arabic", "Noto Sans JP", "Hiragino Sans", sans-serif`;
   }
 
   // 1) Authoritative classification from word/fontTable.xml §17.8.3.10.
@@ -927,9 +938,9 @@ export function normalizeFontFamilyUncached(
   if (tableClass && tableClass !== 'auto') {
     switch (tableClass) {
       case 'roman':
-        return `${head}, ${serifTail(cjk)}`;
+        return `${head}, ${serifTail(cjk, cjkFallback)}`;
       case 'swiss':
-        return `${head}, ${sansTail(cjk)}`;
+        return `${head}, ${sansTail(cjk, cjkFallback)}`;
       case 'modern': {
         // §17.8.3.10 `modern` is the "modern/monospace" typeface family, but the
         // family value classifies the DESIGN, not the pitch — §17.8.3.14
@@ -950,7 +961,7 @@ export function normalizeFontFamilyUncached(
               : cjkFallbackChain(cjk, 'sans');
             return `${head}, ${quoteAll([...cjkFallbacks, 'Courier New'])}, monospace`;
           }
-          return `${head}, "Courier New", monospace`;
+          return `${head}, ${monoTail}`;
         }
         break;
       }
@@ -972,31 +983,33 @@ export function normalizeFontFamilyUncached(
   //    mono on the name path), so no prior serif/sans coverage is lost.
   const generic = classifyFontGeneric(family);
   if (generic === 'serif') {
-    return `${head}, ${serifTail(cjk)}`;
+    return `${head}, ${serifTail(cjk, cjkFallback)}`;
   }
   if (generic === 'mono') {
     // Mirror the fontTable `modern` branch's monospace fallback. NEW for the
     // name path: core now detects consolas/courier/等幅 etc. as mono.
-    return `${head}, "Courier New", monospace`;
+    return `${head}, ${monoTail}`;
   }
 
   // Japanese system-font hints (only meaningful for JP / Latin faces; a non-JP
   // CJK face skips these so its matching Noto CJK leads the tail).
   if (cjk == null || cjk === 'jp') {
     if (lower.includes('meiryo') || family.includes('メイリオ')) {
-      return `${head}, "Meiryo UI", "Meiryo", ${sansTail(cjk)}`;
+      return `${head}, "Meiryo UI", "Meiryo", ${sansTail(cjk, cjkFallback)}`;
     }
     if (family.includes('游ゴシック') || /\byu\s*gothic\b/i.test(family) || lower.includes('yugothic')) {
-      return `${head}, "Yu Gothic", "YuGothic", ${sansTail(cjk)}`;
+      return `${head}, "Yu Gothic", "YuGothic", ${sansTail(cjk, cjkFallback)}`;
     }
     if (lower.includes('ipa')) {
-      return `${head}, "IPAexGothic", ${sansTail(cjk)}`;
+      return `${head}, "IPAexGothic", ${sansTail(cjk, cjkFallback)}`;
     }
     if (lower.includes('segoe')) {
-      return `${head}, "Segoe UI", ${quoteAll([...ARABIC_TAIL_SANS, ...NON_CJK_SANS_FALLBACKS])}, sans-serif`;
+      return cjkFallback
+        ? `${head}, "Segoe UI", ${sansTail(null, cjkFallback)}`
+        : `${head}, "Segoe UI", ${quoteAll([...ARABIC_TAIL_SANS, ...NON_CJK_SANS_FALLBACKS])}, sans-serif`;
     }
   }
-  return `${head}, ${sansTail(cjk)}`;
+  return `${head}, ${sansTail(cjk, cjkFallback)}`;
 }
 
 export function buildFont(

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -255,7 +255,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerWireRequest | WorkerSvgDecod
         // Pagination measures text, so fonts must land before canonical layout —
         // same ordering the main-mode load() guarantees.
         googleFaces = await preloadGoogleFonts(
-          docxFontPreloadNames(model),
+          docxFontPreloadNames(model, req.cjkFallback),
           DOCX_GOOGLE_FONTS,
           undefined,
           req.googleFontsCssOrigin,
@@ -285,6 +285,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerWireRequest | WorkerSvgDecod
           source.fontFamilyCharsets,
         ),
         useGoogleFonts: !!req.useGoogleFonts,
+        cjkFallback: req.cjkFallback,
         embeddedFaces: embeddedFonts.faces,
         googleFaces,
         mathResources: preparedMath?.records,

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -647,6 +647,7 @@ export class DocxScrollViewer implements ZoomableViewer {
         password: this._opts.password,
         useGoogleFonts: this._opts.useGoogleFonts,
         googleFontsCssOrigin: this._opts.googleFontsCssOrigin,
+        cjkFallback: this._opts.cjkFallback,
         maxZipEntryBytes: this._opts.maxZipEntryBytes,
         resourceLimits: this._opts.resourceLimits,
         debug: this._opts.debug,

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -287,6 +287,7 @@ export class DocxViewer implements ZoomableViewer {
         password: this._opts.password,
         useGoogleFonts: this._opts.useGoogleFonts,
         googleFontsCssOrigin: this._opts.googleFontsCssOrigin,
+        cjkFallback: this._opts.cjkFallback,
         maxZipEntryBytes: this._opts.maxZipEntryBytes,
         resourceLimits: this._opts.resourceLimits,
         debug: this._opts.debug,

--- a/packages/docx/src/worker-protocol.ts
+++ b/packages/docx/src/worker-protocol.ts
@@ -104,7 +104,7 @@ export type RenderWorkerRequest =
   // changes measured widths, so each combination is a genuinely different
   // pagination with its own page count. Omitted means the document's default
   // view, which is what every load selected before these existed.
-  | { type: 'parse'; id: number; data: ArrayBuffer; resourcePolicy: NormalizedOoxmlResourcePolicy; useGoogleFonts?: boolean; googleFontsCssOrigin?: string; defaultCurrentDateMs: number; currentDateMs?: number; showTrackedChanges?: boolean; renderers?: WorkerRendererDescriptors; progressiveLayout?: boolean }
+  | { type: 'parse'; id: number; data: ArrayBuffer; resourcePolicy: NormalizedOoxmlResourcePolicy; useGoogleFonts?: boolean; googleFontsCssOrigin?: string; cjkFallback?: import('@silurus/ooxml-core').CjkLang; defaultCurrentDateMs: number; currentDateMs?: number; showTrackedChanges?: boolean; renderers?: WorkerRendererDescriptors; progressiveLayout?: boolean }
   | { type: 'selectLayoutView'; id: number; currentDateMs: number; showTrackedChanges: boolean }
   | { type: 'renderPage'; id: number; pageIndex: number; opts: WireRenderPageOptions }
   // IX6 — collect a page's text-run geometry WITHOUT transferring a bitmap. The

--- a/packages/node/src/docx.ts
+++ b/packages/node/src/docx.ts
@@ -1,3 +1,4 @@
+import { resolveCjkFallback, type CjkFallback } from '@silurus/ooxml-core';
 import type { DocxDocumentModel, DocxTextRunInfo } from '@silurus/ooxml-docx';
 import type {
   OoxmlResourceUsageSnapshot,
@@ -39,6 +40,7 @@ const getDocxWasmModule = createLazyWasmModule(() => resolveWasm(
 
 /** Options for the bounded Node DOCX page session. */
 export interface OpenDocxDocumentOptions extends OoxmlNodeSessionOptions {
+  cjkFallback?: CjkFallback;
   /** Canvas implementation used for text measurement and page allocation. */
   factory: NodeCanvasFactory;
   /** Stable DATE/TIME field instant captured before pagination. */
@@ -85,6 +87,7 @@ export async function openDocxDocument(
   options: OpenDocxDocumentOptions,
 ): Promise<DocxDocumentSession> {
   if (!options?.factory) throw new TypeError('openDocxDocument requires a canvas factory');
+  const cjkFallback = resolveCjkFallback(options.cjkFallback);
   const acquired = await acquireDocxNodeDocument(
     toUint8(buffer),
     getDocxWasmModule(),
@@ -96,6 +99,7 @@ export async function openDocxDocument(
     throwIfAborted(options.signal);
     const measurementCanvas = options.factory.createCanvas(1, 1);
     const services = createLayoutServices(acquired.result, {
+      cjkFallback,
       measureContext: measurementCanvas.getContext('2d') as CanvasRenderingContext2D,
     });
     const defaultCurrentDateMs = normalizeCurrentDate(options.currentDate);

--- a/packages/node/src/pptx.ts
+++ b/packages/node/src/pptx.ts
@@ -1,3 +1,4 @@
+import { resolveCjkFallback, type CjkFallback, type CjkLang } from '@silurus/ooxml-core';
 import {
   dropDecodedBitmapCache,
   dropSvgImageCache,
@@ -37,7 +38,7 @@ const getPptxWasmModule = createLazyWasmModule(() => resolveWasm(
   ));
 
 /** Options for the bounded Node presentation session. */
-export type OpenPptxPresentationOptions = OoxmlNodeSessionOptions;
+export type OpenPptxPresentationOptions = OoxmlNodeSessionOptions & { cjkFallback?: CjkFallback };
 
 export interface PptxSessionRenderOptions {
   readonly width?: number;
@@ -85,6 +86,7 @@ async function openPptxPresentationImpl(
   buffer: ArrayBuffer | Uint8Array,
   options: OpenPptxPresentationOptions = {},
 ): Promise<PptxPresentationSessionImpl> {
+  const cjkFallback = resolveCjkFallback(options.cjkFallback);
   const acquired = await acquirePptxNodeSession(toUint8(buffer), getPptxWasmModule(), options);
   return new PptxPresentationSessionImpl(
     acquired.closeArchive,
@@ -92,6 +94,7 @@ async function openPptxPresentationImpl(
     acquired.bootstrap,
     acquired.metrics,
     options.signal,
+    cjkFallback,
   );
 }
 
@@ -125,6 +128,7 @@ class PptxPresentationSessionImpl implements PptxPresentationSession {
     private readonly bootstrap: PresentationBootstrap,
     private readonly metrics: OoxmlResourceMetricsSession,
     private readonly signal?: AbortSignal,
+    private readonly cjkFallback?: CjkLang,
   ) {
     this.slideCount = bootstrap.slideCount;
     this.slideWidth = bootstrap.slideWidth;
@@ -202,6 +206,7 @@ class PptxPresentationSessionImpl implements PptxPresentationSession {
       };
       await renderSlideNode(canvas, presentation, 0, {
         ...options,
+        cjkFallback: this.cjkFallback,
         fetchImage: this.fetchImage,
         fetchMedia: this.fetchMedia,
       });

--- a/packages/node/src/render.ts
+++ b/packages/node/src/render.ts
@@ -1,3 +1,4 @@
+import { resolveCjkFallback, type CjkFallback } from '@silurus/ooxml-core';
 /**
  * Server-side rendering helpers. These adapt the browser-bound canvas
  * renderers in `@silurus/ooxml-{pptx,docx,xlsx}` to a user-supplied
@@ -235,6 +236,7 @@ export async function renderSlideNode(
   opts: {
     width?: number;
     dpr?: number;
+    cjkFallback?: CjkFallback;
     factory?: NodeCanvasFactory;
     /**
      * Lazily resolve an embedded image (by zip path + MIME) to a Blob. Pictures
@@ -247,6 +249,7 @@ export async function renderSlideNode(
     fetchMedia?: (path: string) => Promise<Blob>;
   } = {},
 ): Promise<void> {
+  const cjkFallback = resolveCjkFallback(opts.cjkFallback);
   // Direct import of the pure renderer module — avoids `presentation.ts`
   // and `viewer.ts`, both of which pull Vite-specific worker / asset
   // imports that don't resolve under Node.
@@ -276,6 +279,7 @@ export async function renderSlideNode(
       {
         width,
         dpr,
+        cjkFallback,
         defaultTextColor: presentation.defaultTextColor,
         majorFont: presentation.majorFont,
         minorFont: presentation.minorFont,

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -884,6 +884,8 @@ export interface ChartTrendline {
     lineHidden?: boolean | null;
 }
 export type ChartType = 'line' | 'stackedLine' | 'stackedLinePct' | 'clusteredBar' | 'clusteredBarH' | 'stackedBar' | 'stackedBarH' | 'stackedBarPct' | 'stackedBarHPct' | 'area' | 'stackedArea' | 'stackedAreaPct' | 'pie' | 'doughnut' | 'scatter' | 'bubble' | 'radar' | 'waterfall' | 'stock' | 'surface' | 'surface3D' | 'boxWhisker' | 'sunburst' | 'treemap' | string;
+export type CjkFallback = 'auto' | CjkLang;
+type CjkLang = 'kr' | 'sc' | 'tc' | 'hk' | 'jp';
 export type DecodedImageBudgetStrategy = 'adaptive' | 'strict';
 export interface DimOptions {
     color: string;
@@ -1002,6 +1004,7 @@ export type LoadOptions = LoadOptions__emitterCollision1 & {
 };
 interface LoadOptions__emitterCollision1 {
     useGoogleFonts?: boolean;
+    cjkFallback?: CjkFallback;
     googleFontsCssOrigin?: string;
     password?: string;
     wasmUrl?: string | URL;

--- a/packages/pptx/src/font-stack.test.ts
+++ b/packages/pptx/src/font-stack.test.ts
@@ -232,3 +232,27 @@ describe('buildFont — style encoded in a face name', () => {
     expect(font).toMatch(/^bold 48px "Franklin Gothic Medium"/);
   });
 });
+
+
+it('uses per-presentation fallback for neutral fonts while preserving named regions', () => {
+  const sc = cssFontStack('Calibri', 'Calibri', 'sc');
+  expect(sc.indexOf('"Carlito"')).toBeLessThan(sc.indexOf('"Noto Sans SC"'));
+  expect(sc.indexOf('"Noto Sans SC"')).toBeLessThan(sc.indexOf('"Noto Sans JP"'));
+  const tc = cssFontStack('Calibri', 'Calibri', 'tc');
+  expect(tc.indexOf('"Noto Sans TC"')).toBeLessThan(tc.indexOf('"Noto Sans SC"'));
+  const jp = cssFontStack('Meiryo', 'Meiryo', 'sc');
+  expect(jp.indexOf('"Noto Sans JP"')).toBeLessThan(jp.indexOf('"Noto Sans SC"'));
+  expect(buildFont(false, false, 12, 'Arial', {
+    themeMajorFont: 'Meiryo', themeMinorFont: 'Calibri', dpr: 1,
+  }, '漢')).toContain('"Noto Sans JP", "Noto Sans SC"');
+  expect(buildFont(false, false, 12, 'Arial', {
+    themeMajorFont: 'Meiryo', themeMinorFont: 'Calibri', dpr: 1,
+  }, '→')).not.toContain('Noto Sans JP');
+});
+
+
+it('keeps Arabic substitutes ahead of the configured CJK fallback', () => {
+  const stack = cssFontStack('Amiri', 'Amiri', 'sc');
+  expect(stack.indexOf('Noto Naskh Arabic')).toBeLessThan(stack.indexOf('Noto Sans SC'));
+  expect(stack).toContain('"Noto Sans SC", "Noto Sans TC"');
+});

--- a/packages/pptx/src/google-fonts.test.ts
+++ b/packages/pptx/src/google-fonts.test.ts
@@ -4,6 +4,7 @@ import {
   PPTX_GOOGLE_FONTS,
   PptxFontPreloadAccumulator,
   pptxFontPreloadNames,
+  pptxSlideCjkFallback,
 } from './google-fonts';
 import type { Presentation, Slide } from './types';
 
@@ -134,4 +135,24 @@ describe('PptxFontPreloadAccumulator', () => {
       'Noto Sans Hebrew', 'Noto Serif Hebrew',
     ]);
   });
+});
+
+
+it('keeps the union of stable per-slide preferences during progressive preflight', () => {
+  const slideWith = (text: string) => ({ elements: [{ type: 'shape', textBody: {
+    paragraphs: [{ runs: [{ type: 'text', text }] }],
+  } }] } as Slide);
+  const han = slideWith('漢字');
+  const kana = slideWith('漢字かな');
+  const korean = slideWith('漢字한글');
+  const fonts = new PptxFontPreloadAccumulator('Calibri', 'Calibri', undefined, undefined, 'sc');
+  fonts.addSlide(han);
+  expect(fonts.names()).toContain('Noto Sans SC');
+  const next = fonts.withSlide(kana);
+  expect(next.names()).toContain('Noto Sans SC');
+  expect(next.names()).toContain('Noto Sans JP');
+  expect(fonts.names()).not.toContain('Noto Sans JP');
+  expect(pptxSlideCjkFallback(han, 'Calibri', 'Calibri', 'sc')).toBe('sc');
+  expect(pptxSlideCjkFallback(kana, 'Calibri', 'Calibri', 'sc')).toBe('jp');
+  expect(pptxSlideCjkFallback(korean, 'Calibri', 'Calibri', 'sc')).toBe('kr');
 });

--- a/packages/pptx/src/google-fonts.ts
+++ b/packages/pptx/src/google-fonts.ts
@@ -1,5 +1,8 @@
+import type { CjkLang } from '@silurus/ooxml-core';
 import {
   classifyCjkFont,
+  cjkFallbackForText,
+  scriptPreloadNamesForText,
   GOOGLE_FONT_SUBSTITUTES,
   SCRIPT_GOOGLE_FONTS,
   type FontPreloadEntry,
@@ -76,8 +79,10 @@ export class PptxFontPreloadAccumulator {
     private readonly minorFont: string | null,
     scripts?: ScriptPreloadAccumulator,
     families?: Set<string>,
+    private readonly fallback?: CjkLang,
+    private readonly scriptNames = new Set<string>(),
   ) {
-    const cjkLang = classifyCjkFont(majorFont) ?? classifyCjkFont(minorFont) ?? null;
+    const cjkLang = classifyCjkFont(majorFont) ?? classifyCjkFont(minorFont) ?? fallback ?? null;
     this.scripts = scripts ?? new ScriptPreloadAccumulator(cjkLang);
     this.families = families ?? new Set();
     if (majorFont) this.families.add(majorFont);
@@ -86,6 +91,12 @@ export class PptxFontPreloadAccumulator {
 
   addSlide(slide: Slide): void {
     this.scripts.addText(pptxSlideTextRuns(slide));
+    // Keep the union of per-slide choices: later kana must not remove a Han-only
+    // slide's SC preload after that slide has already been published.
+    for (const name of scriptPreloadNamesForText(pptxSlideTextRuns(slide),
+      classifyCjkFont(this.majorFont) ?? classifyCjkFont(this.minorFont) ?? this.fallback ?? null)) {
+      this.scriptNames.add(name);
+    }
     for (const el of slide.elements as SlideElement[]) {
       if (el.type === 'shape') {
         for (const family of textBodyFontFamilies(el.textBody)) this.families.add(family);
@@ -100,7 +111,7 @@ export class PptxFontPreloadAccumulator {
   }
 
   names(): (string | null)[] {
-    return [...this.families, ...this.scripts.names()];
+    return [...new Set([...this.families, ...this.scripts.names(), ...this.scriptNames])];
   }
 
   withSlide(slide: Slide): PptxFontPreloadAccumulator {
@@ -109,6 +120,8 @@ export class PptxFontPreloadAccumulator {
       this.minorFont,
       this.scripts.clone(),
       new Set(this.families),
+      this.fallback,
+      new Set(this.scriptNames),
     );
     candidate.addSlide(slide);
     return candidate;
@@ -130,11 +143,19 @@ export class PptxFontPreloadAccumulator {
  */
 export function pptxFontPreloadNames(
   pres: Presentation,
+  fallback?: CjkLang,
 ): (string | null | undefined)[] {
   const accumulator = new PptxFontPreloadAccumulator(
     pres.majorFont,
     pres.minorFont,
+    undefined, undefined, fallback,
   );
   for (const slide of pres.slides) accumulator.addSlide(slide);
   return accumulator.names();
+}
+
+
+export function pptxSlideCjkFallback(slide: Slide, major: string | null, minor: string | null, fallback: CjkLang): CjkLang {
+  return cjkFallbackForText(pptxSlideTextRuns(slide),
+    classifyCjkFont(major) ?? classifyCjkFont(minor) ?? fallback);
 }

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -155,6 +155,7 @@ export {
   type OoxmlResourceLimit,
   type OoxmlResourceLimitErrorDetails,
   type OoxmlResourceLimits,
+  type CjkFallback,
   type OoxmlResourceMetric,
   type OoxmlResourceMetrics,
   type OoxmlResourceMetricsCheckpoint,

--- a/packages/pptx/src/presentation-preflight.test.ts
+++ b/packages/pptx/src/presentation-preflight.test.ts
@@ -252,7 +252,9 @@ describe('PresentationPreflightBuilder', () => {
     }));
     expect(facts.fontPreloadNames).toContain('Noto Sans KR');
     expect(facts.fontPreloadNames).toContain('Noto Sans JP');
-    expect(facts.fontPreloadNames).not.toContain('Noto Sans SC');
+    // The Han-only slide retains its theme-derived SC route even when later
+    // slides introduce stronger Hangul/Kana hints.
+    expect(facts.fontPreloadNames).toContain('Noto Sans SC');
   });
 
   it('rejects identity drift, extra units, and incomplete finalization', () => {

--- a/packages/pptx/src/presentation-preflight.ts
+++ b/packages/pptx/src/presentation-preflight.ts
@@ -491,6 +491,7 @@ interface PendingAcceptance {
 
 /** @internal Test-only lowering; production cannot raise or replace the hard ceiling. */
 export interface PresentationPreflightBuilderOptions {
+  readonly cjkFallback?: import('@silurus/ooxml-core').CjkLang;
   readonly hardLimitForTesting?: number;
 }
 
@@ -545,6 +546,7 @@ export class PresentationPreflightBuilder {
     this.fonts = new PptxFontPreloadAccumulator(
       this.majorFontValue,
       this.minorFontValue,
+      undefined, undefined, options.cjkFallback,
     );
     this.fontPreloadNames = Object.freeze(this.fonts.names());
     this.fontProjectionBytes = measureStructuralJson(

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -1,3 +1,4 @@
+import { resolveCjkFallback, type CjkLang } from '@silurus/ooxml-core';
 import type { DimOptions, PptxComment } from './types';
 import {
   renderSlideWithEmbeddedFonts,
@@ -224,6 +225,7 @@ export interface PresentSlideOptions extends Omit<RenderSlideOptions, 'skipMedia
  * await pres.renderSlide(canvas, 0, { width: 960 });
  */
 export class PptxPresentation {
+  private _cjkFallback: CjkLang = 'jp';
   private _metrics: OoxmlResourceMetricsSession | null = null;
   private readonly _worker: Worker;
   private readonly _bridge: WorkerBridge<
@@ -332,6 +334,7 @@ export class PptxPresentation {
     source: string | ArrayBuffer,
     opts: LoadOptions = {},
   ): Promise<PptxPresentation> {
+    const cjkFallback = resolveCjkFallback(opts.cjkFallback);
     const resourceOptions = normalizeLoadResourceOptions(opts);
     const googleFontsCssOrigin = opts.useGoogleFonts
       ? normalizeGoogleFontsCssOrigin(opts.googleFontsCssOrigin)
@@ -386,6 +389,7 @@ export class PptxPresentation {
           "[ooxml] a custom 3-D chart renderer cannot cross the worker boundary; charts use their 2-D family fallback in mode: 'worker'. Use the renderer from @silurus/ooxml/three-d.",
         );
       }
+      pres._cjkFallback = cjkFallback;
       pres._math = mode === 'worker' ? undefined : opts.math;
       pres._threeD = mode === 'worker' ? undefined : opts.threeD;
       if (opts.regionMap && mode === 'worker' && !rendererDescriptors?.regionMap) {
@@ -478,7 +482,7 @@ export class PptxPresentation {
     const response = await this._bridge.request(
       (id) =>
         this._mode === 'worker'
-          ? ({ kind: 'parse', id, buffer, resourcePolicy, useGoogleFonts, googleFontsCssOrigin, renderers } satisfies RenderWorkerRequest)
+          ? ({ kind: 'parse', id, buffer, resourcePolicy, useGoogleFonts, googleFontsCssOrigin, cjkFallback: this._cjkFallback, renderers } satisfies RenderWorkerRequest)
           : ({ kind: 'parse', id, buffer, resourcePolicy } satisfies PptxWorkerRequest),
       [buffer],
       { timeoutMs },
@@ -606,7 +610,7 @@ export class PptxPresentation {
         return slide;
       },
     });
-    const builder = new PresentationPreflightBuilder(bootstrap);
+    const builder = new PresentationPreflightBuilder(bootstrap, { cjkFallback: this._cjkFallback });
     const loadedGoogleFonts = new Set<string>();
     const ensureFonts = async (): Promise<void> => {
       await embeddedFontLoad;
@@ -663,7 +667,7 @@ export class PptxPresentation {
       (id) => {
         this._parseRequestId = id;
         return {
-          kind: 'parse', id, buffer, resourcePolicy, useGoogleFonts, googleFontsCssOrigin, renderers,
+          kind: 'parse', id, buffer, resourcePolicy, useGoogleFonts, googleFontsCssOrigin, cjkFallback: this._cjkFallback, renderers,
           progressiveLayout: true,
         } satisfies RenderWorkerRequest;
       },
@@ -1065,6 +1069,7 @@ export class PptxPresentation {
             width,
             dpr,
             defaultTextColor: compact.defaultTextColor,
+            cjkFallback: this._cjkFallback,
             majorFont: compact.majorFont,
             minorFont: compact.minorFont,
             hlinkColor: compact.hlinkColor,

--- a/packages/pptx/src/render-worker.ts
+++ b/packages/pptx/src/render-worker.ts
@@ -1,3 +1,4 @@
+import type { CjkLang } from '@silurus/ooxml-core';
 import init, { PptxArchive, reinit } from './wasm/pptx_parser.js';
 import type { PptxTextRunInfo } from './renderer';
 import { PPTX_GOOGLE_FONTS } from './google-fonts';
@@ -60,6 +61,7 @@ const slidePull = new SlidePullWorker(
 );
 
 let preflight: PresentationPreflight | null = null;
+let cjkFallback: CjkLang | undefined;
 let preflightBuilder: PresentationPreflightBuilder | null = null;
 let slides: PptxSlideRepository | null = null;
 let availableSlideCount = 0;
@@ -179,7 +181,8 @@ async function openPresentation(request: Extract<RenderWorkerRequest, { kind: 'p
   // decoding can overlap the sequential slide preflight without sharing cursor
   // ownership. First paint still waits for `fontsLoaded` below.
   const embeddedFontsLoaded = loadEmbeddedFonts(bootstrap.embeddedFonts, getFontBytes);
-  preflightBuilder = new PresentationPreflightBuilder(bootstrap);
+  cjkFallback = request.cjkFallback;
+  preflightBuilder = new PresentationPreflightBuilder(bootstrap, { cjkFallback });
   slides = new PptxSlideRepository({
     slideCount: bootstrap.slideCount,
     maxCachedSlides: HARD_MAX_PPTX_CACHED_SLIDES,
@@ -342,6 +345,7 @@ self.onmessage = async (event: MessageEvent<RenderWorkerRequest | WorkerSvgDecod
           dpr: request.dpr,
           imageResources: request.imageResources,
           defaultTextColor: compact.defaultTextColor,
+          cjkFallback,
           majorFont: compact.majorFont,
           minorFont: compact.minorFont,
           hlinkColor: compact.hlinkColor,
@@ -374,6 +378,7 @@ self.onmessage = async (event: MessageEvent<RenderWorkerRequest | WorkerSvgDecod
         await renderSlideWithEmbeddedFonts(canvas, slide, compact.slideWidth, compact.slideHeight, {
           width: request.width,
           defaultTextColor: compact.defaultTextColor,
+          cjkFallback,
           majorFont: compact.majorFont,
           minorFont: compact.minorFont,
           hlinkColor: compact.hlinkColor,

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1,3 +1,5 @@
+import { pptxSlideCjkFallback } from './google-fonts.js';
+import type { CjkLang } from '@silurus/ooxml-core';
 import type {
   Slide,
   SlideElement,
@@ -151,6 +153,7 @@ import { drawEaVertRun } from './vertical-text.js';
 
 /** Theme font context threaded through the render call chain. */
 export interface RenderContext {
+  cjkFallback?: CjkLang;
   themeMajorFont: string | null;
   themeMinorFont: string | null;
   /** Lower-cased authored family → this presentation's isolated FontFace alias. */
@@ -818,7 +821,7 @@ function quoteAll(names: readonly string[]): string {
  *
  * Exported for unit testing the fallback ordering.
  */
-export function cssFontStack(normalized: string, authoredFamily = normalized): string {
+export function cssFontStack(normalized: string, authoredFamily = normalized, fallback?: CjkLang): string {
   const generic = genericFallback(authoredFamily);
   const sub = OFFICE_FONT_SUBSTITUTE[authoredFamily.toLowerCase()];
   const subPart = sub ? `"${sub}", ` : '';
@@ -827,17 +830,21 @@ export function cssFontStack(normalized: string, authoredFamily = normalized): s
   // Arabic faces keep the historical chain unchanged (Arabic leads; appending a
   // CJK or non-CJK tail would let Latin/digits leak away from the Arabic face).
   if (isArabicScriptFace(authoredFamily)) {
-    return `"${normalized}", ${subPart}${ARABIC_FALLBACKS}, ${generic}`;
+    const cjk = fallback ? cjkFallbackChain(fallback, 'sans') : [];
+    return `"${normalized}", ${subPart}${ARABIC_FALLBACKS}, ${cjk.length ? `${quoteAll(cjk)}, ` : ''}${generic}`;
   }
   const variant: 'sans' | 'serif' = generic === 'serif' ? 'serif' : 'sans';
-  const cjk = classifyCjkFont(authoredFamily);
+  const authoredCjk = classifyCjkFont(authoredFamily);
+  const cjk = authoredCjk ?? fallback;
   const cjkFamilies = cjk
     ? cjkFallbackChain(cjk, variant).filter((name) => name !== googleAlias)
     : [];
   const cjkPart = cjkFamilies.length > 0 ? `${quoteAll(cjkFamilies)}, ` : '';
   const nonCjk = variant === 'serif' ? NON_CJK_SERIF_FALLBACKS : NON_CJK_SANS_FALLBACKS;
   const nonCjkPart = `${quoteAll(nonCjk)}, `;
-  return `"${normalized}", ${subPart}${aliasPart}${cjkPart}${nonCjkPart}${generic}`;
+  return authoredCjk
+    ? `"${normalized}", ${subPart}${aliasPart}${cjkPart}${nonCjkPart}${generic}`
+    : `"${normalized}", ${subPart}${aliasPart}${nonCjkPart}${cjkPart}${generic}`;
 }
 
 /**
@@ -992,16 +999,30 @@ function applyTextRunReflection(
   liveCtx.restore();
 }
 
-export function buildFont(bold: boolean, italic: boolean, sizePx: number, family: string, rc: RenderContext): string {
+export function buildFont(
+  bold: boolean,
+  italic: boolean,
+  sizePx: number,
+  family: string,
+  rc: RenderContext,
+  text = '',
+): string {
   const style  = italic ? 'italic ' : '';
   const normalized = normalizeFontFamily(family, rc);
   const authoredFamily = rc.embeddedFontAuthoredFamilies?.get(normalized) ?? normalized;
   const inferredWeight = namedFaceWeight(authoredFamily);
   const weight = bold ? 'bold ' : inferredWeight ? `${inferredWeight} ` : '';
+  const fallback = /\p{Script=Han}/u.test(text)
+    ? rc.cjkFallback ?? classifyCjkFont(rc.themeMajorFont) ?? classifyCjkFont(rc.themeMinorFont) ?? undefined
+    : undefined;
   if (CSS_GENERIC_FAMILIES.has(normalized)) {
-    return `${style}${weight}${sizePx}px ${normalized}`;
+    const families = fallback ? cjkFallbackChain(fallback, normalized === 'serif' ? 'serif' : 'sans') : [];
+    const latin = normalized === 'monospace' ? ['Courier New', 'Liberation Mono']
+      : normalized === 'serif' ? [...NON_CJK_SERIF_FALLBACKS, 'Times New Roman', 'Liberation Serif']
+      : [...NON_CJK_SANS_FALLBACKS, 'Arial', 'Helvetica', 'Liberation Sans'];
+    return `${style}${weight}${sizePx}px ${families.length ? `${quoteAll([...latin, ...families])}, ` : ''}${normalized}`;
   }
-  return `${style}${weight}${sizePx}px ${cssFontStack(normalized, authoredFamily)}`;
+  return `${style}${weight}${sizePx}px ${cssFontStack(normalized, authoredFamily, fallback)}`;
 }
 
 /**
@@ -1183,7 +1204,14 @@ export function naturalWidthExceedsBbox(
       const family = normalizeFontFamily(run.fontFamily ?? para.defFontFamily ?? null, rc);
       const isBold = run.bold ?? para.defBold ?? body.defaultBold ?? false;
       const isItalic = run.italic ?? para.defItalic ?? body.defaultItalic ?? false;
-      ctx.font = buildFont(isBold, isItalic, baselineDrawSizePx(sizePx, run.baseline ?? undefined), family, rc);
+      ctx.font = buildFont(
+        isBold,
+        isItalic,
+        baselineDrawSizePx(sizePx, run.baseline ?? undefined),
+        family,
+        rc,
+        run.text,
+      );
       const letterSpacingPx = (run.letterSpacing ?? 0) * PT_TO_EMU * scale;
       lineW += measureTextAdvance(ctx, run.text, letterSpacingPx);
       if (lineW > textMaxW) return true;
@@ -1637,9 +1665,9 @@ export function layoutParagraph(
     // Cascade: run → paragraph defRPr → body/layout default → false
     const isBold   = run.bold   ?? para.defBold   ?? defaultBold;
     const isItalic = run.italic ?? para.defItalic ?? defaultItalic;
-    const font   = buildFont(isBold, isItalic, drawSizePx, family, rc);
+    const font   = buildFont(isBold, isItalic, drawSizePx, family, rc, run.text);
     const fontEa = familyEa
-      ? buildFont(isBold, isItalic, drawSizePx, familyEa, rc)
+      ? buildFont(isBold, isItalic, drawSizePx, familyEa, rc, run.text)
       : font;
     ctx.font = font;
 
@@ -1759,9 +1787,9 @@ export function layoutParagraph(
             const mapped = symbolFontToUnicode(ch, symName);
             if (mapped !== ch) {
               drawCh = mapped;
-              chFont = buildFont(isBold, isItalic, drawSizePx, 'sans-serif', rc);
+              chFont = buildFont(isBold, isItalic, drawSizePx, 'sans-serif', rc, drawCh);
             } else {
-              chFont = buildFont(isBold, isItalic, drawSizePx, symName, rc);
+              chFont = buildFont(isBold, isItalic, drawSizePx, symName, rc, drawCh);
             }
           }
           ctx.font = chFont;
@@ -4428,7 +4456,7 @@ export function renderTextBody(
       // If the char was mapped to a Unicode symbol, use sans-serif for reliable rendering.
       // Otherwise use the specified font (e.g. Wingdings on systems that have it).
       const convertedFamily = bulletLabel !== b.char ? 'sans-serif' : normalizeFontFamily(b.fontFamily ?? null, rc);
-      bulletFont  = buildFont(false, false, bSizePx, convertedFamily, rc);
+      bulletFont  = buildFont(false, false, bSizePx, convertedFamily, rc, bulletLabel);
       bulletColor = b.color ? hexToRgba(b.color) : bulletInheritedColor;
     } else if (bullet.type === 'autoNum') {
       const b = bullet;
@@ -4443,6 +4471,7 @@ export function renderTextBody(
         bSizePx,
         normalizeFontFamily(b.fontFamily ?? firstRunFontFamily, rc),
         rc,
+        bulletLabel,
       );
       // ECMA-376 §21.1.2.4.4 (buClr): an explicit `<a:buClr>` colours the
       // auto-number marker, mirroring the char-bullet branch above. Only when it
@@ -7020,6 +7049,7 @@ export type SlideRenderOptions = RenderOptions & {
  * render options. They are an implementation detail of embedded-font lifetime
  * isolation, not a caller-configurable rendering policy. */
 type InternalSlideRenderOptions = SlideRenderOptions & {
+  cjkFallback?: CjkLang;
   embeddedFontAliases?: ReadonlyMap<string, string>;
   embeddedFontAuthoredFamilies?: ReadonlyMap<string, string>;
   svgDecoder?: SvgBlobDecoder;
@@ -7252,6 +7282,7 @@ async function renderSlideLeased(
 
   const pictureBulletImages = new Map<string, SvgImageSource | null>();
   const rc: RenderContext = {
+    cjkFallback: opts.cjkFallback ? pptxSlideCjkFallback(slide, opts.majorFont ?? null, opts.minorFont ?? null, opts.cjkFallback) : undefined,
     themeMajorFont: opts.majorFont ?? null,
     themeMinorFont: opts.minorFont ?? null,
     themeHlinkColor: opts.hlinkColor ?? null,

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -603,6 +603,7 @@ export class PptxScrollViewer implements ZoomableViewer {
         password: this._opts.password,
         useGoogleFonts: this._opts.useGoogleFonts,
         googleFontsCssOrigin: this._opts.googleFontsCssOrigin,
+        cjkFallback: this._opts.cjkFallback,
         maxZipEntryBytes: this._opts.maxZipEntryBytes,
         resourceLimits: this._opts.resourceLimits,
         debug: this._opts.debug,

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -330,6 +330,7 @@ export class PptxViewer implements ZoomableViewer {
         password: this.opts.password,
         useGoogleFonts: this.opts.useGoogleFonts,
         googleFontsCssOrigin: this.opts.googleFontsCssOrigin,
+        cjkFallback: this.opts.cjkFallback,
         maxZipEntryBytes: this.opts.maxZipEntryBytes,
         resourceLimits: this.opts.resourceLimits,
         debug: this.opts.debug,

--- a/packages/pptx/src/worker-protocol.ts
+++ b/packages/pptx/src/worker-protocol.ts
@@ -89,6 +89,7 @@ export type RenderWorkerRequest =
       resourcePolicy: NormalizedOoxmlResourcePolicy;
       useGoogleFonts?: boolean;
       googleFontsCssOrigin?: string;
+      cjkFallback?: import('@silurus/ooxml-core').CjkLang;
       renderers?: WorkerRendererDescriptors;
       progressiveLayout?: boolean;
     }

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -983,6 +983,8 @@ export interface ChartTrendline {
     lineHidden?: boolean | null;
 }
 export type ChartType = 'line' | 'stackedLine' | 'stackedLinePct' | 'clusteredBar' | 'clusteredBarH' | 'stackedBar' | 'stackedBarH' | 'stackedBarPct' | 'stackedBarHPct' | 'area' | 'stackedArea' | 'stackedAreaPct' | 'pie' | 'doughnut' | 'scatter' | 'bubble' | 'radar' | 'waterfall' | 'stock' | 'surface' | 'surface3D' | 'boxWhisker' | 'sunburst' | 'treemap' | string;
+export type CjkFallback = 'auto' | CjkLang;
+type CjkLang = 'kr' | 'sc' | 'tc' | 'hk' | 'jp';
 export interface ConditionalFormat {
     sqref: WorksheetCellRange[];
     rules: CfRule[];
@@ -1147,6 +1149,7 @@ export interface LoadOptions extends LoadOptions__emitterCollision1 {
 }
 interface LoadOptions__emitterCollision1 {
     useGoogleFonts?: boolean;
+    cjkFallback?: CjkFallback;
     googleFontsCssOrigin?: string;
     password?: string;
     wasmUrl?: string | URL;

--- a/packages/xlsx/src/delimited-text-protocol.ts
+++ b/packages/xlsx/src/delimited-text-protocol.ts
@@ -9,6 +9,7 @@ export type DelimitedTextParseRequest = {
   readonly options: ResolvedDelimitedTextOptions;
   readonly useGoogleFonts?: boolean;
   readonly googleFontsCssOrigin?: string;
+  readonly cjkFallback?: import('@silurus/ooxml-core').CjkLang;
   readonly renderers?: WorkerRendererDescriptors;
 };
 

--- a/packages/xlsx/src/font-stack.test.ts
+++ b/packages/xlsx/src/font-stack.test.ts
@@ -119,3 +119,17 @@ describe('cssTailFor / fontStackFor — Latin serif & mono (bug fix)', () => {
     expect(cssTailFor('Microsoft YaHei').endsWith('sans-serif')).toBe(true);
   });
 });
+
+
+it('uses per-workbook fallback only for Han while preserving authored regions', () => {
+  for (const family of [null, 'Calibri', 'Arial']) {
+    const sc = fontStackFor(family, 'sc', '漢');
+    expect(sc.indexOf('"Carlito"')).toBeLessThan(sc.indexOf('"Noto Sans SC"'));
+    expect(sc.indexOf('"Noto Sans SC"')).toBeLessThan(sc.indexOf('"Noto Sans JP"'));
+    const tc = fontStackFor(family, 'tc', '漢');
+    expect(tc.indexOf('"Noto Sans TC"')).toBeLessThan(tc.indexOf('"Noto Sans SC"'));
+    expect(fontStackFor(family, 'sc', '→')).not.toContain('Noto Sans SC');
+  }
+  const jp = fontStackFor('Meiryo', 'sc', '→');
+  expect(jp.indexOf('"Noto Sans JP"')).toBeLessThan(jp.indexOf('"Noto Sans SC"'));
+});

--- a/packages/xlsx/src/google-fonts.test.ts
+++ b/packages/xlsx/src/google-fonts.test.ts
@@ -1,3 +1,5 @@
+import { xlsxFontPreloadNames, xlsxCjkFallback } from './google-fonts.js';
+import type { ParsedWorkbook } from './types.js';
 import { describe, expect, it } from 'vitest';
 import type { FontPreloadEntry } from '@silurus/ooxml-core';
 import { XLSX_GOOGLE_FONTS } from './google-fonts.js';
@@ -69,4 +71,25 @@ describe('XLSX_GOOGLE_FONTS — shared registry consolidation (oracle)', () => {
       loadFamily: 'Libre Franklin',
     });
   });
+});
+
+
+it('matches workbook preload and render preferences without fetching fonts for Latin-only text', () => {
+  const wb = { styles: { fonts: [{ name: 'Calibri' }] }, sharedStrings: [{ text: '漢字' }] } as ParsedWorkbook;
+  expect(xlsxCjkFallback(wb, 'sc')).toBe('sc');
+  expect(xlsxFontPreloadNames(wb, 'sc')).toContain('Noto Sans SC');
+  expect(xlsxFontPreloadNames(wb, 'sc')).not.toContain('Noto Sans JP');
+  wb.styles.fonts[0].name = 'Meiryo';
+  expect(xlsxCjkFallback(wb, 'sc')).toBe('jp');
+  expect(xlsxFontPreloadNames(wb, 'sc')).toContain('Noto Sans JP');
+  wb.sharedStrings = [{ text: 'Hello' }];
+  expect([...xlsxFontPreloadNames(wb, 'sc')]).toEqual(['Meiryo']);
+});
+
+
+it('uses the same strong script evidence for workbook rendering and preload', () => {
+  const wb = { styles: { fonts: [{ name: 'Calibri' }] }, sharedStrings: [{ text: '漢字かな' }] } as ParsedWorkbook;
+  expect(xlsxCjkFallback(wb, 'sc')).toBe('jp');
+  expect(xlsxFontPreloadNames(wb, 'sc')).toContain('Noto Sans JP');
+  expect(xlsxFontPreloadNames(wb, 'sc')).not.toContain('Noto Sans SC');
 });

--- a/packages/xlsx/src/google-fonts.ts
+++ b/packages/xlsx/src/google-fonts.ts
@@ -1,5 +1,6 @@
 import {
   classifyCjkFont,
+  cjkFallbackForText,
   scriptPreloadNamesForText,
   GOOGLE_FONT_SUBSTITUTES,
   SCRIPT_GOOGLE_FONTS,
@@ -55,7 +56,7 @@ function* xlsxTextRuns(wb: ParsedWorkbook | undefined): Generator<string> {
  * both modes preload an identical set — worker/main rendering must stay
  * pixel-equivalent.
  */
-export function xlsxFontPreloadNames(wb: ParsedWorkbook | undefined): Set<string> {
+export function xlsxFontPreloadNames(wb: ParsedWorkbook | undefined, fallback?: CjkLang): Set<string> {
   const names = new Set<string>();
   let cjkLang: CjkLang | null = null;
   for (const f of wb?.styles?.fonts ?? []) {
@@ -64,8 +65,17 @@ export function xlsxFontPreloadNames(wb: ParsedWorkbook | undefined): Set<string
       cjkLang ??= classifyCjkFont(f.name);
     }
   }
-  for (const n of scriptPreloadNamesForText(xlsxTextRuns(wb), cjkLang)) {
+  for (const n of scriptPreloadNamesForText(xlsxTextRuns(wb), cjkLang ?? fallback ?? null)) {
     names.add(n);
   }
   return names;
+}
+
+/** The same workbook hint is used for preloading and ambiguous cell fallback. */
+export function xlsxCjkFallback(wb: ParsedWorkbook | undefined, fallback: CjkLang): CjkLang {
+  for (const font of wb?.styles?.fonts ?? []) {
+    const region = classifyCjkFont(font.name);
+    if (region) return cjkFallbackForText(xlsxTextRuns(wb), region);
+  }
+  return cjkFallbackForText(xlsxTextRuns(wb), fallback);
 }

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -145,6 +145,7 @@ export {
   type OoxmlResourceLimit,
   type OoxmlResourceLimitErrorDetails,
   type OoxmlResourceLimits,
+  type CjkFallback,
   type OoxmlResourceMetric,
   type OoxmlResourceMetrics,
   type OoxmlResourceMetricsCheckpoint,

--- a/packages/xlsx/src/render-orchestrator.ts
+++ b/packages/xlsx/src/render-orchestrator.ts
@@ -1,3 +1,4 @@
+import type { CjkLang } from '@silurus/ooxml-core';
 import {
   defaultDpr,
   isHTMLCanvas,
@@ -732,6 +733,7 @@ export async function prefetchImages(
 }
 
 export interface RenderDeps {
+  cjkFallback?: CjkLang;
   ws: Worksheet;
   styles: ParsedWorkbook['styles'];
   math?: MathRenderer;
@@ -747,6 +749,7 @@ export function worksheetWithAutoRowHeights(
   ctx: CanvasRenderingContext2D,
   source: Worksheet,
   styles: ParsedWorkbook['styles'],
+  cjkFallback?: CjkLang,
 ): Worksheet {
   if (hasPreparedAutoRowHeights(source)) return source;
   const cached = autoHeightProjectionCache.get(source);
@@ -761,7 +764,7 @@ export function worksheetWithAutoRowHeights(
   // so worker/direct auto-fit wraps at the exact same column pixels.
   const mdw = getGridGeometryForWorksheet(source).maximumDigitWidth;
   GridGeometry.forWorksheet(projection, mdw);
-  applyAutoRowHeights(ctx, projection, styles);
+  applyAutoRowHeights(ctx, projection, styles, cjkFallback);
   // applyAutoRowHeights invalidates geometry after deriving row sizes; seed the
   // rebuilt row axis with the same authoritative MDW rather than remeasuring in
   // another Canvas realm.
@@ -817,7 +820,7 @@ async function renderWorksheetViewportLeased(
   if (!measurementCtx) throw new Error('XLSX render target does not provide a 2-D canvas context');
   const ws = deps.ws.isDialogSheet
     ? deps.ws
-    : worksheetWithAutoRowHeights(measurementCtx, deps.ws, styles);
+    : worksheetWithAutoRowHeights(measurementCtx, deps.ws, styles, deps.cjkFallback);
   const rawW = isHTMLCanvas(target) ? (target.clientWidth || 800) : target.width;
   const rawH = isHTMLCanvas(target) ? (target.clientHeight || 600) : target.height;
   const width = opts.width ?? rawW;
@@ -931,7 +934,7 @@ async function renderWorksheetViewportLeased(
     threeD: deps.threeD,
     regionMap: deps.regionMap,
     chartEx: deps.chartEx,
-  });
+  }, deps.cjkFallback);
 }
 
 /**

--- a/packages/xlsx/src/render-worker.ts
+++ b/packages/xlsx/src/render-worker.ts
@@ -1,3 +1,5 @@
+import type { CjkLang } from '@silurus/ooxml-core';
+import { xlsxCjkFallback } from './google-fonts.js';
 /**
  * Render-capable worker entry: parse → font preload → (lazy) per-sheet parse →
  * render, all worker-side; renders a sheet viewport into an OffscreenCanvas and
@@ -61,6 +63,7 @@ const host = new WasmParserHost<XlsxArchive>(init, {
   // wasm-bindgen singleton). `reinit` forces fresh linear memory after a trap.
   reinit,
 });
+let cjkFallback: CjkLang = 'jp';
 let workbook: ParsedWorkbook | null = null;
 let archiveBacked = false;
 let renderers: LoadedWorkerRenderers = {};
@@ -208,6 +211,7 @@ self.onmessage = async (e: MessageEvent<
       // next document from being served a stale bitmap for an identically-named
       // zip path. Symmetric with XlsxWorkbook.destroy() and the docx/pptx render
       // workers (issue #781).
+      cjkFallback = req.cjkFallback ?? 'jp';
       sheetCache.clear();
       viewProjectionCache.clear();
       sheetCacheUsage.clear();
@@ -222,13 +226,14 @@ self.onmessage = async (e: MessageEvent<
         const { parseDelimitedWorksheet } = await delimitedTextModule;
         const parsed = parseDelimitedWorksheet(req.data, req.options);
         workbook = parsed.workbook;
+        cjkFallback = xlsxCjkFallback(workbook, cjkFallback);
         const measured = measureWorksheet(parsed.worksheet);
         retainedSheetUsage = measured;
         sheetCache.set(0, parsed.worksheet);
         sheetCacheUsage.set(0, measured);
         fontsLoaded = req.useGoogleFonts
           ? preloadGoogleFonts(
-              xlsxFontPreloadNames(parsed.workbook),
+              xlsxFontPreloadNames(parsed.workbook, cjkFallback),
               XLSX_GOOGLE_FONTS,
               undefined,
               req.googleFontsCssOrigin,
@@ -265,13 +270,14 @@ self.onmessage = async (e: MessageEvent<
         () => host.run(() => host.archive!.resource_usage()),
       );
       workbook = bootstrap.workbook;
+      cjkFallback = xlsxCjkFallback(workbook, cjkFallback);
       if (req.useGoogleFonts) {
         // Mirror XlsxWorkbook._load exactly: queue Google Fonts substitutes for
         // every styled font name, plus the generic Arabic fallbacks. Fonts must
         // land before rendering (which measures text), so we keep the promise
         // and await it in the renderViewport handler.
         fontsLoaded = preloadGoogleFonts(
-          xlsxFontPreloadNames(workbook),
+          xlsxFontPreloadNames(workbook, cjkFallback),
           XLSX_GOOGLE_FONTS,
           undefined,
           req.googleFontsCssOrigin,
@@ -311,7 +317,7 @@ self.onmessage = async (e: MessageEvent<
       }
       const canvas = new OffscreenCanvas(1, 1); // orchestrator resizes it
       await renderWorksheetViewport(
-        workerRenderDeps(renderWorksheet, workbook.styles, renderers),
+        { ...workerRenderDeps(renderWorksheet, workbook.styles, renderers), cjkFallback },
         canvas,
         req.viewport,
         // Supply the in-worker byte loader so embedded images decode straight

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -1,3 +1,4 @@
+import type { CjkLang } from '@silurus/ooxml-core';
 import type {
   Worksheet, Styles, Cell, CellValue, CellFont, CellFill, Border, BorderEdge, CellXf,
   ViewportRange, RenderViewportOptions, XlsxTextRunInfo,
@@ -101,16 +102,20 @@ const DEFAULT_MONO_FONT_FAMILY = `"Courier New", "Liberation Mono", monospace`;
  * serif/mono face the host lacks degrades to the matching generic. Exported for
  * unit testing.
  */
-export function cssTailFor(name: string | null | undefined): string {
+export function cssTailFor(name: string | null | undefined, fallback?: CjkLang): string {
   const cjk = name ? classifyCjkFont(name) : null;
   const generic = classifyFontGeneric(name); // 'serif' | 'sans' | 'mono'
   if (!cjk) {
     // Non-CJK (Latin) cell font: choose the default chain by generic class so a
     // Latin serif/mono face the host lacks degrades to the matching generic
     // (Excel renders serif/mono, not the sans default).
-    if (generic === 'serif') return DEFAULT_SERIF_FONT_FAMILY;
-    if (generic === 'mono') return DEFAULT_MONO_FONT_FAMILY;
-    return DEFAULT_FONT_FAMILY;
+    const base = generic === 'serif' ? DEFAULT_SERIF_FONT_FAMILY
+      : generic === 'mono' ? DEFAULT_MONO_FONT_FAMILY : DEFAULT_FONT_FAMILY;
+    if (!fallback) return base;
+    const split = base.lastIndexOf(',');
+    const families = cjkFallbackChain(fallback, generic === 'serif' ? 'serif' : 'sans');
+    return families.length === 0 ? base
+      : `${base.slice(0, split)}, ${families.map(n => `"${n}"`).join(', ')}${base.slice(split)}`;
   }
   const serif = generic === 'serif';
   const googleAlias = googleCjkFontAlias(name);
@@ -129,10 +134,17 @@ export function cssTailFor(name: string | null | undefined): string {
   return `${cjkPrefix}"Calibri", "Carlito", "Cambria", "Caladea", Arial, "Noto Naskh Arabic", "Noto Sans Arabic", ${tail}, ${genericKeyword}`;
 }
 
-/** Full CSS font-family list for a cell font name (named face first). */
-export function fontStackFor(name: string | null | undefined): string {
+/** Full CSS font-family list for a cell font name (named face first). The
+ * consumer-selected region is relevant only to Han glyphs; authored CJK font
+ * names remain authoritative for every string. */
+export function fontStackFor(
+  name: string | null | undefined,
+  cjkFallback?: CjkLang,
+  text = '',
+): string {
   const normalized = name?.trim();
-  return normalized ? `"${normalized}", ${cssTailFor(normalized)}` : DEFAULT_FONT_FAMILY;
+  const fallback = /\p{Script=Han}/u.test(text) ? cjkFallback : undefined;
+  return normalized ? `"${normalized}", ${cssTailFor(normalized, fallback)}` : cssTailFor(null, fallback);
 }
 
 const DEFAULT_FONT_SIZE = 11;
@@ -616,11 +628,11 @@ function vMetricPx(sizePt: number, cs: number, factor = 1, family?: string): num
   return Math.max(base, Math.round(intendedSingleLinePx(family, sizePt * PT_TO_PX * cs)));
 }
 
-function buildFont(font: CellFont, cs = 1): string {
+function buildFont(font: CellFont, cs = 1, cjkFallback?: CjkLang, text = ''): string {
   const style = font.italic ? 'italic ' : '';
   const weight = font.bold ? 'bold ' : '';
   const sizePx = Math.max(1, Math.round(font.size * PT_TO_PX * cs));
-  return `${style}${weight}${sizePx}px ${fontStackFor(font.name)}`;
+  return `${style}${weight}${sizePx}px ${fontStackFor(font.name, cjkFallback, text)}`;
 }
 
 /**
@@ -651,6 +663,7 @@ export function drawPhoneticBand(
   cellTopY: number,
   cs: number,
   color: string,
+  cjkFallback?: CjkLang,
 ): void {
   if (runs.length === 0) return;
   // §18.4.3: fontId selects the reading font; out of bounds → font 0.
@@ -660,7 +673,7 @@ export function drawPhoneticBand(
   const alignment: PhoneticAlignment = pr?.alignment ?? 'left';
 
   ctx.save();
-  ctx.font = buildFont(phFont, cs);
+  ctx.font = buildFont(phFont, cs, cjkFallback, runs.map((run) => run.text).join(''));
   ctx.textBaseline = 'top';
   ctx.textAlign = 'left';
   ctx.fillStyle = color;
@@ -1030,6 +1043,7 @@ export function layoutRichTextLines(
   baseFont: CellFont,
   cs: number,
   maxWidth: number,
+  cjkFallback?: CjkLang,
 ): RichLine[] {
   const lines: RichLine[] = [];
   let cur: RichSeg[] = [];
@@ -1076,7 +1090,7 @@ export function layoutRichTextLines(
     lastTextFamily = font.name;
     // Measure at the *draw* font so a super/subscript token reserves its reduced
     // (~65%) glyph width; the segment keeps the run's full size for line height.
-    ctx.font = buildFont(vertAlignDrawFont(font), cs);
+    ctx.font = buildFont(vertAlignDrawFont(font), cs, cjkFallback, text);
     const w = ctx.measureText(text).width;
     if (cur.length > 0 && curW + w > maxWidth) {
       // Kinsoku at the wrap boundary (ECMA-376 §17.15.1.58–.60): retract
@@ -1117,16 +1131,17 @@ export function layoutRichTextLines(
       if (retract > 0) {
         const keepCps = lastCps.slice(0, lastCps.length - retract);
         const moveCps = lastCps.slice(lastCps.length - retract);
-        ctx.font = buildFont(vertAlignDrawFont(last.font), cs);
         if (keepCps.length === 0) {
           // The whole last segment moves down — drop it from the closing line.
           cur.pop();
         } else {
           const keepText = keepCps.join('');
+          ctx.font = buildFont(vertAlignDrawFont(last.font), cs, cjkFallback, keepText);
           last.text = keepText;
           last.width = ctx.measureText(keepText).width;
         }
         const moveText = moveCps.join('');
+        ctx.font = buildFont(vertAlignDrawFont(last.font), cs, cjkFallback, moveText);
         carry = { text: moveText, font: last.font, width: ctx.measureText(moveText).width };
       }
       flush();
@@ -1135,7 +1150,7 @@ export function layoutRichTextLines(
         curW += carry.width;
         if (carry.font.size > curMaxSize) { curMaxSize = carry.font.size; curMaxFamily = carry.font.name; }
       }
-      ctx.font = buildFont(vertAlignDrawFont(font), cs); // restore for the incoming token below
+      ctx.font = buildFont(vertAlignDrawFont(font), cs, cjkFallback, text); // restore for the incoming token below
     }
     cur.push({ text, font, width: w });
     curW += w;
@@ -1152,7 +1167,7 @@ export function layoutRichTextLines(
     // separate token in this path, so no mixed-CJK offsets are needed here).
     const seaBreaks = seaMixedBreakOffsets(text);
     if (seaBreaks.length === 0) { push(text, font); return; }
-    ctx.font = buildFont(vertAlignDrawFont(font), cs);
+    ctx.font = buildFont(vertAlignDrawFont(font), cs, cjkFallback, text);
     const measureSub = (sub: string): number => ctx.measureText(sub).width;
     // Grapheme-fill runs (Myanmar/Tibetan, #961) have dense per-cluster offsets:
     // O(log n) monotone binary-search fit. Dictionary runs keep the full scan.
@@ -1301,6 +1316,7 @@ export function drawResolvedRichLine(
   cs: number,
   dpr: number,
   opts: { fontColor?: string | null; needBidi?: boolean; baseRtl?: boolean },
+  cjkFallback?: CjkLang,
 ): void {
   ctx.textAlign = 'left';
   ctx.textBaseline = baseline;
@@ -1312,7 +1328,7 @@ export function drawResolvedRichLine(
     if (vis) { try { dctx.direction = vis.rtl[i] ? 'rtl' : 'ltr'; } catch { /* ignore */ } }
     const seg = segs[i];
     const drawFont = vertAlignDrawFont(seg.font);
-    ctx.font = buildFont(drawFont, cs);
+    ctx.font = buildFont(drawFont, cs, cjkFallback, seg.text);
     const segColor = opts.fontColor ?? seg.font.color;
     ctx.fillStyle = segColor ? hexToRgba(segColor) : '#000000';
     // Baseline shift for super/subscript, relative to the run's *base* size: up
@@ -1365,6 +1381,7 @@ function drawRichSegments(
   opts: { fontColor?: string | null; readingOrder?: number },
   textY: number,
   baseline: CanvasTextBaseline,
+  cjkFallback?: CjkLang,
 ): void {
   const { alignH, cx, cellW, leftPad, paddingX } = geom;
   const totalWidth = segs.reduce((a, s) => a + s.width, 0);
@@ -1373,7 +1390,7 @@ function drawRichSegments(
   else if (alignH === 'center') startX = cx + cellW / 2 - totalWidth / 2;
   else startX = cx + leftPad;
   const { needBidi, baseRtl } = resolveCellBidi(opts.readingOrder, segs.map((s) => s.text).join(''));
-  drawResolvedRichLine(ctx, segs, startX, textY, baseline, cs, dpr, { fontColor: opts.fontColor, needBidi, baseRtl });
+  drawResolvedRichLine(ctx, segs, startX, textY, baseline, cs, dpr, { fontColor: opts.fontColor, needBidi, baseRtl }, cjkFallback);
 }
 
 function drawRichLine(
@@ -1386,13 +1403,14 @@ function drawRichLine(
   opts: { fontColor?: string | null; readingOrder?: number },
   textY: number,
   baseline: CanvasTextBaseline,
+  cjkFallback?: CjkLang,
 ): void {
   const segs: RichSeg[] = lineRuns.map((r) => {
     const font = applyRunFont(baseFont, r);
-    ctx.font = buildFont(vertAlignDrawFont(font), cs);
+    ctx.font = buildFont(vertAlignDrawFont(font), cs, cjkFallback, r.text);
     return { text: r.text, font, width: ctx.measureText(r.text).width };
   });
-  drawRichSegments(ctx, segs, geom, cs, dpr, opts, textY, baseline);
+  drawRichSegments(ctx, segs, geom, cs, dpr, opts, textY, baseline, cjkFallback);
 }
 
 /**
@@ -1411,9 +1429,10 @@ function drawSingleLineRichText(
   cs: number,
   dpr: number,
   opts: { fontColor?: string | null; readingOrder?: number } = {},
+  cjkFallback?: CjkLang,
 ): void {
   const { baseline, textY } = singleLineVerticalAnchor(geom);
-  drawRichLine(ctx, runs, baseFont, geom, cs, dpr, opts, textY, baseline);
+  drawRichLine(ctx, runs, baseFont, geom, cs, dpr, opts, textY, baseline, cjkFallback);
 }
 
 /**
@@ -1432,6 +1451,7 @@ function drawMultiLineRichText(
   cs: number,
   dpr: number,
   opts: { fontColor?: string | null; readingOrder?: number } = {},
+  cjkFallback?: CjkLang,
 ): void {
   const { alignV, cy, cellH, paddingY } = geom;
 
@@ -1445,7 +1465,7 @@ function drawMultiLineRichText(
 
   for (const line of lines) {
     // A blank line draws nothing but still reserves its height.
-    if (line.runs.length > 0) drawRichLine(ctx, line.runs, baseFont, geom, cs, dpr, opts, yy, 'top');
+    if (line.runs.length > 0) drawRichLine(ctx, line.runs, baseFont, geom, cs, dpr, opts, yy, 'top', cjkFallback);
     yy += line.heightPx;
   }
 }
@@ -1470,11 +1490,12 @@ export function drawNonWrapRichText(
   cs: number,
   dpr: number,
   opts: { fontColor?: string | null; readingOrder?: number } = {},
+  cjkFallback?: CjkLang,
 ): void {
   if (runs.some((r) => r.text.includes('\n'))) {
-    drawMultiLineRichText(ctx, runs, baseFont, geom, cs, dpr, opts);
+    drawMultiLineRichText(ctx, runs, baseFont, geom, cs, dpr, opts, cjkFallback);
   } else {
-    drawSingleLineRichText(ctx, runs, baseFont, geom, cs, dpr, opts);
+    drawSingleLineRichText(ctx, runs, baseFont, geom, cs, dpr, opts, cjkFallback);
   }
 }
 
@@ -1537,14 +1558,15 @@ export function drawWrappedRichText(
   cs: number,
   dpr: number,
   opts: { fontColor?: string | null; readingOrder?: number } = {},
+  cjkFallback?: CjkLang,
 ): void {
   const { alignH, alignV, cx, cy, cellW, cellH, leftPad, paddingX, paddingY } = geom;
-  const rLines = layoutRichTextLines(ctx, runs, baseFont, cs, cellW - leftPad - paddingX);
+  const rLines = layoutRichTextLines(ctx, runs, baseFont, cs, cellW - leftPad - paddingX, cjkFallback);
   // layoutRichTextLines preserves leading, trailing, and consecutive hard-break
   // regions, so exactly one produced line also proves there was no hard break.
   if (rLines.length === 1) {
     const { baseline, textY } = singleLineVerticalAnchor(geom);
-    drawRichSegments(ctx, rLines[0].segments, geom, cs, dpr, opts, textY, baseline);
+    drawRichSegments(ctx, rLines[0].segments, geom, cs, dpr, opts, textY, baseline, cjkFallback);
     return;
   }
   const totalH = rLines.reduce((s, l) => s + vMetricPx(l.maxFontSize, cs, 1.2, l.maxFontFamily ?? undefined), 0);
@@ -1566,7 +1588,7 @@ export function drawWrappedRichText(
     else if (alignH === 'center') xx = cx + cellW / 2 - totalW / 2;
     else xx = cx + leftPad;
     const { needBidi, baseRtl } = paraBidi[line.para];
-    drawResolvedRichLine(ctx, line.segments, xx, yy, 'top', cs, dpr, { fontColor: opts.fontColor, needBidi, baseRtl });
+    drawResolvedRichLine(ctx, line.segments, xx, yy, 'top', cs, dpr, { fontColor: opts.fontColor, needBidi, baseRtl }, cjkFallback);
     yy += vMetricPx(line.maxFontSize, cs, 1.2, line.maxFontFamily ?? undefined);
   }
 }
@@ -1951,6 +1973,7 @@ function renderQuadrant(
   pixOffsetX: number, pixOffsetY: number,
   originX: number, originY: number,
   clipX: number, clipY: number, clipW: number, clipH: number,
+  cjkFallback?: CjkLang,
 ): void {
   if (clipW <= 0 || clipH <= 0) return;
 
@@ -2086,7 +2109,7 @@ function renderQuadrant(
       effectiveUnderline !== font.underline || effectiveStrike !== font.strike
     ) ? { ...font, bold: effectiveBold, italic: effectiveItalic, underline: effectiveUnderline, strike: effectiveStrike }
       : font;
-    ctx.font = buildFont(fontForDraw, cs);
+    ctx.font = buildFont(fontForDraw, cs, cjkFallback, text);
     const hyperlinkUrl = rc.hyperlinkMap.get(key);
     // Colour precedence: hyperlink theme colour > conditional-formatting font
     // colour > number-format section colour ([Red] etc., §18.8.30) > the cell's
@@ -2130,7 +2153,7 @@ function renderQuadrant(
       drawWrappedRichText(
         ctx, runs, fontForDraw,
         { alignH, alignV, cx: aCx, cy: aCy, cellW: cW, cellH: cH, leftPad, paddingX, paddingY },
-        cs, dpr, { fontColor: cf.fontColor, readingOrder: xf.readingOrder },
+        cs, dpr, { fontColor: cf.fontColor, readingOrder: xf.readingOrder }, cjkFallback
       );
     } else if (xf.wrapText) {
       drawWrappedPlainText(
@@ -2148,7 +2171,7 @@ function renderQuadrant(
       drawNonWrapRichText(
         ctx, runs, fontForDraw,
         { alignH, alignV, cx: aCx, cy: aCy, cellW: cW, cellH: cH, leftPad, paddingX, paddingY },
-        cs, dpr, { fontColor: cf.fontColor, readingOrder: xf.readingOrder },
+        cs, dpr, { fontColor: cf.fontColor, readingOrder: xf.readingOrder }, cjkFallback
       );
     } else {
       const { baseline, textY } = singleLineVerticalAnchor({
@@ -2514,7 +2537,7 @@ function renderQuadrant(
       )
         ? { ...font, bold: effectiveBold, italic: effectiveItalic, underline: effectiveUnderline, strike: effectiveStrike }
         : font;
-      ctx.font = buildFont(fontForDraw, cs);
+      ctx.font = buildFont(fontForDraw, cs, cjkFallback, text);
       const hyperlinkUrl = rc.hyperlinkMap.get(key);
       // Table-style element dxfs can override font color (ECMA-376 §18.8.83),
       // following the same element hierarchy as the fill/bold above.
@@ -2796,7 +2819,7 @@ function renderQuadrant(
         drawWrappedRichText(
           ctx, runs, fontForDraw,
           { alignH, alignV, cx, cy, cellW, cellH, leftPad, paddingX, paddingY },
-          cs, dpr, { fontColor: cf.fontColor, readingOrder: xf.readingOrder },
+          cs, dpr, { fontColor: cf.fontColor, readingOrder: xf.readingOrder }, cjkFallback
         );
       } else if (xf.wrapText) {
         drawWrappedPlainText(
@@ -2816,7 +2839,7 @@ function renderQuadrant(
         drawNonWrapRichText(
           ctx, runs, fontForDraw,
           { alignH, alignV, cx, cy, cellW, cellH, leftPad, paddingX, paddingY },
-          cs, dpr, { fontColor: cf.fontColor, readingOrder: xf.readingOrder },
+          cs, dpr, { fontColor: cf.fontColor, readingOrder: xf.readingOrder }, cjkFallback
         );
       } else {
         // ECMA-376 §18.4.14 vertAlign / ST_VerticalAlignRun §22.9.2.17 —
@@ -2833,7 +2856,7 @@ function renderQuadrant(
           ? { ...fontForDraw, size: fontForDraw.size * 0.65 }
           : fontForDraw;
         if (cellVertAlign) {
-          ctx.font = buildFont(drawFont, cs);
+          ctx.font = buildFont(drawFont, cs, cjkFallback, text);
         }
 
         // Measure once for both underline and strike
@@ -2909,7 +2932,7 @@ function renderQuadrant(
       // measured base width.
       const phRuns = cell.value.type === 'text' ? cell.value.phoneticRuns : undefined;
       if (cell.showPhonetic && phRuns && phRuns.length > 0 && !text.includes('\n')) {
-        const baseFontStr = buildFont(fontForDraw, cs);
+        const baseFontStr = buildFont(fontForDraw, cs, cjkFallback, text);
         const baseTextW = measureInFont(ctx, text, baseFontStr);
         let baseLeftX: number;
         if (alignH === 'right') baseLeftX = cx + cellW - paddingX - baseTextW;
@@ -2926,7 +2949,7 @@ function renderQuadrant(
           baseLeftX,
           cy,
           cs,
-          phColor,
+          phColor, cjkFallback
         );
       }
 
@@ -3177,6 +3200,7 @@ function requiredAutoCellHeightPx(
   mdw: number,
   iconSet: CfResult['iconSet'],
   currentRowHeightPx: number,
+  cjkFallback?: CjkLang,
 ): number {
   const paddingX = 3;
   const paddingY = 2;
@@ -3195,7 +3219,7 @@ function requiredAutoCellHeightPx(
   const hasRichText = !!runs?.length;
   const rotation = xf.textRotation ?? 0;
 
-  ctx.font = buildFont(font, 1);
+  ctx.font = buildFont(font, 1, cjkFallback, text);
   if (rotation === 255) {
     // Paint deliberately uses the compact 1.1 slot without a document-family
     // design-line floor for stacked glyphs; auto-fit must use the same metric.
@@ -3214,10 +3238,10 @@ function requiredAutoCellHeightPx(
 
   let lineHeights: number[];
   if (xf.wrapText && hasRichText) {
-    lineHeights = layoutRichTextLines(ctx, runs, font, 1, availableWidth)
+    lineHeights = layoutRichTextLines(ctx, runs, font, 1, availableWidth, cjkFallback)
       .map((line) => vMetricPx(line.maxFontSize, 1, 1.2, line.maxFontFamily ?? undefined));
   } else if (xf.wrapText) {
-    ctx.font = buildFont(font, 1);
+    ctx.font = buildFont(font, 1, cjkFallback, text);
     const lineHeight = vMetricPx(font.size, 1, 1.2, font.name ?? undefined);
     lineHeights = wrapTextLines(ctx, text, availableWidth).map(() => lineHeight);
   } else if (hasRichText) {
@@ -3277,6 +3301,7 @@ export function applyAutoRowHeights(
   ctx: CanvasRenderingContext2D,
   worksheet: Worksheet,
   styles: Styles,
+  cjkFallback?: CjkLang,
 ): boolean {
   if (autoRowHeightState.has(worksheet) || worksheet.isChartSheet) return false;
   if (worksheet.defaultRowHeightCustom === true) {
@@ -3344,7 +3369,7 @@ export function applyAutoRowHeights(
           cellWidthPx,
           geometry.maximumDigitWidth,
           cf.iconSet,
-          Math.ceil(requiredPx),
+          Math.ceil(requiredPx), cjkFallback
         ));
         if (cf.iconSet) {
           iconMeasurements.push({ cell, text, font: measuredFont, xf, cellWidthPx, iconSet: cf.iconSet });
@@ -3373,7 +3398,7 @@ export function applyAutoRowHeights(
             measurement.cellWidthPx,
             geometry.maximumDigitWidth,
             measurement.iconSet,
-            candidateHeightPx,
+            candidateHeightPx, cjkFallback
           ));
         }
         requiredPx = nextRequiredPx;
@@ -3390,7 +3415,7 @@ export function applyAutoRowHeights(
             measurement.cellWidthPx,
             geometry.maximumDigitWidth,
             measurement.iconSet,
-            measurement.cellWidthPx,
+            measurement.cellWidthPx, cjkFallback
           ));
         }
       }
@@ -3520,6 +3545,7 @@ function virtualizedTextOverflowOverscan(
   cs: number,
   mdw: number,
   rtl: boolean,
+  cjkFallback?: CjkLang,
 ): OverflowColumnOverscan {
   let startCol = visibleStartCol;
   let endCol = visibleEndCol;
@@ -3565,7 +3591,7 @@ function virtualizedTextOverflowOverscan(
     const effectiveFont = (effectiveBold !== font.bold || effectiveItalic !== font.italic)
       ? { ...font, bold: effectiveBold, italic: effectiveItalic }
       : font;
-    ctx.font = buildFont(effectiveFont, cs);
+    ctx.font = buildFont(effectiveFont, cs, cjkFallback, text);
 
     const alignH = xf.alignH ?? 'left';
     const paddingX = 3;
@@ -3647,6 +3673,7 @@ export function renderViewport(
   styles: Styles,
   viewport: ViewportRange,
   opts: RenderViewportOptions = {},
+  cjkFallback?: CjkLang,
 ): void {
   const dpr = opts.dpr ?? 1;
   const cs = opts.cellScale ?? 1;
@@ -3760,7 +3787,7 @@ export function renderViewport(
     freezeCols + 1,
     cs,
     mdw,
-    worksheet.rightToLeft === true,
+    worksheet.rightToLeft === true, cjkFallback
   );
   const renderScrollColBands = colAxis.bandsToCover(
     overflowOverscan.startCol,
@@ -3811,7 +3838,7 @@ export function renderViewport(
       frozenColIndices, frozenRowIndices,
       0, 0,
       cellAreaX, cellAreaY,
-      cellAreaX, cellAreaY, frozenW, frozenH,
+      cellAreaX, cellAreaY, frozenW, frozenH, cjkFallback
     );
   }
 
@@ -3822,7 +3849,7 @@ export function renderViewport(
       renderScrollColIndices, frozenRowIndices,
       renderScrollOffsetX, 0,
       scrollAreaX, cellAreaY,
-      scrollAreaX, cellAreaY, scrollAreaW, frozenH,
+      scrollAreaX, cellAreaY, scrollAreaW, frozenH, cjkFallback
     );
   }
 
@@ -3833,7 +3860,7 @@ export function renderViewport(
       frozenColIndices, scrollRowIndices,
       0, scrollOffsetY,
       cellAreaX, scrollAreaY,
-      cellAreaX, scrollAreaY, frozenW, scrollAreaH,
+      cellAreaX, scrollAreaY, frozenW, scrollAreaH, cjkFallback
     );
   }
 
@@ -3844,7 +3871,7 @@ export function renderViewport(
       renderScrollColIndices, scrollRowIndices,
       renderScrollOffsetX, scrollOffsetY,
       scrollAreaX, scrollAreaY,
-      scrollAreaX, scrollAreaY, scrollAreaW, scrollAreaH,
+      scrollAreaX, scrollAreaY, scrollAreaW, scrollAreaH, cjkFallback
     );
   }
 
@@ -3853,7 +3880,7 @@ export function renderViewport(
     ctx, worksheet, colAxis, rowAxis, opts.loadedImages, cs,
     startRow, startCol, scrollOffsetX, scrollOffsetY,
     scrollAreaX, scrollAreaY, scrollAreaW, scrollAreaH,
-    worksheet.rightToLeft === true, canvasW, opts.threeD, opts.regionMap, opts.chartEx,
+    worksheet.rightToLeft === true, canvasW, opts.threeD, opts.regionMap, opts.chartEx, cjkFallback
   );
 
   // ── Anchored slicers (Office 2010+ pivot/table filter buttons) ──
@@ -4162,6 +4189,7 @@ function renderAnchoredDrawings(
   threeD?: ChartThreeDRenderer,
   regionMap?: ChartRegionMapRenderer,
   chartEx?: ChartExRenderer,
+  cjkFallback?: CjkLang,
 ): void {
   const drawings: AnchoredDrawing[] = [];
   let fallbackOrder = 0;
@@ -4194,7 +4222,7 @@ function renderAnchoredDrawings(
         startRow, startCol, scrollOffsetX, scrollOffsetY,
         scrollAreaX, scrollAreaY, scrollAreaW, scrollAreaH,
         loadedImages, rtl, canvasW,
-        [{ ...drawing.anchor, shapes: [drawing.shape] }],
+        [{ ...drawing.anchor, shapes: [drawing.shape] }], cjkFallback
       );
     } else {
       renderCharts(
@@ -4351,6 +4379,7 @@ function renderShapeGroups(
   rtl: boolean,
   canvasW: number,
   anchors: readonly ShapeAnchor[] = ws.shapeGroups ?? [],
+  cjkFallback?: CjkLang,
 ): void {
   if (scrollAreaW <= 0 || scrollAreaH <= 0) return;
   if (anchors.length === 0) return;
@@ -4401,7 +4430,7 @@ function renderShapeGroups(
       const sw = shape.w * w;
       const sh = shape.h * h;
       if (sw <= 0 || sh <= 0) continue;
-      drawShape(ctx, shape, sx, sy, sw, sh, cs, loadedImages);
+      drawShape(ctx, shape, sx, sy, sw, sh, cs, loadedImages, cjkFallback);
     }
   }
 
@@ -4414,6 +4443,7 @@ function drawShape(
   sx: number, sy: number, sw: number, sh: number,
   cs: number,
   loadedImages?: Map<string, CanvasImageSource | null>,
+  cjkFallback?: CjkLang,
 ): void {
   ctx.save();
   if (shape.rot !== 0 || shape.flipH || shape.flipV) {
@@ -4565,7 +4595,7 @@ function drawShape(
   // Shape text body (ECMA-376 §20.5.2.34 `<xdr:txBody>`). Drawn after
   // fill/stroke so it sits on top of the shape's background.
   if (shape.text) {
-    drawShapeText(ctx, shape.text, sw, sh, cs);
+    drawShapeText(ctx, shape.text, sw, sh, cs, cjkFallback);
   }
   ctx.restore();
 }
@@ -4672,6 +4702,7 @@ export function drawShapeText(
   txt: import('./types.js').ShapeText,
   sw: number, sh: number,
   cs: number,
+  cjkFallback?: CjkLang,
 ): void {
   if (sw <= 0 || sh <= 0 || txt.paragraphs.length === 0) return;
   // The shape box (sw,sh) is already cellScale-scaled by the caller, but font
@@ -4708,7 +4739,7 @@ export function drawShapeText(
   const textFont = (run: Extract<import('./types.js').ShapeTextRun, { type: 'text' }>): { font: string; px: number } => {
     const size = run.size > 0 ? run.size : DEFAULT_FONT_SIZE;
     const px = size * PT_TO_PX * cs;
-    const family = fontStackFor(run.fontFace);
+    const family = fontStackFor(run.fontFace, cjkFallback, run.text);
     return { font: `${run.italic ? 'italic ' : ''}${run.bold ? 'bold ' : ''}${px}px ${family}`, px };
   };
 
@@ -4805,6 +4836,8 @@ export function drawShapeText(
         // to keep the Line shape consistent. Measure it the same way as text
         // runs — the nearest preceding face at the fallback size — rather than
         // the old 0.85×em constant.
+        // No glyph is painted for an empty line, so a regional Han fallback
+        // must not perturb its generic line metric.
         lineAscent = measuredAscent(`${fallbackPx}px ${fontStackFor(lastTextFace)}`, fallbackPx);
       }
       lineHeight = applyLineSpacing(lineHeight);

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -1214,6 +1214,7 @@ class XlsxViewerEngine implements ZoomableViewer {
           password: this.opts.password,
           useGoogleFonts: this.opts.useGoogleFonts,
           googleFontsCssOrigin: this.opts.googleFontsCssOrigin,
+          cjkFallback: this.opts.cjkFallback,
           maxZipEntryBytes: this.opts.maxZipEntryBytes,
           resourceLimits: this.opts.resourceLimits,
           debug: this.opts.debug,

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -1,3 +1,5 @@
+import { resolveCjkFallback, type CjkLang } from '@silurus/ooxml-core';
+import { xlsxCjkFallback } from './google-fonts.js';
 import InlineWorker from './worker.ts?worker&inline';
 import wasmAssetUrl from './wasm/xlsx_parser_bg.wasm?url';
 import {
@@ -71,7 +73,7 @@ import {
   XlsxWorksheetPullClient,
 } from './worksheet-pull-client.js';
 import { GridGeometry } from './internal/grid-geometry.js';
-import { applyAutoRowHeights, inheritSheetRenderCache } from './renderer.js';
+import { applyAutoRowHeights, inheritSheetRenderCache, getGridGeometryForWorksheet } from './renderer.js';
 import {
   assertDelimitedTextSourceBytes,
   resolveDelimitedTextOptions,
@@ -157,6 +159,7 @@ export class XlsxWorkbook {
   /** Opt-in OMML equation engine, injected once at {@link load}. Every
    *  `renderViewport` call reuses it — equations in shapes render when present,
    *  and are skipped when omitted. */
+  private cjkFallback: CjkLang = 'jp';
   private math: MathRenderer | undefined;
   /** Optional synchronous 3-D chart renderer. Worker mode reconstructs the
    * built-in implementation from its serializable identity. */
@@ -257,6 +260,7 @@ export class XlsxWorkbook {
     opts: LoadOptions,
     sourceOptions: Exclude<XlsxSheetLoadOptions, Readonly<{ format?: 'xlsx' }>>,
   ): Promise<XlsxWorkbook> {
+    opts = { ...opts, cjkFallback: resolveCjkFallback(opts.cjkFallback) };
     const delimited = resolveDelimitedTextOptions(sourceOptions);
     const resourceOptions = normalizeLoadResourceOptions(opts);
     const mode = opts.mode ?? 'main';
@@ -325,6 +329,7 @@ export class XlsxWorkbook {
 
   /** Parse an XLSX from a URL or ArrayBuffer. */
   static async load(source: string | ArrayBuffer, opts: LoadOptions = {}): Promise<XlsxWorkbook> {
+    opts = { ...opts, cjkFallback: resolveCjkFallback(opts.cjkFallback) };
     const resourceOptions = normalizeLoadResourceOptions(opts);
     const mode = opts.mode ?? 'main';
     const metrics = new OoxmlResourceMetricsSession({
@@ -413,6 +418,7 @@ export class XlsxWorkbook {
       ? normalizeGoogleFontsCssOrigin(opts.googleFontsCssOrigin)
       : undefined;
     this.workerTimeoutMs = opts.workerTimeoutMs;
+    this.cjkFallback = resolveCjkFallback(opts.cjkFallback);
     this.math = this._mode === 'worker' ? undefined : opts.math;
     this.threeD = this._mode === 'worker' ? undefined : opts.threeD;
     this.regionMap = this._mode === 'worker' ? undefined : opts.regionMap;
@@ -463,6 +469,7 @@ export class XlsxWorkbook {
               resourcePolicy,
               useGoogleFonts: !!opts.useGoogleFonts,
               googleFontsCssOrigin: this.googleFontsCssOrigin,
+              cjkFallback: this.cjkFallback,
               renderers: rendererDescriptors,
             } satisfies RenderWorkerRequest)
           : ({
@@ -490,6 +497,7 @@ export class XlsxWorkbook {
     }
     const parsedWorkbook = this.parsedWorkbook;
     if (!parsedWorkbook) throw new Error('XLSX worker returned no workbook metadata');
+    this.cjkFallback = xlsxCjkFallback(parsedWorkbook, this.cjkFallback);
     this.ensureWorksheetPullClient();
     // #773: a workbook-level degradation (a present-but-corrupt shared part such
     // as `xl/sharedStrings.xml`, which blanks every string cell across all sheets)
@@ -506,7 +514,7 @@ export class XlsxWorkbook {
       // realm even when paint runs in a worker. Register the same fallback
       // faces in both realms before any worksheet geometry snapshot is made so
       // ECMA-376 MDW is identical across paint and interaction.
-      this.googleFontNames = [...xlsxFontPreloadNames(parsedWorkbook)];
+      this.googleFontNames = [...xlsxFontPreloadNames(parsedWorkbook, this.cjkFallback)];
       if (typeof document !== 'undefined' && document.fonts) {
         await this.retainFontsInSet(document.fonts);
       }
@@ -526,6 +534,7 @@ export class XlsxWorkbook {
       ? normalizeGoogleFontsCssOrigin(opts.googleFontsCssOrigin)
       : undefined;
     this.workerTimeoutMs = opts.workerTimeoutMs;
+    this.cjkFallback = resolveCjkFallback(opts.cjkFallback);
     this.generation++;
     this.math = this._mode === 'worker' ? undefined : opts.math;
     this.threeD = this._mode === 'worker' ? undefined : opts.threeD;
@@ -543,6 +552,7 @@ export class XlsxWorkbook {
         options,
         useGoogleFonts: !!opts.useGoogleFonts,
         googleFontsCssOrigin: this.googleFontsCssOrigin,
+        cjkFallback: this.cjkFallback,
         renderers: rendererDescriptors,
       } satisfies DelimitedTextParseRequest),
       [data],
@@ -560,11 +570,12 @@ export class XlsxWorkbook {
     assertWorksheetJsonBytes(measured.jsonBytes, 'load-delimited-text', undefined);
     assertWorksheetCacheUsage(measured, 'load-delimited-text', undefined);
     this.parsedWorkbook = response.workbook;
+    this.cjkFallback = xlsxCjkFallback(response.workbook, this.cjkFallback);
     this.sheetCache.set(0, worksheet);
     this.retainedSheetUsage = measured;
 
     if (opts.useGoogleFonts) {
-      this.googleFontNames = [...xlsxFontPreloadNames(response.workbook)];
+      this.googleFontNames = [...xlsxFontPreloadNames(response.workbook, this.cjkFallback)];
       if (typeof document !== 'undefined' && document.fonts) {
         await this.retainFontsInSet(document.fonts);
       }
@@ -614,7 +625,8 @@ export class XlsxWorkbook {
    * measurement observes the same faces that the subsequent paint uses. */
   [prepareXlsxViewerRowHeights](worksheet: Worksheet, ctx: CanvasRenderingContext2D): void {
     if (!this.parsedWorkbook) return;
-    applyAutoRowHeights(ctx, worksheet, this.parsedWorkbook.styles);
+    getGridGeometryForWorksheet(worksheet);
+    applyAutoRowHeights(ctx, worksheet, this.parsedWorkbook.styles, this.cjkFallback);
   }
 
   get sheetNames(): string[] {
@@ -986,6 +998,7 @@ export class XlsxWorkbook {
         {
           ws,
           styles,
+          cjkFallback: this.cjkFallback,
           math: this.math,
           threeD: this.threeD,
           regionMap: this.regionMap,

--- a/packages/xlsx/src/worker-protocol.ts
+++ b/packages/xlsx/src/worker-protocol.ts
@@ -224,7 +224,7 @@ export function extractViewerRenderContext(opts: WireRenderViewportOptions): {
 // `init` arm is copied verbatim from `WorkerRequest`.
 export type RenderWorkerRequest =
   | { type: 'init'; wasmUrl: string }
-  | { type: 'parse'; id: number; data: ArrayBuffer; resourcePolicy: NormalizedOoxmlResourcePolicy; useGoogleFonts?: boolean; googleFontsCssOrigin?: string; renderers?: import('@silurus/ooxml-core/worker').WorkerRendererDescriptors }
+  | { type: 'parse'; id: number; data: ArrayBuffer; resourcePolicy: NormalizedOoxmlResourcePolicy; useGoogleFonts?: boolean; googleFontsCssOrigin?: string; cjkFallback?: import('@silurus/ooxml-core').CjkLang; renderers?: import('@silurus/ooxml-core/worker').WorkerRendererDescriptors }
   | DelimitedTextParseRequest
   | ({ type: 'openSheetSession'; id: number; sheetIndex: number; sheetName: string } & PullSessionIdentity<number>)
   | {

--- a/scripts/check-docx-layout-boundaries.mjs
+++ b/scripts/check-docx-layout-boundaries.mjs
@@ -2048,9 +2048,9 @@ function assertBodyKernelServiceOwner(root) {
     && ts.isIdentifier(parentCall.arguments[0])
     && parentCall.arguments[0].text === 'services'
     && parentCall.arguments[1] === call
-    && call.arguments.length === 3
+    && call.arguments.length === 4
     && call.arguments.every((argument, index) => (
-      ts.isIdentifier(argument) && argument.text === ['source', 'context', 'fontMetrics'][index]
+      ts.isIdentifier(argument) && argument.text === ['source', 'context', 'fontMetrics', 'cjkFallback'][index]
     ));
   let insideOwner = false;
   for (let node = parentCall; node; node = node.parent) {

--- a/scripts/check-docx-layout-boundaries.test.mjs
+++ b/scripts/check-docx-layout-boundaries.test.mjs
@@ -94,6 +94,7 @@ export function createLayoutServices(input, context, fontMetrics) {
     source,
     context,
     fontMetrics,
+    cjkFallback,
   ));
   return services;
 }
@@ -366,6 +367,10 @@ test('requires one private concrete body-kernel owner with exact loud attachment
     ['wrong owner arguments', canonicalLayoutRuntime.replace(
       '    context,\n    fontMetrics,',
       '    fontMetrics,',
+    )],
+    ['wrong CJK preference', canonicalLayoutRuntime.replace(
+      '    cjkFallback,',
+      '    unrelatedPreference,',
     )],
     ['wrong source', canonicalLayoutRuntime.replace(
       '    source,',

--- a/site/src/lib/api-reference.ts
+++ b/site/src/lib/api-reference.ts
@@ -85,8 +85,9 @@ const RESOURCE_METRICS = { name: 'onResourceMetrics', type: '(metrics: OoxmlReso
 const RESOURCE_METRICS_METHOD = { sig: 'getResourceMetrics(): Promise<OoxmlResourceMetrics>', desc: 'Return a fresh, content-free package-usage snapshot, including lazy archive work observed since load. Collection is always active; debug controls only console output.', emphasis: 'Collection is always active; debug controls only console output.' };
 const DEBUG = { name: 'debug', type: 'boolean', def: 'false', desc: 'Print one content-free, Ratatui-inspired resource report when the measured load or Node session finishes or fails. Browser DevTools use typography-only %c styling to keep Unicode borders and gauges aligned without changing foreground or background colours; Node and Worker consoles receive one plain argument. Use onResourceMetrics instead for production collection.', emphasis: 'Use onResourceMetrics instead for production collection.' };
 const ZIP = { name: 'maxZipEntryBytes', type: 'number', def: 'resource policy default', desc: 'Deprecated compatibility alias for resourceLimits.maxArchiveEntryBytes. It is scheduled for removal in a future breaking release; new code should use resourceLimits. Existing positive values retain their per-entry meaning; zero / negative values fall back to the standard default.', emphasis: 'It is scheduled for removal in a future breaking release; new code should use resourceLimits.' };
-const GFONTS = { name: 'useGoogleFonts', type: 'boolean', def: 'false', desc: 'Load metric-compatible webfonts and non-Latin script fallbacks (Noto Arabic / CJK KR·SC·TC·JP / Cyrillic / Hebrew / Thai / Devanagari) from Google Fonts so layout matches Office and non-Latin text never falls back to tofu. Off by default for privacy.', emphasis: 'Off by default for privacy.' };
+const GFONTS = { name: 'useGoogleFonts', type: 'boolean', def: 'false', desc: 'Load metric-compatible webfonts and non-Latin script fallbacks (Noto Arabic / CJK KR·SC·TC·HK·JP / Cyrillic / Hebrew / Thai / Devanagari) from Google Fonts so layout matches Office and non-Latin text never falls back to tofu. Off by default for privacy.', emphasis: 'Off by default for privacy.' };
 const GFONTS_ORIGIN = { name: 'googleFontsCssOrigin', type: 'string', def: "'https://fonts.googleapis.com'", desc: 'HTTP(S) origin for a Google Fonts-compatible CSS service. The built-in stylesheet paths and family queries are retained. Relative font-file URLs from the returned CSS resolve against the final stylesheet URL after redirects. Used only when useGoogleFonts is true; a service failure falls back to system fonts without retrying the public endpoint.', emphasis: 'Used only when useGoogleFonts is true' };
+const CJK_FALLBACK = { name: 'cjkFallback', type: "'auto' | 'sc' | 'tc' | 'hk' | 'jp' | 'kr'", def: "'auto'", desc: 'Region for ambiguous CJK font fallback. Authored font regions retain priority. Auto snapshots HTML lang, then navigator.languages and navigator.language; otherwise JP. For Chinese, an explicit Hans/Hant script selects SC/TC before region; without a script, HK/MO selects HK and TW selects TC. Bare zh uses SC. Explicit regions give reproducible output and do not enable webfont downloads.' };
 const PASSWORD = { name: 'password', type: 'string', def: 'undefined', desc: 'Password for an Agile-encrypted OOXML file. Available on self-loading Viewer constructors and headless load(); borrowed fromDocument(), fromPresentation(), and fromWorkbook() factories omit load-only options because their engine is already loaded.', emphasis: 'Available on self-loading Viewer constructors and headless load()' };
 const DPR = { name: 'dpr', type: 'number', def: 'devicePixelRatio', desc: 'Device pixel ratio for the backing store (crispness on HiDPI).' };
 const WASM_URL = { name: 'wasmUrl', type: 'string | URL', def: 'bundled asset', desc: 'Override the URL the parser worker fetches the WebAssembly module from. By default each format resolves the `*_parser_bg.wasm` asset that ships next to its bundle (relative to the module URL); set this to serve it from a CDN or a self-hosted path instead (a relative value resolves against the document URL). Pointing it at a mismatched or missing file makes load() reject when the worker instantiates it.', emphasis: 'Override the URL the parser worker fetches the WebAssembly module from.' };
@@ -245,6 +246,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         DPR,
         GFONTS,
         GFONTS_ORIGIN,
+        CJK_FALLBACK,
         PASSWORD,
         { name: 'enableTextSelection', type: 'boolean', def: 'false', desc: 'Overlay a transparent text layer so users can select & copy slide text.' },
         { name: 'enableElementSelection', type: 'boolean', def: 'false', desc: 'Enable read-only slide-element selection with a non-editable outline and element context; no editor model is exposed.' },
@@ -301,7 +303,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
       name: 'PptxPresentation',
       ctor: 'await PptxPresentation.load(source, options?)',
       note: 'Headless engine — parse once, render any slide into any canvas you supply (scroll views, thumbnail grids, master–detail).',
-      options: [GFONTS, GFONTS_ORIGIN, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, TIFF, MODE, ...PPTX_PROGRESSIVE_OPTIONS],
+      options: [GFONTS, GFONTS_ORIGIN, CJK_FALLBACK, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, TIFF, MODE, ...PPTX_PROGRESSIVE_OPTIONS],
       methods: [
         { sig: 'static load(source, options?): Promise<PptxPresentation>', desc: 'Parse a deck from a URL or ArrayBuffer. With progressiveLayout, resolve when the opening slide is paintable.' },
         { sig: 'get slideCount(): number', desc: 'Total slides.' },
@@ -351,6 +353,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         ENABLE_HYPERLINKS,
         GFONTS,
         GFONTS_ORIGIN,
+        CJK_FALLBACK,
         PASSWORD,
         ZIP,
         RESOURCE_LIMITS,
@@ -398,6 +401,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         DPR,
         GFONTS,
         GFONTS_ORIGIN,
+        CJK_FALLBACK,
         PASSWORD,
         { name: 'enableTextSelection', type: 'boolean', def: 'false', desc: 'Overlay a transparent text layer for native selection & copy.' },
         ...DOCX_LAYOUT_VIEW_OPTIONS,
@@ -451,7 +455,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
       name: 'DocxDocument',
       ctor: 'await DocxDocument.load(source, options?)',
       note: 'Headless engine — render any page into any canvas you supply.',
-      options: [GFONTS, GFONTS_ORIGIN, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, TIFF, MODE, ...DOCX_LAYOUT_VIEW_OPTIONS, DOCX_PROGRESSIVE_LAYOUT, DOCX_SLICE_LAYOUT, DOCX_LAYOUT_PROGRESS, DOCX_LAYOUT_PARTIAL, DOCX_LAYOUT_COMPLETE],
+      options: [GFONTS, GFONTS_ORIGIN, CJK_FALLBACK, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, TIFF, MODE, ...DOCX_LAYOUT_VIEW_OPTIONS, DOCX_PROGRESSIVE_LAYOUT, DOCX_SLICE_LAYOUT, DOCX_LAYOUT_PROGRESS, DOCX_LAYOUT_PARTIAL, DOCX_LAYOUT_COMPLETE],
       methods: [
         { sig: 'static load(source, options?): Promise<DocxDocument>', desc: 'Parse a document from a URL or ArrayBuffer. With progressiveLayout, resolve when the opening pages are paintable while pagination continues in the background.' },
         { sig: 'get comments(): readonly Readonly<DocComment>[]', desc: 'Immutable detached comments and replies stored in the document.' },
@@ -500,6 +504,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         ENABLE_HYPERLINKS,
         GFONTS,
         GFONTS_ORIGIN,
+        CJK_FALLBACK,
         PASSWORD,
         ZIP,
         RESOURCE_LIMITS,
@@ -559,6 +564,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { name: 'hiddenSheetMode', type: "'show' | 'skip' | 'dim'", def: "'show'", desc: 'How hidden / very-hidden sheets (`<sheet state>`, §18.2.19) appear in the tab bar. `show` renders a tab like any other; `skip` hides the tab (`display:none`) and makes sequential navigation jump over it; `dim` renders the tab at reduced opacity. Mirrors pptx `hiddenSlideMode`.' },
         GFONTS,
         GFONTS_ORIGIN,
+        CJK_FALLBACK,
         PASSWORD,
         ZIP,
         RESOURCE_LIMITS,
@@ -633,6 +639,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { name: 'onViewportChange', type: '(offset: XlsxViewportOffset) => void', desc: 'Called with the clamped logical CSS-pixel offset after the active viewport moves. Horizontal x is measured from column A independently of browser RTL scrollLeft conventions.' },
         GFONTS,
         GFONTS_ORIGIN,
+        CJK_FALLBACK,
         PASSWORD,
         WASM_URL,
         ZIP,
@@ -689,7 +696,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
       name: 'XlsxWorkbook',
       ctor: 'await XlsxWorkbook.load(source, options?)',
       note: 'Headless engine — parse once, render any sheet viewport into any canvas you supply.',
-      options: [GFONTS, GFONTS_ORIGIN, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, TIFF, MODE],
+      options: [GFONTS, GFONTS_ORIGIN, CJK_FALLBACK, PASSWORD, WASM_URL, ZIP, RESOURCE_LIMITS, RESOURCE_METRICS, DEBUG, WORKER_TIMEOUT, MATH, THREE_D, REGION_MAP, CHART_EX, TIFF, MODE],
       methods: [
         { sig: 'static load(source, options?): Promise<XlsxWorkbook>', desc: 'Parse a workbook from a URL or ArrayBuffer.' },
         { sig: 'get sheetNames(): string[]', desc: 'Names of all sheets.' },


### PR DESCRIPTION
Ambiguous Han text currently falls back to Japanese when its font names do not identify a CJK region. This PR adds `cjkFallback?: 'auto' | 'sc' | 'tc' | 'hk' | 'jp' | 'kr'` to shared load/viewer options so embedding applications can choose an appropriate regional fallback.

`auto` (also the omitted default) snapshots the first usable CJK preference from `<html lang>`, then ordered `navigator.languages`, then `navigator.language`, with `jp` as the final default. For Chinese, explicit Hans/Hant script subtags select SC/TC before region; without an explicit script, HK/MO selects HK and TW selects TC. Authored regional fonts, preserved DOCX East Asian run language, and existing unambiguous script evidence retain priority.

The resolved preference flows through DOCX, XLSX (including CSV/TSV), and PPTX loading, workers, font preloading, measurement, and ordinary text rendering. The selected regional route applies only to strings containing Han, so Latin text, digits, bullets, and symbols keep their existing selection and metrics. DOCX/PPTX Node rendering accepts the same policy. The option never enables Google Fonts implicitly and works with a custom Google Fonts CSS origin.

No API migration is required. Ambiguous Han glyphs can now differ on CJK-language hosts; applications that require reproducible rendering should set an explicit region. Chart and equation renderers retain their existing policies.

Closes #1499.

### Validation

- Passed the full test suite: 793 test files, 9,032 tests passed; 7 files / 24 tests skipped.
- Passed `pnpm typecheck` and `git diff --check`.
- Passed the final DOCX layout boundary checker, 89 boundary tests, 17 compatibility tests, 26 public API tests, and 2 package-build tests.
- Private self-VRT against the previous renderer is exact for 51 DOCX inputs, 35 PPTX inputs, and 139 XLSX inputs. PPTX worker parity also passed for all 35 inputs. No reference images were updated.
- Public self-VRT remains exact for all 20 decoded images from the original review run.

### Adversarial review

**APPROVE.** The review found and corrected two material edge cases before approval:

- Explicit Chinese script subtags now take precedence over conflicting region subtags.
- Regional CJK fallback is restricted to Han text across DOCX, PPTX, and XLSX, preventing changes to Latin text, digits, bullets, symbols, and XLSX grid geometry.

The implementation keeps shared language policy in core and format-specific wiring in each renderer. It is application font-substitution policy under ECMA-376 §17.8.2 and DrawingML §21.1.2.5 implementation discretion, not a new normative OOXML language rule or an Office compatibility heuristic.

Authored by GPT-6 Astra and reviewed/amended by GPT-5 (OpenAI Codex).
