### PR TITLE
refactor(fonts): centralize Han fallback detection

### DIFF
--- a/packages/core/src/fonts/scripts.ts
+++ b/packages/core/src/fonts/scripts.ts
@@ -324,6 +324,12 @@ export const SCRIPT_PRELOAD_NAMES: string[] = [
   'Noto Sans Hebrew', 'Noto Serif Hebrew',
 ];
 
+/** Shared scalar predicate for the ambiguous Han policy. Kept internal to the
+ * workspace packages so preload, measurement, and paint cannot drift. */
+export function containsHanScript(text: string): boolean {
+  return /\p{Script=Han}/u.test(text);
+}
+
 /**
  * Decide WHICH of the script Noto families above actually need force-loading for
  * a document, by scanning its rendered text for the Unicode scripts that require
@@ -437,12 +443,7 @@ export class ScriptPreloadAccumulator {
           this.hasHangul = true;
         } else if (cp >= 0x3040 && cp <= 0x30ff) {
           this.hasKana = true;
-        } else if (
-          (cp >= 0x3400 && cp <= 0x4dbf) ||
-          (cp >= 0x4e00 && cp <= 0x9fff) ||
-          (cp >= 0xf900 && cp <= 0xfaff) ||
-          (cp >= 0x20000 && cp <= 0x2fa1f)
-        ) {
+        } else if (containsHanScript(ch)) {
           this.hasHan = true;
         } else if (
           (cp >= 0x0600 && cp <= 0x06ff) ||

--- a/packages/core/src/internal/script-preload-accumulator.ts
+++ b/packages/core/src/internal/script-preload-accumulator.ts
@@ -1,3 +1,3 @@
 // Internal streaming adapter: intentionally excluded from the package root API.
-export { ScriptPreloadAccumulator } from '../fonts/scripts.js';
+export { ScriptPreloadAccumulator, containsHanScript } from '../fonts/scripts.js';
 export type { CjkLang } from '../fonts/scripts.js';

--- a/packages/docx/src/layout/text.ts
+++ b/packages/docx/src/layout/text.ts
@@ -28,6 +28,7 @@ import type {
   SourceRef,
   VmlTextPathAcquisitionInput,
 } from './types.js';
+import { containsHanScript } from '@silurus/ooxml-core/internal/script-preload-accumulator';
 import type { TextBoxAcquisitionInput } from './textbox-input.js';
 import type { AnchorAcquisitionInput } from './anchor-input.js';
 
@@ -594,7 +595,7 @@ export function createTextLayoutService(input: TextLayoutServiceInput): TextLayo
       // consumer policy changes only the script classes covered by Word output
       // evidence; every authored direct/theme face remains authoritative above.
       : request.genericFamily ?? defaultGenericForSlot(request.slot);
-    const hasHan = /\p{Script=Han}/u.test(request.text ?? '');
+    const hasHan = containsHanScript(request.text ?? '');
     return input.fonts.resolve({
       requestedFamily: authoredFamily,
       cjkFallback: hasHan ? input.cjkFallback : undefined,

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1,5 +1,6 @@
 import { pptxSlideCjkFallback } from './google-fonts.js';
 import type { CjkLang } from '@silurus/ooxml-core';
+import { containsHanScript } from '@silurus/ooxml-core/internal/script-preload-accumulator';
 import type {
   Slide,
   SlideElement,
@@ -1012,7 +1013,7 @@ export function buildFont(
   const authoredFamily = rc.embeddedFontAuthoredFamilies?.get(normalized) ?? normalized;
   const inferredWeight = namedFaceWeight(authoredFamily);
   const weight = bold ? 'bold ' : inferredWeight ? `${inferredWeight} ` : '';
-  const fallback = /\p{Script=Han}/u.test(text)
+  const fallback = containsHanScript(text)
     ? rc.cjkFallback ?? classifyCjkFont(rc.themeMajorFont) ?? classifyCjkFont(rc.themeMinorFont) ?? undefined
     : undefined;
   if (CSS_GENERIC_FAMILIES.has(normalized)) {

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -1,4 +1,5 @@
 import type { CjkLang } from '@silurus/ooxml-core';
+import { containsHanScript } from '@silurus/ooxml-core/internal/script-preload-accumulator';
 import type {
   Worksheet, Styles, Cell, CellValue, CellFont, CellFill, Border, BorderEdge, CellXf,
   ViewportRange, RenderViewportOptions, XlsxTextRunInfo,
@@ -143,7 +144,7 @@ export function fontStackFor(
   text = '',
 ): string {
   const normalized = name?.trim();
-  const fallback = /\p{Script=Han}/u.test(text) ? cjkFallback : undefined;
+  const fallback = containsHanScript(text) ? cjkFallback : undefined;
   return normalized ? `"${normalized}", ${cssTailFor(normalized, fallback)}` : cssTailFor(null, fallback);
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1500. Use one internal Han-script predicate for font preloading and the DOCX, XLSX, and PPTX measurement/paint paths. This keeps the locale-selected regional fallback scoped consistently and prevents the three renderers from drifting.

## Validation

- Focused cross-format font tests: 168 passed
- Full suite: 9,032 passed, 24 skipped across 786 files
- Typecheck: passed
- Public API build/baseline and public type exports: passed
- DOCX layout boundary, compatibility, package-build, and architecture gates: passed
- Self-VRT against the previous renderer:
  - DOCX demo: 6/6 pages exact
  - XLSX demo: 5/5 sheets exact
  - PPTX demo: 7/9 slides exact; slides 7 and 9 are expected locale-font changes and improve Office-reference fidelity (slide 7 MAE 5.06 to 1.75; slide 9 match 98.4% to 99.9%)
  - A transient aggregate-run difference on a non-Han PPTX slide was isolated to browser font-cache state: an isolated rerun matched the prior-renderer SHA-256 exactly, and instrumentation confirmed the Han route was not entered.

## Adversarial review

APPROVE. The change is specification-compatible implementation policy under ECMA-376 Part 1 section 17.8.2, introduces no sample-specific heuristic, keeps the policy in the shared core boundary, preserves authored-font priority, adds no public API surface, and has no unbounded work or retained state. DOCX, XLSX, PPTX, workers, preload, measurement, and paint integration points were checked. No unresolved findings remain.