### PR TITLE
test(fonts): harden custom CSS origin coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,29 @@ per-render argument. (Excel stores "Insert > Equation" as OMML inside the shared
 DrawingML `<xdr:txBody>` grammar, so `XlsxViewer` renders equations embedded in
 shapes / text boxes the same way.)
 
+### Custom Google Fonts CSS service
+
+When `useGoogleFonts` is enabled, set `googleFontsCssOrigin` to use a regional
+mirror or an internal Google Fonts-compatible CSS service. The option works for
+DOCX, XLSX, and PPTX engines and self-loading viewers, including worker and
+progressive loading:
+
+```typescript
+await DocxDocument.load(data, {
+  useGoogleFonts: true,
+  googleFontsCssOrigin: 'https://fonts.internal.example',
+});
+```
+
+Supply an HTTP(S) origin only, without a path, query, fragment, or credentials.
+Built-in stylesheet paths and family queries are preserved. Relative font-file
+URLs in the returned CSS resolve against the stylesheet's final URL, including
+after redirects. A fully internal deployment must therefore host or proxy the
+font files as well as the CSS and return URLs reachable by the browser. Configure
+CORS and your application's `connect-src` and `font-src` CSP directives for the
+selected CSS and font hosts. Failures retain the existing system-font fallback
+and do not retry the public Google Fonts service.
+
 ### Optional rendering modules
 
 Classic DrawingML 2-D chart families are included in every format entry.

--- a/packages/core/src/fonts/preload.test.ts
+++ b/packages/core/src/fonts/preload.test.ts
@@ -54,15 +54,25 @@ describe('parseFontFaceRules', () => {
     expect(faces[1].descriptors.style).toBe('normal');
   });
 
-  it('resolves relative font files against the final stylesheet URL', () => {
+  it.each([
+    ['url(../files/a.woff2)', 'url("https://cdn.internal.example/files/a.woff2")'],
+    ["url('/files/a.woff2')", 'url("https://cdn.internal.example/files/a.woff2")'],
+    ['url(a.woff2)', 'url("https://cdn.internal.example/styles/a.woff2")'],
+    [
+      'url(//assets.internal.example/a.woff2)',
+      'url("https://assets.internal.example/a.woff2")',
+    ],
+    [
+      'local("Internal"), url(/files/a.woff2) format("woff2")',
+      'local("Internal"), url("https://cdn.internal.example/files/a.woff2") format("woff2")',
+    ],
+  ])('resolves font sources against the final stylesheet URL: %s', (src, expected) => {
     const faces = parseFontFaceRules(
-      "@font-face { font-family: 'Internal'; src: url(../files/internal.woff2) format('woff2'); }",
+      `@font-face { font-family: 'Internal'; src: ${src}; }`,
       'https://cdn.internal.example/styles/css2?family=Internal',
     );
 
-    expect(faces[0].src).toBe(
-      'url("https://cdn.internal.example/files/internal.woff2") format(\'woff2\')',
-    );
+    expect(faces[0].src).toBe(expected);
   });
 });
 
@@ -74,10 +84,14 @@ describe('normalizeGoogleFontsCssOrigin', () => {
   });
 
   it.each([
+    '',
+    'file:///fonts',
     'ftp://fonts.internal.example',
     'https://user@fonts.internal.example',
+    'https://user:pass@fonts.internal.example',
     'https://fonts.internal.example/css',
     'https://fonts.internal.example?tenant=a',
+    'https://fonts.internal.example#fragment',
     'not a URL',
   ])('rejects a value that is not an HTTP(S) origin: %s', (value) => {
     expect(() => normalizeGoogleFontsCssOrigin(value)).toThrow(TypeError);
@@ -169,13 +183,19 @@ describe('preloadGoogleFonts', () => {
     G.document = { fonts: set };
     delete G.self;
 
-    const [publicFaces, internalFaces] = await Promise.all([
+    const [publicFaces, internalFaces, internalFacesAgain] = await Promise.all([
       preloadGoogleFonts(['Calibri'], MAP, set as unknown as FontFaceSet),
       preloadGoogleFonts(
         ['Calibri'],
         MAP,
         set as unknown as FontFaceSet,
         'https://fonts.internal.example:8443',
+      ),
+      preloadGoogleFonts(
+        ['Calibri'],
+        MAP,
+        set as unknown as FontFaceSet,
+        'https://fonts.internal.example:8443/',
       ),
     ]);
 
@@ -187,6 +207,7 @@ describe('preloadGoogleFonts', () => {
       'https://fonts.internal.example:8443/css2?family=Carlito',
     );
     expect(publicFaces[0]).not.toBe(internalFaces[0]);
+    expect(internalFacesAgain[0]).toBe(internalFaces[0]);
   });
 
   it('uses the redirected stylesheet URL as the base for relative font files', async () => {
@@ -209,6 +230,28 @@ describe('preloadGoogleFonts', () => {
 
     expect(added[0].source).toContain(
       'url("https://assets.internal.example/fonts/carlito.woff2")',
+    );
+  });
+
+  it('uses the requested stylesheet URL when a response URL is unavailable', async () => {
+    const { set, added } = installFakes();
+    G.document = { fonts: set };
+    delete G.self;
+    G.fetch = vi.fn(async () => ({
+      ok: true,
+      text: async () =>
+        '@font-face { font-family: Carlito; src: local("Carlito"), url(/fonts/carlito.woff2) format("woff2"); }',
+    }));
+
+    await preloadGoogleFonts(
+      ['Calibri'],
+      MAP,
+      set as unknown as FontFaceSet,
+      'https://fonts.internal.example',
+    );
+
+    expect(added[0].source).toBe(
+      'local("Carlito"), url("https://fonts.internal.example/fonts/carlito.woff2") format("woff2")',
     );
   });
 

--- a/packages/pptx/src/presentation-destroy.test.ts
+++ b/packages/pptx/src/presentation-destroy.test.ts
@@ -240,6 +240,7 @@ describe('PptxPresentation.destroy() — rejects in-flight worker requests', () 
     const presentation = await PptxPresentation.load(new ArrayBuffer(0), {
       mode: 'main',
       useGoogleFonts: false,
+      googleFontsCssOrigin: 'https://fonts.internal.example',
     });
 
     expect(fetch).not.toHaveBeenCalled();

--- a/packages/xlsx/src/workbook-delimited-text.test.ts
+++ b/packages/xlsx/src/workbook-delimited-text.test.ts
@@ -85,7 +85,10 @@ afterEach(() => {
 describe('XlsxSheetViewer delimited-text workbook bridge', () => {
   it('loads CSV off the main thread without initializing XLSX WASM', async () => {
     const source = new TextEncoder().encode('id,name\n00123,Ada').buffer as ArrayBuffer;
-    const workbook = await XlsxWorkbook[loadXlsxSheetSource](source, {}, {
+    const workbook = await XlsxWorkbook[loadXlsxSheetSource](source, {
+      useGoogleFonts: true,
+      googleFontsCssOrigin: 'https://fonts.internal.example',
+    }, {
       format: 'csv',
       sheetName: 'Import',
     });
@@ -94,6 +97,8 @@ describe('XlsxSheetViewer delimited-text workbook bridge', () => {
     expect(worker.messages).toHaveLength(1);
     expect(worker.messages[0]).toMatchObject({
       type: 'parseDelimitedText',
+      useGoogleFonts: true,
+      googleFontsCssOrigin: 'https://fonts.internal.example',
       options: { delimiter: ',', encoding: 'utf-8', sheetName: 'Import' },
     });
     expect(worker.messages[0]).not.toMatchObject({ type: 'init' });


### PR DESCRIPTION
## Summary

- incorporate reusable documentation and boundary tests from #1498 on top of the implementation merged in #1501
- cover normalized-origin cache sharing, stylesheet-relative font URL forms, and the requested-URL fallback
- verify PPTX remains offline when Google Fonts is disabled and XLSX delimited-text workers receive the configured origin when explicitly enabled

No migration is required. This follow-up changes no runtime behavior.

## Adversarial review

- **Contract:** remote loading remains explicitly opt-in; the XLSX test intentionally requires `useGoogleFonts: true`
- **URL handling:** coverage includes parent-relative, root-relative, bare, protocol-relative, and mixed `local()`/`url()` sources
- **Cross-format wiring:** the shared core loader, PPTX opt-out path, and XLSX delimited-text worker path are exercised; existing #1501 tests continue to cover DOCX and progressive/viewer propagation
- **Risk:** test/documentation-only diff; no performance, resource ownership, worker protocol, or public API behavior changes
- **Result:** no unresolved findings

## Verification

- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm exec vitest run packages/core/src/fonts/preload.test.ts packages/pptx/src/presentation-destroy.test.ts packages/xlsx/src/workbook-delimited-text.test.ts` (59 passed)
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm test` (9,040 passed, 25 skipped; private-corpus harness 2 passed)
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm typecheck`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm lint` (pre-existing warnings only)
- `git diff --check`
