### PR TITLE
fix(docx): tolerate unset script slot in intrinsic-merge fingerprint

### DIFF
--- a/packages/docx/src/layout/intrinsic-width.ts
+++ b/packages/docx/src/layout/intrinsic-width.ts
@@ -132,8 +132,10 @@ function compatibleTextKey(segment: LayoutTextSeg): string {
     segment.widthBalanceSpaceAdjustmentPt ?? null,
     // The snap-to-character-grid allocator consumes contiguous script blocks.
     // A shaping-compatible Latin→East-Asian seam is therefore still a semantic
-    // grid boundary and must survive this intrinsic-only merge.
-    segment.script,
+    // grid boundary and must survive this intrinsic-only merge. The slot is
+    // optional: metric-only anchor-host segments never pass through the
+    // shaping service, so their script stays unset.
+    segment.script ?? null,
     segment.tateChuYoko ?? false,
     // A tate-chu-yoko run is one authored one-em cell (§17.3.2.10). Two
     // adjacent runs with identical fonts remain two cells, so their source-run

--- a/packages/docx/src/paragraph-measure.test.ts
+++ b/packages/docx/src/paragraph-measure.test.ts
@@ -229,6 +229,27 @@ describe('measureParagraph', () => {
     expect(measureParagraphIntrinsicWidth(doc, context, 25, measurer, environment())).toBe(25);
   });
 
+  it('fingerprints anchor-host segments whose shaping script slot is unset', () => {
+    // anchorHost runs acquire as metric-only empty segments (line-layout.ts),
+    // which never pass through the shaping service, so their optional
+    // LayoutTextSeg.script stays undefined. The intrinsic-merge fingerprint
+    // must tolerate that instead of throwing "Cannot fingerprint undefined".
+    const doc = paragraph({
+      spaceBefore: 0,
+      spaceAfter: 0,
+      runs: [
+        { type: 'anchorHost', fontSize: 10, anchorOccurrenceId: 'occ-1' } as never,
+        { type: 'text', ...textRun('abc') },
+      ],
+    });
+    const context = layoutContext({ spaceBeforePt: 0, spaceAfterPt: 0 });
+
+    expect(() => measureParagraphIntrinsicWidth(doc, context, 200, measurer, environment()))
+      .not.toThrow();
+    expect(measureParagraphIntrinsicWidth(doc, context, 200, measurer, environment()))
+      .toBeGreaterThan(0);
+  });
+
   it('includes paragraph indents, hanging numbering space, tabs, bidi, and inline resources', () => {
     const indented = layoutContext({
       spaceBeforePt: 0, spaceAfterPt: 0,

--- a/packages/docx/src/paragraph-measure.test.ts
+++ b/packages/docx/src/paragraph-measure.test.ts
@@ -238,16 +238,14 @@ describe('measureParagraph', () => {
       spaceBefore: 0,
       spaceAfter: 0,
       runs: [
-        { type: 'anchorHost', fontSize: 10, anchorOccurrenceId: 'occ-1' } as never,
+        { type: 'anchorHost', fontSize: 10 },
         { type: 'text', ...textRun('abc') },
       ],
     });
     const context = layoutContext({ spaceBeforePt: 0, spaceAfterPt: 0 });
 
-    expect(() => measureParagraphIntrinsicWidth(doc, context, 200, measurer, environment()))
-      .not.toThrow();
     expect(measureParagraphIntrinsicWidth(doc, context, 200, measurer, environment()))
-      .toBeGreaterThan(0);
+      .toBe(15);
   });
 
   it('includes paragraph indents, hanging numbering space, tabs, bidi, and inline resources', () => {


### PR DESCRIPTION
## Problem

Opening a DOCX whose body contains an `anchorHost` run (a floating-object anchor carrier paragraph) crashes during intrinsic-width measurement with:

```
TypeError: Cannot fingerprint undefined at $[16]
```

## Root cause

`anchorHost` runs acquire as **metric-only empty text segments** (`line-layout.ts`, `text: ''`, `metricOnly: true`). These segments never pass through the shaping service, so the optional `LayoutTextSeg.script` (the §17.3.2.26 font slot selected by the authoritative shaping service) legitimately stays `undefined`.

`compatibleTextKey()` in `layout/intrinsic-width.ts` passed `segment.script` into `stableFingerprint('paragraph-intrinsic-text', …)` bare — index 16 of that tuple — and `canonicalValue` throws on `undefined` by design (a fingerprint is an identity, not a hash hint).

## Fix

Coerce with `?? null`, exactly like every other optional field in the same tuple (`fontRoute`, `fitTextPerGapPx`, …). Absent script and an explicitly unset slot are the same identity for intrinsic-merge purposes.

## Verification

- New regression test `fingerprints anchor-host segments whose shaping script slot is unset` in `paragraph-measure.test.ts` — fails on main with the exact reported error, passes with the fix.
- `vitest run packages/docx/src`: 3421 passed.
- Repo gates: `check-docx-layout-boundaries` (89), `check-public-api` (26), and `check-docx-compatibility-evidence` (17) all pass; `tsc --build`, `ast-grep scan`, and `pnpm build` succeed.

## Maintainer adversarial review

- Confirmed the failure on the pre-fix code as `Cannot fingerprint undefined at $[16]` and the focused regression passes with the fix.
- Verified that `script` is optional by contract and legitimately absent only on the zero-advance, metric-only anchor-host path; normal visible text receives an authoritative script slot.
- Confirmed that `null` preserves a distinct identity from every valid script slot, introduces no heuristic, changes no public API, and adds no unbounded work or retained resources.
- Strengthened the regression in `bea55f41` to use a type-safe anchor-host fixture and assert the exact 15pt content width, ensuring the host remains zero-advance rather than merely avoiding the exception.
- Re-ran the DOCX suite (3421 passed), TypeScript build, production build, layout-boundary tests (89), public-API tests (26), compatibility-evidence tests (17), and final compatibility registry verification (105 rules).
- Rebuilt all parser WASM and ran the complete private-corpus self-VRT against release `v0.86.1`, bound to commit `a82fc6e5146f51fde0a060e6a8a53df60487fc3b`: 51 DOCX files / 411 pages, 139 XLSX files / 365 sheets, and 35 PPTX files / 361 slides. All 1,137 images were pixel-identical; there are no visual differences requiring adjudication.

Co-Authored-By: Kimi <noreply@moonshot.ai>
